### PR TITLE
Add doc for assistant ID support

### DIFF
--- a/api-reference/agents/delete-agents.mdx
+++ b/api-reference/agents/delete-agents.mdx
@@ -13,6 +13,12 @@ Delete an existing AI agent.
 |--------|----------|
 | `DELETE` | `https://new-prod.vocera.ai/test_framework/v1/aiagents-external/:agent_id/` |
 
+## Path Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `agent_id` | string | Yes | Unique identifier of the agent or associated assistant ID  |
+
 ## Authentication
 
 Include your API key in the request headers:

--- a/api-reference/agents/update-agents.mdx
+++ b/api-reference/agents/update-agents.mdx
@@ -13,6 +13,12 @@ Update an existing AI agent's configurations.
 |--------|----------|
 | `PATCH` | `https://new-prod.vocera.ai/test_framework/v1/aiagents-external/{agent_id}` |
 
+## Path Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `agent_id` | string | Yes | Unique identifier of the agent or associated assistant ID  |
+
 ## Authentication
 
 Include your API key in the request headers:

--- a/api-reference/calls/reevaluate-calls.mdx
+++ b/api-reference/calls/reevaluate-calls.mdx
@@ -25,7 +25,10 @@ Include your API key in the request headers:
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `call_logs` | array\|string\|integer | Yes | Array of call log IDs to run OR `"all"` to run all OR number to run first N calls |
-| `agent_id` | integer | Yes | Required only when `call_logs` is `"all"` OR is number of first N calls |
+| `agent_id` | integer | Yes* | Unique identifier of the agent |
+| `assistant_id` | string | Yes* | The assistant ID associated with agent |
+
+\* Required only when `call_logs` is "all" OR is number of first N calls. Only either of `agent_id` or `assistant_id` is required
 
 
 ### Example Requests

--- a/api-reference/evaluators/create-evaluators.mdx
+++ b/api-reference/evaluators/create-evaluators.mdx
@@ -28,7 +28,11 @@ Include your API key in the request headers:
 | `name` | string | Yes | Name of the evaluator |
 | `personality` | integer | Yes | ID of the personality to use |
 | `instructions` | string | Yes | Instructions for the evaluator |
-| `agent` | integer | Yes | ID of the agent |
+| `agent` | integer | Yes* | ID of the agent |
+| `assistant_id` | string | Yes* | The assistant ID associated with agent |
+
+\* Only either of `agent` or `assistant_id` is required
+
 
 ### Example Request Body
 

--- a/api-reference/evaluators/generate-evaluators.mdx
+++ b/api-reference/evaluators/generate-evaluators.mdx
@@ -24,13 +24,16 @@ Include your API key in the request headers:
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `agent_id` | integer | Yes | ID of the agent to generate evaluators for |
+| `agent_id` | integer | Yes* | ID of the agent to generate evaluators for |
+| `assistant_id` | string | Yes* | The assistant ID associated with agent to generate evaluators for |
 | `num_scenarios` | integer | Yes | Number of evaluators to generate |
 | `extra_instructions` | string | No | Additional instructions for scenario generation |
 | `information_fields` | object | No | Key-value pairs of information to include in scenarios |
 | `personalities` | array | No | Array of personality IDs to use |
 | `first_message` | string | No | Initial message for the conversation |
 | `inbound_phone_number` | integer | No | ID of the inbound phone number (See [inbound numbers](/api-reference/phone-numbers/list-inbound-phone-numbers)) |
+
+\* Only either of `agent_id` or `assistant_id` is required
 
 ### Example Request Body
 

--- a/api-reference/evaluators/list-evaluators.mdx
+++ b/api-reference/evaluators/list-evaluators.mdx
@@ -24,7 +24,10 @@ Include your API key in the request headers:
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `agent_id` | integer | Yes | Filter evaluators by agent ID |
+| `agent_id` | integer | Yes* | Filter evaluators by agent ID |
+| `assistant_id` | string | Yes* | Filter evaluators by assistant ID associated with agent |
+
+\* Only either of `agent_id` or `assistant_id` is required
 
 ## Response Format
 

--- a/api-reference/evaluators/running-evaluators.mdx
+++ b/api-reference/evaluators/running-evaluators.mdx
@@ -26,7 +26,10 @@ Include your API key in the request headers:
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `scenarios` | array\|string\|integer | Yes | Array of evaluator IDs to run OR `"all"` to run all OR number to run first N evaluators |
-| `agent_id` | integer | Yes | Required only when `scenarios` is `"all"` OR is number of first N evaluators |
+| `agent_id` | integer | Yes* | Unique identifier of the agent |
+| `assistant_id` | integer | Yes* | The assistant ID associated with agent |
+
+\* Required only when `scenarios` is `"all"` OR is number of first N evaluators. Only either of `agent_id` or `assistant_id` is required
 
 ### Example Request Body
 Running evaluators using ids
