### PR TITLE
Add call-logs delete

### DIFF
--- a/api-reference/calls/delete-call.mdx
+++ b/api-reference/calls/delete-call.mdx
@@ -1,0 +1,72 @@
+---
+title: 'Deleting Calls'
+description: 'Learn how to delete existing call logs'
+---
+
+# Delete Call API
+
+Delete an existing call log.
+
+## API Endpoint
+
+| Method | Endpoint |
+|--------|----------|
+| `DELETE` | `https://new-prod.vocera.ai/observability/v1/call-logs-external/:call_log_id/` |
+
+## Authentication
+
+Include your API key in the request headers:
+
+| Header | Description |
+|--------|-------------|
+| `X-VOCERA-API-KEY` | Your API key obtained from the dashboard |
+
+## Path Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `call_log_id` | integer | Yes | The ID of the call log to delete |
+
+## Response
+
+A successful deletion returns a 204 No Content response.
+
+## Code Examples
+
+<CodeGroup>
+
+```bash Curl
+curl -X DELETE https://new-prod.vocera.ai/observability/v1/call-logs-external/:call_log_id/ \
+  -H "X-VOCERA-API-KEY: <your-api-key-here>"
+```
+
+```python Python
+import requests
+
+def delete_call(api_key, call_log_id):
+    url = f'https://new-prod.vocera.ai/observability/v1/call-logs-external/{call_log_id}/'
+    
+    headers = {
+        'X-VOCERA-API-KEY': api_key
+    }
+
+    response = requests.delete(url, headers=headers)
+    return response.status_code == 204
+```
+
+```javascript JavaScript
+async function deleteCall(apiKey, callLogId) {
+  const url = `https://new-prod.vocera.ai/observability/v1/call-logs-external/${callLogId}/`;
+  
+  const response = await fetch(url, {
+    method: 'DELETE',
+    headers: {
+      'X-VOCERA-API-KEY': apiKey
+    }
+  });
+
+  return response.status === 204;
+}
+```
+
+</CodeGroup>

--- a/mint.json
+++ b/mint.json
@@ -46,7 +46,8 @@
           "pages": [
             "api-reference/calls/introduction",
             "api-reference/calls/get-calls",
-            "api-reference/calls/reevaluate-calls"
+            "api-reference/calls/reevaluate-calls",
+            "api-reference/calls/delete-call"
           ]
         },
         {


### PR DESCRIPTION
Resolve VOC-763
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add documentation for a new DELETE API endpoint to remove call logs, including examples and navigation updates.
> 
>   - **API Documentation**:
>     - Adds `delete-call.mdx` to document the new DELETE API for call logs.
>     - Specifies endpoint `DELETE /observability/v1/call-logs-external/:call_log_id/`.
>     - Includes authentication details, path parameters, and response information.
>     - Provides code examples in Bash, Python, and JavaScript.
>   - **Configuration**:
>     - Updates `mint.json` to include `api-reference/calls/delete-call` in the API documentation navigation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=vocera-ai%2Fdocs&utm_source=github&utm_medium=referral)<sup> for 3e29a9418c58f9ed55de0b15b635c8c7ddd4a742. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->