### PR TITLE
Add runs numbers to run scenarios

### DIFF
--- a/documentation/api/evaluators/running-evaluators.mdx
+++ b/documentation/api/evaluators/running-evaluators.mdx
@@ -72,16 +72,40 @@ A successful request returns details about created result.
 | `status` | string | Status of the result, can be one of:<br/>• `running` - Initial state when evaluator starts<br/>• `in_progress` - Call is currently executing<br/>• `completed` - Call has finished successfully<br/>• `failed` - Call encountered an error<br/>• `pending` - Testing agent is waiting to be called |
 | `success_rate` | float | Percentage of runs that passed |
 | `run_as_text` | boolean | If executed as text (llm websocket) or not |
+| `runs` | array | List of individual scenario runs |
+| `created_at` | string | ISO 8601 timestamp of when the result was created |
+
+#### Run Fields
+Each object in the `runs` array contains:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | integer | Unique identifier for the individual run |
+| `scenario` | integer | ID of the scenario being run |
+| `number` | string\|null | Phone number assigned to the run if outbound call |
 
 ### Example Response
 
 ```json
 {
-    "id": 188,
+    "id": 167,
     "agent": 1,
-    "status": "running",
-    "success_rate": 0,
-    "run_as_text": false
+    "status": "pending",
+    "success_rate": 0.0,
+    "run_as_text": false,
+    "runs": [
+        {
+            "id": 274,
+            "scenario": 1,
+            "number": "+11234567890"
+        },
+        {
+            "id": 273,
+            "scenario": 2,
+            "number": "+11234567890"
+        }
+    ],
+    "created_at": "2025-02-25T21:00:01.990052Z"
 }
 ```
 
@@ -244,16 +268,40 @@ A successful request returns details about the running evaluators.
 | `status` | string | Status of the result, can be one of:<br/>• `running` - Initial state when evaluator starts<br/>• `in_progress` - Call is currently executing<br/>• `completed` - Call has finished successfully<br/>• `failed` - Call encountered an error<br/>• `pending` - Testing agent is waiting to be called |
 | `success_rate` | float | Percentage of runs that passed |
 | `run_as_text` | boolean | If executed as text (llm websocket) or not |
+| `runs` | array | List of individual scenario runs |
+| `created_at` | string | ISO 8601 timestamp of when the result was created |
+
+#### Run Fields
+Each object in the `runs` array contains:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | integer | Unique identifier for the individual run |
+| `scenario` | integer | ID of the scenario being run |
+| `number` | integer\|null | Sequential number of the run (when freq > 1) |
 
 ### Example Response
 
 ```json
 {
-    "id": 189,
+    "id": 167,
     "agent": 1,
     "status": "running",
-    "success_rate": 0,
-    "run_as_text": true
+    "success_rate": 0.0,
+    "run_as_text": false,
+    "runs": [
+        {
+            "id": 274,
+            "scenario": 1,
+            "number": null
+        },
+        {
+            "id": 273,
+            "scenario": 2,
+            "number": null
+        }
+    ],
+    "created_at": "2025-02-25T21:00:01.990052Z"
 }
 ```
 


### PR DESCRIPTION
Resolve VOC-1273
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `runs` field to evaluator responses, detailing individual scenario runs, and update documentation accordingly.
> 
>   - **API Response Changes**:
>     - Added `runs` field to response in `running-evaluators.mdx`, containing individual scenario run details.
>     - Each run includes `id`, `scenario`, and `number` (phone number or sequential number).
>   - **Documentation Updates**:
>     - Updated example responses to include `runs` field.
>     - Added `Run Fields` section to describe fields in `runs` array.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=vocera-ai%2Fdocs&utm_source=github&utm_medium=referral)<sup> for 0eeec6b96a558da85aaf71e828426f47c37cae8a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->