### PR TITLE
Add re-evaluation apis

### DIFF
--- a/api-reference/calls/reevaluate-calls.mdx
+++ b/api-reference/calls/reevaluate-calls.mdx
@@ -1,0 +1,153 @@
+---
+title: 'Reevaluating Calls'
+description: 'Learn how to reevaluate metrics for existing calls'
+---
+
+# Reevaluate Calls API
+Trigger a reevaluation of metrics for specified calls
+
+## API Endpoint
+
+| Method | Endpoint |
+|--------|----------|
+| `POST` | `https://new-prod.vocera.ai/observability/v1/call-logs-external/rerun_evaluation/` |
+
+## Authentication
+
+Include your API key in the request headers:
+
+| Header | Description |
+|--------|--------|
+| `X-VOCERA-API-KEY` | Your API key obtained from the dashboard |
+
+## Request Body
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `call_logs` | array\|string\|integer | Yes | Array of call log IDs to run OR `"all"` to run all OR number to run first N calls |
+| `agent_id` | integer | Yes | Required only when `call_logs` is `"all"` OR is number of first N calls |
+
+
+### Example Requests
+
+```json
+{
+    "agent_id": 1,
+    "call_logs": 2
+}
+```
+
+```json
+{
+    "call_logs": [123, 456, 789]
+}
+```
+
+```json
+{
+    "agent_id": 1,
+    "call_logs": "all"
+}
+```
+
+## Response Format
+
+The API returns an array of call objects. Please note the evaluation is run in background.
+
+### Response Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | integer | The call log ID |
+| `timestamp` | string | ISO 8601 timestamp of when the call occurred |
+| `duration` | string | Duration of the call in MM:SS format |
+| `success` | boolean | Whether the call was successful (null if evaluation pending) |
+| `call_ended_reason` | string | Reason for call termination |
+| `customer_number` | string | Customer's phone number |
+| `agent` | integer | ID of the agent handling the call |
+| `call_id` | string | External reference ID for the call |
+
+### Example Response
+
+```json
+[
+    {
+        "id": 668,
+        "timestamp": "2024-12-19T19:50:18.678545Z",
+        "duration": "00:39",
+        "success": null,
+        "call_ended_reason": "",
+        "customer_number": "",
+        "agent": 1,
+        "call_id": "1000001"
+    },
+    {
+        "id": 667,
+        "timestamp": "2024-12-19T19:47:15.000673Z",
+        "duration": "00:11",
+        "success": null,
+        "call_ended_reason": "",
+        "customer_number": "",
+        "agent": 1,
+        "call_id": "1000002"
+    }
+]
+```
+
+## Code Examples
+
+<CodeGroup>
+
+```bash Curl
+curl -X POST https://new-prod.vocera.ai/observability/v1/call-logs-external/rerun_evaluation/ \
+  -H "X-VOCERA-API-KEY: <your-api-key-here>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "agent_id": 1,
+    "call_logs": 2
+  }'
+```
+
+```python Python
+import requests
+
+def reevaluate_calls(api_key, call_logs, agent_id=None):
+    url = 'https://new-prod.vocera.ai/observability/v1/call-logs-external/rerun_evaluation/'
+    headers = {
+        'X-VOCERA-API-KEY': api_key,
+        'Content-Type': 'application/json'
+    }
+    data = {
+        'call_logs': call_logs
+    }
+    if agent_id:
+        data['agent_id'] = agent_id
+
+    response = requests.post(url, headers=headers, json=data)
+    return response.json()
+```
+
+```javascript JavaScript
+async function reevaluateCalls(apiKey, callLogs, agentId = null) {
+  const url = 'https://new-prod.vocera.ai/observability/v1/call-logs-external/rerun_evaluation/';
+  
+  const data = {
+    call_logs: callLogs
+  };
+  if (agentId) {
+    data.agent_id = agentId;
+  }
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'X-VOCERA-API-KEY': apiKey,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(data)
+  });
+
+  return await response.json();
+}
+```
+</CodeGroup>

