### PR TITLE
manual Changes in Observing call doc

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1,216 +1,605 @@
 {
-  "openapi": "3.0.1",
-  "info": {
-    "title": "Vocera AI API",
-    "description": "Complete API documentation for Vocera AI Platform. This API provides endpoints for managing AI-powered conversations, call analytics, and quality monitoring features.",
-    "version": "v1"
-  },
-  "servers": [
-    {
-      "url": "https://new-prod.vocera.ai"
-    }
-  ],
-  "security": [
-    {
-      "api_key": []
-    }
-  ],
-  "paths": {
-    "/enums/": {
-      "get": {
-        "tags": [
-          "enums"
-        ],
-        "operationId": "enums_list",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {}
+    "openapi": "3.0.1",
+    "info": {
+      "title": "Vocera AI API",
+      "description": "Complete API documentation for Vocera AI Platform. This API provides endpoints for managing AI-powered conversations, call analytics, and quality monitoring features.",
+      "version": "v1"
+    },
+    "servers": [
+      {
+        "url": "http://127.0.0.1:8000/"
+      }
+    ],
+    "security": [
+      {
+        "api_key": []
+      }
+    ],
+    "paths": {
+      "/api/schema/": {
+        "get": {
+          "tags": [
+            "api"
+          ],
+          "summary": "OpenApi3 schema for this API. Format can be selected via content negotiation.",
+          "description": "- YAML: application/vnd.oai.openapi\n- JSON: application/vnd.oai.openapi+json",
+          "operationId": "api_schema_list",
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {}
+            }
           }
         }
-      }
-    },
-    "/observability/call_log/": {
-      "get": {
-        "tags": [
-          "observability"
-        ],
-        "operationId": "observability_call_log_list",
-        "parameters": [
-          {
-            "name": "call_ended_reason__in",
-            "in": "query",
-            "description": "call_ended_reason__in",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "call_ended_reason__icontains",
-            "in": "query",
-            "description": "call_ended_reason__icontains",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "id__in",
-            "in": "query",
-            "description": "id__in",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "timestamp__gte",
-            "in": "query",
-            "description": "timestamp__gte",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "timestamp__lte",
-            "in": "query",
-            "description": "timestamp__lte",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "duration__gte",
-            "in": "query",
-            "description": "duration__gte",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "duration__lte",
-            "in": "query",
-            "description": "duration__lte",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "customer_number__in",
-            "in": "query",
-            "description": "customer_number__in",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "customer_number__icontains",
-            "in": "query",
-            "description": "customer_number__icontains",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "call_id__in",
-            "in": "query",
-            "description": "call_id__in",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "call_id__icontains",
-            "in": "query",
-            "description": "call_id__icontains",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "success",
-            "in": "query",
-            "description": "success",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "metrics",
-            "in": "query",
-            "description": "metrics",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "search",
-            "in": "query",
-            "description": "search",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "timestamp_range",
-            "in": "query",
-            "description": "timestamp_range",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "call_ended_reason_not_equals",
-            "in": "query",
-            "description": "call_ended_reason_not_equals",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "description": "A page number within the paginated result set.",
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "name": "page_size",
-            "in": "query",
-            "description": "Number of results to return per page.",
-            "schema": {
-              "type": "integer"
+      },
+      "/api/schema/redoc/": {
+        "get": {
+          "tags": [
+            "api"
+          ],
+          "operationId": "api_schema_redoc_list",
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {}
             }
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
+        }
+      },
+      "/api/schema/swagger-ui/": {
+        "get": {
+          "tags": [
+            "api"
+          ],
+          "operationId": "api_schema_swagger-ui_list",
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {}
+            }
+          }
+        }
+      },
+      "/enums/": {
+        "get": {
+          "tags": [
+            "enums"
+          ],
+          "operationId": "enums_list",
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {}
+            }
+          }
+        }
+      },
+      "/observability/call_log/": {
+        "get": {
+          "tags": [
+            "observability"
+          ],
+          "operationId": "observability_call_log_list",
+          "parameters": [
+            {
+              "name": "call_ended_reason__in",
+              "in": "query",
+              "description": "call_ended_reason__in",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "call_ended_reason__icontains",
+              "in": "query",
+              "description": "call_ended_reason__icontains",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "id__in",
+              "in": "query",
+              "description": "id__in",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "timestamp__gte",
+              "in": "query",
+              "description": "timestamp__gte",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "timestamp__lte",
+              "in": "query",
+              "description": "timestamp__lte",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "duration__gte",
+              "in": "query",
+              "description": "duration__gte",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "duration__lte",
+              "in": "query",
+              "description": "duration__lte",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "customer_number__in",
+              "in": "query",
+              "description": "customer_number__in",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "customer_number__icontains",
+              "in": "query",
+              "description": "customer_number__icontains",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "call_id__in",
+              "in": "query",
+              "description": "call_id__in",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "call_id__icontains",
+              "in": "query",
+              "description": "call_id__icontains",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "success",
+              "in": "query",
+              "description": "success",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "metrics",
+              "in": "query",
+              "description": "metrics",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "search",
+              "in": "query",
+              "description": "search",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "timestamp_range",
+              "in": "query",
+              "description": "timestamp_range",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "call_ended_reason_not_equals",
+              "in": "query",
+              "description": "call_ended_reason_not_equals",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "page",
+              "in": "query",
+              "description": "A page number within the paginated result set.",
+              "schema": {
+                "type": "integer"
+              }
+            },
+            {
+              "name": "page_size",
+              "in": "query",
+              "description": "Number of results to return per page.",
+              "schema": {
+                "type": "integer"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "required": [
+                      "count",
+                      "results"
+                    ],
+                    "type": "object",
+                    "properties": {
+                      "count": {
+                        "type": "integer"
+                      },
+                      "next": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true
+                      },
+                      "previous": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true
+                      },
+                      "results": {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/components/schemas/CallLogList"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "post": {
+          "tags": [
+            "observability"
+          ],
+          "operationId": "observability_call_log_create",
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
-                  "required": [
-                    "count",
-                    "results"
-                  ],
-                  "type": "object",
-                  "properties": {
-                    "count": {
-                      "type": "integer"
-                    },
-                    "next": {
-                      "type": "string",
-                      "format": "uri",
-                      "nullable": true
-                    },
-                    "previous": {
-                      "type": "string",
-                      "format": "uri",
-                      "nullable": true
-                    },
-                    "results": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/CallLogList"
+                  "$ref": "#/components/schemas/CallLogDetail"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/CallLogDetail"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/observability/call_log/create_scenarios/": {
+        "post": {
+          "tags": [
+            "observability"
+          ],
+          "operationId": "observability_call_log_create_scenarios",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallLogDetail"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/CallLogDetail"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/observability/call_log/critical_categories/": {
+        "post": {
+          "tags": [
+            "observability"
+          ],
+          "operationId": "observability_call_log_critical_categories",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallLogDetail"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/CallLogDetail"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/observability/call_log/delete_call_logs/": {
+        "post": {
+          "tags": [
+            "observability"
+          ],
+          "operationId": "observability_call_log_delete_call_logs",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallLogDetail"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/CallLogDetail"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/observability/call_log/evaluate_metrics/": {
+        "post": {
+          "tags": [
+            "observability"
+          ],
+          "operationId": "observability_call_log_evaluate_metrics",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallLogDetail"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/CallLogDetail"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/observability/call_log/filters/": {
+        "get": {
+          "tags": [
+            "observability"
+          ],
+          "operationId": "observability_call_log_filters",
+          "parameters": [
+            {
+              "name": "call_ended_reason__in",
+              "in": "query",
+              "description": "call_ended_reason__in",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "call_ended_reason__icontains",
+              "in": "query",
+              "description": "call_ended_reason__icontains",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "id__in",
+              "in": "query",
+              "description": "id__in",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "timestamp__gte",
+              "in": "query",
+              "description": "timestamp__gte",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "timestamp__lte",
+              "in": "query",
+              "description": "timestamp__lte",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "duration__gte",
+              "in": "query",
+              "description": "duration__gte",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "duration__lte",
+              "in": "query",
+              "description": "duration__lte",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "customer_number__in",
+              "in": "query",
+              "description": "customer_number__in",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "customer_number__icontains",
+              "in": "query",
+              "description": "customer_number__icontains",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "call_id__in",
+              "in": "query",
+              "description": "call_id__in",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "call_id__icontains",
+              "in": "query",
+              "description": "call_id__icontains",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "success",
+              "in": "query",
+              "description": "success",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "metrics",
+              "in": "query",
+              "description": "metrics",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "search",
+              "in": "query",
+              "description": "search",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "timestamp_range",
+              "in": "query",
+              "description": "timestamp_range",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "call_ended_reason_not_equals",
+              "in": "query",
+              "description": "call_ended_reason_not_equals",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "page",
+              "in": "query",
+              "description": "A page number within the paginated result set.",
+              "schema": {
+                "type": "integer"
+              }
+            },
+            {
+              "name": "page_size",
+              "in": "query",
+              "description": "Number of results to return per page.",
+              "schema": {
+                "type": "integer"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "required": [
+                      "count",
+                      "results"
+                    ],
+                    "type": "object",
+                    "properties": {
+                      "count": {
+                        "type": "integer"
+                      },
+                      "next": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true
+                      },
+                      "previous": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true
+                      },
+                      "results": {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/components/schemas/CallLogDetail"
+                        }
                       }
                     }
                   }
@@ -220,310 +609,188 @@
           }
         }
       },
-      "post": {
-        "tags": [
-          "observability"
-        ],
-        "operationId": "observability_call_log_create",
-        "requestBody": {
-          "content": {
-            "application/json": {
+      "/observability/call_log/filters_call_id/": {
+        "get": {
+          "tags": [
+            "observability"
+          ],
+          "operationId": "observability_call_log_filters_call_id",
+          "parameters": [
+            {
+              "name": "call_ended_reason__in",
+              "in": "query",
+              "description": "call_ended_reason__in",
               "schema": {
-                "$ref": "#/components/schemas/CallLogDetail"
+                "type": "string"
               }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CallLogDetail"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/observability/call_log/create_scenarios/": {
-      "post": {
-        "tags": [
-          "observability"
-        ],
-        "operationId": "observability_call_log_create_scenarios",
-        "requestBody": {
-          "content": {
-            "application/json": {
+            },
+            {
+              "name": "call_ended_reason__icontains",
+              "in": "query",
+              "description": "call_ended_reason__icontains",
               "schema": {
-                "$ref": "#/components/schemas/CallLogDetail"
+                "type": "string"
               }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CallLogDetail"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/observability/call_log/delete_call_logs/": {
-      "post": {
-        "tags": [
-          "observability"
-        ],
-        "operationId": "observability_call_log_delete_call_logs",
-        "requestBody": {
-          "content": {
-            "application/json": {
+            },
+            {
+              "name": "id__in",
+              "in": "query",
+              "description": "id__in",
               "schema": {
-                "$ref": "#/components/schemas/CallLogDetail"
+                "type": "string"
               }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CallLogDetail"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/observability/call_log/evaluate_metrics/": {
-      "post": {
-        "tags": [
-          "observability"
-        ],
-        "operationId": "observability_call_log_evaluate_metrics",
-        "requestBody": {
-          "content": {
-            "application/json": {
+            },
+            {
+              "name": "timestamp__gte",
+              "in": "query",
+              "description": "timestamp__gte",
               "schema": {
-                "$ref": "#/components/schemas/CallLogDetail"
+                "type": "string"
+              }
+            },
+            {
+              "name": "timestamp__lte",
+              "in": "query",
+              "description": "timestamp__lte",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "duration__gte",
+              "in": "query",
+              "description": "duration__gte",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "duration__lte",
+              "in": "query",
+              "description": "duration__lte",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "customer_number__in",
+              "in": "query",
+              "description": "customer_number__in",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "customer_number__icontains",
+              "in": "query",
+              "description": "customer_number__icontains",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "call_id__in",
+              "in": "query",
+              "description": "call_id__in",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "call_id__icontains",
+              "in": "query",
+              "description": "call_id__icontains",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "success",
+              "in": "query",
+              "description": "success",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "metrics",
+              "in": "query",
+              "description": "metrics",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "search",
+              "in": "query",
+              "description": "search",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "timestamp_range",
+              "in": "query",
+              "description": "timestamp_range",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "call_ended_reason_not_equals",
+              "in": "query",
+              "description": "call_ended_reason_not_equals",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "page",
+              "in": "query",
+              "description": "A page number within the paginated result set.",
+              "schema": {
+                "type": "integer"
+              }
+            },
+            {
+              "name": "page_size",
+              "in": "query",
+              "description": "Number of results to return per page.",
+              "schema": {
+                "type": "integer"
               }
             }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CallLogDetail"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/observability/call_log/filters/": {
-      "get": {
-        "tags": [
-          "observability"
-        ],
-        "operationId": "observability_call_log_filters",
-        "parameters": [
-          {
-            "name": "call_ended_reason__in",
-            "in": "query",
-            "description": "call_ended_reason__in",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "call_ended_reason__icontains",
-            "in": "query",
-            "description": "call_ended_reason__icontains",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "id__in",
-            "in": "query",
-            "description": "id__in",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "timestamp__gte",
-            "in": "query",
-            "description": "timestamp__gte",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "timestamp__lte",
-            "in": "query",
-            "description": "timestamp__lte",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "duration__gte",
-            "in": "query",
-            "description": "duration__gte",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "duration__lte",
-            "in": "query",
-            "description": "duration__lte",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "customer_number__in",
-            "in": "query",
-            "description": "customer_number__in",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "customer_number__icontains",
-            "in": "query",
-            "description": "customer_number__icontains",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "call_id__in",
-            "in": "query",
-            "description": "call_id__in",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "call_id__icontains",
-            "in": "query",
-            "description": "call_id__icontains",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "success",
-            "in": "query",
-            "description": "success",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "metrics",
-            "in": "query",
-            "description": "metrics",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "search",
-            "in": "query",
-            "description": "search",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "timestamp_range",
-            "in": "query",
-            "description": "timestamp_range",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "call_ended_reason_not_equals",
-            "in": "query",
-            "description": "call_ended_reason_not_equals",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "description": "A page number within the paginated result set.",
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "name": "page_size",
-            "in": "query",
-            "description": "Number of results to return per page.",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "required": [
-                    "count",
-                    "results"
-                  ],
-                  "type": "object",
-                  "properties": {
-                    "count": {
-                      "type": "integer"
-                    },
-                    "next": {
-                      "type": "string",
-                      "format": "uri",
-                      "nullable": true
-                    },
-                    "previous": {
-                      "type": "string",
-                      "format": "uri",
-                      "nullable": true
-                    },
-                    "results": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/CallLogDetail"
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "required": [
+                      "count",
+                      "results"
+                    ],
+                    "type": "object",
+                    "properties": {
+                      "count": {
+                        "type": "integer"
+                      },
+                      "next": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true
+                      },
+                      "previous": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true
+                      },
+                      "results": {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/components/schemas/CallLogDetail"
+                        }
                       }
                     }
                   }
@@ -532,189 +799,189 @@
             }
           }
         }
-      }
-    },
-    "/observability/call_log/filters_call_id/": {
-      "get": {
-        "tags": [
-          "observability"
-        ],
-        "operationId": "observability_call_log_filters_call_id",
-        "parameters": [
-          {
-            "name": "call_ended_reason__in",
-            "in": "query",
-            "description": "call_ended_reason__in",
-            "schema": {
-              "type": "string"
+      },
+      "/observability/call_log/filters_customer_number/": {
+        "get": {
+          "tags": [
+            "observability"
+          ],
+          "operationId": "observability_call_log_filters_customer_number",
+          "parameters": [
+            {
+              "name": "call_ended_reason__in",
+              "in": "query",
+              "description": "call_ended_reason__in",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "call_ended_reason__icontains",
+              "in": "query",
+              "description": "call_ended_reason__icontains",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "id__in",
+              "in": "query",
+              "description": "id__in",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "timestamp__gte",
+              "in": "query",
+              "description": "timestamp__gte",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "timestamp__lte",
+              "in": "query",
+              "description": "timestamp__lte",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "duration__gte",
+              "in": "query",
+              "description": "duration__gte",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "duration__lte",
+              "in": "query",
+              "description": "duration__lte",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "customer_number__in",
+              "in": "query",
+              "description": "customer_number__in",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "customer_number__icontains",
+              "in": "query",
+              "description": "customer_number__icontains",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "call_id__in",
+              "in": "query",
+              "description": "call_id__in",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "call_id__icontains",
+              "in": "query",
+              "description": "call_id__icontains",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "success",
+              "in": "query",
+              "description": "success",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "metrics",
+              "in": "query",
+              "description": "metrics",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "search",
+              "in": "query",
+              "description": "search",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "timestamp_range",
+              "in": "query",
+              "description": "timestamp_range",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "call_ended_reason_not_equals",
+              "in": "query",
+              "description": "call_ended_reason_not_equals",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "page",
+              "in": "query",
+              "description": "A page number within the paginated result set.",
+              "schema": {
+                "type": "integer"
+              }
+            },
+            {
+              "name": "page_size",
+              "in": "query",
+              "description": "Number of results to return per page.",
+              "schema": {
+                "type": "integer"
+              }
             }
-          },
-          {
-            "name": "call_ended_reason__icontains",
-            "in": "query",
-            "description": "call_ended_reason__icontains",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "id__in",
-            "in": "query",
-            "description": "id__in",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "timestamp__gte",
-            "in": "query",
-            "description": "timestamp__gte",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "timestamp__lte",
-            "in": "query",
-            "description": "timestamp__lte",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "duration__gte",
-            "in": "query",
-            "description": "duration__gte",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "duration__lte",
-            "in": "query",
-            "description": "duration__lte",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "customer_number__in",
-            "in": "query",
-            "description": "customer_number__in",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "customer_number__icontains",
-            "in": "query",
-            "description": "customer_number__icontains",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "call_id__in",
-            "in": "query",
-            "description": "call_id__in",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "call_id__icontains",
-            "in": "query",
-            "description": "call_id__icontains",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "success",
-            "in": "query",
-            "description": "success",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "metrics",
-            "in": "query",
-            "description": "metrics",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "search",
-            "in": "query",
-            "description": "search",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "timestamp_range",
-            "in": "query",
-            "description": "timestamp_range",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "call_ended_reason_not_equals",
-            "in": "query",
-            "description": "call_ended_reason_not_equals",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "description": "A page number within the paginated result set.",
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "name": "page_size",
-            "in": "query",
-            "description": "Number of results to return per page.",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "required": [
-                    "count",
-                    "results"
-                  ],
-                  "type": "object",
-                  "properties": {
-                    "count": {
-                      "type": "integer"
-                    },
-                    "next": {
-                      "type": "string",
-                      "format": "uri",
-                      "nullable": true
-                    },
-                    "previous": {
-                      "type": "string",
-                      "format": "uri",
-                      "nullable": true
-                    },
-                    "results": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/CallLogDetail"
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "required": [
+                      "count",
+                      "results"
+                    ],
+                    "type": "object",
+                    "properties": {
+                      "count": {
+                        "type": "integer"
+                      },
+                      "next": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true
+                      },
+                      "previous": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true
+                      },
+                      "results": {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/components/schemas/CallLogDetail"
+                        }
                       }
                     }
                   }
@@ -723,1145 +990,1183 @@
             }
           }
         }
-      }
-    },
-    "/observability/call_log/filters_customer_number/": {
-      "get": {
-        "tags": [
-          "observability"
-        ],
-        "operationId": "observability_call_log_filters_customer_number",
-        "parameters": [
-          {
-            "name": "call_ended_reason__in",
-            "in": "query",
-            "description": "call_ended_reason__in",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "call_ended_reason__icontains",
-            "in": "query",
-            "description": "call_ended_reason__icontains",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "id__in",
-            "in": "query",
-            "description": "id__in",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "timestamp__gte",
-            "in": "query",
-            "description": "timestamp__gte",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "timestamp__lte",
-            "in": "query",
-            "description": "timestamp__lte",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "duration__gte",
-            "in": "query",
-            "description": "duration__gte",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "duration__lte",
-            "in": "query",
-            "description": "duration__lte",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "customer_number__in",
-            "in": "query",
-            "description": "customer_number__in",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "customer_number__icontains",
-            "in": "query",
-            "description": "customer_number__icontains",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "call_id__in",
-            "in": "query",
-            "description": "call_id__in",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "call_id__icontains",
-            "in": "query",
-            "description": "call_id__icontains",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "success",
-            "in": "query",
-            "description": "success",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "metrics",
-            "in": "query",
-            "description": "metrics",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "search",
-            "in": "query",
-            "description": "search",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "timestamp_range",
-            "in": "query",
-            "description": "timestamp_range",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "call_ended_reason_not_equals",
-            "in": "query",
-            "description": "call_ended_reason_not_equals",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "description": "A page number within the paginated result set.",
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "name": "page_size",
-            "in": "query",
-            "description": "Number of results to return per page.",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
+      },
+      "/observability/call_log/improve_prompt/": {
+        "post": {
+          "tags": [
+            "observability"
+          ],
+          "operationId": "observability_call_log_improve_prompt",
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
-                  "required": [
-                    "count",
-                    "results"
-                  ],
-                  "type": "object",
-                  "properties": {
-                    "count": {
-                      "type": "integer"
-                    },
-                    "next": {
-                      "type": "string",
-                      "format": "uri",
-                      "nullable": true
-                    },
-                    "previous": {
-                      "type": "string",
-                      "format": "uri",
-                      "nullable": true
-                    },
-                    "results": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/CallLogDetail"
-                      }
-                    }
+                  "$ref": "#/components/schemas/CallLogDetail"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/CallLogDetail"
                   }
                 }
               }
             }
-          }
-        }
-      }
-    },
-    "/observability/call_log/rerun_evaluation/": {
-      "post": {
-        "tags": [
-          "observability"
-        ],
-        "operationId": "observability_call_log_rerun_evaluation",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CallLogDetail"
-              }
-            }
           },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CallLogDetail"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/observability/call_log/{id}/": {
-      "get": {
-        "tags": [
-          "observability"
-        ],
-        "operationId": "observability_call_log_read",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CallLogDetail"
-                }
-              }
-            }
-          }
+          "x-codegen-request-body-name": "data"
         }
       },
-      "put": {
-        "tags": [
-          "observability"
-        ],
-        "operationId": "observability_call_log_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CallLogDetail"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
+      "/observability/call_log/rerun_evaluation/": {
+        "post": {
+          "tags": [
+            "observability"
+          ],
+          "operationId": "observability_call_log_rerun_evaluation",
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CallLogDetail"
                 }
               }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      },
-      "delete": {
-        "tags": [
-          "observability"
-        ],
-        "operationId": "observability_call_log_delete",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "",
-            "content": {}
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "observability"
-        ],
-        "operationId": "observability_call_log_partial_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CallLogDetail"
-              }
-            }
+            },
+            "required": true
           },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CallLogDetail"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/observability/call_log/{id}/create_scenario/": {
-      "post": {
-        "tags": [
-          "observability"
-        ],
-        "operationId": "observability_call_log_create_scenario",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CallLogDetail"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CallLogDetail"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/observability/call_log/{id}/mark_critical_scenario_wrong/": {
-      "post": {
-        "tags": [
-          "observability"
-        ],
-        "operationId": "observability_call_log_mark_critical_scenario_wrong",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CallLogDetail"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CallLogDetail"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/observability/call_log/{id}/unmark_critical_scenario_wrong/": {
-      "post": {
-        "tags": [
-          "observability"
-        ],
-        "operationId": "observability_call_log_unmark_critical_scenario_wrong",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CallLogDetail"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CallLogDetail"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/observability/overall_evaluation/": {
-      "get": {
-        "tags": [
-          "observability"
-        ],
-        "operationId": "observability_overall_evaluation_list",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/OverallEvaluation"
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/CallLogDetail"
                   }
                 }
               }
             }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "observability"
-        ],
-        "operationId": "observability_overall_evaluation_create",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/OverallEvaluation"
-              }
-            }
           },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OverallEvaluation"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/observability/overall_evaluation/generate_overall_summary/": {
-      "get": {
-        "tags": [
-          "observability"
-        ],
-        "operationId": "observability_overall_evaluation_generate_overall_summary",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/OverallEvaluation"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/observability/overall_evaluation/realtime/": {
-      "get": {
-        "tags": [
-          "observability"
-        ],
-        "operationId": "observability_overall_evaluation_realtime",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/OverallEvaluation"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/observability/overall_evaluation/{id}/": {
-      "get": {
-        "tags": [
-          "observability"
-        ],
-        "operationId": "observability_overall_evaluation_read",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OverallEvaluation"
-                }
-              }
-            }
-          }
+          "x-codegen-request-body-name": "data"
         }
       },
-      "put": {
-        "tags": [
-          "observability"
-        ],
-        "operationId": "observability_overall_evaluation_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
+      "/observability/call_log/{id}/": {
+        "get": {
+          "tags": [
+            "observability"
+          ],
+          "operationId": "observability_call_log_read",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
               "schema": {
-                "$ref": "#/components/schemas/OverallEvaluation"
+                "type": "string"
               }
             }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OverallEvaluation"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      },
-      "delete": {
-        "tags": [
-          "observability"
-        ],
-        "operationId": "observability_overall_evaluation_delete",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "",
-            "content": {}
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "observability"
-        ],
-        "operationId": "observability_overall_evaluation_partial_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/OverallEvaluation"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OverallEvaluation"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/observability/v1/call-logs-external/": {
-      "get": {
-        "tags": [
-          "observability"
-        ],
-        "operationId": "observability_v1_call-logs-external_list",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
                     "$ref": "#/components/schemas/CallLogDetail"
                   }
                 }
               }
             }
           }
-        }
-      }
-    },
-    "/observability/v1/call-logs-external/rerun_evaluation/": {
-      "post": {
-        "tags": [
-          "observability"
-        ],
-        "operationId": "observability_v1_call-logs-external_rerun_evaluation",
-        "requestBody": {
-          "content": {
-            "application/json": {
+        },
+        "put": {
+          "tags": [
+            "observability"
+          ],
+          "operationId": "observability_call_log_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
               "schema": {
-                "$ref": "#/components/schemas/CallLogDetail"
+                "type": "string"
               }
             }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
+          ],
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CallLogDetail"
                 }
               }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/CallLogDetail"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        },
+        "delete": {
+          "tags": [
+            "observability"
+          ],
+          "operationId": "observability_call_log_delete",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "204": {
+              "description": "",
+              "content": {}
             }
           }
         },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/observability/v1/call-logs-external/{id}/": {
-      "get": {
-        "tags": [
-          "observability"
-        ],
-        "operationId": "observability_v1_call-logs-external_read",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
+        "patch": {
+          "tags": [
+            "observability"
+          ],
+          "operationId": "observability_call_log_partial_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
             }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
+          ],
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CallLogDetail"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/CallLogDetail"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/observability/call_log/{id}/create_scenario/": {
+        "post": {
+          "tags": [
+            "observability"
+          ],
+          "operationId": "observability_call_log_create_scenario",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallLogDetail"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/CallLogDetail"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/observability/call_log/{id}/mark_critical_scenario_wrong/": {
+        "post": {
+          "tags": [
+            "observability"
+          ],
+          "operationId": "observability_call_log_mark_critical_scenario_wrong",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallLogDetail"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/CallLogDetail"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/observability/call_log/{id}/unmark_critical_scenario_wrong/": {
+        "post": {
+          "tags": [
+            "observability"
+          ],
+          "operationId": "observability_call_log_unmark_critical_scenario_wrong",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallLogDetail"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/CallLogDetail"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/observability/overall_evaluation/": {
+        "get": {
+          "tags": [
+            "observability"
+          ],
+          "operationId": "observability_overall_evaluation_list",
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/OverallEvaluation"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "post": {
+          "tags": [
+            "observability"
+          ],
+          "operationId": "observability_overall_evaluation_create",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OverallEvaluation"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/OverallEvaluation"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/observability/overall_evaluation/generate_overall_summary/": {
+        "get": {
+          "tags": [
+            "observability"
+          ],
+          "operationId": "observability_overall_evaluation_generate_overall_summary",
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/OverallEvaluation"
+                    }
+                  }
                 }
               }
             }
           }
         }
       },
-      "delete": {
-        "tags": [
-          "observability"
-        ],
-        "operationId": "observability_v1_call-logs-external_delete",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
+      "/observability/overall_evaluation/realtime/": {
+        "get": {
+          "tags": [
+            "observability"
+          ],
+          "operationId": "observability_overall_evaluation_realtime",
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/OverallEvaluation"
+                    }
+                  }
+                }
+              }
             }
           }
