### PR TITLE
Add get runs with ids

### DIFF
--- a/api-reference/runs/get-runs-bulk.mdx
+++ b/api-reference/runs/get-runs-bulk.mdx
@@ -1,0 +1,257 @@
+---
+title: 'Getting Runs with IDs'
+description: 'Learn how to retrieve multiple runs in bulk'
+---
+
+# Get Runs Bulk API
+Retrieve multiple runs by their IDs in a single request
+
+## API Endpoint
+
+| Method | Endpoint |
+|--------|----------|
+| `GET` | `https://new-prod.vocera.ai/test_framework/v1/runs-external/bulk/` |
+
+## Authentication
+
+Include your API key in the request headers:
+
+| Header | Description |
+|--------|--------|
+| `X-VOCERA-API-KEY` | Your API key obtained from the dashboard |
+
+## Query Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `run_ids` | string | Yes | Comma-separated list of run IDs to retrieve |
+
+## Response Format
+
+The API returns an array of run objects.
+
+### Run Object Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | integer | The run ID |
+| `scenario` | integer | ID of the associated scenario |
+| `scenario_name` | string | Name of the scenario |
+| `success` | boolean | Whether the run passed or failed |
+| `evaluation` | object\|null | Evaluation results and metrics |
+| `transcript` | string | Full conversation transcript |
+| `transcript_object` | array | Structured conversation turns |
+| `duration` | string | Total duration of the run |
+| `voice_recording_url` | string\|null | URL to voice recording if available |
+| `email_id` | string\|null | Associated email ID if applicable |
+| `status` | string | Status of the run, can be one of:<br/>• `running` - Initial state when evaluator starts<br/>• `in_progress` - Call is currently executing<br/>• `completed` - Call has finished successfully<br/>• `failed` - Call encountered an error<br/>• `pending` - Testing agent is waiting to be called |
+| `metadata` | object\|null | Additional metadata |
+| `timestamp` | string | ISO 8601 timestamp of the run |
+| `critical_categories` | array | List of critical workflow metric categories and scenarios |
+
+### Critical Category Object Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `category` | string | Description of the critical issue identified |
+| `scenario_id` | integer | ID of the scenario where the issue occurred |
+| `scenario` | string | Detailed explanation of how the issue manifested |
+| `priority` | string | Priority level of the issue (e.g., "high", "medium", "low" "not_a_bug" and "wrongly_identified") |
+
+
+### Example Response
+
+```json
+[
+    {
+        "id": 181,
+        "scenario": 67,
+        "scenario_name": "Demo scenario",
+        "success": true,
+        "evaluation": {
+            "metrics": [
+                {
+                    "id": 33,
+                    "name": "Latency",
+                    "type": "numeric",
+                    "score": 3024.03,
+                    "explanation": "",
+                    "function_name": "get_latency"
+                }
+                // Additional metrics...
+            ]
+        },
+        "transcript": "...",
+        "transcript_object": [...],
+        "duration": "01:02",
+        "voice_recording_url": null,
+        "status": "completed",
+        "timestamp": "2025-01-08T12:06:15.042852Z",
+        "critical_categories": [
+            {
+                "category": "Agent failed to verify customer identity before discussing account details",
+                "scenario_id": 67,
+                "scenario": "Agent proceeded with account discussion without completing required identity verification steps",
+                "priority": "high"
+            },
+            {
+                "category": "Agent provided incorrect information about service pricing",
+                "scenario_id": 67,
+                "scenario": "Agent quoted outdated pricing information instead of checking current rates",
+                "priority": "medium"
+            }
+        ]
+    }
+    // Additional runs...
+]
+```
+
+**Transcript JSON Example:**
+
+```json
+[
+   {
+      "role": "Testing Agent",
+      "time": "0:01",
+      "content": "Hello.",
+      "end_time": 1.9399999,
+      "start_time": 1.4399999
+   },
+   {
+      "role": "Main Agent",
+      "time": "0:03",
+      "content": "Hello. I want to book appointment today. My name is John.",
+      "end_time": 7.539999511718751,
+      "start_time": 3.1
+   },
+   {
+      "role": "Testing Agent",
+      "time": "0:12",
+      "content": "Well, I mean, sure. What time exactly are we talking about here",
+      "end_time": 15.71,
+      "start_time": 12.01
+   },
+   {
+      "role": "Main Agent",
+      "time": "0:17",
+      "content": "6 PM.",
+      "end_time": 18.269999,
+      "start_time": 17.609999
+   },
+   {
+      "role": "Testing Agent",
+      "time": "0:19",
+      "content": "Great. I'll book that for you. Just a sec.",
+      "end_time": 21.45,
+      "start_time": 19.16
+   },
+   {
+      "role": "Main Agent",
+      "time": "0:22",
+      "content": "Okay.",
+      "end_time": 23.25,
+      "start_time": 22.75
+   },
+   {
+      "data": {
+         "id": "call_5otWH44dxeXEHY8RlhYYaFbV",
+         "name": "bookUserAppointment",
+         "arguments": "{\"name\": \"John\", \"datetime\": \"2024-10-17T18:00:00\"}"
+      },
+      "role": "Function Call",
+      "time": "0:23",
+      "content": "",
+      "end_time": 23.164,
+      "start_time": 23.164
+   },
+   {
+      "data": {
+         "id": "call_5otWH44dxeXEHY8RlhYYaFbV",
+         "name": "bookUserAppointment",
+         "result": "No result returned."
+      },
+      "role": "Function Call Result",
+      "time": "0:24",
+      "end_time": 24.6,
+      "start_time": 24.6
+   },
+   {
+      "role": "Testing Agent",
+      "time": "0:25",
+      "content": "1 moment.",
+      "end_time": 25.92,
+      "start_time": 25.1
+   },
+   {
+      "role": "Main Agent",
+      "time": "0:27",
+      "content": "Yes. Yes.",
+      "end_time": 27.979999999999997,
+      "start_time": 27.08
+   },
+   {
+      "role": "Testing Agent",
+      "time": "0:27",
+      "content": "Appointment booked for 6 PM today.",
+      "end_time": 29.5,
+      "start_time": 27.08
+   },
+   {
+      "role": "Main Agent",
+      "time": "0:30",
+      "content": "Oh, okay. Bye.",
+      "end_time": 31.72,
+      "start_time": 30.64
+   },
+   {
+      "role": "Testing Agent",
+      "time": "0:33",
+      "content": "Bye.",
+      "end_time": 33.6,
+      "start_time": 33.1
+   }
+]
+```
+
+## Code Examples
+
+<CodeGroup>
+
+```bash Curl
+curl -X GET "https://new-prod.vocera.ai/test_framework/v1/runs-external/bulk/?run_ids=181,180" \
+  -H "X-VOCERA-API-KEY: <your-api-key-here>"
+```
+
+```python Python
+import requests
+
+def get_runs_bulk(api_key, run_ids):
+    url = 'https://new-prod.vocera.ai/test_framework/v1/runs-external/bulk/'
+    headers = {
+        'X-VOCERA-API-KEY': api_key
+    }
+    params = {
+        'run_ids': ','.join(map(str, run_ids))
+    }
+
+    response = requests.get(url, headers=headers, params=params)
+    return response.json()
+```
+
+```javascript JavaScript
+async function getRunsBulk(apiKey, runIds) {
+  const url = new URL('https://new-prod.vocera.ai/test_framework/v1/runs-external/bulk/');
+  url.searchParams.append('run_ids', runIds.join(','));
+
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: {
+      'X-VOCERA-API-KEY': apiKey
+    },
+  });
+
+  return await response.json();
+}
+```
+
+</CodeGroup>

--- a/mint.json
+++ b/mint.json
@@ -93,6 +93,12 @@
           ]
         },
         {
+          "group": "Runs",
+          "pages": [
+            "api-reference/runs/get-runs-bulk"
+          ]
+        },
+        {
           "group": "Personalities",
           "pages": [
             "api-reference/personalities/list-personalities"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add documentation and configuration for new "Get Runs Bulk API" to retrieve multiple runs by IDs.
> 
>   - **API Documentation**:
>     - Adds `get-runs-bulk.mdx` to document the new "Get Runs Bulk API" for retrieving multiple runs by IDs.
>     - Details include endpoint, authentication, query parameters, response format, and example responses.
>     - Provides code examples in Bash, Python, and JavaScript.
>   - **Configuration**:
>     - Updates `mint.json` to include the new "Runs" group with `get-runs-bulk` page in the navigation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=vocera-ai%2Fdocs&utm_source=github&utm_medium=referral)<sup> for d6e5c6d8bb6f3ba9ae81e00da507753e9e3467b6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->