### PR TITLE
Add expected outcome n metrics to scenarios

### DIFF
--- a/api-reference/evaluators/create-evaluators.mdx
+++ b/api-reference/evaluators/create-evaluators.mdx
@@ -97,7 +97,7 @@ curl -X POST https://new-prod.vocera.ai/test_framework/v1/scenarios-external/ \
     "name": "<evaluator-name>",
     "agent": <agent-id>,
     "personality": <personality-id>,
-    "instructions": "<evaluator-instructions>"
+    "instructions": "<evaluator-instructions>",
     "metrics": [<metric-id>, <metric-ids>],
     "expected_outcome_prompt": "<expected-outcome-prompt>"
   }'

--- a/api-reference/evaluators/create-evaluators.mdx
+++ b/api-reference/evaluators/create-evaluators.mdx
@@ -25,11 +25,13 @@ Include your API key in the request headers:
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
+| `agent` | integer | Yes* | ID of the agent |
+| `assistant_id` | string | Yes* | The assistant ID associated with agent |
 | `name` | string | Yes | Name of the evaluator |
 | `personality` | integer | Yes | ID of the personality to use |
 | `instructions` | string | Yes | Instructions for the evaluator |
-| `agent` | integer | Yes* | ID of the agent |
-| `assistant_id` | string | Yes* | The assistant ID associated with agent |
+| `expected_outcome_prompt` | string | No | Prompt to evaluate expected outcome |
+| `metrics` | array | No | Array of metric IDs |
 
 \* Only either of `agent` or `assistant_id` is required
 
@@ -38,10 +40,12 @@ Include your API key in the request headers:
 
 ```json
 {
+  "agent": 4,
   "name": "Demo evaluator",
   "personality": 2,
   "instructions": "Some instructions",
-  "agent": 4
+  "expected_outcome_prompt": "Issue was resolved with a refund or replacement",
+  "metrics": [1,2]
 }
 ```
 
@@ -61,6 +65,8 @@ A successful request returns the created evaluator details.
 | `retell_agent_id` | string | UUID of the retell agent |
 | `runs` | array | List of evaluator runs (empty for new evaluators) |
 | `instructions` | string | Evaluator instructions |
+| `expected_outcome_prompt` | string | Prompt to evaluate expected outcome |
+| `metrics` | array | Array of metric IDs |
 
 ### Example Response
 
@@ -73,7 +79,9 @@ A successful request returns the created evaluator details.
     "personality_name": "Frustrated Dutch, English",
     "retell_agent_id": "edc58747-b69d-47a5-be64-a1d6309c6c65",
     "runs": [],
-    "instructions": "Some instructions"
+    "instructions": "Some instructions",
+    "expected_outcome_prompt": "Issue was resolved with a refund or replacement",
+    "metrics": [1,2]
 }
 ```
 
@@ -90,13 +98,15 @@ curl -X POST https://new-prod.vocera.ai/test_framework/v1/scenarios-external/ \
     "agent": <agent-id>,
     "personality": <personality-id>,
     "instructions": "<evaluator-instructions>"
+    "metrics": [<metric-id>, <metric-ids>],
+    "expected_outcome_prompt": "<expected-outcome-prompt>"
   }'
 ```
 
 ```python Python
 import requests
 
-def create_evaluator(api_key, name, agent_id, personality_id, instructions):
+def create_evaluator(api_key, **kwargs):
     url = 'https://new-prod.vocera.ai/test_framework/v1/scenarios-external/'
     
     headers = {
@@ -104,27 +114,16 @@ def create_evaluator(api_key, name, agent_id, personality_id, instructions):
         'Content-Type': 'application/json'
     }
     
-    data = {
-        'name': name,
-        'agent': agent_id,
-        'personality': personality_id,
-        'instructions': instructions,
-    }
+    # Only include non-None values in the request
+    data = {k: v for k, v in kwargs.items() if v is not None}
 
     response = requests.post(url, headers=headers, json=data)
     return response.json()
 ```
 
 ```javascript JavaScript
-async function createEvaluator(apiKey, name, personalityId, instructions, agentId) {
+async function createEvaluator(apiKey, updateData) {
   const url = 'https://new-prod.vocera.ai/test_framework/v1/scenarios-external/';
-  
-  const data = {
-    name,
-    personality: personalityId,
-    instructions,
-    agent: agentId,
-  };
 
   const response = await fetch(url, {
     method: 'POST',
@@ -132,7 +131,7 @@ async function createEvaluator(apiKey, name, personalityId, instructions, agentI
       'X-VOCERA-API-KEY': apiKey,
       'Content-Type': 'application/json'
     },
-    body: JSON.stringify(data)
+    body: JSON.stringify(updateData)
   });
 
   return await response.json();

--- a/api-reference/evaluators/get-evaluator.mdx
+++ b/api-reference/evaluators/get-evaluator.mdx
@@ -48,6 +48,7 @@ The API returns detailed information about the specified evaluator.
 | `inbound_phone_number` | integer\|null | ID of the inbound phone number |
 | `inbound_phone_number_data` | object\|null | Details about the inbound phone number (see below) |
 | `instructions` | string | Evaluator instructions |
+| `expected_outcome_prompt` | string | Prompt to evaluate expected outcome |
 
 ### Inbound Phone Number Data Fields
 
@@ -82,7 +83,8 @@ The API returns detailed information about the specified evaluator.
         "number": "+1234567890",
         "phone_number_id": "123"
     },
-    "instructions": "Act as an angry customer who received a defective product. Be persistent but not abusive."
+    "instructions": "Act as an angry customer who received a defective product. Be persistent but not abusive.",
+    "expected_outcome_prompt": "Issue was resolved with a refund or replacement"
 }
 ```
 

