### PR TITLE
Add chat testing

### DIFF
--- a/api-reference/scenarios/create-scenario.mdx
+++ b/api-reference/scenarios/create-scenario.mdx
@@ -29,7 +29,6 @@ Include your API key in the request headers:
 | `personality` | integer | Yes | ID of the personality to use |
 | `instructions` | string | Yes | Instructions for the scenario |
 | `agent` | integer | Yes | ID of the agent |
-| `metrics` | array | Yes | Array of metric IDs to track |
 
 ### Example Request Body
 
@@ -38,8 +37,7 @@ Include your API key in the request headers:
   "name": "Demo scenario",
   "personality": 2,
   "instructions": "Some instructions",
-  "agent": 4,
-  "metrics": [11, 1]
+  "agent": 4
 }
 ```
 
@@ -58,8 +56,6 @@ A successful request returns the created scenario details.
 | `personality_name` | string | Human-readable name of the personality |
 | `retell_agent_id` | string | UUID of the retell agent |
 | `runs` | array | List of scenario runs (empty for new scenarios) |
-| `metrics` | array | List of metric IDs being tracked |
-| `metric_names` | array | Human-readable names of the metrics |
 | `instructions` | string | Scenario instructions |
 
 ### Example Response
@@ -73,11 +69,6 @@ A successful request returns the created scenario details.
     "personality_name": "Frustrated Dutch, English",
     "retell_agent_id": "edc58747-b69d-47a5-be64-a1d6309c6c65",
     "runs": [],
-    "metrics": [11, 1],
-    "metric_names": [
-        "Deviation Avoidance",
-        "Appointment Bookeds"
-    ],
     "instructions": "Some instructions"
 }
 ```
@@ -94,15 +85,14 @@ curl -X POST https://new-prod.vocera.ai/test_framework/v1/scenario-external/ \
     "name": "<scenario-name>",
     "agent": <agent-id>,
     "personality": <personality-id>,
-    "instructions": "<scenario-instructions>",
-    "metrics": [<metric-id-1>, <metric-id-2>, ...]
+    "instructions": "<scenario-instructions>"
   }'
 ```
 
 ```python Python
 import requests
 
