### PR TITLE
Add example observe request

### DIFF
--- a/documentation/api/calls/introduction.mdx
+++ b/documentation/api/calls/introduction.mdx
@@ -44,7 +44,7 @@ Send a POST request to [`https://new-prod.vocera.ai/observability/v1/observe/`](
 ```json
 {
     "call_id": "call_20240317_123456",
-    "agent": "agent_789xyz",
+    "agent": 1,
     "voice_recording_url": "https://storage.example.com/calls/recording_123.wav",
     "call_ended_reason": "completed",
     "customer_number": "+1234567890",

--- a/documentation/api/calls/introduction.mdx
+++ b/documentation/api/calls/introduction.mdx
@@ -39,6 +39,43 @@ Send a POST request to [`https://new-prod.vocera.ai/observability/v1/observe/`](
 
 * `dynamic_variables` (optional): Dictionary of dynamic variables and values. These values will replace variables in double curly braces in the agent description.
 
+## Example Request
+
+```json
+{
+    "call_id": "call_20240317_123456",
+    "agent": "agent_789xyz",
+    "voice_recording_url": "https://storage.example.com/calls/recording_123.wav",
+    "call_ended_reason": "completed",
+    "customer_number": "+1234567890",
+    "transcript_type": "vocera",
+    "transcript_json": [
+        {
+            "role": "Testing Agent",
+            "content": "Hello, how can I help you today?",
+            "end_time": 1.94,
+            "start_time": 1.44
+        },
+        {
+            "role": "Main Agent",
+            "content": "Hi, I need help with my account.",
+            "end_time": 7.54,
+            "start_time": 3.1
+        }
+    ],
+    "metadata": {
+        "customer_id": "cust_456",
+        "department": "support",
+        "priority": "high"
+    },
+    "dynamic_variables": {
+        "customer_name": "John Smith",
+        "account_type": "premium",
+        "last_interaction": "2024-03-10"
+    }
+}
+```
+
 **Transcript JSON Example:**
 
 Vocera Format


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add example request to `introduction.mdx` for the `observe` API endpoint documentation.
> 
>   - **Documentation**:
>     - Adds an example request to `introduction.mdx` for the `observe` API endpoint.
>     - Example includes fields like `call_id`, `agent`, `voice_recording_url`, `call_ended_reason`, `customer_number`, `transcript_type`, `transcript_json`, `metadata`, and `dynamic_variables`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=vocera-ai%2Fdocs&utm_source=github&utm_medium=referral)<sup> for c53535831bf57f9a8c7a23a6681835b679286e8f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->