### PR TITLE
Remove retell agent id

### DIFF
--- a/documentation/api/evaluators/create-evaluators.mdx
+++ b/documentation/api/evaluators/create-evaluators.mdx
@@ -64,7 +64,6 @@ A successful request returns the created evaluator details.
 | `agent` | integer | ID of the associated agent |
 | `personality` | integer | ID of the personality used |
 | `personality_name` | string | Human-readable name of the personality |
-| `retell_agent_id` | string | UUID of the retell agent |
 | `runs` | array | List of evaluator runs (empty for new evaluators) |
 | `instructions` | string | Evaluator instructions |
 | `expected_outcome_prompt` | string | Prompt to evaluate expected outcome |
@@ -79,7 +78,6 @@ A successful request returns the created evaluator details.
     "agent": 4,
     "personality": 2,
     "personality_name": "Frustrated Dutch, English",
-    "retell_agent_id": "edc58747-b69d-47a5-be64-a1d6309c6c65",
     "runs": [],
     "instructions": "Some instructions",
     "expected_outcome_prompt": "Issue was resolved with a refund or replacement",

--- a/documentation/api/evaluators/generate-evaluators.mdx
+++ b/documentation/api/evaluators/generate-evaluators.mdx
@@ -67,7 +67,6 @@ The API returns an array of generated evaluator objects.
 | `personality` | integer | ID of the personality used |
 | `personality_name` | string | Name of the personality |
 | `tags` | array | List of tags associated with the evaluator |
-| `retell_agent_id` | string | UUID of the retell agent |
 | `runs` | array | List of evaluator run IDs |
 | `metrics` | array | List of metric IDs |
 | `metric_names` | array | List of human-readable metric names |
@@ -95,7 +94,6 @@ The API returns an array of generated evaluator objects.
         "personality": 1,
         "personality_name": "Highly Interruptive American Man",
         "tags": ["verification", "high_priority", "english"],
-        "retell_agent_id": "ad023bcd-92a6-4911-bf96-ffa7d4c1055e",
         "runs": [],
         "metrics": [1, 3, 20, 21, 28, 31],
         "metric_names": [

--- a/documentation/api/evaluators/get-evaluator.mdx
+++ b/documentation/api/evaluators/get-evaluator.mdx
@@ -40,7 +40,6 @@ The API returns detailed information about the specified evaluator.
 | `personality` | integer | ID of the personality used |
 | `personality_name` | string | Human-readable name of the personality |
 | `tags` | array | List of tags associated with the evaluator |
-| `retell_agent_id` | string | UUID of the retell agent |
 | `runs` | array | List of evaluator run IDs |
 | `metrics` | array | List of metric IDs |
 | `metric_names` | array | List of human-readable metric names |
@@ -68,7 +67,6 @@ The API returns detailed information about the specified evaluator.
     "personality": 456,
     "personality_name": "Frustrated Customer Persona",
     "tags": ["angry_customer", "product_complaint", "high_priority"],
-    "retell_agent_id": "f16f6561-xxxx-xxxx-xxxx-5fde4dff123f",
     "runs": [501, 502, 503],
     "metrics": [789, 790, 791],
     "metric_names": [

--- a/documentation/api/evaluators/update-evaluators.mdx
+++ b/documentation/api/evaluators/update-evaluators.mdx
@@ -71,7 +71,6 @@ The API returns detailed information about the updated evaluator.
 | `personality` | integer | ID of the personality used |
 | `personality_name` | string | Name of the personality |
 | `tags` | array | List of tags associated with the evaluator |
-| `retell_agent_id` | string | UUID of the retell agent |
 | `runs` | array | List of evaluator run IDs |
 | `metrics` | array | List of metric IDs |
 | `metric_names` | array | List of human-readable metric names |
@@ -99,7 +98,6 @@ The API returns detailed information about the updated evaluator.
     "personality": 456,
     "personality_name": "Frustrated Customer Persona",
     "tags": ["angry_customer", "product_complaint", "high_priority"],
-    "retell_agent_id": "f16f6561-xxxx-xxxx-xxxx-5fde4dff123f",
     "runs": [501, 502, 503],
     "metrics": [789, 790, 791],
     "metric_names": [


### PR DESCRIPTION
Ref VOC-1506
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `retell_agent_id` field from evaluator API documentation response fields and examples.
> 
>   - **Documentation**:
>     - Remove `retell_agent_id` field from response fields in `create-evaluators.mdx`, `generate-evaluators.mdx`, `get-evaluator.mdx`, and `update-evaluators.mdx`.
>     - Update example responses to exclude `retell_agent_id` in the same files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=vocera-ai%2Fdocs&utm_source=github&utm_medium=referral)<sup> for ca94ab0df7a55da85e3e706dc6de6f531cd17134. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->