--- a/api-reference/results/reevaluate-metrics.mdx
+++ b/api-reference/results/reevaluate-metrics.mdx
@@ -1,0 +1,124 @@
+---
+title: 'Reevaluating metrics'
+description: 'Learn how to reevaluate metrics for specific runs'
+---
+
+# Reevaluate Metrics API
+Reevaluate specific metrics for selected test runs
+
+## API Endpoint
+
+| Method | Endpoint |
+|--------|----------|
+| `POST` | `https://new-prod.vocera.ai/test_framework/v1/results-external/:result-id/evaluate_metrics/` |
+
+## Authentication
+
+Include your API key in the request headers:
+
+| Header | Description |
+|--------|--------|
+| `X-VOCERA-API-KEY` | Your API key obtained from the dashboard |
+
+## URL Parameters
+
+Include the result ID in the URL:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `result-id` | integer | Yes | ID of the result to reevaluate |
+
+## Request Body
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `run_ids` | array | Yes | Array of run IDs to reevaluate |
+| `metric_ids` | array | Yes | Array of metric IDs to reevaluate |
+
+### Example Request
+
+```json
+{
+    "run_ids": [16, 17],
+    "metric_ids": [1, 2, 3]
+}
+```
+
+## Response Format
+
+A successful request returns details about the reevaluation result.
+
+### Response Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | integer | The result ID |
+| `agent` | integer | ID of associated agent |
+| `status` | string | Status of the result, can be one of:<br/>• `running` - Initial state when evaluator starts<br/>• `in_progress` - Call is currently executing<br/>• `completed` - Call has finished successfully<br/>• `failed` - Call encountered an error<br/>• `pending` - Testing agent is waiting to be called |
+| `success_rate` | float | Percentage of runs that passed |
+| `run_as_text` | boolean | If executed as text (llm websocket) or not |
+
+### Example Response
+
+```json
+{
+    "id": 7,
+    "agent": 1,
+    "status": "completed",
+    "success_rate": 0,
+    "run_as_text": false
+}
+```
+
+## Code Examples
+
+<CodeGroup>
+
+```bash Curl
+curl -X POST https://new-prod.vocera.ai/test_framework/v1/results-external/:your-result-id/evaluate_metrics/ \
+  -H "X-VOCERA-API-KEY: <your-api-key-here>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "run_ids": [16, 17],
+    "metric_ids": [1, 2, 3]
+  }'
+```
+
+```python Python
+import requests
+
+def reevaluate_metrics(api_key, result_id, run_ids, metric_ids):
+    url = f'https://new-prod.vocera.ai/test_framework/v1/results-external/{result_id}/evaluate_metrics/'
+    headers = {
+        'X-VOCERA-API-KEY': api_key,
+        'Content-Type': 'application/json'
+    }
+    data = {
+        'run_ids': run_ids,
+        'metric_ids': metric_ids
+    }
+
+    response = requests.post(url, headers=headers, json=data)
+    return response.json()
+```
+
+```javascript JavaScript
+async function reevaluateMetrics(apiKey, resultId, runIds, metricIds) {
+  const url = `https://new-prod.vocera.ai/test_framework/v1/results-external/${resultId}/evaluate_metrics/`;
+  
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'X-VOCERA-API-KEY': apiKey,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      run_ids: runIds,
+      metric_ids: metricIds
+    })
+  });
+
+  return await response.json();
+}
+```
+</CodeGroup>

--- a/api-reference/results/rerun-results.mdx
+++ b/api-reference/results/rerun-results.mdx
@@ -1,0 +1,111 @@
+---
+title: 'Rerunning results'
+description: 'Learn how to rerun an existing result'
+---
+
+# Rerun Result API
+Rerun an existing result by ID
+
+## API Endpoint
+
+| Method | Endpoint |
+|--------|----------|
+| `POST` | `https://new-prod.vocera.ai/test_framework/v1/results-external/:result-id/rerun/` |
+
+## Authentication
+
+Include your API key in the request headers:
+
+| Header | Description |
+|--------|--------|
+| `X-VOCERA-API-KEY` | Your API key obtained from the dashboard |
+
+## URL Parameters
+
+Include the result ID in the URL:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `result-id` | integer | Yes | ID of the result to rerun |
+
+## Response Format
+
+A successful request returns details about the newly created rerun result.
+
+### Response Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | integer | The result ID |
+| `agent` | integer | ID of associated agent |
+| `status` | string | Status of the result, can be one of:<br/>• `running` - Initial state when evaluator starts<br/>• `in_progress` - Call is currently executing<br/>• `completed` - Call has finished successfully<br/>• `failed` - Call encountered an error<br/>• `pending` - Testing agent is waiting to be called |
+| `success_rate` | float | Percentage of runs that passed |
+| `total_runs_count` | integer | Total number of test runs |
+| `completed_runs_count` | integer | Number of completed test runs |
+| `success_runs_count` | integer | Number of successful test runs |
+| `failed_runs_count` | integer | Number of failed test runs |
+| `run_as_text` | boolean | If executed as text (llm websocket) or not |
+| `scenario_names` | array | List of scenario names being tested |
+| `created_at` | string | ISO 8601 timestamp of creation |
+| `updated_at` | string | ISO 8601 timestamp of last update |
+
+### Example Response
+
+```json
+{
+    "id": 65,
+    "agent": 1,
+    "status": "running",
+    "success_rate": 0,
+    "total_runs_count": 1,
+    "completed_runs_count": 0,
+    "success_runs_count": 0,
+    "failed_runs_count": 0,
+    "run_as_text": false,
+    "scenario_names": [
+        "Check Appointment Scheduling",
+        "Verify Insurance Coverage",
+        "Handle Patient Complaints"
+    ],
+    "created_at": "2024-12-19T12:21:30.274636Z",
+    "updated_at": "2024-12-19T12:21:30.275047Z"
+}
+```
+
+## Code Examples
+
+<CodeGroup>
+
+```bash Curl
+curl -X POST https://new-prod.vocera.ai/test_framework/v1/results-external/:your-result-id/rerun/ \
+  -H "X-VOCERA-API-KEY: <your-api-key-here>"
+```
+
+```python Python
+import requests
+
+def rerun_result(api_key, result_id):
+    url = f'https://new-prod.vocera.ai/test_framework/v1/results-external/{result_id}/rerun/'
+    headers = {
+        'X-VOCERA-API-KEY': api_key
+    }
+
+    response = requests.post(url, headers=headers)
+    return response.json()
+```
+
+```javascript JavaScript
+async function rerunResult(apiKey, resultId) {
+  const url = `https://new-prod.vocera.ai/test_framework/v1/results-external/${resultId}/rerun/`;
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'X-VOCERA-API-KEY': apiKey
+    },
+  });
+
+  return await response.json();
+}
+```
+</CodeGroup>

--- a/mint.json
+++ b/mint.json
@@ -45,7 +45,8 @@
           "group": "Calls",
           "pages": [
             "api-reference/calls/introduction",
-            "api-reference/calls/get-calls"
+            "api-reference/calls/get-calls",
+            "api-reference/calls/reevaluate-calls"
           ]
         },
         {
@@ -69,7 +70,9 @@
           "group": "Results",
           "pages": [
             "api-reference/results/list-results",
-            "api-reference/results/get-results"
+            "api-reference/results/get-results",
+            "api-reference/results/rerun-results",
+            "api-reference/results/reevaluate-metrics"
           ]
         },
         {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add APIs for reevaluating calls and metrics, and rerunning results, with updated documentation.
> 
>   - **APIs**:
>     - Add `Reevaluate Calls API` in `reevaluate-calls.mdx` to trigger reevaluation of metrics for specified calls.
>     - Add `Reevaluate Metrics API` in `reevaluate-metrics.mdx` to reevaluate specific metrics for selected test runs.
>     - Add `Rerun Result API` in `rerun-results.mdx` to rerun an existing result by ID.
>   - **Documentation**:
>     - Update `mint.json` to include new API documentation pages for reevaluating calls, reevaluating metrics, and rerunning results.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=vocera-ai%2Fdocs&utm_source=github&utm_medium=referral)<sup> for 2b8a77d4bdd563d867593b3bed1628be25b7eaaf. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->