### PR TITLE
Add predefined metrics to create agent

### DIFF
--- a/api-reference/agents/create-agents.mdx
+++ b/api-reference/agents/create-agents.mdx
@@ -32,6 +32,7 @@ Include your API key in the request headers:
 | `language` | string | Yes | ISO 639-1 language code (e.g., "en") |
 | `assistant_id` | string | No | Vapi or Retell assistant ID |
 | `websocket_url` | string | No | URL for LLM websocket |
+| `predefined_metrics` | array|string | No | IDs of predefined metrics to add or 'all' to add all |
 
 ### Example Request Body
 


### PR DESCRIPTION
Resolve VOC-758
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `predefined_metrics` parameter to agent creation API to specify or include all predefined metrics.
> 
>   - **API Changes**:
>     - Add `predefined_metrics` parameter to `create-agents.mdx` request parameters table.
>     - `predefined_metrics` can be an array of strings or 'all' to include all predefined metrics.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=vocera-ai%2Fdocs&utm_source=github&utm_medium=referral)<sup> for a19b076a3ed2288626b9d67fd4f26488f7adc888. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->