### PR TITLE
Add deepgram transcript

### DIFF
--- a/api-reference/calls/introduction.mdx
+++ b/api-reference/calls/introduction.mdx
@@ -353,6 +353,49 @@ Retell Format
 ]
 ```
 
+Deepgram Format
+
+```json
+[
+   {
+      "word": "Hello",
+      "start": 0.07,
+      "end": 0.3888888,
+      "confidence": 0.98545563,
+      "speaker": 0,
+      "speaker_confidence": 0.9830952,
+      "punctuated_word": "Hello."
+   },
+   {
+      "word": "How",
+      "start": 0.39999998,
+      "end": 0.71999997,
+      "confidence": 0.95238054,
+      "speaker": 0,
+      "speaker_confidence": 0.9730953,
+      "punctuated_word": "How"
+   },
+   {
+      "word": "are",
+      "start": 0.71999997,
+      "end": 0.79999996,
+      "confidence": 0.89988324,
+      "speaker": 0,
+      "speaker_confidence": 0.9730953,
+      "punctuated_word": "are"
+   },
+   {
+      "word": "you",
+      "start": 0.79999997,
+      "end": 1.3,
+      "confidence": 0.9957689,
+      "speaker": 0,
+      "speaker_confidence": 0.9730953,
+      "punctuated_word": "you?"
+   }
+]
+```
+
 ### Method 1: Using a Voice Recording URL
 
 Send a voice recording URL to be processed by our API.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add Deepgram transcript format to API documentation in `introduction.mdx`.
> 
>   - **Documentation**:
>     - Adds `Deepgram Format` example to `introduction.mdx` in the API reference for call transcripts.
>     - The format includes fields like `word`, `start`, `end`, `confidence`, `speaker`, `speaker_confidence`, and `punctuated_word`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=vocera-ai%2Fdocs&utm_source=github&utm_medium=referral)<sup> for 4f42afda1e725984fa1ecf7d4ac4efba37a57647. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->