### PR TITLE
Update running-evaluators API endpoint

### DIFF
--- a/documentation/api/evaluators/running-evaluators.mdx
+++ b/documentation/api/evaluators/running-evaluators.mdx
@@ -27,7 +27,8 @@ Include your API key in the request headers:
 |-----------|------|----------|-------------|
 | `agent_id` | integer | Yes* | Unique identifier of the agent |
 | `assistant_id` | integer | Yes* | The assistant ID associated with agent |
-| `scenarios` | array\|string\|integer | Yes | Array of evaluator IDs to run OR `"all"` to run all OR number to run first N evaluators |
+| `scenarios` | array\|string\|integer | Yes | Array of evaluator IDs to run OR `"all"` to run all OR number to run first N evaluators. Either scenarios or tags must be provided.  |
+| `tags` | array\[string\]| Yes | List of tags to filter scenarios to run. Either scenarios or tags must be provided.|
 | `freq` | integer | No | Number of times to run each scenario (default: 1) |
 
 \* Required only when `scenarios` is `"all"` OR is number of first N evaluators. Only either of `agent_id` or `assistant_id` is required
@@ -37,6 +38,12 @@ Running evaluators using ids
 ```json
 {
     "scenarios": [201, 187],
+    "freq": 5
+}
+```
+```json
+{
+    "tags": ["short", "long"],
     "freq": 5
 }
 ```


### PR DESCRIPTION
• Updated  scenarios  field description to include the requirement that either scenarios or tags must be provided.
• Added new  tags  field as an alternative to filter scenarios. • Provided examples of API requests using both scenarios and tags.