-        ],
-        "responses": {
-          "204": {
-            "description": "",
-            "content": {}
-          }
         }
-      }
-    },
-    "/observability/v1/observe/": {
-      "post": {
-        "tags": [
-          "observability"
-        ],
-        "operationId": "observability_observe_create",
-        "requestBody": {
-          "content": {
-            "application/json": {
+      },
+      "/observability/overall_evaluation/{id}/": {
+        "get": {
+          "tags": [
+            "observability"
+          ],
+          "operationId": "observability_overall_evaluation_read",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
               "schema": {
-                "type": "object",
-                "required": [
-                  "call_id",
-                  "transcript_json",
-                  "voice_recording",
-                  "voice_recording_url"
-                ],
-                "properties": {
-                  "call_id": {
-                    "type": "string",
-                    "description": "Unique identifier for the call"
-                  },
-                  "agent": {
-                    "type": "string",
-                    "description": "The agent ID as shown on your dashboard"
-                  },
-                  "assistant_id": {
-                    "type": "string",
-                    "description": "The assistant ID associated with agent"
-                  },
-                  "voice_recording": {
-                    "type": "string",
-                    "description": "Audio file of the call recording"
-                  },
-                  "voice_recording_url": {
-                    "type": "string",
-                    "description": "URL to the call recording audio file"
-                  },
-                  "call_ended_reason": {
-                    "type": "string",
-                    "description": "Reason for call termination"
-                  },
-                  "customer_number": {
-                    "type": "string",
-                    "description": "Phone number of the customer"
-                  },
-                  "transcript_json": {
-                    "type": "object",
-                    "description": "JSON object containing the transcript of the call. Can be in Vocera, Vapi or Retell format"
-                  },
-                  "metadata": {
-                    "type": "object",
-                    "description": "Dictionary with additional data"
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/OverallEvaluation"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "put": {
+          "tags": [
+            "observability"
+          ],
+          "operationId": "observability_overall_evaluation_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OverallEvaluation"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/OverallEvaluation"
                   }
                 }
               }
             }
           },
-          "required": true
+          "x-codegen-request-body-name": "data"
         },
-        "responses": {
-          "201": {
-            "description": "Created",
+        "delete": {
+          "tags": [
+            "observability"
+          ],
+          "operationId": "observability_overall_evaluation_delete",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "204": {
+              "description": "",
+              "content": {}
+            }
+          }
+        },
+        "patch": {
+          "tags": [
+            "observability"
+          ],
+          "operationId": "observability_overall_evaluation_partial_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/OverallEvaluation"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/OverallEvaluation"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/observability/v1/call-logs-external/": {
+        "get": {
+          "tags": [
+            "observability"
+          ],
+          "summary": "Manage external call logs.",
+          "description": "This view provides endpoints to retrieve, delete, and list call logs for external users.\nA call log represents a record of a communication event, including details such as the agent involved,\nthe call ID, and the outcome of the call. This information is crucial for monitoring and evaluating\nthe performance of agents and the quality of interactions.",
+          "operationId": "observability_v1_call-logs-external_list",
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/CallLogDetail"
+                    }
+                  }
                 }
               }
             }
           }
         }
-      }
-    },
-    "/observability/v1/retell/observe/": {
-      "post": {
-        "tags": [
-          "observability"
-        ],
-        "operationId": "observability_v1_retell_observe_create",
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {}
-          }
-        }
-      }
-    },
-    "/observability/v1/vapi/observe/": {
-      "post": {
-        "tags": [
-          "observability"
-        ],
-        "operationId": "observability_v1_vapi_observe_create",
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {}
-          }
-        }
-      }
-    },
-    "/schedules/cron-jobs/": {
-      "get": {
-        "tags": [
-          "schedules"
-        ],
-        "operationId": "schedules_cron-jobs_list",
-        "responses": {
-          "200": {
-            "description": "",
+      },
+      "/observability/v1/call-logs-external/rerun_evaluation/": {
+        "post": {
+          "tags": [
+            "observability"
+          ],
+          "summary": "Manage external call logs.",
+          "description": "This view provides endpoints to retrieve, delete, and list call logs for external users.\nA call log represents a record of a communication event, including details such as the agent involved,\nthe call ID, and the outcome of the call. This information is crucial for monitoring and evaluating\nthe performance of agents and the quality of interactions.",
+          "operationId": "observability_v1_call-logs-external_rerun_evaluation",
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
+                  "$ref": "#/components/schemas/CallLogDetail"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/CallLogDetail"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/observability/v1/call-logs-external/{id}/": {
+        "get": {
+          "tags": [
+            "observability"
+          ],
+          "summary": "Manage external call logs.",
+          "description": "This view provides endpoints to retrieve, delete, and list call logs for external users.\nA call log represents a record of a communication event, including details such as the agent involved,\nthe call ID, and the outcome of the call. This information is crucial for monitoring and evaluating\nthe performance of agents and the quality of interactions.",
+          "operationId": "observability_v1_call-logs-external_read",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/CallLogDetail"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "delete": {
+          "tags": [
+            "observability"
+          ],
+          "summary": "Manage external call logs.",
+          "description": "This view provides endpoints to retrieve, delete, and list call logs for external users.\nA call log represents a record of a communication event, including details such as the agent involved,\nthe call ID, and the outcome of the call. This information is crucial for monitoring and evaluating\nthe performance of agents and the quality of interactions.",
+          "operationId": "observability_v1_call-logs-external_delete",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "204": {
+              "description": "",
+              "content": {}
+            }
+          }
+        }
+      },
+      "/observability/v1/observe/": {
+        "post": {
+          "tags": [
+            "observability"
+          ],
+          "description": "Create a new call log entry.This endpoint allows users to create a new call log entry by providing the necessary datain the request body. The API key must be included in the request headers for authorization.",
+          "operationId": "observability_v1_observe_create",
+          "parameters": [
+            {
+              "name": "X-VOCERA-API-KEY",
+              "in": "header",
+              "description": "API key for authorization",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateCallLog"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "Call log created successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/CallLogList"
+                  }
+                }
+              }
+            },
+            "404": {
+                "description": "Not found",
+                "content": {
+                "application/json": {
+                    "schema": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                        "type": "object",
+                        "properties": {
+                            "message": {
+                            "type": "string",
+                            "description": "No agent found for assistant_id"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+        }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/observability/v1/retell/observe/": {
+        "post": {
+          "tags": [
+            "observability"
+          ],
+          "summary": "Handle incoming Retell webhook requests.",
+          "description": "This endpoint processes webhook requests from the Retell service, validates the request data,\nand creates a call log entry based on the received data. Retell sends webhooks at the end of the call,\nproviding important information about the interaction.",
+          "operationId": "observability_v1_retell_observe_create",
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {}
+            }
+          }
+        }
+      },
+      "/observability/v1/vapi/observe/": {
+        "post": {
+          "tags": [
+            "observability"
+          ],
+          "summary": "Handle incoming VAPI webhook requests.",
+          "description": "This endpoint processes webhook requests from the VAPI service, validates the API key,\nand creates a call log entry based on the received data. VAPI sends webhooks at the end of the call,\nproviding important information about the interaction.",
+          "operationId": "observability_v1_vapi_observe_create",
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {}
+            }
+          }
+        }
+      },
+      "/schedules/cron-jobs/": {
+        "get": {
+          "tags": [
+            "schedules"
+          ],
+          "operationId": "schedules_cron-jobs_list",
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/CronJob"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "post": {
+          "tags": [
+            "schedules"
+          ],
+          "operationId": "schedules_cron-jobs_create",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CronJob"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/CronJob"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/schedules/cron-jobs/{id}/": {
+        "get": {
+          "tags": [
+            "schedules"
+          ],
+          "operationId": "schedules_cron-jobs_read",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
                     "$ref": "#/components/schemas/CronJob"
                   }
                 }
               }
             }
           }
-        }
-      },
-      "post": {
-        "tags": [
-          "schedules"
-        ],
-        "operationId": "schedules_cron-jobs_create",
-        "requestBody": {
-          "content": {
-            "application/json": {
+        },
+        "put": {
+          "tags": [
+            "schedules"
+          ],
+          "operationId": "schedules_cron-jobs_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
               "schema": {
-                "$ref": "#/components/schemas/CronJob"
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CronJob"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/CronJob"
+                  }
+                }
               }
             }
           },
-          "required": true
+          "x-codegen-request-body-name": "data"
         },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CronJob"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/schedules/cron-jobs/{id}/": {
-      "get": {
-        "tags": [
-          "schedules"
-        ],
-        "operationId": "schedules_cron-jobs_read",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CronJob"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "schedules"
-        ],
-        "operationId": "schedules_cron-jobs_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
+        "delete": {
+          "tags": [
+            "schedules"
+          ],
+          "operationId": "schedules_cron-jobs_delete",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
               "schema": {
-                "$ref": "#/components/schemas/CronJob"
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "204": {
+              "description": "",
+              "content": {}
+            }
+          }
+        },
+        "patch": {
+          "tags": [
+            "schedules"
+          ],
+          "operationId": "schedules_cron-jobs_partial_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CronJob"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/CronJob"
+                  }
+                }
               }
             }
           },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CronJob"
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/slack/interact/": {
+        "post": {
+          "tags": [
+            "slack"
+          ],
+          "description": "Handle Slack interactive component callbacks",
+          "operationId": "slack_interact_create",
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {}
+            }
+          }
+        }
+      },
+      "/slack/oauth/": {
+        "post": {
+          "tags": [
+            "slack"
+          ],
+          "operationId": "slack_oauth_create",
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {}
+            }
+          }
+        }
+      },
+      "/slack/slack-workspaces/": {
+        "get": {
+          "tags": [
+            "slack"
+          ],
+          "operationId": "slack_slack-workspaces_list",
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/SlackWorkspace"
+                    }
+                  }
                 }
               }
             }
           }
         },
-        "x-codegen-request-body-name": "data"
-      },
-      "delete": {
-        "tags": [
-          "schedules"
-        ],
-        "operationId": "schedules_cron-jobs_delete",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "",
-            "content": {}
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "schedules"
-        ],
-        "operationId": "schedules_cron-jobs_partial_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CronJob"
+        "post": {
+          "tags": [
+            "slack"
+          ],
+          "operationId": "slack_slack-workspaces_create",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SlackWorkspace"
+                }
               }
-            }
+            },
+            "required": true
           },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CronJob"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/slack/interact/": {
-      "post": {
-        "tags": [
-          "slack"
-        ],
-        "description": "Handle Slack interactive component callbacks",
-        "operationId": "slack_interact_create",
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {}
-          }
-        }
-      }
-    },
-    "/slack/oauth/": {
-      "post": {
-        "tags": [
-          "slack"
-        ],
-        "operationId": "slack_oauth_create",
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {}
-          }
-        }
-      }
-    },
-    "/slack/slack-workspaces/": {
-      "get": {
-        "tags": [
-          "slack"
-        ],
-        "operationId": "slack_slack-workspaces_list",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
                     "$ref": "#/components/schemas/SlackWorkspace"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/slack/slack-workspaces/{id}/": {
+        "get": {
+          "tags": [
+            "slack"
+          ],
+          "operationId": "slack_slack-workspaces_read",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/SlackWorkspace"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "put": {
+          "tags": [
+            "slack"
+          ],
+          "operationId": "slack_slack-workspaces_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SlackWorkspace"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/SlackWorkspace"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        },
+        "delete": {
+          "tags": [
+            "slack"
+          ],
+          "operationId": "slack_slack-workspaces_delete",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "204": {
+              "description": "",
+              "content": {}
+            }
+          }
+        },
+        "patch": {
+          "tags": [
+            "slack"
+          ],
+          "operationId": "slack_slack-workspaces_partial_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SlackWorkspace"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/SlackWorkspace"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/subscriptions/create-checkout-session/": {
+        "post": {
+          "tags": [
+            "subscriptions"
+          ],
+          "operationId": "subscriptions_create-checkout-session_create",
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {}
+            }
+          }
+        }
+      },
+      "/subscriptions/packs/": {
+        "get": {
+          "tags": [
+            "subscriptions"
+          ],
+          "operationId": "subscriptions_packs_list",
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Pack"
+                    }
                   }
                 }
               }
@@ -1869,194 +2174,29 @@
           }
         }
       },
-      "post": {
-        "tags": [
-          "slack"
-        ],
-        "operationId": "slack_slack-workspaces_create",
-        "requestBody": {
-          "content": {
-            "application/json": {
+      "/subscriptions/packs/{id}/": {
+        "get": {
+          "tags": [
+            "subscriptions"
+          ],
+          "operationId": "subscriptions_packs_read",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "description": "A unique integer value identifying this pack.",
+              "required": true,
               "schema": {
-                "$ref": "#/components/schemas/SlackWorkspace"
+                "type": "integer"
               }
             }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SlackWorkspace"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/slack/slack-workspaces/{id}/": {
-      "get": {
-        "tags": [
-          "slack"
-        ],
-        "operationId": "slack_slack-workspaces_read",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SlackWorkspace"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "slack"
-        ],
-        "operationId": "slack_slack-workspaces_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SlackWorkspace"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SlackWorkspace"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      },
-      "delete": {
-        "tags": [
-          "slack"
-        ],
-        "operationId": "slack_slack-workspaces_delete",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "",
-            "content": {}
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "slack"
-        ],
-        "operationId": "slack_slack-workspaces_partial_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SlackWorkspace"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SlackWorkspace"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/subscriptions/create-checkout-session/": {
-      "post": {
-        "tags": [
-          "subscriptions"
-        ],
-        "operationId": "subscriptions_create-checkout-session_create",
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {}
-          }
-        }
-      }
-    },
-    "/subscriptions/packs/": {
-      "get": {
-        "tags": [
-          "subscriptions"
-        ],
-        "operationId": "subscriptions_packs_list",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
                     "$ref": "#/components/schemas/Pack"
                   }
                 }
@@ -2064,67 +2204,66 @@
             }
           }
         }
-      }
-    },
-    "/subscriptions/packs/{id}/": {
-      "get": {
-        "tags": [
-          "subscriptions"
-        ],
-        "operationId": "subscriptions_packs_read",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "A unique integer value identifying this pack.",
-            "required": true,
-            "schema": {
-              "type": "integer"
+      },
+      "/subscriptions/stripe/webhook/": {
+        "post": {
+          "tags": [
+            "subscriptions"
+          ],
+          "operationId": "subscriptions_stripe_webhook_create",
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {}
             }
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Pack"
+        }
+      },
+      "/subscriptions/subscriptions/": {
+        "get": {
+          "tags": [
+            "subscriptions"
+          ],
+          "operationId": "subscriptions_subscriptions_list",
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Subscription"
+                    }
+                  }
                 }
               }
             }
           }
         }
-      }
-    },
-    "/subscriptions/stripe/webhook/": {
-      "post": {
-        "tags": [
-          "subscriptions"
-        ],
-        "operationId": "subscriptions_stripe_webhook_create",
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {}
-          }
-        }
-      }
-    },
-    "/subscriptions/subscriptions/": {
-      "get": {
-        "tags": [
-          "subscriptions"
-        ],
-        "operationId": "subscriptions_subscriptions_list",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
+      },
+      "/subscriptions/subscriptions/{id}/": {
+        "get": {
+          "tags": [
+            "subscriptions"
+          ],
+          "operationId": "subscriptions_subscriptions_read",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
                     "$ref": "#/components/schemas/Subscription"
                   }
                 }
@@ -2132,484 +2271,1003 @@
             }
           }
         }
-      }
-    },
-    "/subscriptions/subscriptions/{id}/": {
-      "get": {
-        "tags": [
-          "subscriptions"
-        ],
-        "operationId": "subscriptions_subscriptions_read",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
+      },
+      "/subscriptions/subscriptions/{id}/cancel/": {
+        "post": {
+          "tags": [
+            "subscriptions"
+          ],
+          "operationId": "subscriptions_subscriptions_cancel",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
             }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
+          ],
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Subscription"
                 }
               }
-            }
-          }
-        }
-      }
-    },
-    "/subscriptions/subscriptions/{id}/cancel/": {
-      "post": {
-        "tags": [
-          "subscriptions"
-        ],
-        "operationId": "subscriptions_subscriptions_cancel",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Subscription"
-              }
-            }
+            },
+            "required": true
           },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Subscription"
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Subscription"
+                  }
                 }
               }
             }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/aiagents/": {
+        "get": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_aiagents_list",
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {}
+            }
           }
         },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/aiagents/": {
-      "get": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_aiagents_list",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {}
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_aiagents_create",
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {}
+            }
           }
         }
       },
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_aiagents_create",
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {}
-          }
-        }
-      }
-    },
-    "/test_framework/aiagents/{id}/": {
-      "get": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_aiagents_read",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
+      "/test_framework/aiagents/{id}/": {
+        "get": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_aiagents_read",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {}
             }
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {}
+        },
+        "put": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_aiagents_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {}
+            }
+          }
+        },
+        "delete": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_aiagents_delete",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "204": {
+              "description": "",
+              "content": {}
+            }
+          }
+        },
+        "patch": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_aiagents_partial_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {}
+            }
           }
         }
       },
-      "put": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_aiagents_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
+      "/test_framework/aiagents/{id}/copy/": {
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_aiagents_copy",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
             }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {}
+          ],
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {}
+            }
           }
         }
       },
-      "delete": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_aiagents_delete",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
+      "/test_framework/aiagents/{id}/disable_personalities/": {
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_aiagents_disable_personalities",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
             }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "",
-            "content": {}
+          ],
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {}
+            }
           }
         }
       },
-      "patch": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_aiagents_partial_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
+      "/test_framework/aiagents/{id}/enable_personalities/": {
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_aiagents_enable_personalities",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {}
             }
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {}
-          }
         }
-      }
-    },
-    "/test_framework/aiagents/{id}/copy/": {
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_aiagents_copy",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
+      },
+      "/test_framework/aiagents/{id}/personalities/": {
+        "get": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_aiagents_personalities",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {}
             }
           }
-        ],
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {}
-          }
         }
-      }
-    },
-    "/test_framework/aiagents/{id}/disable_personalities/": {
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_aiagents_disable_personalities",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {}
-          }
-        }
-      }
-    },
-    "/test_framework/aiagents/{id}/enable_personalities/": {
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_aiagents_enable_personalities",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {}
-          }
-        }
-      }
-    },
-    "/test_framework/aiagents/{id}/personalities/": {
-      "get": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_aiagents_personalities",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {}
-          }
-        }
-      }
-    },
-    "/test_framework/billing/": {
-      "get": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_billing_list",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Billing"
+      },
+      "/test_framework/billing/": {
+        "get": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_billing_list",
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Billing"
+                    }
                   }
                 }
               }
             }
           }
         }
-      }
-    },
-    "/test_framework/billing/runs/": {
-      "get": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_billing_get_billing_runs",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Billing"
+      },
+      "/test_framework/billing/runs/": {
+        "get": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_billing_get_billing_runs",
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Billing"
+                    }
                   }
                 }
               }
             }
           }
         }
-      }
-    },
-    "/test_framework/critical-scenarios/{id}/": {
-      "put": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_critical-scenarios_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
+      },
+      "/test_framework/critical-scenarios/{id}/": {
+        "put": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_critical-scenarios_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
               "schema": {
-                "$ref": "#/components/schemas/CriticalMetricScenario"
+                "type": "string"
               }
             }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
+          ],
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CriticalMetricScenario"
                 }
               }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      },
-      "patch": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_critical-scenarios_partial_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CriticalMetricScenario"
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/CriticalMetricScenario"
+                  }
+                }
               }
             }
           },
-          "required": true
+          "x-codegen-request-body-name": "data"
         },
-        "responses": {
-          "200": {
-            "description": "",
+        "patch": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_critical-scenarios_partial_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CriticalMetricScenario"
                 }
               }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/CriticalMetricScenario"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/generate_scenarios/": {
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_generate_scenarios_create",
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {}
+            }
+          }
+        }
+      },
+      "/test_framework/metric-reviews/delete_reviews/": {
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_metric-reviews_delete_reviews",
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {}
+            }
+          }
+        }
+      },
+      "/test_framework/metric-reviews/{id}/": {
+        "delete": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_metric-reviews_delete",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "204": {
+              "description": "",
+              "content": {}
+            }
+          }
+        }
+      },
+      "/test_framework/metrics/": {
+        "get": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_metrics_list",
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/MetricList"
+                    }
+                  }
+                }
+              }
             }
           }
         },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/generate_scenarios/": {
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_generate_scenarios_create",
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {}
-          }
-        }
-      }
-    },
-    "/test_framework/metric-reviews/delete_reviews/": {
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_metric-reviews_delete_reviews",
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {}
-          }
-        }
-      }
-    },
-    "/test_framework/metric-reviews/{id}/": {
-      "delete": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_metric-reviews_delete",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "",
-            "content": {}
-          }
-        }
-      }
-    },
-    "/test_framework/metrics/": {
-      "get": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_metrics_list",
-        "responses": {
-          "200": {
-            "description": "",
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_metrics_create",
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/MetricList"
+                  "$ref": "#/components/schemas/MetricEdit"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/MetricEdit"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/metrics/bulk_create/": {
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_metrics_bulk_create",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetricDetail"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/MetricDetail"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/metrics/delete_metrics/": {
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_metrics_delete_metrics",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetricDetail"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/MetricDetail"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/metrics/generate_metrics/": {
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_metrics_generate_metrics",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetricDetail"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/MetricDetail"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/metrics/{id}/": {
+        "get": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_metrics_read",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/MetricDetail"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "put": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_metrics_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetricEdit"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/MetricEdit"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        },
+        "delete": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_metrics_delete",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "204": {
+              "description": "",
+              "content": {}
+            }
+          }
+        },
+        "patch": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_metrics_partial_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetricEdit"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/MetricEdit"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/metrics/{id}/add_to_predefined_metrics/": {
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_metrics_add_to_predefined_metrics",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetricDetail"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/MetricDetail"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/metrics/{id}/run_reviews/": {
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_metrics_run_reviews",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetricDetail"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/MetricDetail"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/personalities/": {
+        "get": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_personalities_list",
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {}
+            }
+          }
+        },
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_personalities_create",
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {}
+            }
+          }
+        }
+      },
+      "/test_framework/personalities/{id}/": {
+        "get": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_personalities_read",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {}
+            }
+          }
+        },
+        "put": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_personalities_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {}
+            }
+          }
+        },
+        "delete": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_personalities_delete",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "204": {
+              "description": "",
+              "content": {}
+            }
+          }
+        },
+        "patch": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_personalities_partial_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {}
+            }
+          }
+        }
+      },
+      "/test_framework/personalities/{id}/fork/": {
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_personalities_fork",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {}
+            }
+          }
+        }
+      },
+      "/test_framework/phone_number/": {
+        "get": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_phone_number_list",
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/PhoneNumber"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_phone_number_create",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PhoneNumber"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/PhoneNumber"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/phone_number/inbound/": {
+        "get": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_phone_number_inbound",
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/PhoneNumber"
+                    }
                   }
                 }
               }
@@ -2617,941 +3275,1368 @@
           }
         }
       },
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_metrics_create",
-        "requestBody": {
-          "content": {
-            "application/json": {
+      "/test_framework/phone_number/{id}/": {
+        "get": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_phone_number_read",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
               "schema": {
-                "$ref": "#/components/schemas/MetricEdit"
+                "type": "string"
               }
             }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MetricEdit"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/metrics/bulk_create/": {
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_metrics_bulk_create",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MetricDetail"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MetricDetail"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/metrics/delete_metrics/": {
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_metrics_delete_metrics",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MetricDetail"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MetricDetail"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/metrics/generate_metrics/": {
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_metrics_generate_metrics",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MetricDetail"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MetricDetail"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/metrics/{id}/": {
-      "get": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_metrics_read",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MetricDetail"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_metrics_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MetricEdit"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MetricEdit"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      },
-      "delete": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_metrics_delete",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "",
-            "content": {}
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_metrics_partial_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MetricEdit"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MetricEdit"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/metrics/{id}/add_to_predefined_metrics/": {
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_metrics_add_to_predefined_metrics",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MetricDetail"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MetricDetail"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/metrics/{id}/run_reviews/": {
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_metrics_run_reviews",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MetricDetail"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MetricDetail"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/personalities/": {
-      "get": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_personalities_list",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {}
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_personalities_create",
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {}
-          }
-        }
-      }
-    },
-    "/test_framework/personalities/{id}/": {
-      "get": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_personalities_read",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {}
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_personalities_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {}
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_personalities_delete",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "",
-            "content": {}
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_personalities_partial_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {}
-          }
-        }
-      }
-    },
-    "/test_framework/personalities/{id}/fork/": {
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_personalities_fork",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {}
-          }
-        }
-      }
-    },
-    "/test_framework/phone_number/": {
-      "get": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_phone_number_list",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
                     "$ref": "#/components/schemas/PhoneNumber"
                   }
                 }
               }
             }
           }
-        }
-      }
-    },
-    "/test_framework/phone_number/inbound/": {
-      "get": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_phone_number_inbound",
-        "responses": {
-          "200": {
-            "description": "",
+        },
+        "put": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_phone_number_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
+                  "$ref": "#/components/schemas/PhoneNumber"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
                     "$ref": "#/components/schemas/PhoneNumber"
                   }
                 }
               }
             }
-          }
-        }
-      }
-    },
-    "/test_framework/phone_number/{id}/": {
-      "get": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_phone_number_read",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
+          },
+          "x-codegen-request-body-name": "data"
+        },
+        "delete": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_phone_number_delete",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "204": {
+              "description": "",
+              "content": {}
             }
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
+        },
+        "patch": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_phone_number_partial_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PhoneNumber"
                 }
               }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_phone_number_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PhoneNumber"
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/PhoneNumber"
+                  }
+                }
               }
             }
           },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PhoneNumber"
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/predefined-metrics/": {
+        "get": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_predefined-metrics_list",
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/PredefinedMetric"
+                    }
+                  }
                 }
               }
             }
           }
         },
-        "x-codegen-request-body-name": "data"
-      },
-      "delete": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_phone_number_delete",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "",
-            "content": {}
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_phone_number_partial_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PhoneNumber"
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_predefined-metrics_create",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PredefinedMetric"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/PredefinedMetric"
+                  }
+                }
               }
             }
           },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/predefined-metrics/copy/": {
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_predefined-metrics_copy",
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PhoneNumber"
+                  "$ref": "#/components/schemas/PredefinedMetric"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/PredefinedMetric"
+                  }
                 }
               }
             }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/predefined-metrics/": {
-      "get": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_predefined-metrics_list",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/predefined-metrics/{id}/": {
+        "get": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_predefined-metrics_read",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "description": "A unique integer value identifying this predefined metric.",
+              "required": true,
+              "schema": {
+                "type": "integer"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
                     "$ref": "#/components/schemas/PredefinedMetric"
                   }
                 }
               }
             }
           }
+        },
+        "put": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_predefined-metrics_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "description": "A unique integer value identifying this predefined metric.",
+              "required": true,
+              "schema": {
+                "type": "integer"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PredefinedMetric"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/PredefinedMetric"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        },
+        "delete": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_predefined-metrics_delete",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "description": "A unique integer value identifying this predefined metric.",
+              "required": true,
+              "schema": {
+                "type": "integer"
+              }
+            }
+          ],
+          "responses": {
+            "204": {
+              "description": "",
+              "content": {}
+            }
+          }
+        },
+        "patch": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_predefined-metrics_partial_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "description": "A unique integer value identifying this predefined metric.",
+              "required": true,
+              "schema": {
+                "type": "integer"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PredefinedMetric"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/PredefinedMetric"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
         }
       },
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_predefined-metrics_create",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PredefinedMetric"
-              }
+      "/test_framework/process-message-response/": {
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "API view to process incoming message responses from VAPI.\nThis view handles the storage of incoming webhook data and updates \nthe status of runs based on the call status received in the payload.",
+          "operationId": "test_framework_process-message-response_create",
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {}
             }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PredefinedMetric"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/predefined-metrics/copy/": {
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_predefined-metrics_copy",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PredefinedMetric"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PredefinedMetric"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/predefined-metrics/{id}/": {
-      "get": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_predefined-metrics_read",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "A unique integer value identifying this predefined metric.",
-            "required": true,
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PredefinedMetric"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_predefined-metrics_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "A unique integer value identifying this predefined metric.",
-            "required": true,
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PredefinedMetric"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PredefinedMetric"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      },
-      "delete": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_predefined-metrics_delete",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "A unique integer value identifying this predefined metric.",
-            "required": true,
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "",
-            "content": {}
           }
         }
       },
