### PR TITLE
Make transcript required in observe

### DIFF
--- a/api-reference/calls/introduction.mdx
+++ b/api-reference/calls/introduction.mdx
@@ -20,7 +20,7 @@ Send a POST request to `https://new-prod.vocera.ai/observability/v1/observe/` wi
   - `voice_recording_url`: URL to the call recording audio file
 - `call_ended_reason` (optional): Reason for call termination
 - `customer_number` (optional): Phone number of the customer
-- `transcript_json` (optional): JSON object containing the transcript of the call. Can be in Vocera, Vapi or Retell format
+- `transcript_json` (required): JSON object containing the transcript of the call. Can be in Vocera, Vapi or Retell format
 
 **Transcript JSON Example:**
 
@@ -361,7 +361,7 @@ Send a voice recording URL to be processed by our API.
 - `voice_recording_url` (required): URL to the call recording audio file
 - `call_ended_reason` (optional): Reason for call termination
 - `customer_number` (optional): Phone number of the customer
-- `transcript_json` (optional): JSON object containing the transcript of the call
+- `transcript_json` (required): JSON object containing the transcript of the call
 
 <CodeGroup>
 ```bash Curl
@@ -439,7 +439,7 @@ Upload an audio file directly in the request.
 - `voice_recording` (required): Audio file of the call recording
 - `call_ended_reason` (optional): Reason for call termination
 - `customer_number` (optional): Phone number of the customer
-- `transcript_json` (optional): JSON object containing the transcript of the call
+- `transcript_json` (required): JSON object containing the transcript of the call
 
 <CodeGroup>
 ```bash Curl


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Make `transcript_json` required in observe requests in `introduction.mdx`.
> 
>   - **API Documentation**:
>     - Change `transcript_json` from optional to required in `introduction.mdx` for observe requests.
>     - Affects sections: general observe request, using a voice recording URL, and using a voice recording file.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=vocera-ai%2Fdocs&utm_source=github&utm_medium=referral)<sup> for b7d64c6b1484ba5e746d88d62b288854bf30ac02. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->