### PR TITLE
Add transcript json example

### DIFF
--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -22,6 +22,112 @@ Send a POST request to `https://new-prod.vocera.ai/observability/v1/observe/` wi
 - `customer_number` (optional): Phone number of the customer
 - `transcript_json` (optional): JSON object containing the transcript of the call
 
+**Transcript JSON Example:**
+```json
+[
+   {
+      "role": "Testing Agent",
+      "time": "0:01",
+      "content": "Hello.",
+      "end_time": 1.9399999,
+      "start_time": 1.4399999
+   },
+   {
+      "role": "Main Agent",
+      "time": "0:03",
+      "content": "Hello. I want to book appointment today. My name is John.",
+      "end_time": 7.539999511718751,
+      "start_time": 3.1
+   },
+   {
+      "role": "Testing Agent",
+      "time": "0:12",
+      "content": "Well, I mean, sure. What time exactly are we talking about here",
+      "end_time": 15.71,
+      "start_time": 12.01
+   },
+   {
+      "role": "Main Agent",
+      "time": "0:17",
+      "content": "6 PM.",
+      "end_time": 18.269999,
+      "start_time": 17.609999
+   },
+   {
+      "role": "Testing Agent",
+      "time": "0:19",
+      "content": "Great. I'll book that for you. Just a sec.",
+      "end_time": 21.45,
+      "start_time": 19.16
+   },
+   {
+      "role": "Main Agent",
+      "time": "0:22",
+      "content": "Okay.",
+      "end_time": 23.25,
+      "start_time": 22.75
+   },
+   {
+      "data": {
+         "id": "call_5otWH44dxeXEHY8RlhYYaFbV",
+         "name": "bookUserAppointment",
+         "arguments": "{\"name\": \"John\", \"datetime\": \"2024-10-17T18:00:00\"}"
+      },
+      "role": "Function Call",
+      "time": "0:23",
+      "content": "",
+      "end_time": 23.164,
+      "start_time": 23.164
+   },
+   {
+      "data": {
+         "id": "call_5otWH44dxeXEHY8RlhYYaFbV",
+         "name": "bookUserAppointment",
+         "result": "No result returned."
+      },
+      "role": "Function Call Result",
+      "time": "0:24",
+      "end_time": 24.6,
+      "start_time": 24.6
+   },
+   {
+      "role": "Testing Agent",
+      "time": "0:25",
+      "content": "1 moment.",
+      "end_time": 25.92,
+      "start_time": 25.1
+   },
+   {
+      "role": "Main Agent",
+      "time": "0:27",
+      "content": "Yes. Yes.",
+      "end_time": 27.979999999999997,
+      "start_time": 27.08
+   },
+   {
+      "role": "Testing Agent",
+      "time": "0:27",
+      "content": "Appointment booked for 6 PM today.",
+      "end_time": 29.5,
+      "start_time": 27.08
+   },
+   {
+      "role": "Main Agent",
+      "time": "0:30",
+      "content": "Oh, okay. Bye.",
+      "end_time": 31.72,
+      "start_time": 30.64
+   },
+   {
+      "role": "Testing Agent",
+      "time": "0:33",
+      "content": "Bye.",
+      "end_time": 33.6,
+      "start_time": 33.1
+   }
+]
+```
+
 ### Method 1: Using a Voice Recording URL
 
 Send a voice recording URL to be processed by our API.


### PR DESCRIPTION
Resolve VOC-431
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a JSON example for `transcript_json` in the API documentation to illustrate the expected format.
> 
>   - **Documentation**:
>     - Adds a JSON example for `transcript_json` in `api-reference/introduction.mdx` to illustrate the expected format for call transcripts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=vocera-ai%2Fdocs&utm_source=github&utm_medium=referral)<sup> for 10aad094a06e4dbdeb29b23c80f11c7a957ff1b0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->