### PR TITLE
Add freq to run scenarios and created at to result list

### DIFF
--- a/api-reference/evaluators/running-evaluators.mdx
+++ b/api-reference/evaluators/running-evaluators.mdx
@@ -25,9 +25,10 @@ Include your API key in the request headers:
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `scenarios` | array\|string\|integer | Yes | Array of evaluator IDs to run OR `"all"` to run all OR number to run first N evaluators |
 | `agent_id` | integer | Yes* | Unique identifier of the agent |
 | `assistant_id` | integer | Yes* | The assistant ID associated with agent |
+| `scenarios` | array\|string\|integer | Yes | Array of evaluator IDs to run OR `"all"` to run all OR number to run first N evaluators |
+| `freq` | integer | No | Number of times to run each scenario (default: 1) |
 
 \* Required only when `scenarios` is `"all"` OR is number of first N evaluators. Only either of `agent_id` or `assistant_id` is required
 
@@ -35,7 +36,8 @@ Include your API key in the request headers:
 Running evaluators using ids
 ```json
 {
-    "scenarios": [201, 187]
+    "scenarios": [201, 187],
+    "freq": 5
 }
 ```
 
@@ -43,7 +45,8 @@ Running all evaluators
 ```json
 {
     "agent_id": 1,
-    "scenarios": "all"
+    "scenarios": "all",
+    "freq": 5
 }
 ```
 
@@ -51,7 +54,8 @@ Running first N evaluators
 ```json
 {
     "agent_id": 1,
-    "scenarios": 10
+    "scenarios": 10,
+    "freq": 5
 }
 ```
 
@@ -90,7 +94,10 @@ A successful request returns details about created result.
 curl -X POST https://new-prod.vocera.ai/test_framework/v1/scenarios-external/run_scenarios/ \
   -H "X-VOCERA-API-KEY: <your-api-key-here>" \
   -H "Content-Type: application/json" \
-  -d '{"scenarios": [<evaluator-id-1>, <evaluator-id-2>, ...]}'
+  -d '{
+      "scenarios": [<evaluator-id-1>, <evaluator-id-2>, ...],
+      "freq": 1
+    }'
 
 # Running all evaluators
 curl -X POST https://new-prod.vocera.ai/test_framework/v1/scenarios-external/run_scenarios/ \
@@ -98,7 +105,8 @@ curl -X POST https://new-prod.vocera.ai/test_framework/v1/scenarios-external/run
   -H "Content-Type: application/json" \
   -d '{
     "scenarios": "all",
-    "agent_id": <agent-id>
+    "agent_id": <agent-id>,
+    "freq": 1
   }'
 
 # Running first N evaluators
@@ -107,12 +115,13 @@ curl -X POST https://new-prod.vocera.ai/test_framework/v1/scenarios-external/run
   -H "Content-Type: application/json" \
   -d '{
     "scenarios": <number-of-evaluators>,
-    "agent_id": <agent-id>
+    "agent_id": <agent-id>,
+    "freq": 1
   }'
 ```
 
 ```python Python
-def run_evaluators(api_key, evaluators, agent_id=None):
+def run_evaluators(api_key, evaluators, agent_id=None, freq=1):
     url = 'https://new-prod.vocera.ai/test_framework/v1/scenarios-external/run_scenarios/'
 
     headers = {
@@ -121,7 +130,8 @@ def run_evaluators(api_key, evaluators, agent_id=None):
     }
 
     data = {
-        'scenarios': evaluators
+        'scenarios': evaluators,
+        'freq': freq
     }
 
     if isinstance(evaluators, (int, str)):
@@ -135,11 +145,12 @@ def run_evaluators(api_key, evaluators, agent_id=None):
 ```
 
 ```javascript JavaScript
