### PR TITLE
Add predefined metrics

### DIFF
--- a/api-reference/agents/create-agents.mdx
+++ b/api-reference/agents/create-agents.mdx
@@ -32,7 +32,7 @@ Include your API key in the request headers:
 | `language` | string | Yes | ISO 639-1 language code (e.g., "en") |
 | `assistant_id` | string | No | Vapi or Retell assistant ID |
 | `websocket_url` | string | No | URL for LLM websocket |
-| `predefined_metrics` | array|string | No | IDs of predefined metrics to add or 'all' to add all |
+| `predefined_metrics` | array\|string | No | Codes of predefined metrics to add or 'all' to add all (See [predefined metrics](/api-reference/predefined-metrics/list-predefined-metrics)) |
 
 ### Example Request Body
 

--- a/api-reference/predefined-metrics/list-predefined-metrics.mdx
+++ b/api-reference/predefined-metrics/list-predefined-metrics.mdx
@@ -1,0 +1,92 @@
+---
+title: 'Listing Predefined Metrics'
+description: 'Learn how to retrieve a list of predefined metrics'
+---
+
+# List Predefined Metrics API
+Retrieve a list of predefined metrics from your account
+
+## API Endpoint
+
+| Method | Endpoint |
+|--------|----------|
+| `GET` | `https://new-prod.vocera.ai/test_framework/v1/predefined-metrics-external/` |
+
+## Authentication
+
+Include your API key in the request headers:
+
+| Header | Description |
+|--------|--------|
+| `X-VOCERA-API-KEY` | Your API key obtained from the dashboard |
+
+## Response Format
+
+The API returns a list of predefined metric objects.
+
+### Predefined Metric Object
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `id` | integer | Unique identifier for the metric |
+| `name` | string | Name of the metric |
+| `description` | string | Description of what the metric evaluates |
+| `code` | string | Unique code identifier for the metric |
+
+## Example Response
+
+```json
+[
+    {
+        "id": 4,
+        "name": "Annoyance level",
+        "description": "How annoyed were they?",
+        "code": "f540ac0e"
+    },
+    {
+        "id": 1,
+        "name": "Call Pickup",
+        "description": "Was the call picked up?",
+        "code": "204ba6ac"
+    }
+    // Additional metrics...
+]
+```
+
+## Code Examples
+
+<CodeGroup>
+
+```bash Curl
+curl -X GET https://new-prod.vocera.ai/test_framework/v1/predefined-metrics-external/ \
+  -H "X-VOCERA-API-KEY: <your-api-key-here>"
+```
+
+```python Python
+import requests
+
+def list_predefined_metrics(api_key):
+    url = 'https://new-prod.vocera.ai/test_framework/v1/predefined-metrics-external/'
+    headers = {
+        'X-VOCERA-API-KEY': api_key
+    }
+
+    response = requests.get(url, headers=headers)
+    return response.json()
+```
+
+```javascript JavaScript
+async function listPredefinedMetrics(apiKey) {
+  const url = 'https://new-prod.vocera.ai/test_framework/v1/predefined-metrics-external/';
+
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: {
+      'X-VOCERA-API-KEY': apiKey
+    },
+  });
+
+  return await response.json();
+}
+```
+</CodeGroup>

--- a/mint.json
+++ b/mint.json
@@ -99,6 +99,12 @@
           ]
         },
         {
+          "group": "Predefined Metrics",
+          "pages": [
+            "api-reference/predefined-metrics/list-predefined-metrics"
+          ]
+        },
+        {
           "group": "Phone Numbers",
           "pages": [
             "api-reference/phone-numbers/list-inbound-phone-numbers"


### PR DESCRIPTION
Resolve VOC-758
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds API documentation for listing predefined metrics and updates related configurations and links.
> 
>   - **API Documentation**:
>     - Adds `list-predefined-metrics.mdx` for listing predefined metrics API.
>     - Updates `create-agents.mdx` to link to predefined metrics documentation.
>   - **Configuration**:
>     - Updates `mint.json` to include "Predefined Metrics" group with `list-predefined-metrics` page.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=vocera-ai%2Fdocs&utm_source=github&utm_medium=referral)<sup> for 6a2f5ec35b6a6b7e2d7620759e9fa83c1a1e9e59. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->