-def create_scenario(api_key, name, agent_id, personality_id, instructions, metric_ids):
+def create_scenario(api_key, name, agent_id, personality_id, instructions):
     url = 'https://new-prod.vocera.ai/test_framework/v1/scenario-external/'
     
     headers = {
@@ -115,7 +105,6 @@ def create_scenario(api_key, name, agent_id, personality_id, instructions, metri
         'agent': agent_id,
         'personality': personality_id,
         'instructions': instructions,
-        'metrics': metric_ids
     }
 
     response = requests.post(url, headers=headers, json=data)
@@ -123,7 +112,7 @@ def create_scenario(api_key, name, agent_id, personality_id, instructions, metri
 ```
 
 ```javascript JavaScript
-async function createScenario(apiKey, name, personalityId, instructions, agentId, metricIds) {
+async function createScenario(apiKey, name, personalityId, instructions, agentId) {
   const url = 'https://new-prod.vocera.ai/test_framework/v1/scenarios-external/';
   
   const data = {
@@ -131,7 +120,6 @@ async function createScenario(apiKey, name, personalityId, instructions, agentId
     personality: personalityId,
     instructions,
     agent: agentId,
-    metrics: metricIds
   };
 
   const response = await fetch(url, {

--- a/api-reference/scenarios/get-scenarios.mdx
+++ b/api-reference/scenarios/get-scenarios.mdx
@@ -46,6 +46,7 @@ The API returns a paginated list of scenarios.
 | `id` | integer | Unique identifier for the scenario |
 | `name` | string | Name of the scenario |
 | `personality_name` | string | Name of the associated personality |
+| `phone_number` | string | Phone number associated with scenario |
 
 ## Example Response
 
@@ -58,7 +59,8 @@ The API returns a paginated list of scenarios.
         {
             "id": 201,
             "name": "Hindi Elderly Telephonic Inquiry",
-            "personality_name": "Hindi, Old, Hearing Issue"
+            "personality_name": "Hindi, Old, Hearing Issue",
+            "phone_number": "+14159976447"
         },
         // Additional scenarios ...
     ]
@@ -73,7 +75,7 @@ The API returns a paginated list of scenarios.
 curl -X GET https://new-prod.vocera.ai/test_framework/v1/scenarios-external/ \
   -H "X-VOCERA-API-KEY: <your-api-key-here>" \
   -G \
-  -d "agent=<agent-id-number>"
+  -d "agent_id=<agent-id-number>"
 ```
 
 ```python Python

--- a/api-reference/scenarios/llm-websocket-server-example.mdx
+++ b/api-reference/scenarios/llm-websocket-server-example.mdx
@@ -1,0 +1,73 @@
+---
+title: 'LLM Websocket Server Example'
+description: 'Setup an LLM websocket server'
+---
+
+## Getting Started
+
+### Requirements
+ - Python 3.9+
+ - OpenAI API key
+ - Ngrok
+
+### Installation
+```bash
+# Clone the repository
+git clone https://github.com/vocera-ai/llm-websocket-server-example.git
+
+# Enter into the directory
+cd llm-websocket-server-example/
+
+# Create virtual environment
+python3 -m venv .venv
+
+# Activate virtual environment
+source .venv/bin/activate
+
+# Install the dependencies
+pip install -r requirements.txt
+```
+
+Update OpenAI API key and prompt in `main.py`
+```py
+...
+
+api_key = 'YOUR-OPENAI-API-KEY'
+
+...
+
+SYSTEM_PROMPT = {
+    "role": "system",
+    "content": """Your system prompt"""
+}
+
+...
+```
+
+### Starting the application
+```bash
+python main.py
+```
+
+## Serving LLM Websocket Server Over Internet
+
+### Installing ngrok
+Please refer: https://dashboard.ngrok.com/get-started/setup/linux
+```bash
+# Install ngrok
+curl -sSL https://ngrok-agent.s3.amazonaws.com/ngrok.asc \
+	| sudo tee /etc/apt/trusted.gpg.d/ngrok.asc >/dev/null \
+	&& echo "deb https://ngrok-agent.s3.amazonaws.com buster main" \
+	| sudo tee /etc/apt/sources.list.d/ngrok.list \
+	&& sudo apt update \
+	&& sudo apt install ngrok
+
+# Authenticate
+# get your token from: https://dashboard.ngrok.com/get-started/your-authtoken
+ngrok config add-authtoken <your-token>
+```
+
+### Forwarding port
+```bash
+ngrok http 127.0.0.1:8765
+```

--- a/api-reference/scenarios/running-scenarios.mdx
+++ b/api-reference/scenarios/running-scenarios.mdx
@@ -25,13 +25,30 @@ Include your API key in the request headers:
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `scenario_ids` | array | Yes | Array of scenario IDs to run |
+| `scenarios` | array\|string\|integer | Yes | Array of scenario IDs to run OR `"all"` to run all OR number to run first N scenarios |
+| `agent_id` | integer | Yes | Required only when `scenarios` is `"all"` OR is number of first N scenarios |
 
 ### Example Request Body
-
+Running scenarios using ids
 ```json
 {
-    "scenario_ids": [201, 187]
+    "scenarios": [201, 187]
+}
+```
+
+Running all scenarios
+```json
+{
+    "agent_id": 1,
+    "scenarios": "all"
+}
+```
+
+Running first N scenarios
+```json
+{
+    "agent_id": 1,
+    "scenarios": 10
 }
 ```
 
@@ -72,14 +89,33 @@ A successful request returns details about the running scenarios.
 <CodeGroup>
 
 ```bash Curl
+# Running using scenario IDs
 curl -X POST https://new-prod.vocera.ai/test_framework/v1/scenarios-external/run_scenarios/ \
   -H "X-VOCERA-API-KEY: <your-api-key-here>" \
   -H "Content-Type: application/json" \
-  -d '{"scenario_ids": [<scenario-id-1>, <scenario-id-2>, ...]}'
+  -d '{"scenarios": [<scenario-id-1>, <scenario-id-2>, ...]}'
+
+# Running all scenarios
+curl -X POST https://new-prod.vocera.ai/test_framework/v1/scenarios-external/run_scenarios/ \
+  -H "X-VOCERA-API-KEY: <your-api-key-here>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "scenarios": "all",
+    "agent_id": <agent-id>
+  }'
+
+# Running first N scenarios
+curl -X POST https://new-prod.vocera.ai/test_framework/v1/scenarios-external/run_scenarios/ \
+  -H "X-VOCERA-API-KEY: <your-api-key-here>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "scenarios": <number-of-scenarios>,
+    "agent_id": <agent-id>
+  }'
 ```
 
 ```python Python
-def run_scenarios(api_key, scenario_ids):
+def run_scenarios(api_key, scenarios, agent_id=None):
     url = 'https://new-prod.vocera.ai/test_framework/v1/scenarios-external/run_scenarios/'
 
     headers = {
@@ -88,19 +124,32 @@ def run_scenarios(api_key, scenario_ids):
     }
 
     data = {
-        'scenario_ids': scenario_ids
+        'scenarios': scenarios
     }
+
+    if isinstance(scenarios, (int, str)):
+        if agent_id is None:
+            raise ValueError("`agent_id` is required when scenarios is int or str")
+
+        data["agent_id"] = agent_id
 
     response = requests.post(url, headers=headers, json=data)
     return response.json()
 ```
 
 ```javascript JavaScript
-async function runScenarios(apiKey, scenarioIds) {
+async function runScenarios(apiKey, scenarios, agentId=null) {
   const url = 'https://new-prod.vocera.ai/test_framework/v1/scenarios-external/run_scenarios/';
 
   const data = {
-    scenario_ids: scenarioIds
+    scenarios: scenarios
+  }
+
+  if (typeof scenarios === 'number' || typeof scenarios === 'string') {
+    if (!agentId) {
+      throw new Error('`agentId` is required when scenarios is number or string');
+    }
+    data.agent_id = agentId;
   }
 
   const response = await fetch(url, {

--- a/api-reference/scenarios/running-scenarios.mdx
+++ b/api-reference/scenarios/running-scenarios.mdx
@@ -3,11 +3,11 @@ title: 'Running Scenarios'
 description: 'Learn how to run multiple scenarios simultaneously'
 ---
 
-# Run Scenarios API
+# Running using Voice Calls
 
 Run multiple scenarios at once and receive their execution details.
 
-## API Endpoint
+## API Endpont
 
 | Method | Endpoint |
 |--------|----------|
@@ -140,6 +140,170 @@ def run_scenarios(api_key, scenarios, agent_id=None):
 ```javascript JavaScript
 async function runScenarios(apiKey, scenarios, agentId=null) {
   const url = 'https://new-prod.vocera.ai/test_framework/v1/scenarios-external/run_scenarios/';
+
+  const data = {
+    scenarios: scenarios
+  }
+
+  if (typeof scenarios === 'number' || typeof scenarios === 'string') {
+    if (!agentId) {
+      throw new Error('`agentId` is required when scenarios is number or string');
+    }
+    data.agent_id = agentId;
+  }
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'X-VOCERA-API-KEY': apiKey
+    },
+    body: JSON.stringify(data)
+  });
+
+  return await response.json();
+}
+```
+
+</CodeGroup>
+
+
+# Running using LLM Websocket
+Run multiple scenarios at once using your LLM websocket and receive their execution details.
+
+You need to add the url to your LLM websocket in your agent at Vocera.
+For demo websocket server you can use [wss://echo.websocket.org](wss://echo.websocket.org) or install using [this repo](https://github.com/vocera-ai/llm-websocket-server-example).
+
+| Method | Endpoint |
+|--------|----------|
+| `POST` | `https://new-prod.vocera.ai/test_framework/v1/scenarios-external/run_scenarios_text/` |
+
+## Authentication
+
+Include your API key in the request headers:
+
+| Header | Description |
+|--------|-------------|
+| `X-VOCERA-API-KEY` | Your API key obtained from the dashboard |
+
+## Request Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `scenarios` | array\|string\|integer | Yes | Array of scenario IDs to run OR `"all"` to run all OR number to run first N scenarios |
+| `agent_id` | integer | Yes | Required only when `scenarios` is `"all"` OR is number of first N scenarios |
+
+### Example Request Body
+Running scenarios using ids
+```json
+{
+    "scenarios": [201, 187]
+}
+```
+
+Running all scenarios
+```json
+{
+    "agent_id": 1,
+    "scenarios": "all"
+}
+```
+
+Running first N scenarios
+```json
+{
+    "agent_id": 1,
+    "scenarios": 10
+}
+```
+
+## Response
+
+A successful request returns details about the running scenarios.
+
+### Response Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | integer | The scenario ID |
+| `phone_number` | string | Phone number assigned for the scenario |
+| `information_fields` | object | Additional scenario-specific information |
+
+### Example Response
+
+```json
+[
+    {
+        "id": 201,
+        "phone_number": "+14159976447",
+        "information_fields": {
+            "name": "Edwin",
+            "age": 25
+        }
+    },
+    {
+        "id": 187,
+        "phone_number": "+14159976447",
+        "information_fields": {}
+    }
+]
+```
+
+## Code Examples
+
+<CodeGroup>
+
+```bash Curl
+# Running using scenario IDs
+curl -X POST https://new-prod.vocera.ai/test_framework/v1/scenarios-external/run_scenarios_text/ \
+  -H "X-VOCERA-API-KEY: <your-api-key-here>" \
+  -H "Content-Type: application/json" \
+  -d '{"scenarios": [<scenario-id-1>, <scenario-id-2>, ...]}'
+
+# Running all scenarios
+curl -X POST https://new-prod.vocera.ai/test_framework/v1/scenarios-external/run_scenarios_text/ \
+  -H "X-VOCERA-API-KEY: <your-api-key-here>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "scenarios": "all",
+    "agent_id": <agent-id>
+  }'
+
+# Running first N scenarios
+curl -X POST https://new-prod.vocera.ai/test_framework/v1/scenarios-external/run_scenarios_text/ \
+  -H "X-VOCERA-API-KEY: <your-api-key-here>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "scenarios": <number-of-scenarios>,
+    "agent_id": <agent-id>
+  }'
+```
+
+```python Python
+def run_scenarios(api_key, scenarios, agent_id=None):
+    url = 'https://new-prod.vocera.ai/test_framework/v1/scenarios-external/run_scenarios_text/'
+
+    headers = {
+        'X-VOCERA-API-KEY': api_key,
+        'Content-Type': 'application/json'
+    }
+
+    data = {
+        'scenarios': scenarios
+    }
+
+    if isinstance(scenarios, (int, str)):
+        if agent_id is None:
+            raise ValueError("`agent_id` is required when scenarios is int or str")
+
+        data["agent_id"] = agent_id
+
+    response = requests.post(url, headers=headers, json=data)
+    return response.json()
+```
+
+```javascript JavaScript
+async function runScenarios(apiKey, scenarios, agentId=null) {
+  const url = 'https://new-prod.vocera.ai/test_framework/v1/scenarios-external/run_scenarios_text/';
 
   const data = {
     scenarios: scenarios

--- a/mint.json
+++ b/mint.json
@@ -44,7 +44,8 @@
         "api-reference/introduction",
         "api-reference/scenarios/create-scenario",
         "api-reference/scenarios/get-scenarios",
-        "api-reference/scenarios/running-scenarios"
+        "api-reference/scenarios/running-scenarios",
+        "api-reference/scenarios/llm-websocket-server-example"
       ]
     }
   ],


### PR DESCRIPTION
Resolve VOC-255
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> This PR updates scenario management API documentation, removing `metrics`, adding `phone_number`, and supporting new scenario running options, plus a new LLM Websocket server setup guide.
> 
>   - **Create Scenario API**:
>     - Removed `metrics` parameter from request and response in `create-scenario.mdx`.
>     - Updated code examples to reflect removal of `metrics`.
>   - **Get Scenarios API**:
>     - Added `phone_number` field to response in `get-scenarios.mdx`.
>     - Updated example response to include `phone_number`.
>   - **Run Scenarios API**:
>     - Changed `scenario_ids` to `scenarios` in `running-scenarios.mdx`.
>     - Added support for running all scenarios or first N scenarios.
>     - Updated code examples to reflect new `scenarios` parameter behavior.
>     - Added new section for running scenarios using LLM Websocket.
>   - **Misc**:
>     - Added `llm-websocket-server-example.mdx` for setting up an LLM Websocket server.
>     - Updated `mint.json` to include new documentation paths.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=vocera-ai%2Fdocs&utm_source=github&utm_medium=referral)<sup> for d3aba9463e3584b516da3e154655afcc7c4a4650. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->