-      "patch": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_predefined-metrics_partial_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "A unique integer value identifying this predefined metric.",
-            "required": true,
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
+      "/test_framework/results/": {
+        "get": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_results_list",
+          "parameters": [
+            {
+              "name": "page",
+              "in": "query",
+              "description": "A page number within the paginated result set.",
               "schema": {
-                "$ref": "#/components/schemas/PredefinedMetric"
+                "type": "integer"
+              }
+            },
+            {
+              "name": "page_size",
+              "in": "query",
+              "description": "Number of results to return per page.",
+              "schema": {
+                "type": "integer"
               }
             }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PredefinedMetric"
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "required": [
+                      "count",
+                      "results"
+                    ],
+                    "type": "object",
+                    "properties": {
+                      "count": {
+                        "type": "integer"
+                      },
+                      "next": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true
+                      },
+                      "previous": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true
+                      },
+                      "results": {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/components/schemas/ResultList"
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
           }
         },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/process-message-response/": {
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_process-message-response_create",
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {}
-          }
-        }
-      }
-    },
-    "/test_framework/results/": {
-      "get": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_results_list",
-        "parameters": [
-          {
-            "name": "page",
-            "in": "query",
-            "description": "A page number within the paginated result set.",
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "name": "page_size",
-            "in": "query",
-            "description": "Number of results to return per page.",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_results_create",
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
-                  "required": [
-                    "count",
-                    "results"
-                  ],
-                  "type": "object",
-                  "properties": {
-                    "count": {
-                      "type": "integer"
-                    },
-                    "next": {
-                      "type": "string",
-                      "format": "uri",
-                      "nullable": true
-                    },
-                    "previous": {
-                      "type": "string",
-                      "format": "uri",
-                      "nullable": true
-                    },
-                    "results": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/ResultList"
+                  "$ref": "#/components/schemas/ResultDetail"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ResultDetail"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/results/{id}/": {
+        "get": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_results_read",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ResultDetail"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "put": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_results_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResultDetail"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ResultDetail"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        },
+        "delete": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_results_delete",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "204": {
+              "description": "",
+              "content": {}
+            }
+          }
+        },
+        "patch": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_results_partial_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResultDetail"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ResultDetail"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/results/{id}/evaluate_metrics/": {
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_results_evaluate_metrics",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResultDetail"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ResultDetail"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/results/{id}/improve_prompt/": {
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_results_improve_prompt",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResultDetail"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ResultDetail"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/results/{id}/rerun/": {
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_results_rerun",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResultDetail"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ResultDetail"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/results/{id}/rerun_text/": {
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_results_rerun_text",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResultDetail"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ResultDetail"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/runs/": {
+        "get": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_runs_list",
+          "parameters": [
+            {
+              "name": "page",
+              "in": "query",
+              "description": "A page number within the paginated result set.",
+              "schema": {
+                "type": "integer"
+              }
+            },
+            {
+              "name": "page_size",
+              "in": "query",
+              "description": "Number of results to return per page.",
+              "schema": {
+                "type": "integer"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "required": [
+                      "count",
+                      "results"
+                    ],
+                    "type": "object",
+                    "properties": {
+                      "count": {
+                        "type": "integer"
+                      },
+                      "next": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true
+                      },
+                      "previous": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true
+                      },
+                      "results": {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/components/schemas/RunList"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_runs_create",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Run"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Run"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/runs/{id}/": {
+        "get": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_runs_read",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Run"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "put": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_runs_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Run"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Run"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        },
+        "delete": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_runs_delete",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "204": {
+              "description": "",
+              "content": {}
+            }
+          }
+        },
+        "patch": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_runs_partial_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Run"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Run"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/runs/{id}/end_call/": {
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_runs_end_call",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Run"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Run"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/runs/{id}/get_listen_url/": {
+        "get": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_runs_get_listen_url",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Run"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/test_framework/runs/{id}/mark_critical_scenario_wrong/": {
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_runs_mark_critical_scenario_wrong",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Run"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Run"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/runs/{id}/unmark_critical_scenario_wrong/": {
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_runs_unmark_critical_scenario_wrong",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Run"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Run"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/scenarios/": {
+        "get": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_scenarios_list",
+          "parameters": [
+            {
+              "name": "page",
+              "in": "query",
+              "description": "A page number within the paginated result set.",
+              "schema": {
+                "type": "integer"
+              }
+            },
+            {
+              "name": "page_size",
+              "in": "query",
+              "description": "Number of results to return per page.",
+              "schema": {
+                "type": "integer"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "required": [
+                      "count",
+                      "results"
+                    ],
+                    "type": "object",
+                    "properties": {
+                      "count": {
+                        "type": "integer"
+                      },
+                      "next": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true
+                      },
+                      "previous": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true
+                      },
+                      "results": {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/components/schemas/Scenario"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_scenarios_create",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Scenario"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Scenario"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/scenarios/delete_scenarios/": {
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_scenarios_delete_scenarios",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Scenario"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Scenario"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/scenarios/run_scenarios/": {
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_scenarios_run_scenarios",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Scenario"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Scenario"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/scenarios/run_scenarios_text/": {
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_scenarios_run_scenarios_text",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Scenario"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Scenario"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/scenarios/tags/": {
+        "get": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_scenarios_tags",
+          "parameters": [
+            {
+              "name": "page",
+              "in": "query",
+              "description": "A page number within the paginated result set.",
+              "schema": {
+                "type": "integer"
+              }
+            },
+            {
+              "name": "page_size",
+              "in": "query",
+              "description": "Number of results to return per page.",
+              "schema": {
+                "type": "integer"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "required": [
+                      "count",
+                      "results"
+                    ],
+                    "type": "object",
+                    "properties": {
+                      "count": {
+                        "type": "integer"
+                      },
+                      "next": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true
+                      },
+                      "previous": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true
+                      },
+                      "results": {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/components/schemas/Scenario"
+                        }
                       }
                     }
                   }
@@ -3561,1874 +4646,1231 @@
           }
         }
       },
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_results_create",
-        "requestBody": {
-          "content": {
-            "application/json": {
+      "/test_framework/scenarios/{id}/": {
+        "get": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_scenarios_read",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
               "schema": {
-                "$ref": "#/components/schemas/ResultDetail"
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Scenario"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "put": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_scenarios_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Scenario"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Scenario"
+                  }
+                }
               }
             }
           },
-          "required": true
+          "x-codegen-request-body-name": "data"
         },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ResultDetail"
-                }
+        "delete": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_scenarios_delete",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
               }
+            }
+          ],
+          "responses": {
+            "204": {
+              "description": "",
+              "content": {}
             }
           }
         },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/results/{id}/": {
-      "get": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_results_read",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
+        "patch": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_scenarios_partial_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
             }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
+          ],
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ResultDetail"
+                  "$ref": "#/components/schemas/Scenario"
                 }
               }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Scenario"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/scenarios/{id}/edit/": {
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_scenarios_edit",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Scenario"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Scenario"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/scenarios/{id}/run_scenario_demo/": {
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_scenarios_run_scenario_demo",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Scenario"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Scenario"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/scenarios/{id}/switch_phone_number/": {
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_scenarios_switch_phone_number",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Scenario"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Scenario"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/test-outbound-caller/": {
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "API view to test outbound calls. \nThis view allows users to run scenarios associated with a specific agent \nby updating the phone number in the VAPI system.",
+          "operationId": "test_framework_test-outbound-caller_create",
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {}
             }
           }
         }
       },
-      "put": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_results_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ResultDetail"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ResultDetail"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      },
-      "delete": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_results_delete",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "",
-            "content": {}
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_results_partial_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ResultDetail"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ResultDetail"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/results/{id}/evaluate_metrics/": {
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_results_evaluate_metrics",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ResultDetail"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ResultDetail"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/results/{id}/rerun/": {
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_results_rerun",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ResultDetail"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ResultDetail"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/results/{id}/rerun_text/": {
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_results_rerun_text",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ResultDetail"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ResultDetail"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/runs/": {
-      "get": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_runs_list",
-        "parameters": [
-          {
-            "name": "page",
-            "in": "query",
-            "description": "A page number within the paginated result set.",
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "name": "page_size",
-            "in": "query",
-            "description": "Number of results to return per page.",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "required": [
-                    "count",
-                    "results"
-                  ],
-                  "type": "object",
-                  "properties": {
-                    "count": {
-                      "type": "integer"
-                    },
-                    "next": {
-                      "type": "string",
-                      "format": "uri",
-                      "nullable": true
-                    },
-                    "previous": {
-                      "type": "string",
-                      "format": "uri",
-                      "nullable": true
-                    },
-                    "results": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/RunList"
-                      }
+      "/test_framework/test-sets/": {
+        "get": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_test-sets_list",
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/TestSetList"
                     }
                   }
                 }
               }
             }
           }
+        },
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_test-sets_create",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestSetDetail"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/TestSetDetail"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
         }
       },
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_runs_create",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Run"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
+      "/test_framework/test-sets/create_from_call_log/": {
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_test-sets_create_from_call_log",
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Run"
+                  "$ref": "#/components/schemas/TestSetDetail"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/TestSetDetail"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/test-sets/create_from_call_logs/": {
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_test-sets_create_from_call_logs",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestSetDetail"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/TestSetDetail"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/test-sets/create_from_run/": {
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_test-sets_create_from_run",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestSetDetail"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/TestSetDetail"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/test-sets/create_testsets/": {
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_test-sets_create_testsets",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestSetDetail"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/TestSetDetail"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/test-sets/{id}/": {
+        "get": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_test-sets_read",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/TestSetDetail"
+                  }
                 }
               }
             }
           }
         },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/runs/{id}/": {
-      "get": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_runs_read",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
+        "put": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_test-sets_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
             }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
+          ],
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Run"
+                  "$ref": "#/components/schemas/TestSetDetail"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/TestSetDetail"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        },
+        "delete": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_test-sets_delete",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "204": {
+              "description": "",
+              "content": {}
+            }
+          }
+        },
+        "patch": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_test-sets_partial_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestSetDetail"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/TestSetDetail"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/test-sets/{id}/add_metrics/": {
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_test-sets_add_metrics",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestSetDetail"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/TestSetDetail"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/test-sets/{id}/review_metrics/": {
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_test-sets_review_metrics",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestSetDetail"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/TestSetDetail"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/test-sets/{id}/voice_recording_url/": {
+        "get": {
+          "tags": [
+            "test_framework"
+          ],
+          "operationId": "test_framework_test-sets_voice_recording_url",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/TestSetDetail"
+                  }
                 }
               }
             }
           }
         }
       },
-      "put": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_runs_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Run"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Run"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      },
-      "delete": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_runs_delete",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "",
-            "content": {}
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_runs_partial_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Run"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Run"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/runs/{id}/end_call/": {
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_runs_end_call",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Run"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Run"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/runs/{id}/get_listen_url/": {
-      "get": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_runs_get_listen_url",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Run"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/test_framework/runs/{id}/mark_critical_scenario_wrong/": {
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_runs_mark_critical_scenario_wrong",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Run"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Run"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/runs/{id}/unmark_critical_scenario_wrong/": {
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_runs_unmark_critical_scenario_wrong",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Run"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Run"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/scenarios/": {
-      "get": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_scenarios_list",
-        "parameters": [
-          {
-            "name": "page",
-            "in": "query",
-            "description": "A page number within the paginated result set.",
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "name": "page_size",
-            "in": "query",
-            "description": "Number of results to return per page.",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "required": [
-                    "count",
-                    "results"
-                  ],
-                  "type": "object",
-                  "properties": {
-                    "count": {
-                      "type": "integer"
-                    },
-                    "next": {
-                      "type": "string",
-                      "format": "uri",
-                      "nullable": true
-                    },
-                    "previous": {
-                      "type": "string",
-                      "format": "uri",
-                      "nullable": true
-                    },
-                    "results": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/Scenario"
-                      }
+      "/test_framework/v1/aiagents-external/": {
+        "get": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "External API view set for managing AI agents.\nThis view set provides endpoints to create, retrieve, update, and delete \nAI agents associated with a specific organization, authenticated via API key.",
+          "operationId": "test_framework_v1_aiagents-external_list",
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/AIAgentExternal"
                     }
                   }
                 }
               }
             }
           }
-        }
-      },
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_scenarios_create",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Scenario"
-              }
-            }
-          },
-          "required": true
         },
-        "responses": {
-          "201": {
-            "description": "",
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "External API view set for managing AI agents.\nThis view set provides endpoints to create, retrieve, update, and delete \nAI agents associated with a specific organization, authenticated via API key.",
+          "operationId": "test_framework_v1_aiagents-external_create",
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Scenario"
+                  "$ref": "#/components/schemas/AIAgentExternal"
                 }
               }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/scenarios/delete_scenarios/": {
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_scenarios_delete_scenarios",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Scenario"
-              }
-            }
+            },
+            "required": true
           },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Scenario"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/scenarios/run_scenarios/": {
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_scenarios_run_scenarios",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Scenario"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Scenario"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/scenarios/run_scenarios_text/": {
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_scenarios_run_scenarios_text",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Scenario"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Scenario"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/scenarios/tags/": {
-      "get": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_scenarios_tags",
-        "parameters": [
-          {
-            "name": "page",
-            "in": "query",
-            "description": "A page number within the paginated result set.",
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "name": "page_size",
-            "in": "query",
-            "description": "Number of results to return per page.",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "required": [
-                    "count",
-                    "results"
-                  ],
-                  "type": "object",
-                  "properties": {
-                    "count": {
-                      "type": "integer"
-                    },
-                    "next": {
-                      "type": "string",
-                      "format": "uri",
-                      "nullable": true
-                    },
-                    "previous": {
-                      "type": "string",
-                      "format": "uri",
-                      "nullable": true
-                    },
-                    "results": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/Scenario"
-                      }
-                    }
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/AIAgentExternal"
                   }
                 }
               }
             }
-          }
-        }
-      }
-    },
-    "/test_framework/scenarios/{id}/": {
-      "get": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_scenarios_read",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Scenario"
-                }
-              }
-            }
-          }
+          },
+          "x-codegen-request-body-name": "data"
         }
       },
-      "put": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_scenarios_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
+      "/test_framework/v1/aiagents-external/{id}/": {
+        "get": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "External API view set for managing AI agents.\nThis view set provides endpoints to create, retrieve, update, and delete \nAI agents associated with a specific organization, authenticated via API key.",
+          "operationId": "test_framework_v1_aiagents-external_read",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
               "schema": {
-                "$ref": "#/components/schemas/Scenario"
+                "type": "string"
               }
             }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Scenario"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      },
-      "delete": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_scenarios_delete",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "",
-            "content": {}
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_scenarios_partial_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Scenario"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Scenario"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/scenarios/{id}/edit/": {
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_scenarios_edit",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Scenario"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Scenario"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/scenarios/{id}/run_scenario_demo/": {
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_scenarios_run_scenario_demo",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Scenario"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Scenario"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/scenarios/{id}/switch_phone_number/": {
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_scenarios_switch_phone_number",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Scenario"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Scenario"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/test-outbound-caller/": {
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_test-outbound-caller_create",
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {}
-          }
-        }
-      }
-    },
-    "/test_framework/test-sets/": {
-      "get": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_test-sets_list",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/TestSetList"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_test-sets_create",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/TestSetDetail"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TestSetDetail"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/test-sets/create_from_call_log/": {
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_test-sets_create_from_call_log",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/TestSetDetail"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TestSetDetail"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/test-sets/create_from_call_logs/": {
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_test-sets_create_from_call_logs",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/TestSetDetail"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TestSetDetail"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/test-sets/create_from_run/": {
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_test-sets_create_from_run",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/TestSetDetail"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TestSetDetail"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/test-sets/create_testsets/": {
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_test-sets_create_testsets",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/TestSetDetail"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TestSetDetail"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/test-sets/{id}/": {
-      "get": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_test-sets_read",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TestSetDetail"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_test-sets_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/TestSetDetail"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TestSetDetail"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      },
-      "delete": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_test-sets_delete",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "",
-            "content": {}
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_test-sets_partial_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/TestSetDetail"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TestSetDetail"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/test-sets/{id}/add_metrics/": {
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_test-sets_add_metrics",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/TestSetDetail"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TestSetDetail"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/test-sets/{id}/review_metrics/": {
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_test-sets_review_metrics",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/TestSetDetail"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TestSetDetail"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/test-sets/{id}/voice_recording_url/": {
-      "get": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_test-sets_voice_recording_url",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TestSetDetail"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/test_framework/v1/aiagents-external/": {
-      "get": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_v1_aiagents-external_list",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
                     "$ref": "#/components/schemas/AIAgentExternal"
                   }
                 }
               }
             }
           }
+        },
+        "put": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "External API view set for managing AI agents.\nThis view set provides endpoints to create, retrieve, update, and delete \nAI agents associated with a specific organization, authenticated via API key.",
+          "operationId": "test_framework_v1_aiagents-external_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AIAgentExternal"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/AIAgentExternal"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        },
+        "delete": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "External API view set for managing AI agents.\nThis view set provides endpoints to create, retrieve, update, and delete \nAI agents associated with a specific organization, authenticated via API key.",
+          "operationId": "test_framework_v1_aiagents-external_delete",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "204": {
+              "description": "",
+              "content": {}
+            }
+          }
+        },
+        "patch": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "External API view set for managing AI agents.\nThis view set provides endpoints to create, retrieve, update, and delete \nAI agents associated with a specific organization, authenticated via API key.",
+          "operationId": "test_framework_v1_aiagents-external_partial_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AIAgentExternal"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/AIAgentExternal"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
         }
       },
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_v1_aiagents-external_create",
-        "requestBody": {
-          "content": {
-            "application/json": {
+      "/test_framework/v1/critical-metric-scenarios-external/{id}/": {
+        "put": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "External API view set for managing critical metric scenarios.\nThis view set provides endpoints to update and manage critical metric \nscenarios associated with a specific organization.",
+          "operationId": "test_framework_v1_critical-metric-scenarios-external_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
               "schema": {
-                "$ref": "#/components/schemas/AIAgentExternal"
+                "type": "string"
               }
             }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AIAgentExternal"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/v1/aiagents-external/{id}/": {
-      "get": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_v1_aiagents-external_read",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AIAgentExternal"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_v1_aiagents-external_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AIAgentExternal"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AIAgentExternal"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      },
-      "delete": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_v1_aiagents-external_delete",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "",
-            "content": {}
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_v1_aiagents-external_partial_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AIAgentExternal"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AIAgentExternal"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/v1/critical-metric-scenarios-external/{id}/": {
-      "put": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_v1_critical-metric-scenarios-external_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CriticalMetricScenario"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
+          ],
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CriticalMetricScenario"
                 }
               }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      },
-      "patch": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_v1_critical-metric-scenarios-external_partial_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CriticalMetricScenario"
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/CriticalMetricScenario"
+                  }
+                }
               }
             }
           },
-          "required": true
+          "x-codegen-request-body-name": "data"
         },
-        "responses": {
-          "200": {
-            "description": "",
+        "patch": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "External API view set for managing critical metric scenarios.\nThis view set provides endpoints to update and manage critical metric \nscenarios associated with a specific organization.",
+          "operationId": "test_framework_v1_critical-metric-scenarios-external_partial_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CriticalMetricScenario"
                 }
               }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/CriticalMetricScenario"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/v1/metrics-external/": {
+        "get": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "External API view set for managing metrics.\nThis view set provides endpoints to create, retrieve, update, and delete \nmetrics associated with AI agents within a specific organization.",
+          "operationId": "test_framework_v1_metrics-external_list",
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/MetricList"
+                    }
+                  }
+                }
+              }
             }
           }
         },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/v1/metrics-external/": {
-      "get": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_v1_metrics-external_list",
-        "responses": {
-          "200": {
-            "description": "",
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "External API view set for managing metrics.\nThis view set provides endpoints to create, retrieve, update, and delete \nmetrics associated with AI agents within a specific organization.",
+          "operationId": "test_framework_v1_metrics-external_create",
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/MetricList"
+                  "$ref": "#/components/schemas/MetricEdit"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/MetricEdit"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/v1/metrics-external/bulk_create/": {
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "External API view set for managing metrics.\nThis view set provides endpoints to create, retrieve, update, and delete \nmetrics associated with AI agents within a specific organization.",
+          "operationId": "test_framework_v1_metrics-external_bulk_create",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetricDetailExternal"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/MetricDetailExternal"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/v1/metrics-external/generate_metrics/": {
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "External API view set for managing metrics.\nThis view set provides endpoints to create, retrieve, update, and delete \nmetrics associated with AI agents within a specific organization.",
+          "operationId": "test_framework_v1_metrics-external_generate_metrics",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetricDetailExternal"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/MetricDetailExternal"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/v1/metrics-external/{id}/": {
+        "get": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "External API view set for managing metrics.\nThis view set provides endpoints to create, retrieve, update, and delete \nmetrics associated with AI agents within a specific organization.",
+          "operationId": "test_framework_v1_metrics-external_read",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/MetricDetailExternal"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "put": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "External API view set for managing metrics.\nThis view set provides endpoints to create, retrieve, update, and delete \nmetrics associated with AI agents within a specific organization.",
+          "operationId": "test_framework_v1_metrics-external_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetricEdit"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/MetricEdit"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        },
+        "delete": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "External API view set for managing metrics.\nThis view set provides endpoints to create, retrieve, update, and delete \nmetrics associated with AI agents within a specific organization.",
+          "operationId": "test_framework_v1_metrics-external_delete",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "204": {
+              "description": "",
+              "content": {}
+            }
+          }
+        },
+        "patch": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "External API view set for managing metrics.\nThis view set provides endpoints to create, retrieve, update, and delete \nmetrics associated with AI agents within a specific organization.",
+          "operationId": "test_framework_v1_metrics-external_partial_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetricEdit"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/MetricEdit"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/v1/personalities-external/": {
+        "get": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "External API view set for retrieving personalities.\nThis view set allows users to access predefined personalities that are \nnot associated with any organization.",
+          "operationId": "test_framework_v1_personalities-external_list",
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/PersonalityExternal"
+                    }
                   }
                 }
               }
@@ -5436,242 +5878,30 @@
           }
         }
       },
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_v1_metrics-external_create",
-        "requestBody": {
-          "content": {
-            "application/json": {
+      "/test_framework/v1/personalities-external/{id}/": {
+        "get": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "External API view set for retrieving personalities.\nThis view set allows users to access predefined personalities that are \nnot associated with any organization.",
+          "operationId": "test_framework_v1_personalities-external_read",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "description": "A unique integer value identifying this personality.",
+              "required": true,
               "schema": {
-                "$ref": "#/components/schemas/MetricEdit"
+                "type": "integer"
               }
             }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MetricEdit"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/v1/metrics-external/bulk_create/": {
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_v1_metrics-external_bulk_create",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MetricDetailExternal"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MetricDetailExternal"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/v1/metrics-external/generate_metrics/": {
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_v1_metrics-external_generate_metrics",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MetricDetailExternal"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MetricDetailExternal"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/v1/metrics-external/{id}/": {
-      "get": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_v1_metrics-external_read",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MetricDetailExternal"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_v1_metrics-external_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MetricEdit"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MetricEdit"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      },
-      "delete": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_v1_metrics-external_delete",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "",
-            "content": {}
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_v1_metrics-external_partial_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MetricEdit"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MetricEdit"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/v1/personalities-external/": {
-      "get": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_v1_personalities-external_list",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
                     "$ref": "#/components/schemas/PersonalityExternal"
                   }
                 }
@@ -5679,54 +5909,78 @@
             }
           }
         }
-      }
-    },
-    "/test_framework/v1/personalities-external/{id}/": {
-      "get": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_v1_personalities-external_read",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "A unique integer value identifying this personality.",
-            "required": true,
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PersonalityExternal"
+      },
+      "/test_framework/v1/phone-numbers-external/": {
+        "get": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "External API view set for managing phone numbers.\nThis view set provides endpoints to list and manage phone numbers \nassociated with a specific organization.",
+          "operationId": "test_framework_v1_phone-numbers-external_list",
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/PhoneNumber"
+                    }
+                  }
                 }
               }
             }
           }
-        }
-      }
-    },
-    "/test_framework/v1/phone-numbers-external/": {
-      "get": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_v1_phone-numbers-external_list",
-        "responses": {
-          "200": {
-            "description": "",
+        },
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "External API view set for managing phone numbers.\nThis view set provides endpoints to list and manage phone numbers \nassociated with a specific organization.",
+          "operationId": "test_framework_v1_phone-numbers-external_create",
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
+                  "$ref": "#/components/schemas/PhoneNumber"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
                     "$ref": "#/components/schemas/PhoneNumber"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/v1/phone-numbers-external/inbound/": {
+        "get": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "External API view set for managing phone numbers.\nThis view set provides endpoints to list and manage phone numbers \nassociated with a specific organization.",
+          "operationId": "test_framework_v1_phone-numbers-external_inbound",
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/PhoneNumber"
+                    }
                   }
                 }
               }
@@ -5734,203 +5988,188 @@
           }
         }
       },
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_v1_phone-numbers-external_create",
-        "requestBody": {
-          "content": {
-            "application/json": {
+      "/test_framework/v1/phone-numbers-external/{id}/": {
+        "get": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "External API view set for managing phone numbers.\nThis view set provides endpoints to list and manage phone numbers \nassociated with a specific organization.",
+          "operationId": "test_framework_v1_phone-numbers-external_read",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
               "schema": {
-                "$ref": "#/components/schemas/PhoneNumber"
+                "type": "string"
               }
             }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PhoneNumber"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/v1/phone-numbers-external/inbound/": {
-      "get": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_v1_phone-numbers-external_inbound",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
                     "$ref": "#/components/schemas/PhoneNumber"
                   }
                 }
               }
             }
           }
-        }
-      }
-    },
-    "/test_framework/v1/phone-numbers-external/{id}/": {
-      "get": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_v1_phone-numbers-external_read",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
+        },
+        "put": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "External API view set for managing phone numbers.\nThis view set provides endpoints to list and manage phone numbers \nassociated with a specific organization.",
+          "operationId": "test_framework_v1_phone-numbers-external_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
             }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
+          ],
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PhoneNumber"
                 }
               }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_v1_phone-numbers-external_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PhoneNumber"
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/PhoneNumber"
+                  }
+                }
               }
             }
           },
-          "required": true
+          "x-codegen-request-body-name": "data"
         },
-        "responses": {
-          "200": {
-            "description": "",
+        "delete": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "External API view set for managing phone numbers.\nThis view set provides endpoints to list and manage phone numbers \nassociated with a specific organization.",
+          "operationId": "test_framework_v1_phone-numbers-external_delete",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "204": {
+              "description": "",
+              "content": {}
+            }
+          }
+        },
+        "patch": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "External API view set for managing phone numbers.\nThis view set provides endpoints to list and manage phone numbers \nassociated with a specific organization.",
+          "operationId": "test_framework_v1_phone-numbers-external_partial_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PhoneNumber"
                 }
               }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      },
-      "delete": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_v1_phone-numbers-external_delete",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "",
-            "content": {}
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_v1_phone-numbers-external_partial_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PhoneNumber"
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/PhoneNumber"
+                  }
+                }
               }
             }
           },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PhoneNumber"
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/v1/predefined-metrics-external/": {
+        "get": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "External API view set for retrieving predefined metrics.\nThis view set allows users to access predefined metrics that are \nnot associated with any organization.",
+          "operationId": "test_framework_v1_predefined-metrics-external_list",
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/PredefinedMetricExternal"
+                    }
+                  }
                 }
               }
             }
           }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/v1/predefined-metrics-external/": {
