### PR TITLE
Add transcript type in observe

### DIFF
--- a/documentation/api/calls/introduction.mdx
+++ b/documentation/api/calls/introduction.mdx
@@ -22,6 +22,7 @@ Send a POST request to `https://new-prod.vocera.ai/observability/v1/observe/` wi
   - `voice_recording_url`: URL to the call recording audio file
 - `call_ended_reason` (optional): Reason for call termination
 - `customer_number` (optional): Phone number of the customer
+- `transcript_type` (required): Format the transcript is sent in. can be `vocera`, `vapi`, `retell` or `deepgram`
 - `transcript_json` (required): JSON object containing the transcript of the call. Can be in Vocera, Vapi or Retell format
 - `metadata` (optional): Dictionary with additional data
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `transcript_type` as a required field in the `observe` API documentation to specify transcript format.
> 
>   - **Documentation Update**:
>     - Adds `transcript_type` as a required field in `introduction.mdx` for the `observe` API endpoint.
>     - `transcript_type` specifies the format of the transcript: `vocera`, `vapi`, `retell`, or `deepgram`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=vocera-ai%2Fdocs&utm_source=github&utm_medium=referral)<sup> for e5a9871829d0ec0cf5e65e6fb41269604ff01a9b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->