### PR TITLE
Add evaluation trigger to metric

### DIFF
--- a/documentation/api/metrics/create-bulk-metrics.mdx
+++ b/documentation/api/metrics/create-bulk-metrics.mdx
@@ -35,6 +35,8 @@ The request body should be an array of metric objects. Each metric object has th
 | `audio_enabled` | boolean | No | Whether audio analysis is enabled. Defaults to false |
 | `prompt_enabled` | boolean | No | Whether to use a custom prompt. Defaults to false |
 | `prompt` | string | No | Custom evaluation prompt template when prompt_enabled is true |
+| `evaluation_trigger` | string | No | Trigger type for evaluation (always, automatic, custom) |
+| `evaluation_trigger_prompt` | string | No | Custom trigger prompt when evaluation_trigger is "custom" |
 
 ### Example Request Body
 


### PR DESCRIPTION
Resolve VOC-1183
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `evaluation_trigger` and `evaluation_trigger_prompt` fields to bulk metrics API documentation.
> 
>   - **Documentation**:
>     - Adds `evaluation_trigger` and `evaluation_trigger_prompt` fields to `create-bulk-metrics.mdx`.
>     - `evaluation_trigger` specifies the trigger type for evaluation (always, automatic, custom).
>     - `evaluation_trigger_prompt` provides a custom trigger prompt when `evaluation_trigger` is "custom".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=vocera-ai%2Fdocs&utm_source=github&utm_medium=referral)<sup> for d99adabb61d0fcf0506476be138a8e0fc5019921. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->