-      "get": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_v1_predefined-metrics-external_list",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
+        }
+      },
+      "/test_framework/v1/predefined-metrics-external/{id}/": {
+        "get": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "External API view set for retrieving predefined metrics.\nThis view set allows users to access predefined metrics that are \nnot associated with any organization.",
+          "operationId": "test_framework_v1_predefined-metrics-external_read",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "description": "A unique integer value identifying this predefined metric.",
+              "required": true,
+              "schema": {
+                "type": "integer"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
                     "$ref": "#/components/schemas/PredefinedMetricExternal"
                   }
                 }
@@ -5938,345 +6177,668 @@
             }
           }
         }
-      }
-    },
-    "/test_framework/v1/predefined-metrics-external/{id}/": {
-      "get": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_v1_predefined-metrics-external_read",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "A unique integer value identifying this predefined metric.",
-            "required": true,
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PredefinedMetricExternal"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/test_framework/v1/results-external/": {
-      "get": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_v1_results-external_list",
-        "parameters": [
-          {
-            "name": "page",
-            "in": "query",
-            "description": "A page number within the paginated result set.",
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "name": "page_size",
-            "in": "query",
-            "description": "Number of results to return per page.",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "required": [
-                    "count",
-                    "results"
-                  ],
-                  "type": "object",
-                  "properties": {
-                    "count": {
-                      "type": "integer"
-                    },
-                    "next": {
-                      "type": "string",
-                      "format": "uri",
-                      "nullable": true
-                    },
-                    "previous": {
-                      "type": "string",
-                      "format": "uri",
-                      "nullable": true
-                    },
-                    "results": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/ResultExternal"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/test_framework/v1/results-external/result_ids/": {
-      "get": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_v1_results-external_result_ids",
-        "parameters": [
-          {
-            "name": "page",
-            "in": "query",
-            "description": "A page number within the paginated result set.",
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "name": "page_size",
-            "in": "query",
-            "description": "Number of results to return per page.",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "required": [
-                    "count",
-                    "results"
-                  ],
-                  "type": "object",
-                  "properties": {
-                    "count": {
-                      "type": "integer"
-                    },
-                    "next": {
-                      "type": "string",
-                      "format": "uri",
-                      "nullable": true
-                    },
-                    "previous": {
-                      "type": "string",
-                      "format": "uri",
-                      "nullable": true
-                    },
-                    "results": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/ResultExternal"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/test_framework/v1/results-external/{id}/": {
-      "get": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_v1_results-external_read",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ResultDetailExternal"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/test_framework/v1/results-external/{id}/evaluate_metrics/": {
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_v1_results-external_evaluate_metrics",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
+      },
+      "/test_framework/v1/results-external/": {
+        "get": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "External API view set for retrieving results.\nThis view set allows users to access results associated with their \norganization, providing endpoints to list and retrieve detailed results.",
+          "operationId": "test_framework_v1_results-external_list",
+          "parameters": [
+            {
+              "name": "page",
+              "in": "query",
+              "description": "A page number within the paginated result set.",
               "schema": {
-                "$ref": "#/components/schemas/ResultExternal"
+                "type": "integer"
+              }
+            },
+            {
+              "name": "page_size",
+              "in": "query",
+              "description": "Number of results to return per page.",
+              "schema": {
+                "type": "integer"
               }
             }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "required": [
+                      "count",
+                      "results"
+                    ],
+                    "type": "object",
+                    "properties": {
+                      "count": {
+                        "type": "integer"
+                      },
+                      "next": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true
+                      },
+                      "previous": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true
+                      },
+                      "results": {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/components/schemas/ResultExternal"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/test_framework/v1/results-external/result_ids/": {
+        "get": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "External API view set for retrieving results.\nThis view set allows users to access results associated with their \norganization, providing endpoints to list and retrieve detailed results.",
+          "operationId": "test_framework_v1_results-external_result_ids",
+          "parameters": [
+            {
+              "name": "page",
+              "in": "query",
+              "description": "A page number within the paginated result set.",
+              "schema": {
+                "type": "integer"
+              }
+            },
+            {
+              "name": "page_size",
+              "in": "query",
+              "description": "Number of results to return per page.",
+              "schema": {
+                "type": "integer"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "required": [
+                      "count",
+                      "results"
+                    ],
+                    "type": "object",
+                    "properties": {
+                      "count": {
+                        "type": "integer"
+                      },
+                      "next": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true
+                      },
+                      "previous": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true
+                      },
+                      "results": {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/components/schemas/ResultExternal"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/test_framework/v1/results-external/{id}/": {
+        "get": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "External API view set for retrieving results.\nThis view set allows users to access results associated with their \norganization, providing endpoints to list and retrieve detailed results.",
+          "operationId": "test_framework_v1_results-external_read",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ResultDetailExternal"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/test_framework/v1/results-external/{id}/evaluate_metrics/": {
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "External API view set for retrieving results.\nThis view set allows users to access results associated with their \norganization, providing endpoints to list and retrieve detailed results.",
+          "operationId": "test_framework_v1_results-external_evaluate_metrics",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ResultExternal"
                 }
               }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/v1/results-external/{id}/rerun/": {
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_v1_results-external_rerun",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ResultExternal"
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ResultExternal"
+                  }
+                }
               }
             }
           },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/v1/results-external/{id}/rerun/": {
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "External API view set for retrieving results.\nThis view set allows users to access results associated with their \norganization, providing endpoints to list and retrieve detailed results.",
+          "operationId": "test_framework_v1_results-external_rerun",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ResultExternal"
                 }
               }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ResultExternal"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/v1/runs-external/bulk/": {
+        "get": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "API view for retrieving detailed information about runs.\nThis view allows users to fetch details of specific runs associated \nwith their organization based on provided run IDs.",
+          "operationId": "test_framework_v1_runs-external_bulk_list",
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {}
+            }
+          }
+        }
+      },
+      "/test_framework/v1/scenarios-external/": {
+        "get": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "External API view set for managing scenarios.\nThis view set provides endpoints to list, create, and manage scenarios \nassociated with a specific organization, authenticated via API key.",
+          "operationId": "test_framework_v1_scenarios-external_list",
+          "parameters": [
+            {
+              "name": "page",
+              "in": "query",
+              "description": "A page number within the paginated result set.",
+              "schema": {
+                "type": "integer"
+              }
+            },
+            {
+              "name": "page_size",
+              "in": "query",
+              "description": "Number of results to return per page.",
+              "schema": {
+                "type": "integer"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "required": [
+                      "count",
+                      "results"
+                    ],
+                    "type": "object",
+                    "properties": {
+                      "count": {
+                        "type": "integer"
+                      },
+                      "next": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true
+                      },
+                      "previous": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true
+                      },
+                      "results": {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/components/schemas/ScenarioExternal"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
             }
           }
         },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/v1/runs-external/bulk/": {
-      "get": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_v1_runs-external_bulk_list",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {}
-          }
-        }
-      }
-    },
-    "/test_framework/v1/scenarios-external/": {
-      "get": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_v1_scenarios-external_list",
-        "parameters": [
-          {
-            "name": "page",
-            "in": "query",
-            "description": "A page number within the paginated result set.",
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "name": "page_size",
-            "in": "query",
-            "description": "Number of results to return per page.",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "External API view set for managing scenarios.\nThis view set provides endpoints to list, create, and manage scenarios \nassociated with a specific organization, authenticated via API key.",
+          "operationId": "test_framework_v1_scenarios-external_create",
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
-                  "required": [
-                    "count",
-                    "results"
-                  ],
-                  "type": "object",
-                  "properties": {
-                    "count": {
-                      "type": "integer"
-                    },
-                    "next": {
-                      "type": "string",
-                      "format": "uri",
-                      "nullable": true
-                    },
-                    "previous": {
-                      "type": "string",
-                      "format": "uri",
-                      "nullable": true
-                    },
-                    "results": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/ScenarioExternal"
-                      }
+                  "$ref": "#/components/schemas/Scenario"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Scenario"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/v1/scenarios-external/generate/": {
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "External API view set for managing scenarios.\nThis view set provides endpoints to list, create, and manage scenarios \nassociated with a specific organization, authenticated via API key.",
+          "operationId": "test_framework_v1_scenarios-external_generate_scenarios",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Scenario"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Scenario"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/v1/scenarios-external/run_scenarios/": {
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "External API view set for managing scenarios.\nThis view set provides endpoints to list, create, and manage scenarios \nassociated with a specific organization, authenticated via API key.",
+          "operationId": "test_framework_v1_scenarios-external_run_scenarios",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Scenario"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Scenario"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/v1/scenarios-external/run_scenarios_jotform/": {
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "External API view set for managing scenarios.\nThis view set provides endpoints to list, create, and manage scenarios \nassociated with a specific organization, authenticated via API key.",
+          "operationId": "test_framework_v1_scenarios-external_run_scenarios_jotform",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Scenario"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Scenario"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/v1/scenarios-external/run_scenarios_text/": {
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "External API view set for managing scenarios.\nThis view set provides endpoints to list, create, and manage scenarios \nassociated with a specific organization, authenticated via API key.",
+          "operationId": "test_framework_v1_scenarios-external_run_scenarios_text",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Scenario"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Scenario"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/v1/scenarios-external/run_scenarios_with_websockets/": {
+        "post": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "External API view set for managing scenarios.\nThis view set provides endpoints to list, create, and manage scenarios \nassociated with a specific organization, authenticated via API key.",
+          "operationId": "test_framework_v1_scenarios-external_run_scenarios_with_websockets",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Scenario"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Scenario"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/test_framework/v1/scenarios-external/{id}/": {
+        "get": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "External API view set for managing scenarios.\nThis view set provides endpoints to list, create, and manage scenarios \nassociated with a specific organization, authenticated via API key.",
+          "operationId": "test_framework_v1_scenarios-external_read",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Scenario"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "put": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "External API view set for managing scenarios.\nThis view set provides endpoints to list, create, and manage scenarios \nassociated with a specific organization, authenticated via API key.",
+          "operationId": "test_framework_v1_scenarios-external_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Scenario"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Scenario"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        },
+        "delete": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "External API view set for managing scenarios.\nThis view set provides endpoints to list, create, and manage scenarios \nassociated with a specific organization, authenticated via API key.",
+          "operationId": "test_framework_v1_scenarios-external_delete",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "204": {
+              "description": "",
+              "content": {}
+            }
+          }
+        },
+        "patch": {
+          "tags": [
+            "test_framework"
+          ],
+          "description": "External API view set for managing scenarios.\nThis view set provides endpoints to list, create, and manage scenarios \nassociated with a specific organization, authenticated via API key.",
+          "operationId": "test_framework_v1_scenarios-external_partial_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Scenario"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Scenario"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/user/api/v1/user-api-key/": {
+        "get": {
+          "tags": [
+            "user"
+          ],
+          "operationId": "user_api_v1_user-api-key_list",
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/UserAPIKey"
                     }
                   }
                 }
@@ -6285,304 +6847,28 @@
           }
         }
       },
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_v1_scenarios-external_create",
-        "requestBody": {
-          "content": {
-            "application/json": {
+      "/user/api/v1/user-api-key/{id}/": {
+        "get": {
+          "tags": [
+            "user"
+          ],
+          "operationId": "user_api_v1_user-api-key_read",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
               "schema": {
-                "$ref": "#/components/schemas/Scenario"
+                "type": "string"
               }
             }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Scenario"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/v1/scenarios-external/generate/": {
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_v1_scenarios-external_generate_scenarios",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Scenario"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Scenario"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/v1/scenarios-external/run_scenarios/": {
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_v1_scenarios-external_run_scenarios",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Scenario"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Scenario"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/v1/scenarios-external/run_scenarios_text/": {
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_v1_scenarios-external_run_scenarios_text",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Scenario"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Scenario"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/v1/scenarios-external/run_scenarios_with_websockets/": {
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_v1_scenarios-external_run_scenarios_with_websockets",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Scenario"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Scenario"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/test_framework/v1/scenarios-external/{id}/": {
-      "get": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_v1_scenarios-external_read",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Scenario"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_v1_scenarios-external_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Scenario"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Scenario"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      },
-      "delete": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_v1_scenarios-external_delete",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "",
-            "content": {}
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_v1_scenarios-external_partial_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Scenario"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Scenario"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/user/api/v1/user-api-key/": {
-      "get": {
-        "tags": [
-          "user"
-        ],
-        "operationId": "user_api_v1_user-api-key_list",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
                     "$ref": "#/components/schemas/UserAPIKey"
                   }
                 }
@@ -6590,53 +6876,75 @@
             }
           }
         }
-      }
-    },
-    "/user/api/v1/user-api-key/{id}/": {
-      "get": {
-        "tags": [
-          "user"
-        ],
-        "operationId": "user_api_v1_user-api-key_read",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserAPIKey"
+      },
+      "/user/invites/": {
+        "get": {
+          "tags": [
+            "user"
+          ],
+          "operationId": "user_invites_list",
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Invite"
+                    }
+                  }
                 }
               }
             }
           }
-        }
-      }
-    },
-    "/user/invites/": {
-      "get": {
-        "tags": [
-          "user"
-        ],
-        "operationId": "user_invites_list",
-        "responses": {
-          "200": {
-            "description": "",
+        },
+        "post": {
+          "tags": [
+            "user"
+          ],
+          "operationId": "user_invites_create",
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
+                  "$ref": "#/components/schemas/Invite"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
                     "$ref": "#/components/schemas/Invite"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/user/invites/my_invites/": {
+        "get": {
+          "tags": [
+            "user"
+          ],
+          "operationId": "user_invites_my_invites",
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Invite"
+                    }
                   }
                 }
               }
@@ -6644,483 +6952,643 @@
           }
         }
       },
-      "post": {
-        "tags": [
-          "user"
-        ],
-        "operationId": "user_invites_create",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Invite"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
+      "/user/invites/send_invites/": {
+        "post": {
+          "tags": [
+            "user"
+          ],
+          "operationId": "user_invites_send_invites",
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Invite"
                 }
               }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Invite"
+                  }
+                }
+              }
             }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/user/invites/my_invites/": {
-      "get": {
-        "tags": [
-          "user"
-        ],
-        "operationId": "user_invites_my_invites",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/user/invites/{id}/": {
+        "get": {
+          "tags": [
+            "user"
+          ],
+          "operationId": "user_invites_read",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
                     "$ref": "#/components/schemas/Invite"
                   }
                 }
               }
             }
           }
-        }
-      }
-    },
-    "/user/invites/send_invites/": {
-      "post": {
-        "tags": [
-          "user"
-        ],
-        "operationId": "user_invites_send_invites",
-        "requestBody": {
-          "content": {
-            "application/json": {
+        },
+        "put": {
+          "tags": [
+            "user"
+          ],
+          "operationId": "user_invites_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
               "schema": {
-                "$ref": "#/components/schemas/Invite"
+                "type": "string"
               }
             }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
+          ],
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Invite"
                 }
               }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Invite"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        },
+        "delete": {
+          "tags": [
+            "user"
+          ],
+          "operationId": "user_invites_delete",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "204": {
+              "description": "",
+              "content": {}
             }
           }
         },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/user/invites/{id}/": {
-      "get": {
-        "tags": [
-          "user"
-        ],
-        "operationId": "user_invites_read",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
+        "patch": {
+          "tags": [
+            "user"
+          ],
+          "operationId": "user_invites_partial_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
             }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
+          ],
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Invite"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Invite"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/user/invites/{id}/accept_invite/": {
+        "post": {
+          "tags": [
+            "user"
+          ],
+          "operationId": "user_invites_accept_invite",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Invite"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Invite"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/user/invites/{id}/reject_invite/": {
+        "post": {
+          "tags": [
+            "user"
+          ],
+          "operationId": "user_invites_reject_invite",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Invite"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Invite"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/user/is-active/": {
+        "get": {
+          "tags": [
+            "user"
+          ],
+          "operationId": "user_is-active_list",
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {}
+            }
+          }
+        }
+      },
+      "/user/memberships/": {
+        "get": {
+          "tags": [
+            "user"
+          ],
+          "operationId": "user_memberships_list",
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/UserMembership"
+                    }
+                  }
                 }
               }
             }
           }
         }
       },
-      "put": {
-        "tags": [
-          "user"
-        ],
-        "operationId": "user_invites_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
+      "/user/memberships/{id}/": {
+        "get": {
+          "tags": [
+            "user"
+          ],
+          "operationId": "user_memberships_read",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
               "schema": {
-                "$ref": "#/components/schemas/Invite"
+                "type": "string"
               }
             }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Invite"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      },
-      "delete": {
-        "tags": [
-          "user"
-        ],
-        "operationId": "user_invites_delete",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "",
-            "content": {}
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "user"
-        ],
-        "operationId": "user_invites_partial_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Invite"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Invite"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/user/invites/{id}/accept_invite/": {
-      "post": {
-        "tags": [
-          "user"
-        ],
-        "operationId": "user_invites_accept_invite",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Invite"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Invite"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/user/invites/{id}/reject_invite/": {
-      "post": {
-        "tags": [
-          "user"
-        ],
-        "operationId": "user_invites_reject_invite",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Invite"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Invite"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/user/is-active/": {
-      "get": {
-        "tags": [
-          "user"
-        ],
-        "operationId": "user_is-active_list",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {}
-          }
-        }
-      }
-    },
-    "/user/memberships/": {
-      "get": {
-        "tags": [
-          "user"
-        ],
-        "operationId": "user_memberships_list",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
                     "$ref": "#/components/schemas/UserMembership"
                   }
                 }
               }
             }
           }
-        }
-      }
-    },
-    "/user/memberships/{id}/": {
-      "get": {
-        "tags": [
-          "user"
-        ],
-        "operationId": "user_memberships_read",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
+        },
+        "put": {
+          "tags": [
+            "user"
+          ],
+          "operationId": "user_memberships_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
             }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
+          ],
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/UserMembership"
                 }
               }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "user"
-        ],
-        "operationId": "user_memberships_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UserMembership"
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/UserMembership"
+                  }
+                }
               }
             }
           },
-          "required": true
+          "x-codegen-request-body-name": "data"
         },
-        "responses": {
-          "200": {
-            "description": "",
+        "delete": {
+          "tags": [
+            "user"
+          ],
+          "operationId": "user_memberships_delete",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "204": {
+              "description": "",
+              "content": {}
+            }
+          }
+        },
+        "patch": {
+          "tags": [
+            "user"
+          ],
+          "operationId": "user_memberships_partial_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/UserMembership"
                 }
               }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      },
-      "delete": {
-        "tags": [
-          "user"
-        ],
-        "operationId": "user_memberships_delete",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "",
-            "content": {}
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "user"
-        ],
-        "operationId": "user_memberships_partial_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UserMembership"
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/UserMembership"
+                  }
+                }
               }
             }
           },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserMembership"
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/user/organizations/": {
+        "get": {
+          "tags": [
+            "user"
+          ],
+          "operationId": "user_organizations_list",
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Organization"
+                    }
+                  }
                 }
               }
             }
           }
         },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/user/organizations/": {
-      "get": {
-        "tags": [
-          "user"
-        ],
-        "operationId": "user_organizations_list",
-        "responses": {
-          "200": {
-            "description": "",
+        "post": {
+          "tags": [
+            "user"
+          ],
+          "operationId": "user_organizations_create",
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
+                  "$ref": "#/components/schemas/Organization"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Organization"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/user/organizations/overview/critical-categories/": {
+        "get": {
+          "tags": [
+            "user"
+          ],
+          "operationId": "user_organizations_overview_overview_critical_categories",
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Organization"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/user/organizations/{id}/": {
+        "get": {
+          "tags": [
+            "user"
+          ],
+          "operationId": "user_organizations_read",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Organization"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "put": {
+          "tags": [
+            "user"
+          ],
+          "operationId": "user_organizations_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Organization"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Organization"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        },
+        "delete": {
+          "tags": [
+            "user"
+          ],
+          "operationId": "user_organizations_delete",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "204": {
+              "description": "",
+              "content": {}
+            }
+          }
+        },
+        "patch": {
+          "tags": [
+            "user"
+          ],
+          "operationId": "user_organizations_partial_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Organization"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Organization"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/user/organizations/{id}/overview/": {
+        "get": {
+          "tags": [
+            "user"
+          ],
+          "operationId": "user_organizations_overview",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
                     "$ref": "#/components/schemas/Organization"
                   }
                 }
@@ -7129,50 +7597,28 @@
           }
         }
       },
-      "post": {
-        "tags": [
-          "user"
-        ],
-        "operationId": "user_organizations_create",
-        "requestBody": {
-          "content": {
-            "application/json": {
+      "/user/organizations/{id}/overview/agents/": {
+        "get": {
+          "tags": [
+            "user"
+          ],
+          "operationId": "user_organizations_overview_overview_agents",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
               "schema": {
-                "$ref": "#/components/schemas/Organization"
+                "type": "string"
               }
             }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Organization"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/user/organizations/overview/critical-categories/": {
-      "get": {
-        "tags": [
-          "user"
-        ],
-        "operationId": "user_organizations_overview_overview_critical_categories",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
                     "$ref": "#/components/schemas/Organization"
                   }
                 }
@@ -7180,4141 +7626,4027 @@
             }
           }
         }
-      }
-    },
-    "/user/organizations/{id}/": {
-      "get": {
-        "tags": [
-          "user"
-        ],
-        "operationId": "user_organizations_read",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Organization"
-                }
-              }
-            }
-          }
-        }
       },
-      "put": {
-        "tags": [
-          "user"
-        ],
-        "operationId": "user_organizations_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Organization"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Organization"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      },
-      "delete": {
-        "tags": [
-          "user"
-        ],
-        "operationId": "user_organizations_delete",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "",
-            "content": {}
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "user"
-        ],
-        "operationId": "user_organizations_partial_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Organization"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Organization"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/user/organizations/{id}/overview/": {
-      "get": {
-        "tags": [
-          "user"
-        ],
-        "operationId": "user_organizations_overview",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Organization"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/user/organizations/{id}/overview/agents/": {
-      "get": {
-        "tags": [
-          "user"
-        ],
-        "operationId": "user_organizations_overview_overview_agents",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Organization"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/user/provider-credentials/": {
-      "get": {
-        "tags": [
-          "user"
-        ],
-        "operationId": "user_provider-credentials_list",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ProviderCredentialList"
+      "/user/provider-credentials/": {
+        "get": {
+          "tags": [
+            "user"
+          ],
+          "operationId": "user_provider-credentials_list",
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/ProviderCredentialList"
+                    }
                   }
                 }
               }
             }
           }
+        },
+        "post": {
+          "tags": [
+            "user"
+          ],
+          "operationId": "user_provider-credentials_create",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderCredentialDetail"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProviderCredentialDetail"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
         }
       },
-      "post": {
-        "tags": [
-          "user"
-        ],
-        "operationId": "user_provider-credentials_create",
-        "requestBody": {
-          "content": {
-            "application/json": {
+      "/user/provider-credentials/{id}/": {
+        "get": {
+          "tags": [
+            "user"
+          ],
+          "operationId": "user_provider-credentials_read",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
               "schema": {
-                "$ref": "#/components/schemas/ProviderCredentialDetail"
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProviderCredentialDetail"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "put": {
+          "tags": [
+            "user"
+          ],
+          "operationId": "user_provider-credentials_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderCredentialDetail"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProviderCredentialDetail"
+                  }
+                }
               }
             }
           },
-          "required": true
+          "x-codegen-request-body-name": "data"
         },
-        "responses": {
-          "201": {
-            "description": "",
+        "delete": {
+          "tags": [
+            "user"
+          ],
+          "operationId": "user_provider-credentials_delete",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "204": {
+              "description": "",
+              "content": {}
+            }
+          }
+        },
+        "patch": {
+          "tags": [
+            "user"
+          ],
+          "operationId": "user_provider-credentials_partial_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ProviderCredentialDetail"
                 }
               }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/user/provider-credentials/{id}/": {
-      "get": {
-        "tags": [
-          "user"
-        ],
-        "operationId": "user_provider-credentials_read",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProviderCredentialDetail"
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProviderCredentialDetail"
+                  }
                 }
               }
             }
-          }
+          },
+          "x-codegen-request-body-name": "data"
         }
       },
-      "put": {
-        "tags": [
-          "user"
-        ],
-        "operationId": "user_provider-credentials_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ProviderCredentialDetail"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProviderCredentialDetail"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      },
-      "delete": {
-        "tags": [
-          "user"
-        ],
-        "operationId": "user_provider-credentials_delete",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "",
-            "content": {}
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "user"
-        ],
-        "operationId": "user_provider-credentials_partial_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ProviderCredentialDetail"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProviderCredentialDetail"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/user/v1/embedded/login/": {
-      "post": {
-        "tags": [
-          "user"
-        ],
-        "operationId": "user_v1_embedded_login_create",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CustomTokenObtainPair"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
+      "/user/v1/embedded/login/": {
+        "post": {
+          "tags": [
+            "user"
+          ],
+          "operationId": "user_v1_embedded_login_create",
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CustomTokenObtainPair"
                 }
               }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/user/v1/embedded/refresh/": {
-      "post": {
-        "tags": [
-          "user"
-        ],
-        "description": "Takes a refresh type JSON web token and returns an access type JSON web\ntoken if the refresh token is valid.",
-        "operationId": "user_v1_embedded_refresh_create",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/TokenRefresh"
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/CustomTokenObtainPair"
+                  }
+                }
               }
             }
           },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/user/v1/embedded/refresh/": {
+        "post": {
+          "tags": [
+            "user"
+          ],
+          "description": "Takes a refresh type JSON web token and returns an access type JSON web\ntoken if the refresh token is valid.",
+          "operationId": "user_v1_embedded_refresh_create",
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/TokenRefresh"
                 }
               }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/TokenRefresh"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/user/webhook/supabase/": {
+        "post": {
+          "tags": [
+            "user"
+          ],
+          "operationId": "user_webhook_supabase_create",
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {}
+            }
+          }
+        }
+      },
+      "/workflows/edges/": {
+        "get": {
+          "tags": [
+            "workflows"
+          ],
+          "operationId": "workflows_edges_list",
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Edge"
+                    }
+                  }
+                }
+              }
             }
           }
         },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/user/webhook/supabase/": {
-      "post": {
-        "tags": [
-          "user"
-        ],
-        "operationId": "user_webhook_supabase_create",
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {}
-          }
-        }
-      }
-    },
-    "/workflows/edges/": {
-      "get": {
-        "tags": [
-          "workflows"
-        ],
-        "operationId": "workflows_edges_list",
-        "responses": {
-          "200": {
-            "description": "",
+        "post": {
+          "tags": [
+            "workflows"
+          ],
+          "operationId": "workflows_edges_create",
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
+                  "$ref": "#/components/schemas/Edge"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Edge"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/workflows/edges/{id}/": {
+        "get": {
+          "tags": [
+            "workflows"
+          ],
+          "operationId": "workflows_edges_read",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
                     "$ref": "#/components/schemas/Edge"
                   }
                 }
               }
             }
           }
-        }
-      },
-      "post": {
-        "tags": [
-          "workflows"
-        ],
-        "operationId": "workflows_edges_create",
-        "requestBody": {
-          "content": {
-            "application/json": {
+        },
+        "put": {
+          "tags": [
+            "workflows"
+          ],
+          "operationId": "workflows_edges_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
               "schema": {
-                "$ref": "#/components/schemas/Edge"
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Edge"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Edge"
+                  }
+                }
               }
             }
           },
-          "required": true
+          "x-codegen-request-body-name": "data"
         },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Edge"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/workflows/edges/{id}/": {
-      "get": {
-        "tags": [
-          "workflows"
-        ],
-        "operationId": "workflows_edges_read",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Edge"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "workflows"
-        ],
-        "operationId": "workflows_edges_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
+        "delete": {
+          "tags": [
+            "workflows"
+          ],
+          "operationId": "workflows_edges_delete",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
               "schema": {
-                "$ref": "#/components/schemas/Edge"
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "204": {
+              "description": "",
+              "content": {}
+            }
+          }
+        },
+        "patch": {
+          "tags": [
+            "workflows"
+          ],
+          "operationId": "workflows_edges_partial_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Edge"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Edge"
+                  }
+                }
               }
             }
           },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Edge"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      },
