### PR TITLE
Update outbound evaluators documentation with correct API references

### DIFF
--- a/documentation/key-concepts/testing-agents/outbound-evaluators.mdx
+++ b/documentation/key-concepts/testing-agents/outbound-evaluators.mdx
@@ -18,7 +18,7 @@ To retrieve the available evaluators and their associated phone numbers:
 2. The response will include both evaluators and their corresponding phone numbers for testing
 
 <Card title="API Reference" icon="link">
-Check out the [List Evaluators API](/api-reference/evaluators/list-evaluators) documentation
+Check out the [List Evaluators API](/api-reference/test_framework/get-test_frameworkv1scenarios-external) documentation
 </Card>
 
 ### Example Response Structure
@@ -50,6 +50,6 @@ Once you have your list of evaluators and phone numbers:
 4. Monitor the test results through the dashboard
 
 <Card title="API Reference" icon="link">
-Learn more about the [Running Evaluators API](/documentation/api/evaluators/create-evaluators)
+Learn more about the [Running Evaluators API](/api-reference/test_framework/post-test_frameworkv1scenarios-externalrun_scenarios)
 </Card>
 


### PR DESCRIPTION
- Update API reference links for List Evaluators and Running Evaluators
- Modify documentation to point to the correct test framework API endpoints