-async function runEvaluators(apiKey, evaluators, agentId=null) {
+async function runEvaluators(apiKey, evaluators, agentId=null, freq=1) {
   const url = 'https://new-prod.vocera.ai/test_framework/v1/scenarios-external/run_scenarios/';
 
   const data = {
-    scenarios: evaluators
+    scenarios: evaluators,
+    freq: freq
   }
 
   if (typeof evaluators === 'number' || typeof evaluators === 'string') {
@@ -186,9 +197,10 @@ Include your API key in the request headers:
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `scenarios` | array\|string\|integer | Yes | Array of evaluator IDs to run OR `"all"` to run all OR number to run first N evaluators |
 | `agent_id` | integer | Yes* | Unique identifier of the agent |
 | `assistant_id` | string | Yes* | The assistant ID associated with agent |
+| `scenarios` | array\|string\|integer | Yes | Array of evaluator IDs to run OR `"all"` to run all OR number to run first N evaluators |
+| `freq` | integer | No | Number of times to run each scenario (default: 1) |
 
 \* Required only when `scenarios` is `"all"` OR is number of first N evaluators. Only either of `agent_id` or `assistant_id` is required
 
@@ -196,7 +208,8 @@ Include your API key in the request headers:
 Running evaluators using ids
 ```json
 {
-    "scenarios": [201, 187]
+    "scenarios": [201, 187],
+    "freq": 5
 }
 ```
 
@@ -204,7 +217,8 @@ Running all evaluators
 ```json
 {
     "agent_id": 1,
-    "scenarios": "all"
+    "scenarios": "all",
+    "freq": 5
 }
 ```
 
@@ -212,7 +226,8 @@ Running first N evaluators
 ```json
 {
     "agent_id": 1,
-    "scenarios": 10
+    "scenarios": 10,
+    "freq": 5
 }
 ```
 
@@ -318,7 +333,10 @@ Messages related to function execution, including both calls and results.
 curl -X POST https://new-prod.vocera.ai/test_framework/v1/scenarios-external/run_scenarios_text/ \
   -H "X-VOCERA-API-KEY: <your-api-key-here>" \
   -H "Content-Type: application/json" \
-  -d '{"scenarios": [<evaluator-id-1>, <evaluator-id-2>, ...]}'
+  -d '{
+      "scenarios": [<evaluator-id-1>, <evaluator-id-2>, ...],
+      "freq": 1
+    }'
 
 # Running all evaluators
 curl -X POST https://new-prod.vocera.ai/test_framework/v1/scenarios-external/run_scenarios_text/ \
@@ -326,7 +344,8 @@ curl -X POST https://new-prod.vocera.ai/test_framework/v1/scenarios-external/run
   -H "Content-Type: application/json" \
   -d '{
     "scenarios": "all",
-    "agent_id": <agent-id>
+    "agent_id": <agent-id>,
+    "freq": 1
   }'
 
 # Running first N evaluators
@@ -335,12 +354,13 @@ curl -X POST https://new-prod.vocera.ai/test_framework/v1/scenarios-external/run
   -H "Content-Type: application/json" \
   -d '{
     "scenarios": <number-of-evaluators>,
-    "agent_id": <agent-id>
+    "agent_id": <agent-id>,
+    "freq": 1
   }'
 ```
 
 ```python Python
-def run_evaluators(api_key, evaluators, agent_id=None):
+def run_evaluators(api_key, evaluators, agent_id=None, freq=1):
     url = 'https://new-prod.vocera.ai/test_framework/v1/scenarios-external/run_scenarios_text/'
 
     headers = {
@@ -349,7 +369,8 @@ def run_evaluators(api_key, evaluators, agent_id=None):
     }
 
     data = {
-        'scenarios': evaluators
+        'scenarios': evaluators,
+        "freq": freq
     }
 
     if isinstance(evaluators, (int, str)):
@@ -363,11 +384,12 @@ def run_evaluators(api_key, evaluators, agent_id=None):
 ```
 
 ```javascript JavaScript
-async function runEvaluators(apiKey, evaluators, agentId=null) {
+async function runEvaluators(apiKey, evaluators, agentId=null, freq=1) {
   const url = 'https://new-prod.vocera.ai/test_framework/v1/scenarios-external/run_scenarios_text/';
 
   const data = {
-    scenarios: evaluators
+    scenarios: evaluators,
+    freq: freq
   }
 
   if (typeof evaluators === 'number' || typeof evaluators === 'string') {

--- a/api-reference/results/list-results.mdx
+++ b/api-reference/results/list-results.mdx
@@ -53,6 +53,7 @@ Each result object contains:
 | `status` | string | Status of the result, can be one of:<br/>• `running` - Initial state when evaluator starts<br/>• `in_progress` - Call is currently executing<br/>• `completed` - Call has finished successfully<br/>• `failed` - Call encountered an error<br/>• `pending` - Testing agent is waiting to be called |
 | `success_rate` | float | Percentage of runs that passed |
 | `run_as_text` | boolean | If executed as text (llm websocket) or not |
+| `created_at` | string | ISO 8601 timestamp of when the result was created |
 
 ### Example Response
 
@@ -67,14 +68,16 @@ Each result object contains:
             "agent": 1,
             "status": "completed",
             "success_rate": 100,
-            "run_as_text": true
+            "run_as_text": true,
+            "created_at": "2024-12-02T15:38:45.435335Z"
         },
         {
             "id": 184,
             "agent": 1,
             "status": "completed",
             "success_rate": 100,
-            "run_as_text": true
+            "run_as_text": true,
+            "created_at": "2024-12-02T15:38:45.435335Z"
         }
         // ... more results
     ]


### PR DESCRIPTION
Resolve VOC-795
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `freq` parameter to run scenarios multiple times and `created_at` field to results list for timestamping.
> 
>   - **API Changes**:
>     - Added `freq` parameter to `run_scenarios` and `run_scenarios_text` endpoints in `running-evaluators.mdx` to specify the number of times to run each scenario.
>     - Added `created_at` field to result objects in `list-results.mdx` to indicate when the result was created.
>   - **Code Examples**:
>     - Updated Python and JavaScript examples in `running-evaluators.mdx` to include `freq` parameter.
>     - Updated example responses in `list-results.mdx` to include `created_at` field.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=vocera-ai%2Fdocs&utm_source=github&utm_medium=referral)<sup> for 337934db6724e2ae3b97802155c315855f7953c8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->