### PR TITLE
Add runs to retrieve result api

### DIFF
--- a/api-reference/results/get-results.mdx
+++ b/api-reference/results/get-results.mdx
@@ -41,16 +41,70 @@ A successful request returns details about created result.
 | `status` | string | Status of the result, can be one of:<br/>• `running` - Initial state when evaluator starts<br/>• `in_progress` - Call is currently executing<br/>• `completed` - Call has finished successfully<br/>• `failed` - Call encountered an error<br/>• `pending` - Testing agent is waiting to be called |
 | `success_rate` | float | Percentage of runs that passed |
 | `run_as_text` | boolean | If executed as text (llm websocket) or not |
+| `runs` | object | Map of run objects, keyed by run ID |
+| `created_at` | string | ISO 8601 timestamp of when the result was created |
+
+#### Run Object Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | integer | The run ID |
+| `scenario` | object | Details about the test scenario |
+| `success` | boolean | Whether the run passed or failed |
+| `evaluation` | object | Evaluation metrics and scores |
+| `transcript_object` | array | List of conversation turns with timestamps |
+| `voice_recording` | string | URL to the voice recording file |
+| `timestamp` | string | ISO 8601 timestamp of the run |
 
 ### Example Response
 
 ```json
 {
-    "id": 188,
+    "id": 30,
     "agent": 1,
-    "status": "running",
-    "success_rate": 0,
-    "run_as_text": false
+    "status": "completed",
+    "success_rate": 100.0,
+    "run_as_text": false,
+    "runs": {
+        "41": {
+            "id": 41,
+            "scenario": {
+                "id": 44,
+                "name": "\"Secure SIM Confusion Call Test\"",
+                "personality_name": "Highly Interruptive American Man"
+            },
+            "success": true,
+            "evaluation": {
+                "metrics": [
+                    {
+                        "id": 2,
+                        "name": "Call Pickup",
+                        "type": "binary_workflow_adherence",
+                        "score": 5,
+                        "explanation": [
+                            "The AI agent says 'Hello.'",
+                            "The AI agent responded, indicating the call was picked up.",
+                            "No arguments against meeting the metric",
+                            "The AI agent meets the metric as the call was picked up"
+                        ]
+                    }
+                    // ... additional metrics omitted for brevity ...
+                ]
+            },
+            "transcript_object": [
+                {
+                    "role": "Testing Agent",
+                    "time": "0:01",
+                    "content": "Hello.",
+                    "end_time": 2.0399999,
+                    "start_time": 1.5999999
+                }
+            ],
+            "voice_recording": "https://example.com/recording.wav",
+            "timestamp": "2024-12-02T15:38:45.474848Z"
+        }
+    },
+    "created_at": "2024-12-02T15:38:45.435335Z"
 }
 ```
 


### PR DESCRIPTION
Resolve VOC-654
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `runs` field to Get Result API response, detailing individual run objects with specific fields.
> 
>   - **API Changes**:
>     - Add `runs` field to Get Result API response in `get-results.mdx`, containing run objects keyed by run ID.
>     - Each run object includes `id`, `scenario`, `success`, `evaluation`, `transcript_object`, `voice_recording`, and `timestamp` fields.
>   - **Documentation**:
>     - Update example response in `get-results.mdx` to include new `runs` field and its structure.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=vocera-ai%2Fdocs&utm_source=github&utm_medium=referral)<sup> for b487d8aadd7e0a1c2c9718931346da0285b6bdd3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->