### PR TITLE
Add metadata to call

### DIFF
--- a/documentation/api/calls/introduction.mdx
+++ b/documentation/api/calls/introduction.mdx
@@ -23,6 +23,7 @@ Send a POST request to `https://new-prod.vocera.ai/observability/v1/observe/` wi
 - `call_ended_reason` (optional): Reason for call termination
 - `customer_number` (optional): Phone number of the customer
 - `transcript_json` (required): JSON object containing the transcript of the call. Can be in Vocera, Vapi or Retell format
+- `metadata` (optional): Dictionary with additional data
 
 **Transcript JSON Example:**
 
@@ -407,6 +408,7 @@ Send a voice recording URL to be processed by our API.
 - `call_ended_reason` (optional): Reason for call termination
 - `customer_number` (optional): Phone number of the customer
 - `transcript_json` (required): JSON object containing the transcript of the call. Can be in Vocera, Vapi or Retell format
+- `metadata` (optional): Dictionary with additional data
 
 <CodeGroup>
 ```bash Curl
@@ -417,7 +419,8 @@ curl -X POST https://new-prod.vocera.ai/observability/v1/observe/ \
   -F "voice_recording_url=https://example.com/path/to/audio_file.wav" \
   -F "call_ended_reason=optional_reason" \
   -F "customer_number=optional_customer_number" \
-  -F "transcript_json=[]"
+  -F "transcript_json=[]" \
+  -F "metadata={}"
 ```
 
 ```python Python
@@ -429,7 +432,8 @@ def observe_call_with_url(
        agent_id=None, 
        assistant_id=None, 
        reason=None, 
-       customer_number=None
+       customer_number=None,
+       metadata=None,
    ):
     url = 'https://new-prod.vocera.ai/observability/v1/observe/'
     headers = {
@@ -450,6 +454,8 @@ def observe_call_with_url(
         data["call_ended_reason"] = reason
     if customer_number:
         data["customer_number"] = customer_number
+    if metadata:
+        data["metadata"] = metadata
 
     response = requests.post(url, headers=headers, data=data)
     return response.json()
@@ -465,6 +471,7 @@ async function observeCallWithUrl(
     assistantId=null, 
     reason=null, 
     customerNumber=null,
+    metadata=null,
   ) {
   const url = 'https://new-prod.vocera.ai/observability/v1/observe/';
   const formData = new FormData();
@@ -480,6 +487,7 @@ async function observeCallWithUrl(
 
   if (reason) formData.append('call_ended_reason', reason);
   if (customerNumber) formData.append('customer_number', customerNumber);
+  if (metadata) formData.append('metadata', metadata);
 
   const response = await fetch(url, {
     method: 'POST',
@@ -505,6 +513,7 @@ Upload an audio file directly in the request.
 - `call_ended_reason` (optional): Reason for call termination
 - `customer_number` (optional): Phone number of the customer
 - `transcript_json` (required): JSON object containing the transcript of the call. Can be in Vocera, Vapi or Retell format
+- `metadata` (optional): Dictionary with additional data
 
 <CodeGroup>
 ```bash Curl
@@ -514,8 +523,9 @@ curl -X POST https://new-prod.vocera.ai/observability/v1/observe/ \
   -F "agent=your_agent_id" \
   -F "voice_recording=@/path/to/audio_file.wav" \
   -F "call_ended_reason=optional_reason" \
-  -F "customer_number=optional_customer_number"
-  -F "transcript_json=[]"
+  -F "customer_number=optional_customer_number" \
+  -F "transcript_json=[]" \
+  -F "metadata={}"
 ```
 
 ```python Python
@@ -527,7 +537,8 @@ def observe_call_with_file(
        agent_id=None, 
        assistant_id=None, 
        reason=None, 
-       customer_number=None
+       customer_number=None,
+       metadata=None,
    ):
     url = 'https://new-prod.vocera.ai/observability/v1/observe/'
     headers = {
@@ -551,6 +562,8 @@ def observe_call_with_file(
         data["call_ended_reason"] = reason
     if customer_number:
         data["customer_number"] = customer_number
+    if metadata:
+        data["metadata"] = metadata
 
     response = requests.post(url, headers=headers, files=files, data=data)
     return response.json()
@@ -566,6 +579,7 @@ async function observeCallWithFile(
     assistantId=null, 
     reason=null, 
     customerNumber=null,
+    metadata=null,
   ) {
   const url = 'https://new-prod.vocera.ai/observability/v1/observe/';
   const formData = new FormData();
@@ -581,6 +595,7 @@ async function observeCallWithFile(
 
   if (reason) formData.append('call_ended_reason', reason);
   if (customerNumber) formData.append('customer_number', customerNumber);
+  if (metadata) formData.append('metadata', metadata);
 
   const response = await fetch(url, {
     method: 'POST',


### PR DESCRIPTION
Resolve VOC-1116

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds optional `metadata` field to call observation requests in `introduction.mdx`.
> 
>   - **Behavior**:
>     - Adds `metadata` (optional) to request body for observing calls in `introduction.mdx`.
>     - `metadata` is a dictionary with additional data.
>   - **Code Examples**:
>     - Updates Python, JavaScript, and Curl examples to include `metadata` field in `introduction.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=vocera-ai%2Fdocs&utm_source=github&utm_medium=referral)<sup> for 20082d4828493b07281ccd5a6c3f044fd9a99bd7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->