-      "delete": {
-        "tags": [
-          "workflows"
-        ],
-        "operationId": "workflows_edges_delete",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "",
-            "content": {}
-          }
+          "x-codegen-request-body-name": "data"
         }
       },
-      "patch": {
-        "tags": [
-          "workflows"
-        ],
-        "operationId": "workflows_edges_partial_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Edge"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Edge"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/workflows/node-metrics/": {
-      "get": {
-        "tags": [
-          "workflows"
-        ],
-        "operationId": "workflows_node-metrics_list",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/NodeMetric"
+      "/workflows/node-metrics/": {
+        "get": {
+          "tags": [
+            "workflows"
+          ],
+          "operationId": "workflows_node-metrics_list",
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/NodeMetric"
+                    }
                   }
                 }
               }
             }
           }
-        }
-      },
-      "post": {
-        "tags": [
-          "workflows"
-        ],
-        "operationId": "workflows_node-metrics_create",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/NodeMetricCreate"
-              }
-            }
-          },
-          "required": true
         },
-        "responses": {
-          "201": {
-            "description": "",
+        "post": {
+          "tags": [
+            "workflows"
+          ],
+          "operationId": "workflows_node-metrics_create",
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/NodeMetricCreate"
                 }
               }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/workflows/node-metrics/{id}/": {
-      "get": {
-        "tags": [
-          "workflows"
-        ],
-        "operationId": "workflows_node-metrics_read",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NodeMetric"
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/NodeMetricCreate"
+                  }
                 }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "workflows"
-        ],
-        "operationId": "workflows_node-metrics_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/NodeMetric"
               }
             }
           },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NodeMetric"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      },
-      "delete": {
-        "tags": [
-          "workflows"
-        ],
-        "operationId": "workflows_node-metrics_delete",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "",
-            "content": {}
-          }
+          "x-codegen-request-body-name": "data"
         }
       },
-      "patch": {
-        "tags": [
-          "workflows"
-        ],
-        "operationId": "workflows_node-metrics_partial_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
+      "/workflows/node-metrics/{id}/": {
+        "get": {
+          "tags": [
+            "workflows"
+          ],
+          "operationId": "workflows_node-metrics_read",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
               "schema": {
-                "$ref": "#/components/schemas/NodeMetric"
+                "type": "string"
               }
             }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NodeMetric"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/workflows/nodes/": {
-      "get": {
-        "tags": [
-          "workflows"
-        ],
-        "operationId": "workflows_nodes_list",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Node"
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/NodeMetric"
                   }
                 }
               }
             }
           }
-        }
-      },
-      "post": {
-        "tags": [
-          "workflows"
-        ],
-        "operationId": "workflows_nodes_create",
-        "requestBody": {
-          "content": {
-            "application/json": {
+        },
+        "put": {
+          "tags": [
+            "workflows"
+          ],
+          "operationId": "workflows_node-metrics_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
               "schema": {
-                "$ref": "#/components/schemas/NodeCreate"
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NodeMetric"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/NodeMetric"
+                  }
+                }
               }
             }
           },
-          "required": true
+          "x-codegen-request-body-name": "data"
         },
-        "responses": {
-          "201": {
-            "description": "",
+        "delete": {
+          "tags": [
+            "workflows"
+          ],
+          "operationId": "workflows_node-metrics_delete",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "204": {
+              "description": "",
+              "content": {}
+            }
+          }
+        },
+        "patch": {
+          "tags": [
+            "workflows"
+          ],
+          "operationId": "workflows_node-metrics_partial_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NodeMetric"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/NodeMetric"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/workflows/nodes/": {
+        "get": {
+          "tags": [
+            "workflows"
+          ],
+          "operationId": "workflows_nodes_list",
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Node"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "post": {
+          "tags": [
+            "workflows"
+          ],
+          "operationId": "workflows_nodes_create",
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/NodeCreate"
                 }
               }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/workflows/nodes/{id}/": {
-      "get": {
-        "tags": [
-          "workflows"
-        ],
-        "operationId": "workflows_nodes_read",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Node"
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/NodeCreate"
+                  }
                 }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "workflows"
-        ],
-        "operationId": "workflows_nodes_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Node"
               }
             }
           },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Node"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      },
-      "delete": {
-        "tags": [
-          "workflows"
-        ],
-        "operationId": "workflows_nodes_delete",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "",
-            "content": {}
-          }
+          "x-codegen-request-body-name": "data"
         }
       },
-      "patch": {
-        "tags": [
-          "workflows"
-        ],
-        "operationId": "workflows_nodes_partial_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
+      "/workflows/nodes/{id}/": {
+        "get": {
+          "tags": [
+            "workflows"
+          ],
+          "operationId": "workflows_nodes_read",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
               "schema": {
-                "$ref": "#/components/schemas/Node"
+                "type": "string"
               }
             }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Node"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/workflows/workflows/": {
-      "get": {
-        "tags": [
-          "workflows"
-        ],
-        "operationId": "workflows_workflows_list",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Workflow"
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Node"
                   }
                 }
               }
             }
           }
-        }
-      },
-      "post": {
-        "tags": [
-          "workflows"
-        ],
-        "operationId": "workflows_workflows_create",
-        "requestBody": {
-          "content": {
-            "application/json": {
+        },
+        "put": {
+          "tags": [
+            "workflows"
+          ],
+          "operationId": "workflows_nodes_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
               "schema": {
-                "$ref": "#/components/schemas/Workflow"
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Node"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Node"
+                  }
+                }
               }
             }
           },
-          "required": true
+          "x-codegen-request-body-name": "data"
         },
-        "responses": {
-          "201": {
-            "description": "",
+        "delete": {
+          "tags": [
+            "workflows"
+          ],
+          "operationId": "workflows_nodes_delete",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "204": {
+              "description": "",
+              "content": {}
+            }
+          }
+        },
+        "patch": {
+          "tags": [
+            "workflows"
+          ],
+          "operationId": "workflows_nodes_partial_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Node"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Node"
+                  }
+                }
+              }
+            }
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/workflows/workflows/": {
+        "get": {
+          "tags": [
+            "workflows"
+          ],
+          "operationId": "workflows_workflows_list",
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Workflow"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "post": {
+          "tags": [
+            "workflows"
+          ],
+          "operationId": "workflows_workflows_create",
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Workflow"
                 }
               }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Workflow"
+                  }
+                }
+              }
             }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    },
-    "/workflows/workflows/{id}/": {
-      "get": {
-        "tags": [
-          "workflows"
-        ],
-        "operationId": "workflows_workflows_read",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
+          },
+          "x-codegen-request-body-name": "data"
+        }
+      },
+      "/workflows/workflows/{id}/": {
+        "get": {
+          "tags": [
+            "workflows"
+          ],
+          "operationId": "workflows_workflows_read",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
             }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkflowDetail"
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/WorkflowDetail"
+                  }
                 }
               }
             }
           }
-        }
-      },
-      "put": {
-        "tags": [
-          "workflows"
-        ],
-        "operationId": "workflows_workflows_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
+        },
+        "put": {
+          "tags": [
+            "workflows"
+          ],
+          "operationId": "workflows_workflows_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
               "schema": {
-                "$ref": "#/components/schemas/Workflow"
+                "type": "string"
               }
             }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
+          ],
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Workflow"
                 }
               }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      },
-      "delete": {
-        "tags": [
-          "workflows"
-        ],
-        "operationId": "workflows_workflows_delete",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "",
-            "content": {}
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "workflows"
-        ],
-        "operationId": "workflows_workflows_partial_update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Workflow"
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Workflow"
+                  }
+                }
               }
             }
           },
-          "required": true
+          "x-codegen-request-body-name": "data"
         },
-        "responses": {
-          "200": {
-            "description": "",
+        "delete": {
+          "tags": [
+            "workflows"
+          ],
+          "operationId": "workflows_workflows_delete",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "204": {
+              "description": "",
+              "content": {}
+            }
+          }
+        },
+        "patch": {
+          "tags": [
+            "workflows"
+          ],
+          "operationId": "workflows_workflows_partial_update",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Workflow"
                 }
               }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