@@ -184,7 +187,10 @@ Include your API key in the request headers:
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `scenarios` | array\|string\|integer | Yes | Array of evaluator IDs to run OR `"all"` to run all OR number to run first N evaluators |
-| `agent_id` | integer | Yes | Required only when `scenarios` is `"all"` OR is number of first N evaluators |
+| `agent_id` | integer | Yes* | Unique identifier of the agent |
+| `assistant_id` | string | Yes* | The assistant ID associated with agent |
+
+\* Required only when `scenarios` is `"all"` OR is number of first N evaluators. Only either of `agent_id` or `assistant_id` is required
 
 ### Example Request Body
 Running evaluators using ids

--- a/api-reference/metrics/create-metrics.mdx
+++ b/api-reference/metrics/create-metrics.mdx
@@ -30,10 +30,13 @@ Include your API key in the request headers:
 | `audio_enabled` | boolean | No | Whether audio analysis is enabled. Defaults to true |
 | `prompt_enabled` | boolean | No | Whether to use a custom prompt. Defaults to true |
 | `prompt` | string | No | Custom evaluation prompt template when prompt_enabled is true |
-| `agent` | integer | Yes | ID of the agent to evaluate |
+| `agent` | integer | Yes* | ID of the agent to evaluate |
+| `assistant_id` | string | Yes* | The assistant ID associated with agent to evaluate |
 | `eval_type` | string | Yes | Type of metric (binary_workflow_adherence, binary_qualitative, continuous_qualitative, numeric, enum) |
 | `enum_values` | array | No | List of possible values when eval_type is "enum" |
 | `display_order` | integer | No | Order for displaying the metric. Defaults to next available order |
+
+\* Only either of `agent` or `assistant_id` is required
 
 ### Example Request Body
 

--- a/api-reference/metrics/generate-metrics.mdx
+++ b/api-reference/metrics/generate-metrics.mdx
@@ -26,7 +26,10 @@ Include your API key in the request headers:
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `agent_id` | integer | Yes | ID of the agent to generate metrics for |
+| `assistant_id` | string | Yes* | The assistant ID associated with agent to generate metrics for |
 | `num_metrics` | integer | Yes | Number of metrics to generate |
+
+\* Only either of `agent_id` or `assistant_id` is required
 
 ### Example Request Body
 

--- a/api-reference/metrics/list-metrics.mdx
+++ b/api-reference/metrics/list-metrics.mdx
@@ -24,7 +24,10 @@ Include your API key in the request headers:
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `agent_id` | integer | Yes | Filter metrics by agent ID |
+| `agent_id` | integer | Yes* | Filter metrics by agent ID |
+| `assistant_id` | string | Yes* | Filter metrics by assistant ID associated with agent |
+
+\* Only either of `agent_id` or `assistant_id` is required
 
 ## Response Format
 

--- a/api-reference/results/list-results.mdx
+++ b/api-reference/results/list-results.mdx
@@ -24,9 +24,12 @@ Include your API key in the request headers:
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `agent_id` | integer | No | Filter results by agent ID |
+| `agent_id` | integer | Yes* | Filter results by agent ID |
+| `assistant_id` | string | Yes* | Filter evaluators by assistant ID associated with agent |
 | `page` | integer | No | Page number for pagination (default: 1) |
 | `page_size` | integer | No | Number of results per page (default: 30) |
+
+\* Only either of `agent_id` or `assistant_id` is required
 
 ## Response Format
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add documentation for assistant ID support across various API endpoints, allowing use of either `agent_id` or `assistant_id`.
> 
>   - **API Documentation Updates**:
>     - Added `assistant_id` as an alternative to `agent_id` in path parameters for `delete-agents.mdx` and `update-agents.mdx`.
>     - Updated request parameters to include `assistant_id` in `reevaluate-calls.mdx`, `create-evaluators.mdx`, `generate-evaluators.mdx`, `list-evaluators.mdx`, `running-evaluators.mdx`, `create-metrics.mdx`, `generate-metrics.mdx`, `list-metrics.mdx`, and `list-results.mdx`.
>     - Clarified that only one of `agent_id` or `assistant_id` is required in relevant API calls.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=vocera-ai%2Fdocs&utm_source=github&utm_medium=referral)<sup> for 3dca148298db4156321fda79601ac5ca20f96c08. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->