--- a/api-reference/evaluators/update-evaluators.mdx
+++ b/api-reference/evaluators/update-evaluators.mdx
@@ -39,6 +39,7 @@ Include your API key in the request headers:
 | `tags` | array | No | Array of tag strings |
 | `inbound_phone_number` | integer | No | ID of inbound phone number |
 | `first_message` | string | No | Initial message for the conversation |
+| `expected_outcome_prompt` | string | No | Prompt to evaluate expected outcome |
 
 ### Example Request Body
 
@@ -51,7 +52,8 @@ Include your API key in the request headers:
   "metrics": [789, 790, 791],
   "tags": ["angry_customer", "product_complaint", "high_priority"],
   "inbound_phone_number": 555,
-  "first_message": "I need to speak with someone about this broken laptop I received!"
+  "first_message": "I need to speak with someone about this broken laptop I received!",
+  "expected_outcome_prompt": "Issue was resolved with a refund or replacement"
 }
 ```
 
@@ -77,6 +79,7 @@ The API returns detailed information about the updated evaluator.
 | `inbound_phone_number` | integer\|null | ID of the inbound phone number (See [inbound numbers](/api-reference/phone-numbers/list-inbound-phone-numbers))|
 | `inbound_phone_number_data` | object\|null | Details about the inbound phone number (see below) |
 | `instructions` | string | Evaluator instructions |
+| `expected_outcome_prompt` | string | Prompt to evaluate expected outcome |
 
 ### Inbound Phone Number Data Fields
 
@@ -111,7 +114,8 @@ The API returns detailed information about the updated evaluator.
         "number": "+1234567890",
         "phone_number_id": "123"
     },
-    "instructions": "Act as an angry customer who received a defective product. Be persistent but not abusive."
+    "instructions": "Act as an angry customer who received a defective product. Be persistent but not abusive.",
+    "expected_outcome_prompt": "Issue was resolved with a refund or replacement"
 }
 ```
 
@@ -129,7 +133,8 @@ curl -X PATCH https://new-prod.vocera.ai/test_framework/v1/scenarios-external/{s
     "personality": 456,
     "instructions": "Act as an angry customer who received a defective product. Be persistent but not abusive.",
     "metrics": [789, 790, 791],
-    "tags": ["angry_customer", "product_complaint", "high_priority"]
+    "tags": ["angry_customer", "product_complaint", "high_priority"],
+    "expected_outcome_prompt": "Issue was resolved with a refund or replacement"
   }'
 ```
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `expected_outcome_prompt` and `metrics` fields to evaluator API endpoints for enhanced configuration options.
> 
>   - **API Changes**:
>     - Added `expected_outcome_prompt` and `metrics` fields to `create-evaluators.mdx`, `get-evaluator.mdx`, and `update-evaluators.mdx`.
>     - These fields are optional and allow specifying a prompt for expected outcomes and an array of metric IDs.
>   - **Code Examples**:
>     - Updated Python and JavaScript examples in `create-evaluators.mdx` and `update-evaluators.mdx` to include new fields.
>     - Modified function signatures to accept additional parameters via `kwargs` or `updateData`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=vocera-ai%2Fdocs&utm_source=github&utm_medium=referral)<sup> for 77419a059b8a022411b35c11d878450dd998b3b6. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->