-      }
-    }
-  },
-  "components": {
-    "schemas": {
-      "CallLogList": {
-        "required": [
-          "call_id",
-          "duration"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
+            },
+            "required": true
           },
-          "duration": {
-            "title": "Duration",
-            "type": "string"
-          },
-          "success": {
-            "title": "Success",
-            "type": "boolean",
-            "nullable": true
-          },
-          "is_reviewed": {
-            "title": "Is reviewed",
-            "type": "boolean"
-          },
-          "status": {
-            "title": "Status",
-            "type": "string",
-            "enum": [
-              "failure"
-            ]
-          },
-          "feedback": {
-            "title": "Feedback",
-            "type": "string"
-          },
-          "call_ended_reason": {
-            "title": "Call ended reason",
-            "maxLength": 100,
-            "type": "string"
-          },
-          "customer_number": {
-            "title": "Customer number",
-            "maxLength": 15,
-            "type": "string"
-          },
-          "agent": {
-            "title": "Agent",
-            "type": "integer",
-            "nullable": true
-          },
-          "call_id": {
-            "title": "Call id",
-            "maxLength": 100,
-            "minLength": 1,
-            "type": "string"
-          },
-          "metrics": {
-            "title": "Metrics",
-            "type": "string",
-            "readOnly": true
-          },
-          "timestamp": {
-            "title": "Timestamp",
-            "type": "string",
-            "format": "date-time"
-          },
-          "created_at": {
-            "title": "Created at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          },
-          "updated_at": {
-            "title": "Updated at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          }
-        }
-      },
-      "CallLogDetail": {
-        "required": [
-          "call_id",
-          "duration"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "duration": {
-            "title": "Duration",
-            "type": "string"
-          },
-          "voice_recording_url": {
-            "title": "Voice recording url",
-            "type": "string",
-            "readOnly": true
-          },
-          "critical_categories": {
-            "title": "Critical categories",
-            "type": "string",
-            "readOnly": true
-          },
-          "status": {
-            "title": "Status",
-            "type": "string",
-            "enum": [
-              "failure"
-            ]
-          },
-          "timestamp": {
-            "title": "Timestamp",
-            "type": "string",
-            "format": "date-time"
-          },
-          "success": {
-            "title": "Success",
-            "type": "boolean",
-            "nullable": true
-          },
-          "is_reviewed": {
-            "title": "Is reviewed",
-            "type": "boolean"
-          },
-          "feedback": {
-            "title": "Feedback",
-            "type": "string"
-          },
-          "evaluation": {
-            "title": "Evaluation",
-            "type": "object",
-            "properties": {},
-            "nullable": true
-          },
-          "transcript": {
-            "title": "Transcript",
-            "minLength": 1,
-            "type": "string"
-          },
-          "transcript_object": {
-            "title": "Transcript object",
-            "type": "object",
-            "properties": {},
-            "nullable": true
-          },
-          "call_ended_reason": {
-            "title": "Call ended reason",
-            "maxLength": 100,
-            "type": "string"
-          },
-          "dropoff_point": {
-            "title": "Dropoff point",
-            "maxLength": 1000,
-            "type": "string"
-          },
-          "dropoff_reason": {
-            "title": "Dropoff reason",
-            "maxLength": 1000,
-            "type": "string"
-          },
-          "topic": {
-            "title": "Topic",
-            "maxLength": 1000,
-            "type": "string"
-          },
-          "customer_number": {
-            "title": "Customer number",
-            "maxLength": 15,
-            "type": "string"
-          },
-          "user_generated_transcript": {
-            "title": "User generated transcript",
-            "type": "object",
-            "properties": {},
-            "nullable": true
-          },
-          "metadata": {
-            "title": "Metadata",
-            "type": "object",
-            "properties": {}
-          },
-          "created_at": {
-            "title": "Created at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          },
-          "updated_at": {
-            "title": "Updated at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          },
-          "call_id": {
-            "title": "Call id",
-            "maxLength": 100,
-            "minLength": 1,
-            "type": "string"
-          },
-          "agent": {
-            "title": "Agent",
-            "type": "integer",
-            "nullable": true
-          }
-        }
-      },
-      "OverallEvaluation": {
-        "required": [
-          "agent"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "evaluation": {
-            "title": "Evaluation",
-            "type": "object",
-            "properties": {},
-            "nullable": true
-          },
-          "created_at": {
-            "title": "Created at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          },
-          "agent": {
-            "title": "Agent",
-            "type": "integer"
-          }
-        }
-      },
-      "ScenarioInline": {
-        "required": [
-          "agent"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "agent": {
-            "title": "Agent",
-            "type": "integer"
-          },
-          "name": {
-            "title": "Name",
-            "maxLength": 40,
-            "minLength": 1,
-            "type": "string"
-          },
-          "personality": {
-            "title": "Personality",
-            "type": "integer",
-            "nullable": true
-          },
-          "personality_name": {
-            "title": "Personality name",
-            "minLength": 1,
-            "type": "string",
-            "readOnly": true
-          }
-        }
-      },
-      "CronJob": {
-        "required": [
-          "agent",
-          "crontab_expression",
-          "scenarios"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "agent": {
-            "title": "Agent",
-            "type": "integer"
-          },
-          "crontab_expression": {
-            "title": "Crontab expression",
-            "maxLength": 255,
-            "minLength": 1,
-            "type": "string"
-          },
-          "timezone": {
-            "title": "Timezone",
-            "maxLength": 255,
-            "minLength": 1,
-            "type": "string"
-          },
-          "scenarios": {
-            "title": "Scenarios",
-            "type": "object",
-            "properties": {}
-          },
-          "scenario_ids": {
-            "uniqueItems": true,
-            "type": "array",
-            "readOnly": true,
-            "items": {
-              "type": "integer"
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Workflow"
+                  }
+                }
+              }
             }
           },
-          "scenarios_data": {
-            "type": "array",
-            "readOnly": true,
-            "items": {
-              "$ref": "#/components/schemas/ScenarioInline"
-            }
-          },
-          "notify_on": {
-            "title": "Notify on",
-            "type": "string",
-            "enum": [
-              "never",
-              "success",
-              "failure",
-              "both"
-            ]
-          }
-        }
-      },
-      "SlackWorkspace": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "team_name": {
-            "title": "Team name",
-            "minLength": 1,
-            "type": "string",
-            "readOnly": true
-          },
-          "channel_id": {
-            "title": "Channel id",
-            "maxLength": 255,
-            "type": "string"
-          },
-          "organization": {
-            "title": "Organization",
-            "type": "integer",
-            "readOnly": true
-          }
-        }
-      },
-      "Pack": {
-        "required": [
-          "price"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "name": {
-            "title": "Name",
-            "maxLength": 100,
-            "type": "string"
-          },
-          "code": {
-            "title": "Code",
-            "maxLength": 100,
-            "type": "string"
-          },
-          "description": {
-            "title": "Description",
-            "type": "string"
-          },
-          "price": {
-            "title": "Price",
-            "type": "string",
-            "format": "decimal"
-          },
-          "interval": {
-            "title": "Interval",
-            "type": "string",
-            "enum": [
-              "month",
-              "year"
-            ]
-          },
-          "runs_balance": {
-            "title": "Runs balance",
-            "maximum": 2147483647,
-            "minimum": -2147483648,
-            "type": "integer"
-          },
-          "call_logs_balance": {
-            "title": "Call logs balance",
-            "maximum": 2147483647,
-            "minimum": -2147483648,
-            "type": "integer"
-          },
-          "max_agents_limit": {
-            "title": "Max agents limit",
-            "maximum": 2147483647,
-            "minimum": -2147483648,
-            "type": "integer"
-          },
-          "monitoring_minutes": {
-            "title": "Monitoring minutes",
-            "maximum": 2147483647,
-            "minimum": -2147483648,
-            "type": "integer"
-          },
-          "premium_slack_support": {
-            "title": "Premium slack support",
-            "type": "boolean"
-          },
-          "custom_api_integrations": {
-            "title": "Custom api integrations",
-            "type": "boolean"
-          },
-          "dedicated_support_engineer": {
-            "title": "Dedicated support engineer",
-            "type": "boolean"
-          },
-          "custom_feature_requests": {
-            "title": "Custom feature requests",
-            "type": "boolean"
-          },
-          "display_order": {
-            "title": "Display order",
-            "maximum": 2147483647,
-            "minimum": -2147483648,
-            "type": "integer"
-          },
-          "created_at": {
-            "title": "Created at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          },
-          "updated_at": {
-            "title": "Updated at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          }
-        }
-      },
-      "PackInline": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "name": {
-            "title": "Name",
-            "maxLength": 100,
-            "type": "string"
-          },
-          "code": {
-            "title": "Code",
-            "maxLength": 100,
-            "type": "string"
-          }
-        }
-      },
-      "Subscription": {
-        "required": [
-          "expire_at",
-          "pack",
-          "stripe_subscription_id"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "organization": {
-            "title": "Organization",
-            "type": "integer",
-            "nullable": true
-          },
-          "stripe_subscription_id": {
-            "title": "Stripe subscription id",
-            "maxLength": 100,
-            "minLength": 1,
-            "type": "string"
-          },
-          "is_active": {
-            "title": "Is active",
-            "type": "boolean"
-          },
-          "pack": {
-            "$ref": "#/components/schemas/PackInline"
-          },
-          "expire_at": {
-            "title": "Expire at",
-            "type": "string",
-            "format": "date-time"
-          },
-          "created_at": {
-            "title": "Created at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          },
-          "updated_at": {
-            "title": "Updated at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          }
-        }
-      },
-      "Billing": {
-        "required": [
-          "balance_expiry",
-          "total_call_log_minutes",
-          "total_run_minutes"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "organization": {
-            "title": "Organization",
-            "type": "integer",
-            "readOnly": true
-          },
-          "balance": {
-            "title": "Balance",
-            "type": "string",
-            "format": "decimal"
-          },
-          "runs_balance": {
-            "title": "Runs balance",
-            "maximum": 2147483647,
-            "minimum": -2147483648,
-            "type": "integer"
-          },
-          "call_logs_balance": {
-            "title": "Call logs balance",
-            "maximum": 2147483647,
-            "minimum": -2147483648,
-            "type": "integer"
-          },
-          "num_test_cases": {
-            "title": "Num test cases",
-            "maximum": 2147483647,
-            "minimum": -2147483648,
-            "type": "integer"
-          },
-          "total_run_minutes": {
-            "title": "Total run minutes",
-            "type": "string"
-          },
-          "total_call_log_minutes": {
-            "title": "Total call log minutes",
-            "type": "string"
-          },
-          "balance_expiry": {
-            "title": "Balance expiry",
-            "type": "string",
-            "format": "date-time"
-          },
-          "created_at": {
-            "title": "Created at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          },
-          "updated_at": {
-            "title": "Updated at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          }
-        }
-      },
-      "CriticalMetricScenario": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "scenario": {
-            "title": "Scenario",
-            "minLength": 1,
-            "type": "string",
-            "readOnly": true
-          },
-          "priority": {
-            "title": "Priority",
-            "type": "string",
-            "enum": [
-              "high",
-              "medium",
-              "low",
-              "not_a_bug"
-            ]
-          }
-        }
-      },
-      "CriticalMetricCategory": {
-        "required": [
-          "category"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "category": {
-            "title": "Category",
-            "maxLength": 1000,
-            "minLength": 1,
-            "type": "string"
-          },
-          "scenarios": {
-            "type": "array",
-            "readOnly": true,
-            "items": {
-              "$ref": "#/components/schemas/CriticalMetricScenario"
-            }
-          }
-        }
-      },
-      "MetricList": {
-        "required": [
-          "agent",
-          "name"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "agent": {
-            "title": "Agent",
-            "type": "integer"
-          },
-          "name": {
-            "title": "Name",
-            "maxLength": 255,
-            "minLength": 1,
-            "type": "string"
-          },
-          "description": {
-            "title": "Description",
-            "type": "string"
-          },
-          "function_name": {
-            "title": "Function name",
-            "maxLength": 255,
-            "type": "string",
-            "nullable": true
-          },
-          "eval_type": {
-            "title": "Eval type",
-            "type": "string",
-            "enum": [
-              "binary_workflow_adherence",
-              "binary_qualitative",
-              "continuous_qualitative",
-              "numeric",
-              "enum"
-            ]
-          },
-          "enum_values": {
-            "title": "Enum values",
-            "type": "object",
-            "properties": {}
-          },
-          "audio_enabled": {
-            "title": "Audio enabled",
-            "type": "boolean"
-          },
-          "prompt_enabled": {
-            "title": "Prompt enabled",
-            "type": "boolean"
-          },
-          "prompt": {
-            "title": "Prompt",
-            "type": "string"
-          },
-          "display_order": {
-            "title": "Display order",
-            "maximum": 2147483647,
-            "minimum": -2147483648,
-            "type": "integer"
-          },
-          "evaluation_trigger": {
-            "title": "Evaluation trigger",
-            "type": "string",
-            "enum": [
-              "always",
-              "automatic",
-              "custom"
-            ]
-          },
-          "evaluation_trigger_prompt": {
-            "title": "Evaluation trigger prompt",
-            "type": "string"
-          },
-          "vocera_defined_metric_code": {
-            "title": "Vocera defined metric code",
-            "maxLength": 255,
-            "type": "string"
-          },
-          "scenarios": {
-            "uniqueItems": true,
-            "type": "array",
-            "items": {
-              "type": "integer"
-            }
-          },
-          "overall_score": {
-            "title": "Overall score",
-            "type": "string",
-            "readOnly": true
-          },
-          "total_score": {
-            "title": "Total score",
-            "type": "string",
-            "readOnly": true
-          },
-          "critical_categories": {
-            "type": "array",
-            "readOnly": true,
-            "items": {
-              "$ref": "#/components/schemas/CriticalMetricCategory"
-            }
-          }
-        }
-      },
-      "MetricEdit": {
-        "required": [
-          "name"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "agent": {
-            "title": "Agent",
-            "type": "integer"
-          },
-          "assistant_id": {
-            "title": "Assistant id",
-            "minLength": 1,
-            "type": "string"
-          },
-          "name": {
-            "title": "Name",
-            "maxLength": 255,
-            "minLength": 1,
-            "type": "string"
-          },
-          "description": {
-            "title": "Description",
-            "type": "string"
-          },
-          "eval_type": {
-            "title": "Eval type",
-            "type": "string",
-            "enum": [
-              "binary_workflow_adherence",
-              "binary_qualitative",
-              "continuous_qualitative",
-              "numeric",
-              "enum"
-            ]
-          },
-          "enum_values": {
-            "title": "Enum values",
-            "type": "object",
-            "properties": {}
-          },
-          "audio_enabled": {
-            "title": "Audio enabled",
-            "type": "boolean"
-          },
-          "prompt_enabled": {
-            "title": "Prompt enabled",
-            "type": "boolean"
-          },
-          "prompt": {
-            "title": "Prompt",
-            "type": "string"
-          },
-          "evaluation_trigger": {
-            "title": "Evaluation trigger",
-            "type": "string",
-            "enum": [
-              "always",
-              "automatic",
-              "custom"
-            ]
-          },
-          "evaluation_trigger_prompt": {
-            "title": "Evaluation trigger prompt",
-            "type": "string"
-          },
-          "vocera_defined_metric_code": {
-            "title": "Vocera defined metric code",
-            "maxLength": 255,
-            "type": "string"
-          },
-          "display_order": {
-            "title": "Display order",
-            "maximum": 2147483647,
-            "minimum": -2147483648,
-            "type": "integer"
-          },
-          "scenarios": {
-            "title": "Scenarios",
-            "type": "object",
-            "properties": {}
-          },
-          "overall_score": {
-            "title": "Overall score",
-            "type": "string",
-            "readOnly": true
-          },
-          "total_score": {
-            "title": "Total score",
-            "type": "string",
-            "readOnly": true
-          }
-        }
-      },
-      "MetricDetail": {
-        "required": [
-          "agent",
-          "name"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "agent": {
-            "title": "Agent",
-            "type": "integer"
-          },
-          "name": {
-            "title": "Name",
-            "maxLength": 255,
-            "minLength": 1,
-            "type": "string"
-          },
-          "description": {
-            "title": "Description",
-            "type": "string"
-          },
-          "eval_type": {
-            "title": "Eval type",
-            "type": "string",
-            "enum": [
-              "binary_workflow_adherence",
-              "binary_qualitative",
-              "continuous_qualitative",
-              "numeric",
-              "enum"
-            ]
-          },
-          "enum_values": {
-            "title": "Enum values",
-            "type": "object",
-            "properties": {}
-          },
-          "audio_enabled": {
-            "title": "Audio enabled",
-            "type": "boolean"
-          },
-          "prompt_enabled": {
-            "title": "Prompt enabled",
-            "type": "boolean"
-          },
-          "prompt": {
-            "title": "Prompt",
-            "type": "string"
-          },
-          "evaluation_trigger": {
-            "title": "Evaluation trigger",
-            "type": "string",
-            "enum": [
-              "always",
-              "automatic",
-              "custom"
-            ]
-          },
-          "evaluation_trigger_prompt": {
-            "title": "Evaluation trigger prompt",
-            "type": "string"
-          },
-          "vocera_defined_metric_code": {
-            "title": "Vocera defined metric code",
-            "maxLength": 255,
-            "type": "string"
-          },
-          "display_order": {
-            "title": "Display order",
-            "maximum": 2147483647,
-            "minimum": -2147483648,
-            "type": "integer"
-          },
-          "overall_score": {
-            "title": "Overall score",
-            "type": "string",
-            "readOnly": true
-          },
-          "total_score": {
-            "title": "Total score",
-            "type": "string",
-            "readOnly": true
-          },
-          "reviews": {
-            "title": "Reviews",
-            "type": "string",
-            "readOnly": true
-          },
-          "scenarios": {
-            "title": "Scenarios",
-            "type": "object",
-            "properties": {}
-          },
-          "critical_categories": {
-            "type": "array",
-            "readOnly": true,
-            "items": {
-              "$ref": "#/components/schemas/CriticalMetricCategory"
-            }
-          }
-        }
-      },
-      "PhoneNumber": {
-        "required": [
-          "number",
-          "organization",
-          "phone_number_id"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "scenario_id": {
-            "title": "Scenario id",
-            "type": "string",
-            "readOnly": true
-          },
-          "scenario_name": {
-            "title": "Scenario name",
-            "type": "string",
-            "readOnly": true
-          },
-          "number": {
-            "title": "Number",
-            "maxLength": 15,
-            "minLength": 1,
-            "type": "string"
-          },
-          "phone_number_id": {
-            "title": "Phone number id",
-            "maxLength": 255,
-            "minLength": 1,
-            "type": "string"
-          },
-          "organization": {
-            "title": "Organization",
-            "type": "integer"
-          },
-          "user": {
-            "title": "User",
-            "type": "integer",
-            "nullable": true
-          }
-        }
-      },
-      "PredefinedMetric": {
-        "required": [
-          "description",
-          "name"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "name": {
-            "title": "Name",
-            "maxLength": 255,
-            "minLength": 1,
-            "type": "string"
-          },
-          "description": {
-            "title": "Description",
-            "minLength": 1,
-            "type": "string"
-          },
-          "code": {
-            "title": "Code",
-            "maxLength": 255,
-            "minLength": 1,
-            "type": "string"
-          },
-          "eval_type": {
-            "title": "Eval type",
-            "type": "string",
-            "enum": [
-              "binary_workflow_adherence",
-              "binary_qualitative",
-              "continuous_qualitative",
-              "numeric",
-              "enum"
-            ]
-          },
-          "audio_enabled": {
-            "title": "Audio enabled",
-            "type": "boolean"
-          },
-          "prompt_enabled": {
-            "title": "Prompt enabled",
-            "type": "boolean"
-          },
-          "prompt": {
-            "title": "Prompt",
-            "type": "string"
-          },
-          "function_name": {
-            "title": "Function name",
-            "maxLength": 255,
-            "type": "string",
-            "nullable": true
-          },
-          "enum_values": {
-            "title": "Enum values",
-            "type": "object",
-            "properties": {}
-          },
-          "organization": {
-            "title": "Organization",
-            "type": "integer",
-            "nullable": true
-          }
-        }
-      },
-      "ResultList": {
-        "required": [
-          "agent"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "name": {
-            "title": "Name",
-            "maxLength": 255,
-            "minLength": 1,
-            "type": "string"
-          },
-          "agent": {
-            "title": "Agent",
-            "type": "integer"
-          },
-          "status": {
-            "title": "Status",
-            "type": "string",
-            "enum": [
-              "running",
-              "completed",
-              "failed",
-              "pending",
-              "in_progress",
-              "evaluating",
-              "in_queue"
-            ]
-          },
-          "met_expected_outcome_count": {
-            "title": "Met expected outcome count",
-            "type": "string",
-            "readOnly": true
-          },
-          "total_expected_outcome_count": {
-            "title": "Total expected outcome count",
-            "type": "string",
-            "readOnly": true
-          },
-          "success_rate": {
-            "title": "Success rate",
-            "type": "number"
-          },
-          "total_runs_count": {
-            "title": "Total runs count",
-            "type": "string",
-            "readOnly": true
-          },
-          "completed_runs_count": {
-            "title": "Completed runs count",
-            "type": "string",
-            "readOnly": true
-          },
-          "success_runs_count": {
-            "title": "Success runs count",
-            "type": "string",
-            "readOnly": true
-          },
-          "failed_runs_count": {
-            "title": "Failed runs count",
-            "type": "string",
-            "readOnly": true
-          },
-          "run_as_text": {
-            "title": "Run as text",
-            "type": "boolean"
-          },
-          "scenario_names": {
-            "title": "Scenario names",
-            "type": "string",
-            "readOnly": true
-          },
-          "runs": {
-            "title": "Runs",
-            "type": "string",
-            "readOnly": true
-          },
-          "created_at": {
-            "title": "Created at",
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_at": {
-            "title": "Updated at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          }
-        }
-      },
-      "ResultDetail": {
-        "required": [
-          "agent"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "name": {
-            "title": "Name",
-            "maxLength": 255,
-            "minLength": 1,
-            "type": "string"
-          },
-          "agent": {
-            "title": "Agent",
-            "type": "integer"
-          },
-          "status": {
-            "title": "Status",
-            "type": "string",
-            "readOnly": true,
-            "enum": [
-              "running",
-              "completed",
-              "failed",
-              "pending",
-              "in_progress",
-              "evaluating",
-              "in_queue"
-            ]
-          },
-          "met_expected_outcome_count": {
-            "title": "Met expected outcome count",
-            "type": "string",
-            "readOnly": true
-          },
-          "total_expected_outcome_count": {
-            "title": "Total expected outcome count",
-            "type": "string",
-            "readOnly": true
-          },
-          "success_rate": {
-            "title": "Success rate",
-            "type": "number",
-            "readOnly": true
-          },
-          "overall_evaluation": {
-            "title": "Overall evaluation",
-            "type": "object",
-            "properties": {},
-            "nullable": true,
-            "readOnly": true
-          },
-          "run_as_text": {
-            "title": "Run as text",
-            "type": "boolean",
-            "readOnly": true
-          },
-          "runs": {
-            "title": "Runs",
-            "type": "string",
-            "readOnly": true
-          },
-          "total_duration": {
-            "title": "Total duration",
-            "type": "string",
-            "readOnly": true
-          },
-          "total_runs_count": {
-            "title": "Total runs count",
-            "type": "string",
-            "readOnly": true
-          },
-          "completed_runs_count": {
-            "title": "Completed runs count",
-            "type": "string",
-            "readOnly": true
-          },
-          "success_runs_count": {
-            "title": "Success runs count",
-            "type": "string",
-            "readOnly": true
-          },
-          "failed_runs_count": {
-            "title": "Failed runs count",
-            "type": "string",
-            "readOnly": true
-          },
-          "scenario_names": {
-            "title": "Scenario names",
-            "type": "string",
-            "readOnly": true
-          },
-          "critical_categories": {
-            "title": "Critical categories",
-            "type": "string",
-            "readOnly": true
-          },
-          "created_at": {
-            "title": "Created at",
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_at": {
-            "title": "Updated at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          }
-        }
-      },
-      "RunList": {
-        "required": [
-          "duration"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "scenario": {
-            "title": "Scenario",
-            "type": "integer",
-            "nullable": true
-          },
-          "scenario_name": {
-            "title": "Scenario name",
-            "type": "string",
-            "readOnly": true
-          },
-          "duration": {
-            "title": "Duration",
-            "type": "string"
-          },
-          "status": {
-            "title": "Status",
-            "type": "string",
-            "enum": [
-              "running",
-              "completed",
-              "failed",
-              "pending",
-              "in_progress",
-              "evaluating",
-              "in_queue"
-            ]
-          },
-          "expected_outcome": {
-            "title": "Expected outcome",
-            "type": "object",
-            "properties": {}
-          },
-          "success": {
-            "title": "Success",
-            "type": "boolean"
-          },
-          "timestamp": {
-            "title": "Timestamp",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          },
-          "metadata": {
-            "title": "Metadata",
-            "type": "object",
-            "properties": {},
-            "nullable": true
-          },
-          "outbound_number": {
-            "title": "Outbound number",
-            "minLength": 1,
-            "type": "string",
-            "readOnly": true
-          },
-          "critical_categories": {
-            "title": "Critical categories",
-            "type": "string",
-            "readOnly": true
-          },
-          "metrics": {
-            "title": "Metrics",
-            "type": "string",
-            "readOnly": true
-          }
-        }
-      },
-      "Run": {
-        "required": [
-          "duration",
-          "transcript"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "scenario": {
-            "title": "Scenario",
-            "type": "integer",
-            "nullable": true
-          },
-          "scenario_name": {
-            "title": "Scenario name",
-            "type": "string",
-            "readOnly": true
-          },
-          "expected_outcome": {
-            "title": "Expected outcome",
-            "type": "object",
-            "properties": {}
-          },
-          "success": {
-            "title": "Success",
-            "type": "boolean"
-          },
-          "evaluation": {
-            "title": "Evaluation",
-            "type": "object",
-            "properties": {},
-            "nullable": true
-          },
-          "transcript": {
-            "title": "Transcript",
-            "minLength": 1,
-            "type": "string"
-          },
-          "transcript_object": {
-            "title": "Transcript object",
-            "type": "object",
-            "properties": {},
-            "nullable": true
-          },
-          "duration": {
-            "title": "Duration",
-            "type": "string"
-          },
-          "voice_recording_url": {
-            "title": "Voice recording url",
-            "type": "string",
-            "readOnly": true
-          },
-          "email_id": {
-            "title": "Email id",
-            "maxLength": 254,
-            "type": "string",
-            "format": "email",
-            "nullable": true
-          },
-          "status": {
-            "title": "Status",
-            "type": "string",
-            "enum": [
-              "running",
-              "completed",
-              "failed",
-              "pending",
-              "in_progress",
-              "evaluating",
-              "in_queue"
-            ]
-          },
-          "metadata": {
-            "title": "Metadata",
-            "type": "object",
-            "properties": {},
-            "nullable": true
-          },
-          "timestamp": {
-            "title": "Timestamp",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          },
-          "outbound_number": {
-            "title": "Outbound number",
-            "minLength": 1,
-            "type": "string",
-            "readOnly": true
-          },
-          "critical_categories": {
-            "title": "Critical categories",
-            "type": "string",
-            "readOnly": true
-          }
-        }
-      },
-      "PhoneNumberInbound": {
-        "required": [
-          "number",
-          "phone_number_id"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "number": {
-            "title": "Number",
-            "maxLength": 15,
-            "minLength": 1,
-            "type": "string"
-          },
-          "phone_number_id": {
-            "title": "Phone number id",
-            "maxLength": 255,
-            "minLength": 1,
-            "type": "string"
-          }
-        }
-      },
-      "Scenario": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "name": {
-            "title": "Name",
-            "maxLength": 40,
-            "minLength": 1,
-            "type": "string"
-          },
-          "agent": {
-            "title": "Agent",
-            "type": "integer"
-          },
-          "assistant_id": {
-            "title": "Assistant id",
-            "minLength": 1,
-            "type": "string"
-          },
-          "personality": {
-            "title": "Personality",
-            "type": "integer",
-            "nullable": true
-          },
-          "personality_name": {
-            "title": "Personality name",
-            "minLength": 1,
-            "type": "string",
-            "readOnly": true
-          },
-          "tags": {
-            "title": "Tags",
-            "type": "object",
-            "properties": {}
-          },
-          "retell_agent_id": {
-            "title": "Retell agent id",
-            "minLength": 1,
-            "type": "string",
-            "readOnly": true
-          },
-          "runs": {
-            "title": "Runs",
-            "type": "string",
-            "readOnly": true
-          },
-          "metrics": {
-            "title": "Metrics",
-            "type": "object",
-            "properties": {}
-          },
-          "metric_names": {
-            "title": "Metric names",
-            "type": "string",
-            "readOnly": true
-          },
-          "phone_number": {
-            "title": "Phone number",
-            "minLength": 1,
-            "type": "string",
-            "readOnly": true
-          },
-          "first_message": {
-            "title": "First message",
-            "maxLength": 1000,
-            "type": "string"
-          },
-          "inbound_phone_number": {
-            "title": "Inbound phone number",
-            "type": "integer",
-            "nullable": true
-          },
-          "inbound_phone_number_data": {
-            "$ref": "#/components/schemas/PhoneNumberInbound"
-          },
-          "instructions": {
-            "title": "Instructions",
-            "minLength": 1,
-            "type": "string"
-          },
-          "simulation_description": {
-            "title": "Simulation description",
-            "type": "string"
-          },
-          "information_fields": {
-            "title": "Information fields",
-            "type": "object",
-            "properties": {}
-          },
-          "expected_outcome_prompt": {
-            "title": "Expected outcome prompt",
-            "type": "string"
-          }
-        }
-      },
-      "TestSetList": {
-        "required": [
-          "agent",
-          "duration"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "agent": {
-            "title": "Agent",
-            "type": "integer"
-          },
-          "transcript_short": {
-            "title": "Transcript short",
-            "type": "string",
-            "readOnly": true
-          },
-          "duration": {
-            "title": "Duration",
-            "type": "string"
-          },
-          "has_recording": {
-            "title": "Has recording",
-            "type": "string",
-            "readOnly": true
-          },
-          "source_model": {
-            "title": "Source model",
-            "type": "string",
-            "enum": [
-              "CallLog",
-              "Run"
-            ]
-          },
-          "source_id": {
-            "title": "Source id",
-            "maxLength": 255,
-            "type": "string"
-          },
-          "created_at": {
-            "title": "Created at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          },
-          "updated_at": {
-            "title": "Updated at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          }
-        }
-      },
-      "TestSetDetail": {
-        "required": [
-          "agent"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "agent": {
-            "title": "Agent",
-            "type": "integer"
-          },
-          "transcript": {
-            "title": "Transcript",
-            "type": "string"
-          },
-          "voice_recording": {
-            "title": "Voice recording",
-            "type": "string",
-            "format": "uri",
-            "readOnly": true
-          },
-          "voice_recording_url": {
-            "title": "Voice recording url",
-            "type": "string",
-            "readOnly": true
-          },
-          "duration": {
-            "title": "Duration",
-            "type": "string",
-            "readOnly": true
-          },
-          "source_model": {
-            "title": "Source model",
-            "type": "string",
-            "readOnly": true,
-            "enum": [
-              "CallLog",
-              "Run"
-            ]
-          },
-          "source_id": {
-            "title": "Source id",
-            "minLength": 1,
-            "type": "string",
-            "readOnly": true
-          },
-          "metric_reviews": {
-            "title": "Metric reviews",
-            "type": "string",
-            "readOnly": true
-          },
-          "created_at": {
-            "title": "Created at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          },
-          "updated_at": {
-            "title": "Updated at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          }
-        }
-      },
-      "AIAgentExternal": {
-        "required": [
-          "agent_name",
-          "contact_number",
-          "predefined_metrics"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "agent_name": {
-            "title": "Agent name",
-            "maxLength": 255,
-            "minLength": 1,
-            "type": "string"
-          },
-          "contact_number": {
-            "title": "Contact number",
-            "maxLength": 15,
-            "minLength": 12,
-            "pattern": "^\\+\\d*$",
-            "type": "string"
-          },
-          "inbound": {
-            "title": "Inbound",
-            "type": "boolean",
-            "nullable": true
-          },
-          "description": {
-            "title": "Description",
-            "minLength": 1,
-            "type": "string"
-          },
-          "language": {
-            "title": "Language",
-            "type": "string",
-            "enum": [
-              "ar",
-              "bg",
-              "ca",
-              "zh",
-              "cs",
-              "da",
-              "nl",
-              "en",
-              "et",
-              "fi",
-              "fr",
-              "de",
-              "el",
-              "hi",
-              "hu",
-              "id",
-              "it",
-              "ja",
-              "ko",
-              "lv",
-              "lt",
-              "ms",
-              "no",
-              "pl",
-              "pt",
-              "ro",
-              "ru",
-              "sk",
-              "es",
-              "sv",
-              "ta",
-              "th",
-              "tr",
-              "uk",
-              "vi"
-            ]
-          },
-          "assistant_id": {
-            "title": "Assistant id",
-            "maxLength": 255,
-            "minLength": 10,
-            "type": "string",
-            "nullable": true
-          },
-          "websocket_url": {
-            "title": "Websocket url",
-            "type": "string"
-          },
-          "llm_model": {
-            "title": "Llm model",
-            "type": "string",
-            "enum": [
-              "gpt-4o",
-              "gpt-4o-mini",
-              "claude-3-5-sonnet-20240620"
-            ]
-          },
-          "llm_temperature": {
-            "title": "Llm temperature",
-            "type": "number"
-          },
-          "llm_max_tokens": {
-            "title": "Llm max tokens",
-            "maximum": 2147483647,
-            "minimum": -2147483648,
-            "type": "integer"
-          },
-          "predefined_metrics": {
-            "title": "Predefined metrics",
-            "type": "object",
-            "properties": {}
-          }
-        }
-      },
-      "MetricDetailExternal": {
-        "required": [
-          "agent",
-          "name"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "agent": {
-            "title": "Agent",
-            "type": "integer"
-          },
-          "name": {
-            "title": "Name",
-            "maxLength": 255,
-            "minLength": 1,
-            "type": "string"
-          },
-          "description": {
-            "title": "Description",
-            "type": "string"
-          },
-          "eval_type": {
-            "title": "Eval type",
-            "type": "string",
-            "enum": [
-              "binary_workflow_adherence",
-              "binary_qualitative",
-              "continuous_qualitative",
-              "numeric",
-              "enum"
-            ]
-          },
-          "enum_values": {
-            "title": "Enum values",
-            "type": "object",
-            "properties": {}
-          },
-          "audio_enabled": {
-            "title": "Audio enabled",
-            "type": "boolean"
-          },
-          "prompt_enabled": {
-            "title": "Prompt enabled",
-            "type": "boolean"
-          },
-          "prompt": {
-            "title": "Prompt",
-            "type": "string"
-          },
-          "evaluation_trigger": {
-            "title": "Evaluation trigger",
-            "type": "string",
-            "enum": [
-              "always",
-              "automatic",
-              "custom"
-            ]
-          },
-          "evaluation_trigger_prompt": {
-            "title": "Evaluation trigger prompt",
-            "type": "string"
-          },
-          "display_order": {
-            "title": "Display order",
-            "maximum": 2147483647,
-            "minimum": -2147483648,
-            "type": "integer"
-          },
-          "overall_score": {
-            "title": "Overall score",
-            "type": "string",
-            "readOnly": true
-          },
-          "total_score": {
-            "title": "Total score",
-            "type": "string",
-            "readOnly": true
-          }
-        }
-      },
-      "PersonalityExternal": {
-        "required": [
-          "description",
-          "name"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "name": {
-            "title": "Name",
-            "maxLength": 255,
-            "minLength": 1,
-            "type": "string"
-          },
-          "description": {
-            "title": "Description",
-            "minLength": 1,
-            "type": "string"
-          },
-          "language": {
-            "title": "Language",
-            "type": "string",
-            "enum": [
-              "ar",
-              "bg",
-              "ca",
-              "zh",
-              "cs",
-              "da",
-              "nl",
-              "en",
-              "et",
-              "fi",
-              "fr",
-              "de",
-              "el",
-              "hi",
-              "hu",
-              "id",
-              "it",
-              "ja",
-              "ko",
-              "lv",
-              "lt",
-              "ms",
-              "no",
-              "pl",
-              "pt",
-              "ro",
-              "ru",
-              "sk",
-              "es",
-              "sv",
-              "ta",
-              "th",
-              "tr",
-              "uk",
-              "vi"
-            ]
-          }
-        }
-      },
-      "PredefinedMetricExternal": {
-        "required": [
-          "description",
-          "name"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "name": {
-            "title": "Name",
-            "maxLength": 255,
-            "minLength": 1,
-            "type": "string"
-          },
-          "description": {
-            "title": "Description",
-            "minLength": 1,
-            "type": "string"
-          },
-          "code": {
-            "title": "Code",
-            "maxLength": 255,
-            "minLength": 1,
-            "type": "string"
-          }
-        }
-      },
-      "ResultExternal": {
-        "required": [
-          "agent"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "agent": {
-            "title": "Agent",
-            "type": "integer"
-          },
-          "status": {
-            "title": "Status",
-            "type": "string",
-            "enum": [
-              "running",
-              "completed",
-              "failed",
-              "pending",
-              "in_progress",
-              "evaluating",
-              "in_queue"
-            ]
-          },
-          "success_rate": {
-            "title": "Success rate",
-            "type": "number"
-          },
-          "run_as_text": {
-            "title": "Run as text",
-            "type": "boolean"
-          },
-          "runs": {
-            "title": "Runs",
-            "type": "string",
-            "readOnly": true
-          },
-          "created_at": {
-            "title": "Created at",
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      },
-      "ResultDetailExternal": {
-        "required": [
-          "agent"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "agent": {
-            "title": "Agent",
-            "type": "integer"
-          },
-          "status": {
-            "title": "Status",
-            "type": "string",
-            "enum": [
-              "running",
-              "completed",
-              "failed",
-              "pending",
-              "in_progress",
-              "evaluating",
-              "in_queue"
-            ]
-          },
-          "met_expected_outcome_count": {
-            "title": "Met expected outcome count",
-            "type": "string",
-            "readOnly": true
-          },
-          "total_expected_outcome_count": {
-            "title": "Total expected outcome count",
-            "type": "string",
-            "readOnly": true
-          },
-          "success_rate": {
-            "title": "Success rate",
-            "type": "number"
-          },
-          "run_as_text": {
-            "title": "Run as text",
-            "type": "boolean"
-          },
-          "runs": {
-            "title": "Runs",
-            "type": "string",
-            "readOnly": true
-          },
-          "created_at": {
-            "title": "Created at",
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      },
-      "ScenarioExternal": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "name": {
-            "title": "Name",
-            "maxLength": 40,
-            "minLength": 1,
-            "type": "string"
-          },
-          "personality_name": {
-            "title": "Personality name",
-            "minLength": 1,
-            "type": "string",
-            "readOnly": true
-          },
-          "phone_number": {
-            "title": "Phone number",
-            "minLength": 1,
-            "type": "string",
-            "readOnly": true
-          },
-          "expected_outcome_prompt": {
-            "title": "Expected outcome prompt",
-            "minLength": 1,
-            "type": "string",
-            "readOnly": true
-          }
-        }
-      },
-      "UserAPIKey": {
-        "required": [
-          "key",
-          "organization"
-        ],
-        "type": "object",
-        "properties": {
-          "organization": {
-            "title": "Organization",
-            "type": "integer"
-          },
-          "user": {
-            "title": "User",
-            "type": "integer",
-            "nullable": true
-          },
-          "key": {
-            "title": "Key",
-            "maxLength": 255,
-            "minLength": 1,
-            "type": "string"
-          },
-          "created_at": {
-            "title": "Created at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          }
-        }
-      },
-      "Invite": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "organization": {
-            "title": "Organization",
-            "type": "integer",
-            "readOnly": true
-          },
-          "organization_name": {
-            "title": "Organization name",
-            "minLength": 1,
-            "type": "string",
-            "readOnly": true
-          },
-          "email": {
-            "title": "Email",
-            "minLength": 1,
-            "type": "string",
-            "format": "email",
-            "readOnly": true
-          },
-          "role": {
-            "title": "Role",
-            "type": "string",
-            "enum": [
-              "admin",
-              "member"
-            ]
-          },
-          "status": {
-            "title": "Status",
-            "type": "string",
-            "readOnly": true,
-            "enum": [
-              "pending",
-              "accepted",
-              "rejected"
-            ]
-          },
-          "created_at": {
-            "title": "Created at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          },
-          "updated_at": {
-            "title": "Updated at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          }
-        }
-      },
-      "UserInline": {
-        "required": [
-          "email",
-          "name"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "name": {
-            "title": "Name",
-            "maxLength": 255,
-            "minLength": 1,
-            "type": "string"
-          },
-          "email": {
-            "title": "Email",
-            "maxLength": 254,
-            "minLength": 1,
-            "type": "string",
-            "format": "email"
-          }
-        }
-      },
-      "UserMembership": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "organization": {
-            "title": "Organization",
-            "type": "integer",
-            "readOnly": true
-          },
-          "organization_name": {
-            "title": "Organization name",
-            "minLength": 1,
-            "type": "string",
-            "readOnly": true
-          },
-          "user": {
-            "$ref": "#/components/schemas/UserInline"
-          },
-          "role": {
-            "title": "Role",
-            "type": "string",
-            "enum": [
-              "admin",
-              "member"
-            ]
-          },
-          "created_at": {
-            "title": "Created at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          },
-          "updated_at": {
-            "title": "Updated at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          }
-        }
-      },
-      "MembershipInline": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "user": {
-            "$ref": "#/components/schemas/UserInline"
-          },
-          "role": {
-            "title": "Role",
-            "type": "string",
-            "enum": [
-              "admin",
-              "member"
-            ]
-          },
-          "created_at": {
-            "title": "Created at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          },
-          "updated_at": {
-            "title": "Updated at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          }
-        }
-      },
-      "Organization": {
-        "required": [
-          "name",
-          "retell_api_key",
-          "vapi_api_key"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "name": {
-            "title": "Name",
-            "maxLength": 255,
-            "minLength": 1,
-            "type": "string"
-          },
-          "outbound_timeout": {
-            "title": "Outbound timeout",
-            "maximum": 2147483647,
-            "minimum": -2147483648,
-            "type": "integer"
-          },
-          "max_agents_limit": {
-            "title": "Max agents limit",
-            "maximum": 2147483647,
-            "minimum": -2147483648,
-            "type": "integer"
-          },
-          "max_concurrent_runs_limit": {
-            "title": "Max concurrent runs limit",
-            "maximum": 2147483647,
-            "minimum": -2147483648,
-            "type": "integer"
-          },
-          "max_call_duration": {
-            "title": "Max call duration",
-            "maximum": 2147483647,
-            "minimum": -2147483648,
-            "type": "integer"
-          },
-          "evaluate_relevant_metrics_enabled": {
-            "title": "Evaluate relevant metrics enabled",
-            "type": "boolean"
-          },
-          "end_call_enabled": {
-            "title": "End call enabled",
-            "type": "boolean"
-          },
-          "notify_critical_workflow_adherence": {
-            "title": "Notify critical workflow adherence",
-            "type": "boolean"
-          },
-          "notify_daily_report": {
-            "title": "Notify daily report",
-            "type": "boolean"
-          },
-          "notify_cron_failure": {
-            "title": "Notify cron failure",
-            "type": "boolean"
-          },
-          "notify_cron_success": {
-            "title": "Notify cron success",
-            "type": "boolean"
-          },
-          "notify_infra_issues": {
-            "title": "Notify infra issues",
-            "type": "boolean"
-          },
-          "notify_binary_workflow_metrics": {
-            "title": "Notify binary workflow metrics",
-            "type": "boolean"
-          },
-          "notify_latency_spikes": {
-            "title": "Notify latency spikes",
-            "type": "boolean"
-          },
-          "is_send_emails_enabled": {
-            "title": "Is send emails enabled",
-            "type": "boolean"
-          },
-          "vapi_api_key": {
-            "title": "Vapi api key",
-            "type": "string"
-          },
-          "retell_api_key": {
-            "title": "Retell api key",
-            "type": "string"
-          },
-          "webhook_url": {
-            "title": "Webhook url",
-            "maxLength": 200,
-            "type": "string",
-            "format": "uri"
-          },
-          "webhook_secret": {
-            "title": "Webhook secret",
-            "maxLength": 255,
-            "type": "string"
-          },
-          "members": {
-            "type": "array",
-            "readOnly": true,
-            "items": {
-              "$ref": "#/components/schemas/MembershipInline"
-            }
-          },
-          "created_at": {
-            "title": "Created at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          },
-          "updated_at": {
-            "title": "Updated at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          }
-        }
-      },
-      "ProviderCredentialList": {
-        "required": [
-          "organization"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "organization": {
-            "title": "Organization",
-            "type": "integer"
-          },
-          "provider": {
-            "title": "Provider",
-            "type": "string",
-            "default": "vapi",
-            "enum": [
-              "vapi",
-              "retell"
-            ]
-          },
-          "created_at": {
-            "title": "Created at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          }
-        }
-      },
-      "ProviderCredentialDetail": {
-        "required": [
-          "key",
-          "organization"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "organization": {
-            "title": "Organization",
-            "type": "integer"
-          },
-          "provider": {
-            "title": "Provider",
-            "type": "string",
-            "default": "vapi",
-            "enum": [
-              "vapi",
-              "retell"
-            ]
-          },
-          "key": {
-            "title": "Key",
-            "maxLength": 255,
-            "minLength": 1,
-            "type": "string"
-          },
-          "created_at": {
-            "title": "Created at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          }
-        }
-      },
-      "CustomTokenObtainPair": {
-        "required": [
-          "agent_id",
-          "api_key"
-        ],
-        "type": "object",
-        "properties": {
-          "api_key": {
-            "title": "Api key",
-            "minLength": 1,
-            "type": "string"
-          },
-          "agent_id": {
-            "title": "Agent id",
-            "type": "integer"
-          }
-        }
-      },
-      "TokenRefresh": {
-        "required": [
-          "refresh"
-        ],
-        "type": "object",
-        "properties": {
-          "refresh": {
-            "title": "Refresh",
-            "minLength": 1,
-            "type": "string"
-          },
-          "access": {
-            "title": "Access",
-            "minLength": 1,
-            "type": "string",
-            "readOnly": true
-          }
-        }
-      },
-      "Edge": {
-        "required": [
-          "source_node",
-          "target_node"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "source_node": {
-            "title": "Source node",
-            "type": "integer"
-          },
-          "target_node": {
-            "title": "Target node",
-            "type": "integer"
-          },
-          "value": {
-            "title": "Value",
-            "type": "object",
-            "properties": {}
-          },
-          "created_at": {
-            "title": "Created at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          },
-          "updated_at": {
-            "title": "Updated at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          }
-        }
-      },
-      "Metric": {
-        "required": [
-          "name"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "name": {
-            "title": "Name",
-            "maxLength": 255,
-            "minLength": 1,
-            "type": "string"
-          },
-          "description": {
-            "title": "Description",
-            "type": "string"
-          },
-          "eval_type": {
-            "title": "Eval type",
-            "type": "string",
-            "enum": [
-              "binary_workflow_adherence",
-              "binary_qualitative",
-              "continuous_qualitative",
-              "numeric",
-              "enum"
-            ]
-          },
-          "enum_values": {
-            "title": "Enum values",
-            "type": "object",
-            "properties": {}
-          },
-          "display_order": {
-            "title": "Display order",
-            "maximum": 2147483647,
-            "minimum": -2147483648,
-            "type": "integer"
-          }
-        }
-      },
-      "NodeMetric": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "node": {
-            "title": "Node",
-            "type": "integer",
-            "readOnly": true
-          },
-          "metric": {
-            "title": "Metric",
-            "type": "integer",
-            "readOnly": true
-          },
-          "metric_data": {
-            "$ref": "#/components/schemas/Metric"
-          },
-          "is_main": {
-            "title": "Is main",
-            "type": "boolean"
-          },
-          "created_at": {
-            "title": "Created at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          },
-          "updated_at": {
-            "title": "Updated at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          }
-        }
-      },
-      "NodeMetricCreate": {
-        "required": [
-          "metric",
-          "node"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "node": {
-            "title": "Node",
-            "type": "integer"
-          },
-          "metric": {
-            "title": "Metric",
-            "type": "integer"
-          },
-          "is_main": {
-            "title": "Is main",
-            "type": "boolean"
-          },
-          "created_at": {
-            "title": "Created at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          },
-          "updated_at": {
-            "title": "Updated at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          }
-        }
-      },
-      "Node": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "workflow": {
-            "title": "Workflow",
-            "type": "integer",
-            "readOnly": true
-          },
-          "is_root": {
-            "title": "Is root",
-            "type": "boolean"
-          },
-          "metrics": {
-            "type": "array",
-            "readOnly": true,
-            "items": {
-              "$ref": "#/components/schemas/NodeMetric"
-            }
-          },
-          "created_at": {
-            "title": "Created at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          },
-          "updated_at": {
-            "title": "Updated at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          }
-        }
-      },
-      "NodeCreate": {
-        "required": [
-          "metric",
-          "workflow"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "workflow": {
-            "title": "Workflow",
-            "type": "integer"
-          },
-          "is_root": {
-            "title": "Is root",
-            "type": "boolean"
-          },
-          "metric": {
-            "title": "Metric",
-            "type": "integer"
-          },
-          "metrics": {
-            "type": "array",
-            "readOnly": true,
-            "items": {
-              "$ref": "#/components/schemas/NodeMetric"
-            }
-          },
-          "created_at": {
-            "title": "Created at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          },
-          "updated_at": {
-            "title": "Updated at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          }
-        }
-      },
-      "Workflow": {
-        "required": [
-          "agent",
-          "name"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "agent": {
-            "title": "Agent",
-            "type": "integer"
-          },
-          "name": {
-            "title": "Name",
-            "maxLength": 255,
-            "minLength": 1,
-            "type": "string"
-          },
-          "created_at": {
-            "title": "Created at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          },
-          "updated_at": {
-            "title": "Updated at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          }
-        }
-      },
-      "NodeInline": {
-        "required": [
-          "workflow"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "workflow": {
-            "title": "Workflow",
-            "type": "integer"
-          },
-          "is_root": {
-            "title": "Is root",
-            "type": "boolean"
-          },
-          "main_metric": {
-            "title": "Main metric",
-            "type": "string",
-            "readOnly": true
-          },
-          "created_at": {
-            "title": "Created at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          },
-          "updated_at": {
-            "title": "Updated at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          }
-        }
-      },
-      "WorkflowDetail": {
-        "required": [
-          "agent",
-          "name"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "type": "integer",
-            "readOnly": true
-          },
-          "agent": {
-            "title": "Agent",
-            "type": "integer"
-          },
-          "name": {
-            "title": "Name",
-            "maxLength": 255,
-            "minLength": 1,
-            "type": "string"
-          },
-          "nodes": {
-            "type": "array",
-            "readOnly": true,
-            "items": {
-              "$ref": "#/components/schemas/NodeInline"
-            }
-          },
-          "edges": {
-            "title": "Edges",
-            "type": "string",
-            "readOnly": true
-          },
-          "created_at": {
-            "title": "Created at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          },
-          "updated_at": {
-            "title": "Updated at",
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          }
+          "x-codegen-request-body-name": "data"
         }
       }
     },
-    "securitySchemes": {
-      "api_key": {
-        "type": "apiKey",
-        "name": "X-VOCERA-API-KEY",
-        "in": "header"
+    "components": {
+      "schemas": {
+        "CallLogList": {
+          "required": [
+            "call_id",
+            "duration"
+          ],
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "duration": {
+              "title": "Duration",
+              "type": "string"
+            },
+            "success": {
+              "title": "Success",
+              "type": "boolean",
+              "nullable": true
+            },
+            "is_reviewed": {
+              "title": "Is reviewed",
+              "type": "boolean"
+            },
+            "status": {
+              "title": "Status",
+              "type": "string",
+              "enum": [
+                "failure",
+                "failure",
+                "failure",
+                "failure"
+              ]
+            },
+            "feedback": {
+              "title": "Feedback",
+              "type": "string"
+            },
+            "call_ended_reason": {
+              "title": "Call ended reason",
+              "maxLength": 100,
+              "type": "string"
+            },
+            "customer_number": {
+              "title": "Customer number",
+              "maxLength": 15,
+              "type": "string"
+            },
+            "agent": {
+              "title": "Agent",
+              "type": "integer",
+              "nullable": true
+            },
+            "call_id": {
+              "title": "Call id",
+              "maxLength": 100,
+              "minLength": 1,
+              "type": "string"
+            },
+            "metrics": {
+              "title": "Metrics",
+              "type": "string",
+              "readOnly": true
+            },
+            "timestamp": {
+              "title": "Timestamp",
+              "type": "string",
+              "format": "date-time"
+            },
+            "created_at": {
+              "title": "Created at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            },
+            "updated_at": {
+              "title": "Updated at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            }
+          }
+        },
+        "CallLogDetail": {
+          "required": [
+            "call_id",
+            "duration"
+          ],
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "duration": {
+              "title": "Duration",
+              "type": "string"
+            },
+            "voice_recording_url": {
+              "title": "Voice recording url",
+              "type": "string",
+              "readOnly": true
+            },
+            "critical_categories": {
+              "title": "Critical categories",
+              "type": "string",
+              "readOnly": true
+            },
+            "status": {
+              "title": "Status",
+              "type": "string",
+              "enum": [
+                "failure",
+                "failure",
+                "failure",
+                "failure"
+              ]
+            },
+            "timestamp": {
+              "title": "Timestamp",
+              "type": "string",
+              "format": "date-time"
+            },
+            "success": {
+              "title": "Success",
+              "type": "boolean",
+              "nullable": true
+            },
+            "is_reviewed": {
+              "title": "Is reviewed",
+              "type": "boolean"
+            },
+            "feedback": {
+              "title": "Feedback",
+              "type": "string"
+            },
+            "evaluation": {
+              "title": "Evaluation",
+              "type": "object",
+              "properties": {},
+              "nullable": true
+            },
+            "transcript": {
+              "title": "Transcript",
+              "minLength": 1,
+              "type": "string"
+            },
+            "transcript_object": {
+              "title": "Transcript object",
+              "type": "object",
+              "properties": {},
+              "nullable": true
+            },
+            "call_ended_reason": {
+              "title": "Call ended reason",
+              "maxLength": 100,
+              "type": "string"
+            },
+            "dropoff_point": {
+              "title": "Dropoff point",
+              "maxLength": 1000,
+              "type": "string"
+            },
+            "dropoff_reason": {
+              "title": "Dropoff reason",
+              "maxLength": 1000,
+              "type": "string"
+            },
+            "topic": {
+              "title": "Topic",
+              "maxLength": 1000,
+              "type": "string"
+            },
+            "customer_number": {
+              "title": "Customer number",
+              "maxLength": 15,
+              "type": "string"
+            },
+            "user_generated_transcript": {
+              "title": "User generated transcript",
+              "type": "object",
+              "properties": {},
+              "nullable": true
+            },
+            "metadata": {
+              "title": "Metadata",
+              "type": "object",
+              "properties": {}
+            },
+            "created_at": {
+              "title": "Created at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            },
+            "updated_at": {
+              "title": "Updated at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            },
+            "call_id": {
+              "title": "Call id",
+              "maxLength": 100,
+              "minLength": 1,
+              "type": "string"
+            },
+            "agent": {
+              "title": "Agent",
+              "type": "integer",
+              "nullable": true
+            }
+          }
+        },
+        "OverallEvaluation": {
+          "required": [
+            "agent"
+          ],
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "evaluation": {
+              "title": "Evaluation",
+              "type": "object",
+              "properties": {},
+              "nullable": true
+            },
+            "created_at": {
+              "title": "Created at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            },
+            "agent": {
+              "title": "Agent",
+              "type": "integer"
+            }
+          }
+        },
+        "CreateCallLog": {
+          "required": [
+            "call_id"
+          ],
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "call_id": {
+              "title": "Call id",
+              "maxLength": 100,
+              "minLength": 1,
+              "type": "string"
+            },
+            "agent": {
+              "title": "Agent",
+              "type": "integer"
+            },
+            "assistant_id": {
+              "title": "Assistant id",
+              "minLength": 1,
+              "type": "string"
+            },
+            "voice_recording": {
+              "title": "Voice recording",
+              "type": "string",
+              "format": "uri",
+              "readOnly": true
+            },
+            "voice_recording_url": {
+              "title": "Voice recording url",
+              "minLength": 1,
+              "type": "string",
+              "format": "uri"
+            },
+            "transcript_json": {
+              "title": "Transcript json",
+              "type": "object",
+              "properties": {}
+            },
+            "call_ended_reason": {
+              "title": "Call ended reason",
+              "type": "string"
+            },
+            "customer_number": {
+              "title": "Customer number",
+              "type": "string"
+            },
+            "metadata": {
+              "title": "Metadata",
+              "type": "object",
+              "properties": {}
+            },
+            "timestamp": {
+              "title": "Timestamp",
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "ScenarioInline": {
+          "required": [
+            "agent"
+          ],
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "agent": {
+              "title": "Agent",
+              "type": "integer"
+            },
+            "name": {
+              "title": "Name",
+              "maxLength": 40,
+              "minLength": 1,
+              "type": "string"
+            },
+            "personality": {
+              "title": "Personality",
+              "type": "integer",
+              "nullable": true
+            },
+            "personality_name": {
+              "title": "Personality name",
+              "minLength": 1,
+              "type": "string",
+              "readOnly": true
+            }
+          }
+        },
+        "CronJob": {
+          "required": [
+            "agent",
+            "crontab_expression",
+            "scenarios"
+          ],
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "agent": {
+              "title": "Agent",
+              "type": "integer"
+            },
+            "crontab_expression": {
+              "title": "Crontab expression",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            },
+            "timezone": {
+              "title": "Timezone",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            },
+            "scenarios": {
+              "title": "Scenarios",
+              "type": "object",
+              "properties": {}
+            },
+            "scenario_ids": {
+              "uniqueItems": true,
+              "type": "array",
+              "readOnly": true,
+              "items": {
+                "type": "integer"
+              }
+            },
+            "scenarios_data": {
+              "type": "array",
+              "readOnly": true,
+              "items": {
+                "$ref": "#/components/schemas/ScenarioInline"
+              }
+            },
+            "notify_on": {
+              "title": "Notify on",
+              "type": "string",
+              "enum": [
+                "never",
+                "success",
+                "failure",
+                "both"
+              ]
+            }
+          }
+        },
+        "SlackWorkspace": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "team_name": {
+              "title": "Team name",
+              "minLength": 1,
+              "type": "string",
+              "readOnly": true
+            },
+            "channel_id": {
+              "title": "Channel id",
+              "maxLength": 255,
+              "type": "string"
+            },
+            "organization": {
+              "title": "Organization",
+              "type": "integer",
+              "readOnly": true
+            }
+          }
+        },
+        "Pack": {
+          "required": [
+            "price"
+          ],
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "name": {
+              "title": "Name",
+              "maxLength": 100,
+              "type": "string"
+            },
+            "code": {
+              "title": "Code",
+              "maxLength": 100,
+              "type": "string"
+            },
+            "description": {
+              "title": "Description",
+              "type": "string"
+            },
+            "price": {
+              "title": "Price",
+              "type": "string",
+              "format": "decimal"
+            },
+            "interval": {
+              "title": "Interval",
+              "type": "string",
+              "enum": [
+                "month",
+                "year"
+              ]
+            },
+            "runs_balance": {
+              "title": "Runs balance",
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer"
+            },
+            "call_logs_balance": {
+              "title": "Call logs balance",
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer"
+            },
+            "max_agents_limit": {
+              "title": "Max agents limit",
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer"
+            },
+            "monitoring_minutes": {
+              "title": "Monitoring minutes",
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer"
+            },
+            "premium_slack_support": {
+              "title": "Premium slack support",
+              "type": "boolean"
+            },
+            "custom_api_integrations": {
+              "title": "Custom api integrations",
+              "type": "boolean"
+            },
+            "dedicated_support_engineer": {
+              "title": "Dedicated support engineer",
+              "type": "boolean"
+            },
+            "custom_feature_requests": {
+              "title": "Custom feature requests",
+              "type": "boolean"
+            },
+            "display_order": {
+              "title": "Display order",
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer"
+            },
+            "created_at": {
+              "title": "Created at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            },
+            "updated_at": {
+              "title": "Updated at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            }
+          }
+        },
+        "PackInline": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "name": {
+              "title": "Name",
+              "maxLength": 100,
+              "type": "string"
+            },
+            "code": {
+              "title": "Code",
+              "maxLength": 100,
+              "type": "string"
+            }
+          }
+        },
+        "Subscription": {
+          "required": [
+            "expire_at",
+            "pack",
+            "stripe_subscription_id"
+          ],
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "organization": {
+              "title": "Organization",
+              "type": "integer",
+              "nullable": true
+            },
+            "stripe_subscription_id": {
+              "title": "Stripe subscription id",
+              "maxLength": 100,
+              "minLength": 1,
+              "type": "string"
+            },
+            "is_active": {
+              "title": "Is active",
+              "type": "boolean"
+            },
+            "pack": {
+              "$ref": "#/components/schemas/PackInline"
+            },
+            "expire_at": {
+              "title": "Expire at",
+              "type": "string",
+              "format": "date-time"
+            },
+            "created_at": {
+              "title": "Created at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            },
+            "updated_at": {
+              "title": "Updated at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            }
+          }
+        },
+        "Billing": {
+          "required": [
+            "balance_expiry",
+            "total_call_log_minutes",
+            "total_run_minutes"
+          ],
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "organization": {
+              "title": "Organization",
+              "type": "integer",
+              "readOnly": true
+            },
+            "balance": {
+              "title": "Balance",
+              "type": "string",
+              "format": "decimal"
+            },
+            "runs_balance": {
+              "title": "Runs balance",
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer"
+            },
+            "call_logs_balance": {
+              "title": "Call logs balance",
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer"
+            },
+            "num_test_cases": {
+              "title": "Num test cases",
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer"
+            },
+            "total_run_minutes": {
+              "title": "Total run minutes",
+              "type": "string"
+            },
+            "total_call_log_minutes": {
+              "title": "Total call log minutes",
+              "type": "string"
+            },
+            "balance_expiry": {
+              "title": "Balance expiry",
+              "type": "string",
+              "format": "date-time"
+            },
+            "created_at": {
+              "title": "Created at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            },
+            "updated_at": {
+              "title": "Updated at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            }
+          }
+        },
+        "CriticalMetricScenario": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "scenario": {
+              "title": "Scenario",
+              "minLength": 1,
+              "type": "string",
+              "readOnly": true
+            },
+            "priority": {
+              "title": "Priority",
+              "type": "string",
+              "enum": [
+                "high",
+                "medium",
+                "low",
+                "not_a_bug"
+              ]
+            }
+          }
+        },
+        "CriticalMetricCategory": {
+          "required": [
+            "category"
+          ],
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "category": {
+              "title": "Category",
+              "maxLength": 1000,
+              "minLength": 1,
+              "type": "string"
+            },
+            "scenarios": {
+              "type": "array",
+              "readOnly": true,
+              "items": {
+                "$ref": "#/components/schemas/CriticalMetricScenario"
+              }
+            }
+          }
+        },
+        "MetricList": {
+          "required": [
+            "agent",
+            "name"
+          ],
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "agent": {
+              "title": "Agent",
+              "type": "integer"
+            },
+            "name": {
+              "title": "Name",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            },
+            "description": {
+              "title": "Description",
+              "type": "string"
+            },
+            "function_name": {
+              "title": "Function name",
+              "maxLength": 255,
+              "type": "string",
+              "nullable": true
+            },
+            "eval_type": {
+              "title": "Eval type",
+              "type": "string",
+              "enum": [
+                "binary_workflow_adherence",
+                "binary_qualitative",
+                "continuous_qualitative",
+                "numeric",
+                "enum"
+              ]
+            },
+            "enum_values": {
+              "title": "Enum values",
+              "type": "object",
+              "properties": {}
+            },
+            "audio_enabled": {
+              "title": "Audio enabled",
+              "type": "boolean"
+            },
+            "prompt_enabled": {
+              "title": "Prompt enabled",
+              "type": "boolean"
+            },
+            "prompt": {
+              "title": "Prompt",
+              "type": "string"
+            },
+            "display_order": {
+              "title": "Display order",
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer"
+            },
+            "evaluation_trigger": {
+              "title": "Evaluation trigger",
+              "type": "string",
+              "enum": [
+                "always",
+                "automatic",
+                "custom"
+              ]
+            },
+            "evaluation_trigger_prompt": {
+              "title": "Evaluation trigger prompt",
+              "type": "string"
+            },
+            "vocera_defined_metric_code": {
+              "title": "Vocera defined metric code",
+              "maxLength": 255,
+              "type": "string"
+            },
+            "scenarios": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            },
+            "overall_score": {
+              "title": "Overall score",
+              "type": "string",
+              "readOnly": true
+            },
+            "total_score": {
+              "title": "Total score",
+              "type": "string",
+              "readOnly": true
+            },
+            "critical_categories": {
+              "type": "array",
+              "readOnly": true,
+              "items": {
+                "$ref": "#/components/schemas/CriticalMetricCategory"
+              }
+            }
+          }
+        },
+        "MetricEdit": {
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "agent": {
+              "title": "Agent",
+              "type": "integer"
+            },
+            "assistant_id": {
+              "title": "Assistant id",
+              "minLength": 1,
+              "type": "string"
+            },
+            "name": {
+              "title": "Name",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            },
+            "description": {
+              "title": "Description",
+              "type": "string"
+            },
+            "eval_type": {
+              "title": "Eval type",
+              "type": "string",
+              "enum": [
+                "binary_workflow_adherence",
+                "binary_qualitative",
+                "continuous_qualitative",
+                "numeric",
+                "enum"
+              ]
+            },
+            "enum_values": {
+              "title": "Enum values",
+              "type": "object",
+              "properties": {}
+            },
+            "audio_enabled": {
+              "title": "Audio enabled",
+              "type": "boolean"
+            },
+            "prompt_enabled": {
+              "title": "Prompt enabled",
+              "type": "boolean"
+            },
+            "prompt": {
+              "title": "Prompt",
+              "type": "string"
+            },
+            "evaluation_trigger": {
+              "title": "Evaluation trigger",
+              "type": "string",
+              "enum": [
+                "always",
+                "automatic",
+                "custom"
+              ]
+            },
+            "evaluation_trigger_prompt": {
+              "title": "Evaluation trigger prompt",
+              "type": "string"
+            },
+            "vocera_defined_metric_code": {
+              "title": "Vocera defined metric code",
+              "maxLength": 255,
+              "type": "string"
+            },
+            "display_order": {
+              "title": "Display order",
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer"
+            },
+            "scenarios": {
+              "title": "Scenarios",
+              "type": "object",
+              "properties": {}
+            },
+            "overall_score": {
+              "title": "Overall score",
+              "type": "string",
+              "readOnly": true
+            },
+            "total_score": {
+              "title": "Total score",
+              "type": "string",
+              "readOnly": true
+            }
+          }
+        },
+        "MetricDetail": {
+          "required": [
+            "agent",
+            "name"
+          ],
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "agent": {
+              "title": "Agent",
+              "type": "integer"
+            },
+            "name": {
+              "title": "Name",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            },
+            "description": {
+              "title": "Description",
+              "type": "string"
+            },
+            "eval_type": {
+              "title": "Eval type",
+              "type": "string",
+              "enum": [
+                "binary_workflow_adherence",
+                "binary_qualitative",
+                "continuous_qualitative",
+                "numeric",
+                "enum"
+              ]
+            },
+            "enum_values": {
+              "title": "Enum values",
+              "type": "object",
+              "properties": {}
+            },
+            "audio_enabled": {
+              "title": "Audio enabled",
+              "type": "boolean"
+            },
+            "prompt_enabled": {
+              "title": "Prompt enabled",
+              "type": "boolean"
+            },
+            "prompt": {
+              "title": "Prompt",
+              "type": "string"
+            },
+            "evaluation_trigger": {
+              "title": "Evaluation trigger",
+              "type": "string",
+              "enum": [
+                "always",
+                "automatic",
+                "custom"
+              ]
+            },
+            "evaluation_trigger_prompt": {
+              "title": "Evaluation trigger prompt",
+              "type": "string"
+            },
+            "vocera_defined_metric_code": {
+              "title": "Vocera defined metric code",
+              "maxLength": 255,
+              "type": "string"
+            },
+            "display_order": {
+              "title": "Display order",
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer"
+            },
+            "overall_score": {
+              "title": "Overall score",
+              "type": "string",
+              "readOnly": true
+            },
+            "total_score": {
+              "title": "Total score",
+              "type": "string",
+              "readOnly": true
+            },
+            "reviews": {
+              "title": "Reviews",
+              "type": "string",
+              "readOnly": true
+            },
+            "scenarios": {
+              "title": "Scenarios",
+              "type": "object",
+              "properties": {}
+            },
+            "critical_categories": {
+              "type": "array",
+              "readOnly": true,
+              "items": {
+                "$ref": "#/components/schemas/CriticalMetricCategory"
+              }
+            }
+          }
+        },
+        "PhoneNumber": {
+          "required": [
+            "number",
+            "organization",
+            "phone_number_id"
+          ],
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "scenario_id": {
+              "title": "Scenario id",
+              "type": "string",
+              "readOnly": true
+            },
+            "scenario_name": {
+              "title": "Scenario name",
+              "type": "string",
+              "readOnly": true
+            },
+            "number": {
+              "title": "Number",
+              "maxLength": 15,
+              "minLength": 1,
+              "type": "string"
+            },
+            "phone_number_id": {
+              "title": "Phone number id",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            },
+            "organization": {
+              "title": "Organization",
+              "type": "integer"
+            },
+            "user": {
+              "title": "User",
+              "type": "integer",
+              "nullable": true
+            }
+          }
+        },
+        "PredefinedMetric": {
+          "required": [
+            "description",
+            "name"
+          ],
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "name": {
+              "title": "Name",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            },
+            "description": {
+              "title": "Description",
+              "minLength": 1,
+              "type": "string"
+            },
+            "code": {
+              "title": "Code",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            },
+            "eval_type": {
+              "title": "Eval type",
+              "type": "string",
+              "enum": [
+                "binary_workflow_adherence",
+                "binary_qualitative",
+                "continuous_qualitative",
+                "numeric",
+                "enum"
+              ]
+            },
+            "audio_enabled": {
+              "title": "Audio enabled",
+              "type": "boolean"
+            },
+            "prompt_enabled": {
+              "title": "Prompt enabled",
+              "type": "boolean"
+            },
+            "prompt": {
+              "title": "Prompt",
+              "type": "string"
+            },
+            "function_name": {
+              "title": "Function name",
+              "maxLength": 255,
+              "type": "string",
+              "nullable": true
+            },
+            "enum_values": {
+              "title": "Enum values",
+              "type": "object",
+              "properties": {}
+            },
+            "organization": {
+              "title": "Organization",
+              "type": "integer",
+              "nullable": true
+            }
+          }
+        },
+        "ResultList": {
+          "required": [
+            "agent"
+          ],
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "name": {
+              "title": "Name",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            },
+            "agent": {
+              "title": "Agent",
+              "type": "integer"
+            },
+            "status": {
+              "title": "Status",
+              "type": "string",
+              "enum": [
+                "running",
+                "completed",
+                "failed",
+                "pending",
+                "in_progress",
+                "evaluating",
+                "in_queue"
+              ]
+            },
+            "met_expected_outcome_count": {
+              "title": "Met expected outcome count",
+              "type": "string",
+              "readOnly": true
+            },
+            "total_expected_outcome_count": {
+              "title": "Total expected outcome count",
+              "type": "string",
+              "readOnly": true
+            },
+            "success_rate": {
+              "title": "Success rate",
+              "type": "number"
+            },
+            "total_runs_count": {
+              "title": "Total runs count",
+              "type": "string",
+              "readOnly": true
+            },
+            "completed_runs_count": {
+              "title": "Completed runs count",
+              "type": "string",
+              "readOnly": true
+            },
+            "success_runs_count": {
+              "title": "Success runs count",
+              "type": "string",
+              "readOnly": true
+            },
+            "failed_runs_count": {
+              "title": "Failed runs count",
+              "type": "string",
+              "readOnly": true
+            },
+            "run_as_text": {
+              "title": "Run as text",
+              "type": "boolean"
+            },
+            "scenario_names": {
+              "title": "Scenario names",
+              "type": "string",
+              "readOnly": true
+            },
+            "runs": {
+              "title": "Runs",
+              "type": "string",
+              "readOnly": true
+            },
+            "created_at": {
+              "title": "Created at",
+              "type": "string",
+              "format": "date-time"
+            },
+            "updated_at": {
+              "title": "Updated at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            }
+          }
+        },
+        "ResultDetail": {
+          "required": [
+            "agent"
+          ],
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "name": {
+              "title": "Name",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            },
+            "agent": {
+              "title": "Agent",
+              "type": "integer"
+            },
+            "status": {
+              "title": "Status",
+              "type": "string",
+              "readOnly": true,
+              "enum": [
+                "running",
+                "completed",
+                "failed",
+                "pending",
+                "in_progress",
+                "evaluating",
+                "in_queue"
+              ]
+            },
+            "met_expected_outcome_count": {
+              "title": "Met expected outcome count",
+              "type": "string",
+              "readOnly": true
+            },
+            "total_expected_outcome_count": {
+              "title": "Total expected outcome count",
+              "type": "string",
+              "readOnly": true
+            },
+            "success_rate": {
+              "title": "Success rate",
+              "type": "number",
+              "readOnly": true
+            },
+            "overall_evaluation": {
+              "title": "Overall evaluation",
+              "type": "object",
+              "properties": {},
+              "nullable": true,
+              "readOnly": true
+            },
+            "run_as_text": {
+              "title": "Run as text",
+              "type": "boolean",
+              "readOnly": true
+            },
+            "runs": {
+              "title": "Runs",
+              "type": "string",
+              "readOnly": true
+            },
+            "total_duration": {
+              "title": "Total duration",
+              "type": "string",
+              "readOnly": true
+            },
+            "total_runs_count": {
+              "title": "Total runs count",
+              "type": "string",
+              "readOnly": true
+            },
+            "completed_runs_count": {
+              "title": "Completed runs count",
+              "type": "string",
+              "readOnly": true
+            },
+            "success_runs_count": {
+              "title": "Success runs count",
+              "type": "string",
+              "readOnly": true
+            },
+            "failed_runs_count": {
+              "title": "Failed runs count",
+              "type": "string",
+              "readOnly": true
+            },
+            "scenario_names": {
+              "title": "Scenario names",
+              "type": "string",
+              "readOnly": true
+            },
+            "critical_categories": {
+              "title": "Critical categories",
+              "type": "string",
+              "readOnly": true
+            },
+            "created_at": {
+              "title": "Created at",
+              "type": "string",
+              "format": "date-time"
+            },
+            "updated_at": {
+              "title": "Updated at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            }
+          }
+        },
+        "RunList": {
+          "required": [
+            "duration"
+          ],
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "scenario": {
+              "title": "Scenario",
+              "type": "integer",
+              "nullable": true
+            },
+            "scenario_name": {
+              "title": "Scenario name",
+              "type": "string",
+              "readOnly": true
+            },
+            "duration": {
+              "title": "Duration",
+              "type": "string"
+            },
+            "status": {
+              "title": "Status",
+              "type": "string",
+              "enum": [
+                "running",
+                "completed",
+                "failed",
+                "pending",
+                "in_progress",
+                "evaluating",
+                "in_queue"
+              ]
+            },
+            "expected_outcome": {
+              "title": "Expected outcome",
+              "type": "object",
+              "properties": {}
+            },
+            "success": {
+              "title": "Success",
+              "type": "boolean"
+            },
+            "timestamp": {
+              "title": "Timestamp",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            },
+            "metadata": {
+              "title": "Metadata",
+              "type": "object",
+              "properties": {},
+              "nullable": true
+            },
+            "outbound_number": {
+              "title": "Outbound number",
+              "minLength": 1,
+              "type": "string",
+              "readOnly": true
+            },
+            "critical_categories": {
+              "title": "Critical categories",
+              "type": "string",
+              "readOnly": true
+            },
+            "metrics": {
+              "title": "Metrics",
+              "type": "string",
+              "readOnly": true
+            }
+          }
+        },
+        "Run": {
+          "required": [
+            "duration",
+            "transcript"
+          ],
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "scenario": {
+              "title": "Scenario",
+              "type": "integer",
+              "nullable": true
+            },
+            "scenario_name": {
+              "title": "Scenario name",
+              "type": "string",
+              "readOnly": true
+            },
+            "expected_outcome": {
+              "title": "Expected outcome",
+              "type": "object",
+              "properties": {}
+            },
+            "success": {
+              "title": "Success",
+              "type": "boolean"
+            },
+            "evaluation": {
+              "title": "Evaluation",
+              "type": "object",
+              "properties": {},
+              "nullable": true
+            },
+            "transcript": {
+              "title": "Transcript",
+              "minLength": 1,
+              "type": "string"
+            },
+            "transcript_object": {
+              "title": "Transcript object",
+              "type": "object",
+              "properties": {},
+              "nullable": true
+            },
+            "duration": {
+              "title": "Duration",
+              "type": "string"
+            },
+            "voice_recording_url": {
+              "title": "Voice recording url",
+              "type": "string",
+              "readOnly": true
+            },
+            "email_id": {
+              "title": "Email id",
+              "maxLength": 254,
+              "type": "string",
+              "format": "email",
+              "nullable": true
+            },
+            "status": {
+              "title": "Status",
+              "type": "string",
+              "enum": [
+                "running",
+                "completed",
+                "failed",
+                "pending",
+                "in_progress",
+                "evaluating",
+                "in_queue"
+              ]
+            },
+            "metadata": {
+              "title": "Metadata",
+              "type": "object",
+              "properties": {},
+              "nullable": true
+            },
+            "timestamp": {
+              "title": "Timestamp",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            },
+            "outbound_number": {
+              "title": "Outbound number",
+              "minLength": 1,
+              "type": "string",
+              "readOnly": true
+            },
+            "critical_categories": {
+              "title": "Critical categories",
+              "type": "string",
+              "readOnly": true
+            }
+          }
+        },
+        "PhoneNumberInbound": {
+          "required": [
+            "number",
+            "phone_number_id"
+          ],
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "number": {
+              "title": "Number",
+              "maxLength": 15,
+              "minLength": 1,
+              "type": "string"
+            },
+            "phone_number_id": {
+              "title": "Phone number id",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        },
+        "Scenario": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "name": {
+              "title": "Name",
+              "maxLength": 40,
+              "minLength": 1,
+              "type": "string"
+            },
+            "agent": {
+              "title": "Agent",
+              "type": "integer"
+            },
+            "assistant_id": {
+              "title": "Assistant id",
+              "minLength": 1,
+              "type": "string"
+            },
+            "personality": {
+              "title": "Personality",
+              "type": "integer",
+              "nullable": true
+            },
+            "personality_name": {
+              "title": "Personality name",
+              "minLength": 1,
+              "type": "string",
+              "readOnly": true
+            },
+            "tags": {
+              "title": "Tags",
+              "type": "object",
+              "properties": {}
+            },
+            "retell_agent_id": {
+              "title": "Retell agent id",
+              "minLength": 1,
+              "type": "string",
+              "readOnly": true
+            },
+            "runs": {
+              "title": "Runs",
+              "type": "string",
+              "readOnly": true
+            },
+            "metrics": {
+              "title": "Metrics",
+              "type": "object",
+              "properties": {}
+            },
+            "metric_names": {
+              "title": "Metric names",
+              "type": "string",
+              "readOnly": true
+            },
+            "phone_number": {
+              "title": "Phone number",
+              "minLength": 1,
+              "type": "string",
+              "readOnly": true
+            },
+            "first_message": {
+              "title": "First message",
+              "maxLength": 1000,
+              "type": "string"
+            },
+            "inbound_phone_number": {
+              "title": "Inbound phone number",
+              "type": "integer",
+              "nullable": true
+            },
+            "inbound_phone_number_data": {
+              "$ref": "#/components/schemas/PhoneNumberInbound"
+            },
+            "instructions": {
+              "title": "Instructions",
+              "minLength": 1,
+              "type": "string"
+            },
+            "simulation_description": {
+              "title": "Simulation description",
+              "type": "string"
+            },
+            "information_fields": {
+              "title": "Information fields",
+              "type": "object",
+              "properties": {}
+            },
+            "expected_outcome_prompt": {
+              "title": "Expected outcome prompt",
+              "type": "string"
+            }
+          }
+        },
+        "TestSetList": {
+          "required": [
+            "agent",
+            "duration"
+          ],
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "agent": {
+              "title": "Agent",
+              "type": "integer"
+            },
+            "transcript_short": {
+              "title": "Transcript short",
+              "type": "string",
+              "readOnly": true
+            },
+            "duration": {
+              "title": "Duration",
+              "type": "string"
+            },
+            "has_recording": {
+              "title": "Has recording",
+              "type": "string",
+              "readOnly": true
+            },
+            "source_model": {
+              "title": "Source model",
+              "type": "string",
+              "enum": [
+                "CallLog",
+                "Run"
+              ]
+            },
+            "source_id": {
+              "title": "Source id",
+              "maxLength": 255,
+              "type": "string"
+            },
+            "created_at": {
+              "title": "Created at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            },
+            "updated_at": {
+              "title": "Updated at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            }
+          }
+        },
+        "TestSetDetail": {
+          "required": [
+            "agent"
+          ],
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "agent": {
+              "title": "Agent",
+              "type": "integer"
+            },
+            "transcript": {
+              "title": "Transcript",
+              "type": "string"
+            },
+            "transcript_object": {
+              "title": "Transcript object",
+              "type": "object",
+              "properties": {},
+              "nullable": true
+            },
+            "voice_recording": {
+              "title": "Voice recording",
+              "type": "string",
+              "format": "uri",
+              "readOnly": true
+            },
+            "voice_recording_url": {
+              "title": "Voice recording url",
+              "type": "string",
+              "readOnly": true
+            },
+            "duration": {
+              "title": "Duration",
+              "type": "string",
+              "readOnly": true
+            },
+            "source_model": {
+              "title": "Source model",
+              "type": "string",
+              "readOnly": true,
+              "enum": [
+                "CallLog",
+                "Run"
+              ]
+            },
+            "source_id": {
+              "title": "Source id",
+              "minLength": 1,
+              "type": "string",
+              "readOnly": true
+            },
+            "metric_reviews": {
+              "title": "Metric reviews",
+              "type": "string",
+              "readOnly": true
+            },
+            "created_at": {
+              "title": "Created at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            },
+            "updated_at": {
+              "title": "Updated at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            }
+          }
+        },
+        "AIAgentExternal": {
+          "required": [
+            "agent_name",
+            "contact_number",
+            "predefined_metrics"
+          ],
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "agent_name": {
+              "title": "Agent name",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            },
+            "contact_number": {
+              "title": "Contact number",
+              "maxLength": 15,
+              "minLength": 12,
+              "pattern": "^\\+\\d*$",
+              "type": "string"
+            },
+            "inbound": {
+              "title": "Inbound",
+              "type": "boolean",
+              "nullable": true
+            },
+            "description": {
+              "title": "Description",
+              "minLength": 1,
+              "type": "string"
+            },
+            "language": {
+              "title": "Language",
+              "type": "string",
+              "enum": [
+                "ar",
+                "bg",
+                "ca",
+                "zh",
+                "hr",
+                "cs",
+                "da",
+                "nl",
+                "en",
+                "et",
+                "fil",
+                "fi",
+                "fr",
+                "de",
+                "el",
+                "hi",
+                "hu",
+                "id",
+                "it",
+                "ja",
+                "ko",
+                "lv",
+                "lt",
+                "ms",
+                "no",
+                "pl",
+                "pt",
+                "ro",
+                "ru",
+                "sk",
+                "es",
+                "sv",
+                "ta",
+                "th",
+                "tr",
+                "uk",
+                "vi"
+              ]
+            },
+            "assistant_id": {
+              "title": "Assistant id",
+              "maxLength": 255,
+              "minLength": 10,
+              "type": "string",
+              "nullable": true
+            },
+            "websocket_url": {
+              "title": "Websocket url",
+              "type": "string"
+            },
+            "llm_model": {
+              "title": "Llm model",
+              "type": "string",
+              "enum": [
+                "gpt-4o",
+                "gpt-4o-mini",
+                "claude-3-5-sonnet-20240620"
+              ]
+            },
+            "llm_temperature": {
+              "title": "Llm temperature",
+              "type": "number"
+            },
+            "llm_max_tokens": {
+              "title": "Llm max tokens",
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer"
+            },
+            "predefined_metrics": {
+              "title": "Predefined metrics",
+              "type": "object",
+              "properties": {}
+            }
+          }
+        },
+        "MetricDetailExternal": {
+          "required": [
+            "agent",
+            "name"
+          ],
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "agent": {
+              "title": "Agent",
+              "type": "integer"
+            },
+            "name": {
+              "title": "Name",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            },
+            "description": {
+              "title": "Description",
+              "type": "string"
+            },
+            "eval_type": {
+              "title": "Eval type",
+              "type": "string",
+              "enum": [
+                "binary_workflow_adherence",
+                "binary_qualitative",
+                "continuous_qualitative",
+                "numeric",
+                "enum"
+              ]
+            },
+            "enum_values": {
+              "title": "Enum values",
+              "type": "object",
+              "properties": {}
+            },
+            "audio_enabled": {
+              "title": "Audio enabled",
+              "type": "boolean"
+            },
+            "prompt_enabled": {
+              "title": "Prompt enabled",
+              "type": "boolean"
+            },
+            "prompt": {
+              "title": "Prompt",
+              "type": "string"
+            },
+            "evaluation_trigger": {
+              "title": "Evaluation trigger",
+              "type": "string",
+              "enum": [
+                "always",
+                "automatic",
+                "custom"
+              ]
+            },
+            "evaluation_trigger_prompt": {
+              "title": "Evaluation trigger prompt",
+              "type": "string"
+            },
+            "display_order": {
+              "title": "Display order",
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer"
+            },
+            "overall_score": {
+              "title": "Overall score",
+              "type": "string",
+              "readOnly": true
+            },
+            "total_score": {
+              "title": "Total score",
+              "type": "string",
+              "readOnly": true
+            }
+          }
+        },
+        "PersonalityExternal": {
+          "required": [
+            "description",
+            "name"
+          ],
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "name": {
+              "title": "Name",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            },
+            "description": {
+              "title": "Description",
+              "minLength": 1,
+              "type": "string"
+            },
+            "language": {
+              "title": "Language",
+              "type": "string",
+              "enum": [
+                "ar",
+                "bg",
+                "ca",
+                "zh",
+                "hr",
+                "cs",
+                "da",
+                "nl",
+                "en",
+                "et",
+                "fil",
+                "fi",
+                "fr",
+                "de",
+                "el",
+                "hi",
+                "hu",
+                "id",
+                "it",
+                "ja",
+                "ko",
+                "lv",
+                "lt",
+                "ms",
+                "no",
+                "pl",
+                "pt",
+                "ro",
+                "ru",
+                "sk",
+                "es",
+                "sv",
+                "ta",
+                "th",
+                "tr",
+                "uk",
+                "vi"
+              ]
+            }
+          }
+        },
+        "PredefinedMetricExternal": {
+          "required": [
+            "description",
+            "name"
+          ],
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "name": {
+              "title": "Name",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            },
+            "description": {
+              "title": "Description",
+              "minLength": 1,
+              "type": "string"
+            },
+            "code": {
+              "title": "Code",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        },
+        "ResultExternal": {
+          "required": [
+            "agent"
+          ],
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "agent": {
+              "title": "Agent",
+              "type": "integer"
+            },
+            "status": {
+              "title": "Status",
+              "type": "string",
+              "enum": [
+                "running",
+                "completed",
+                "failed",
+                "pending",
+                "in_progress",
+                "evaluating",
+                "in_queue"
+              ]
+            },
+            "success_rate": {
+              "title": "Success rate",
+              "type": "number"
+            },
+            "run_as_text": {
+              "title": "Run as text",
+              "type": "boolean"
+            },
+            "runs": {
+              "title": "Runs",
+              "type": "string",
+              "readOnly": true
+            },
+            "created_at": {
+              "title": "Created at",
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "ResultDetailExternal": {
+          "required": [
+            "agent"
+          ],
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "agent": {
+              "title": "Agent",
+              "type": "integer"
+            },
+            "status": {
+              "title": "Status",
+              "type": "string",
+              "enum": [
+                "running",
+                "completed",
+                "failed",
+                "pending",
+                "in_progress",
+                "evaluating",
+                "in_queue"
+              ]
+            },
+            "met_expected_outcome_count": {
+              "title": "Met expected outcome count",
+              "type": "string",
+              "readOnly": true
+            },
+            "total_expected_outcome_count": {
+              "title": "Total expected outcome count",
+              "type": "string",
+              "readOnly": true
+            },
+            "success_rate": {
+              "title": "Success rate",
+              "type": "number"
+            },
+            "run_as_text": {
+              "title": "Run as text",
+              "type": "boolean"
+            },
+            "runs": {
+              "title": "Runs",
+              "type": "string",
+              "readOnly": true
+            },
+            "created_at": {
+              "title": "Created at",
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "ScenarioExternal": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "name": {
+              "title": "Name",
+              "maxLength": 40,
+              "minLength": 1,
+              "type": "string"
+            },
+            "personality_name": {
+              "title": "Personality name",
+              "minLength": 1,
+              "type": "string",
+              "readOnly": true
+            },
+            "phone_number": {
+              "title": "Phone number",
+              "minLength": 1,
+              "type": "string",
+              "readOnly": true
+            },
+            "expected_outcome_prompt": {
+              "title": "Expected outcome prompt",
+              "minLength": 1,
+              "type": "string",
+              "readOnly": true
+            }
+          }
+        },
+        "UserAPIKey": {
+          "required": [
+            "key",
+            "organization"
+          ],
+          "type": "object",
+          "properties": {
+            "organization": {
+              "title": "Organization",
+              "type": "integer"
+            },
+            "user": {
+              "title": "User",
+              "type": "integer",
+              "nullable": true
+            },
+            "key": {
+              "title": "Key",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            },
+            "created_at": {
+              "title": "Created at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            }
+          }
+        },
+        "Invite": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "organization": {
+              "title": "Organization",
+              "type": "integer",
+              "readOnly": true
+            },
+            "organization_name": {
+              "title": "Organization name",
+              "minLength": 1,
+              "type": "string",
+              "readOnly": true
+            },
+            "email": {
+              "title": "Email",
+              "minLength": 1,
+              "type": "string",
+              "format": "email",
+              "readOnly": true
+            },
+            "role": {
+              "title": "Role",
+              "type": "string",
+              "enum": [
+                "admin",
+                "member"
+              ]
+            },
+            "status": {
+              "title": "Status",
+              "type": "string",
+              "readOnly": true,
+              "enum": [
+                "pending",
+                "accepted",
+                "rejected"
+              ]
+            },
+            "created_at": {
+              "title": "Created at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            },
+            "updated_at": {
+              "title": "Updated at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            }
+          }
+        },
+        "UserInline": {
+          "required": [
+            "email",
+            "name"
+          ],
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "name": {
+              "title": "Name",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            },
+            "email": {
+              "title": "Email",
+              "maxLength": 254,
+              "minLength": 1,
+              "type": "string",
+              "format": "email"
+            }
+          }
+        },
+        "UserMembership": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "organization": {
+              "title": "Organization",
+              "type": "integer",
+              "readOnly": true
+            },
+            "organization_name": {
+              "title": "Organization name",
+              "minLength": 1,
+              "type": "string",
+              "readOnly": true
+            },
+            "user": {
+              "$ref": "#/components/schemas/UserInline"
+            },
+            "role": {
+              "title": "Role",
+              "type": "string",
+              "enum": [
+                "admin",
+                "member"
+              ]
+            },
+            "created_at": {
+              "title": "Created at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            },
+            "updated_at": {
+              "title": "Updated at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            }
+          }
+        },
+        "MembershipInline": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "user": {
+              "$ref": "#/components/schemas/UserInline"
+            },
+            "role": {
+              "title": "Role",
+              "type": "string",
+              "enum": [
+                "admin",
+                "member"
+              ]
+            },
+            "created_at": {
+              "title": "Created at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            },
+            "updated_at": {
+              "title": "Updated at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            }
+          }
+        },
+        "Organization": {
+          "required": [
+            "name",
+            "retell_api_key",
+            "vapi_api_key"
+          ],
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "name": {
+              "title": "Name",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            },
+            "outbound_timeout": {
+              "title": "Outbound timeout",
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer"
+            },
+            "max_agents_limit": {
+              "title": "Max agents limit",
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer"
+            },
+            "max_concurrent_runs_limit": {
+              "title": "Max concurrent runs limit",
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer"
+            },
+            "max_call_duration": {
+              "title": "Max call duration",
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer"
+            },
+            "evaluate_relevant_metrics_enabled": {
+              "title": "Evaluate relevant metrics enabled",
+              "type": "boolean"
+            },
+            "end_call_enabled": {
+              "title": "End call enabled",
+              "type": "boolean"
+            },
+            "notify_critical_workflow_adherence": {
+              "title": "Notify critical workflow adherence",
+              "type": "boolean"
+            },
+            "notify_daily_report": {
+              "title": "Notify daily report",
+              "type": "boolean"
+            },
+            "notify_cron_failure": {
+              "title": "Notify cron failure",
+              "type": "boolean"
+            },
+            "notify_cron_success": {
+              "title": "Notify cron success",
+              "type": "boolean"
+            },
+            "notify_infra_issues": {
+              "title": "Notify infra issues",
+              "type": "boolean"
+            },
+            "notify_binary_workflow_metrics": {
+              "title": "Notify binary workflow metrics",
+              "type": "boolean"
+            },
+            "notify_latency_spikes": {
+              "title": "Notify latency spikes",
+              "type": "boolean"
+            },
+            "is_send_emails_enabled": {
+              "title": "Is send emails enabled",
+              "type": "boolean"
+            },
+            "vapi_api_key": {
+              "title": "Vapi api key",
+              "type": "string"
+            },
+            "retell_api_key": {
+              "title": "Retell api key",
+              "type": "string"
+            },
+            "webhook_url": {
+              "title": "Webhook url",
+              "maxLength": 200,
+              "type": "string",
+              "format": "uri"
+            },
+            "webhook_secret": {
+              "title": "Webhook secret",
+              "maxLength": 255,
+              "type": "string"
+            },
+            "members": {
+              "type": "array",
+              "readOnly": true,
+              "items": {
+                "$ref": "#/components/schemas/MembershipInline"
+              }
+            },
+            "created_at": {
+              "title": "Created at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            },
+            "updated_at": {
+              "title": "Updated at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            }
+          }
+        },
+        "ProviderCredentialList": {
+          "required": [
+            "organization"
+          ],
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "organization": {
+              "title": "Organization",
+              "type": "integer"
+            },
+            "provider": {
+              "title": "Provider",
+              "type": "string",
+              "enum": [
+                "vapi",
+                "retell"
+              ]
+            },
+            "created_at": {
+              "title": "Created at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            }
+          }
+        },
+        "ProviderCredentialDetail": {
+          "required": [
+            "key",
+            "organization"
+          ],
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "organization": {
+              "title": "Organization",
+              "type": "integer"
+            },
+            "provider": {
+              "title": "Provider",
+              "type": "string",
+              "enum": [
+                "vapi",
+                "retell"
+              ]
+            },
+            "key": {
+              "title": "Key",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            },
+            "created_at": {
+              "title": "Created at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            }
+          }
+        },
+        "CustomTokenObtainPair": {
+          "required": [
+            "agent_id",
+            "api_key"
+          ],
+          "type": "object",
+          "properties": {
+            "api_key": {
+              "title": "Api key",
+              "minLength": 1,
+              "type": "string"
+            },
+            "agent_id": {
+              "title": "Agent id",
+              "type": "integer"
+            }
+          }
+        },
+        "TokenRefresh": {
+          "required": [
+            "refresh"
+          ],
+          "type": "object",
+          "properties": {
+            "refresh": {
+              "title": "Refresh",
+              "minLength": 1,
+              "type": "string"
+            },
+            "access": {
+              "title": "Access",
+              "minLength": 1,
+              "type": "string",
+              "readOnly": true
+            }
+          }
+        },
+        "Edge": {
+          "required": [
+            "source_node",
+            "target_node"
+          ],
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "source_node": {
+              "title": "Source node",
+              "type": "integer"
+            },
+            "target_node": {
+              "title": "Target node",
+              "type": "integer"
+            },
+            "value": {
+              "title": "Value",
+              "type": "object",
+              "properties": {}
+            },
+            "created_at": {
+              "title": "Created at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            },
+            "updated_at": {
+              "title": "Updated at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            }
+          }
+        },
+        "Metric": {
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "name": {
+              "title": "Name",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            },
+            "description": {
+              "title": "Description",
+              "type": "string"
+            },
+            "eval_type": {
+              "title": "Eval type",
+              "type": "string",
+              "enum": [
+                "binary_workflow_adherence",
+                "binary_qualitative",
+                "continuous_qualitative",
+                "numeric",
+                "enum"
+              ]
+            },
+            "enum_values": {
+              "title": "Enum values",
+              "type": "object",
+              "properties": {}
+            },
+            "display_order": {
+              "title": "Display order",
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer"
+            }
+          }
+        },
+        "NodeMetric": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "node": {
+              "title": "Node",
+              "type": "integer",
+              "readOnly": true
+            },
+            "metric": {
+              "title": "Metric",
+              "type": "integer",
+              "readOnly": true
+            },
+            "metric_data": {
+              "$ref": "#/components/schemas/Metric"
+            },
+            "is_main": {
+              "title": "Is main",
+              "type": "boolean"
+            },
+            "created_at": {
+              "title": "Created at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            },
+            "updated_at": {
+              "title": "Updated at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            }
+          }
+        },
+        "NodeMetricCreate": {
+          "required": [
+            "metric",
+            "node"
+          ],
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "node": {
+              "title": "Node",
+              "type": "integer"
+            },
+            "metric": {
+              "title": "Metric",
+              "type": "integer"
+            },
+            "is_main": {
+              "title": "Is main",
+              "type": "boolean"
+            },
+            "created_at": {
+              "title": "Created at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            },
+            "updated_at": {
+              "title": "Updated at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            }
+          }
+        },
+        "Node": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "workflow": {
+              "title": "Workflow",
+              "type": "integer",
+              "readOnly": true
+            },
+            "is_root": {
+              "title": "Is root",
+              "type": "boolean"
+            },
+            "metrics": {
+              "type": "array",
+              "readOnly": true,
+              "items": {
+                "$ref": "#/components/schemas/NodeMetric"
+              }
+            },
+            "created_at": {
+              "title": "Created at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            },
+            "updated_at": {
+              "title": "Updated at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            }
+          }
+        },
+        "NodeCreate": {
+          "required": [
+            "metric",
+            "workflow"
+          ],
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "workflow": {
+              "title": "Workflow",
+              "type": "integer"
+            },
+            "is_root": {
+              "title": "Is root",
+              "type": "boolean"
+            },
+            "metric": {
+              "title": "Metric",
+              "type": "integer"
+            },
+            "metrics": {
+              "type": "array",
+              "readOnly": true,
+              "items": {
+                "$ref": "#/components/schemas/NodeMetric"
+              }
+            },
+            "created_at": {
+              "title": "Created at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            },
+            "updated_at": {
+              "title": "Updated at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            }
+          }
+        },
+        "Workflow": {
+          "required": [
+            "agent",
+            "name"
+          ],
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "agent": {
+              "title": "Agent",
+              "type": "integer"
+            },
+            "name": {
+              "title": "Name",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            },
+            "created_at": {
+              "title": "Created at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            },
+            "updated_at": {
+              "title": "Updated at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            }
+          }
+        },
+        "NodeInline": {
+          "required": [
+            "workflow"
+          ],
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "workflow": {
+              "title": "Workflow",
+              "type": "integer"
+            },
+            "is_root": {
+              "title": "Is root",
+              "type": "boolean"
+            },
+            "main_metric": {
+              "title": "Main metric",
+              "type": "string",
+              "readOnly": true
+            },
+            "created_at": {
+              "title": "Created at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            },
+            "updated_at": {
+              "title": "Updated at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            }
+          }
+        },
+        "WorkflowDetail": {
+          "required": [
+            "agent",
+            "name"
+          ],
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "integer",
+              "readOnly": true
+            },
+            "agent": {
+              "title": "Agent",
+              "type": "integer"
+            },
+            "name": {
+              "title": "Name",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            },
+            "nodes": {
+              "type": "array",
+              "readOnly": true,
+              "items": {
+                "$ref": "#/components/schemas/NodeInline"
+              }
+            },
+            "edges": {
+              "title": "Edges",
+              "type": "string",
+              "readOnly": true
+            },
+            "created_at": {
+              "title": "Created at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            },
+            "updated_at": {
+              "title": "Updated at",
+              "type": "string",
+              "format": "date-time",
+              "readOnly": true
+            }
+          }
+        }
+      },
+      "securitySchemes": {
+        "api_key": {
+          "type": "apiKey",
+          "name": "X-VOCERA-API-KEY",
+          "in": "header"
+        }
       }
-    }
-  },
-  "x-original-swagger-version": "2.0"
-}
+    },
+    "x-original-swagger-version": "2.0"
+  }

--- a/openapi.json
+++ b/openapi.json
@@ -1539,11 +1539,71 @@
         "tags": [
           "observability"
         ],
-        "operationId": "observability_v1_observe_create",
+        "operationId": "observability_observe_create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "call_id",
+                  "transcript_json",
+                  "voice_recording",
+                  "voice_recording_url"
+                ],
+                "properties": {
+                  "call_id": {
+                    "type": "string",
+                    "description": "Unique identifier for the call"
+                  },
+                  "agent": {
+                    "type": "string",
+                    "description": "The agent ID as shown on your dashboard"
+                  },
+                  "assistant_id": {
+                    "type": "string",
+                    "description": "The assistant ID associated with agent"
+                  },
+                  "voice_recording": {
+                    "type": "string",
+                    "description": "Audio file of the call recording"
+                  },
+                  "voice_recording_url": {
+                    "type": "string",
+                    "description": "URL to the call recording audio file"
+                  },
+                  "call_ended_reason": {
+                    "type": "string",
+                    "description": "Reason for call termination"
+                  },
+                  "customer_number": {
+                    "type": "string",
+                    "description": "Phone number of the customer"
+                  },
+                  "transcript_json": {
+                    "type": "object",
+                    "description": "JSON object containing the transcript of the call. Can be in Vocera, Vapi or Retell format"
+                  },
+                  "metadata": {
+                    "type": "object",
+                    "description": "Dictionary with additional data"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "201": {
-            "description": "",
-            "content": {}
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           }
         }
       }
@@ -3053,35 +3113,6 @@
             }
           }
         }
-      },
-      "post": {
-        "tags": [
-          "test_framework"
-        ],
-        "operationId": "test_framework_phone_number_create",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PhoneNumber"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PhoneNumber"
-                }
-              }
-            }
-          }
-        },
-        "x-codegen-request-body-name": "data"
       }
     },
     "/test_framework/phone_number/inbound/": {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update OpenAPI documentation for observability API and remove redundant test framework operation.
> 
>   - **OpenAPI Documentation**:
>     - Rename `operationId` from `observability_v1_observe_create` to `observability_observe_create`.
>     - Add `requestBody` schema for `observability_observe_create` with required fields: `call_id`, `transcript_json`, `voice_recording`, `voice_recording_url`.
>     - Update response `201` description to "Created" and add JSON schema.
>   - **Removal**:
>     - Remove redundant `post` operation for `test_framework_phone_number_create`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=vocera-ai%2Fdocs&utm_source=github&utm_medium=referral)<sup> for 95270bf6ca9a2bcd7dc5f049b8123f00e60142f0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->