### PR TITLE
Update API Evaluators with Name Field

### DIFF
--- a/documentation/api/evaluators/running-evaluators.mdx
+++ b/documentation/api/evaluators/running-evaluators.mdx
@@ -30,6 +30,7 @@ Include your API key in the request headers:
 | `scenarios` | array\|string\|integer | Yes | Array of evaluator IDs to run OR `"all"` to run all OR number to run first N evaluators. Either scenarios or tags must be provided.  |
 | `tags` | array\[string\]| Yes | List of tags to filter scenarios to run. Either scenarios or tags must be provided.|
 | `freq` | integer | No | Number of times to run each scenario (default: 1) |
+| `name` | string | No | Label text for the result |
 
 \* Required only when `scenarios` is `"all"` OR is number of first N evaluators. Only either of `agent_id` or `assistant_id` is required
 
@@ -38,13 +39,15 @@ Running evaluators using ids
 ```json
 {
     "scenarios": [201, 187],
-    "freq": 5
+    "freq": 5,
+    "name": "label text" // optional
 }
 ```
 ```json
 {
     "tags": ["short", "long"],
-    "freq": 5
+    "freq": 5,
+    "name": "label text" // optional
 }
 ```
 

--- a/documentation/api/results/get-results.mdx
+++ b/documentation/api/results/get-results.mdx
@@ -37,6 +37,7 @@ A successful request returns details about created result.
 | Field | Type | Description |
 |-------|------|-------------|
 | `id` | integer | The result ID |
+| `name` | string | Result label |
 | `agent` | integer | ID of associated agent |
 | `status` | string | Status of the result, can be one of:<br/>• `running` - Initial state when evaluator starts<br/>• `in_progress` - Call is currently executing<br/>• `completed` - Call has finished successfully<br/>• `failed` - Call encountered an error<br/>• `pending` - Testing agent is waiting to be called |
 | `success_rate` | float | Percentage of runs that passed |
@@ -61,6 +62,7 @@ A successful request returns details about created result.
 ```json
 {
     "id": 30,
+    "name": "result-label",
     "agent": 1,
     "status": "completed",
     "success_rate": 100.0,

--- a/documentation/api/results/list-results.mdx
+++ b/documentation/api/results/list-results.mdx
@@ -49,6 +49,7 @@ Each result object contains:
 | Field | Type | Description |
 |-------|------|-------------|
 | `id` | integer | The result ID |
+| `name` | string | Result label |
 | `agent` | integer | ID of associated agent |
 | `status` | string | Status of the result, can be one of:<br/>• `running` - Initial state when evaluator starts<br/>• `in_progress` - Call is currently executing<br/>• `completed` - Call has finished successfully<br/>• `failed` - Call encountered an error<br/>• `pending` - Testing agent is waiting to be called |
 | `success_rate` | float | Percentage of runs that passed |
@@ -65,6 +66,7 @@ Each result object contains:
     "results": [
         {
             "id": 185,
+            "name": "result-label",
             "agent": 1,
             "status": "completed",
             "success_rate": 100,
@@ -74,6 +76,7 @@ Each result object contains:
         {
             "id": 184,
             "agent": 1,
+            "name": "result-label",
             "status": "completed",
             "success_rate": 100,
             "run_as_text": true,

--- a/openapi.json
+++ b/openapi.json
@@ -6282,6 +6282,41 @@
                 }
             }
         },
+        "/test_framework/test-sets/add/{metric_id}/": {
+            "get": {
+                "operationId": "test_framework_test_sets_add_retrieve",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "metric_id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TestSetDetail"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/test_framework/test-sets/create_from_call_log/": {
             "post": {
                 "operationId": "test_framework_test_sets_create_from_call_log_create",
@@ -8461,7 +8496,8 @@
                                 "$ref": "#/components/schemas/SchemaPostScenario"
                             }
                         }
-                    }
+                    },
+                    "required": true
                 },
                 "security": [
                     {
@@ -11963,7 +11999,7 @@
                             }
                         ],
                         "default": "en",
-                        "description": "The primary language this agent uses for communication (e.g. 'en' for English)\n\n* `ar` - Arabic\n* `bg` - Bulgarian\n* `zh` - Chinese Simplified\n* `hr` - Croatian\n* `cs` - Czech\n* `da` - Danish\n* `nl` - Dutch\n* `en` - English\n* `fil` - Filipino\n* `fi` - Finnish\n* `fr` - French\n* `de` - German\n* `el` - Greek\n* `hi` - Hindi\n* `hu` - Hungarian\n* `id` - Indonesian\n* `it` - Italian\n* `ja` - Japanese\n* `ko` - Korean\n* `ms` - Malay\n* `no` - Norwegian\n* `pl` - Polish\n* `pt` - Portuguese\n* `ro` - Romanian\n* `ru` - Russian\n* `sk` - Slovak\n* `es` - Spanish\n* `sv` - Swedish\n* `ta` - Tamil\n* `tr` - Turkish\n* `uk` - Ukrainian\n* `vi` - Vietnamese"
+                        "description": "The primary language this agent uses for communication (e.g. 'en' for English)\n\n* `ar` - Arabic\n* `bg` - Bulgarian\n* `zh` - Chinese Simplified\n* `cs` - Czech\n* `da` - Danish\n* `nl` - Dutch\n* `en` - English\n* `fi` - Finnish\n* `fr` - French\n* `de` - German\n* `el` - Greek\n* `hi` - Hindi\n* `hu` - Hungarian\n* `id` - Indonesian\n* `it` - Italian\n* `ja` - Japanese\n* `ko` - Korean\n* `ms` - Malay\n* `no` - Norwegian\n* `pl` - Polish\n* `pt` - Portuguese\n* `ro` - Romanian\n* `ru` - Russian\n* `sk` - Slovak\n* `es` - Spanish\n* `sv` - Swedish\n* `tr` - Turkish\n* `uk` - Ukrainian\n* `vi` - Vietnamese"
                     },
                     "assistant_id": {
                         "type": "string",
@@ -12659,12 +12695,10 @@
                     "ar",
                     "bg",
                     "zh",
-                    "hr",
                     "cs",
                     "da",
                     "nl",
                     "en",
-                    "fil",
                     "fi",
                     "fr",
                     "de",
@@ -12684,13 +12718,12 @@
                     "sk",
                     "es",
                     "sv",
-                    "ta",
                     "tr",
                     "uk",
                     "vi"
                 ],
                 "type": "string",
-                "description": "* `ar` - Arabic\n* `bg` - Bulgarian\n* `zh` - Chinese Simplified\n* `hr` - Croatian\n* `cs` - Czech\n* `da` - Danish\n* `nl` - Dutch\n* `en` - English\n* `fil` - Filipino\n* `fi` - Finnish\n* `fr` - French\n* `de` - German\n* `el` - Greek\n* `hi` - Hindi\n* `hu` - Hungarian\n* `id` - Indonesian\n* `it` - Italian\n* `ja` - Japanese\n* `ko` - Korean\n* `ms` - Malay\n* `no` - Norwegian\n* `pl` - Polish\n* `pt` - Portuguese\n* `ro` - Romanian\n* `ru` - Russian\n* `sk` - Slovak\n* `es` - Spanish\n* `sv` - Swedish\n* `ta` - Tamil\n* `tr` - Turkish\n* `uk` - Ukrainian\n* `vi` - Vietnamese"
+                "description": "* `ar` - Arabic\n* `bg` - Bulgarian\n* `zh` - Chinese Simplified\n* `cs` - Czech\n* `da` - Danish\n* `nl` - Dutch\n* `en` - English\n* `fi` - Finnish\n* `fr` - French\n* `de` - German\n* `el` - Greek\n* `hi` - Hindi\n* `hu` - Hungarian\n* `id` - Indonesian\n* `it` - Italian\n* `ja` - Japanese\n* `ko` - Korean\n* `ms` - Malay\n* `no` - Norwegian\n* `pl` - Polish\n* `pt` - Portuguese\n* `ro` - Romanian\n* `ru` - Russian\n* `sk` - Slovak\n* `es` - Spanish\n* `sv` - Swedish\n* `tr` - Turkish\n* `uk` - Ukrainian\n* `vi` - Vietnamese"
             },
             "LlmModelEnum": {
                 "enum": [
@@ -14820,7 +14853,7 @@
                                 "$ref": "#/components/schemas/ScenarioLanguageEnum"
                             }
                         ],
-                        "description": "Language of the scenario\n\n* `ar` - Arabic\n* `bg` - Bulgarian\n* `zh` - Chinese Simplified\n* `hr` - Croatian\n* `cs` - Czech\n* `da` - Danish\n* `nl` - Dutch\n* `en` - English\n* `fil` - Filipino\n* `fi` - Finnish\n* `fr` - French\n* `de` - German\n* `el` - Greek\n* `hi` - Hindi\n* `hu` - Hungarian\n* `id` - Indonesian\n* `it` - Italian\n* `ja` - Japanese\n* `ko` - Korean\n* `ms` - Malay\n* `no` - Norwegian\n* `pl` - Polish\n* `pt` - Portuguese\n* `ro` - Romanian\n* `ru` - Russian\n* `sk` - Slovak\n* `es` - Spanish\n* `sv` - Swedish\n* `ta` - Tamil\n* `tr` - Turkish\n* `uk` - Ukrainian\n* `vi` - Vietnamese"
+                        "description": "Language of the scenario\n\n* `ar` - Arabic\n* `bg` - Bulgarian\n* `zh` - Chinese Simplified\n* `cs` - Czech\n* `da` - Danish\n* `nl` - Dutch\n* `en` - English\n* `fi` - Finnish\n* `fr` - French\n* `de` - German\n* `el` - Greek\n* `hi` - Hindi\n* `hu` - Hungarian\n* `id` - Indonesian\n* `it` - Italian\n* `ja` - Japanese\n* `ko` - Korean\n* `ms` - Malay\n* `no` - Norwegian\n* `pl` - Polish\n* `pt` - Portuguese\n* `ro` - Romanian\n* `ru` - Russian\n* `sk` - Slovak\n* `es` - Spanish\n* `sv` - Swedish\n* `tr` - Turkish\n* `uk` - Ukrainian\n* `vi` - Vietnamese"
                     }
                 }
             },
@@ -14926,7 +14959,7 @@
                     },
                     "personality": {
                         "type": "integer",
-                        "nullable": true
+                        "description": "The personality of the scenario"
                     },
                     "instructions": {
                         "type": "string"
@@ -15875,7 +15908,7 @@
                                 "$ref": "#/components/schemas/ScenarioLanguageEnum"
                             }
                         ],
-                        "description": "Language of the scenario\n\n* `ar` - Arabic\n* `bg` - Bulgarian\n* `zh` - Chinese Simplified\n* `hr` - Croatian\n* `cs` - Czech\n* `da` - Danish\n* `nl` - Dutch\n* `en` - English\n* `fil` - Filipino\n* `fi` - Finnish\n* `fr` - French\n* `de` - German\n* `el` - Greek\n* `hi` - Hindi\n* `hu` - Hungarian\n* `id` - Indonesian\n* `it` - Italian\n* `ja` - Japanese\n* `ko` - Korean\n* `ms` - Malay\n* `no` - Norwegian\n* `pl` - Polish\n* `pt` - Portuguese\n* `ro` - Romanian\n* `ru` - Russian\n* `sk` - Slovak\n* `es` - Spanish\n* `sv` - Swedish\n* `ta` - Tamil\n* `tr` - Turkish\n* `uk` - Ukrainian\n* `vi` - Vietnamese"
+                        "description": "Language of the scenario\n\n* `ar` - Arabic\n* `bg` - Bulgarian\n* `zh` - Chinese Simplified\n* `cs` - Czech\n* `da` - Danish\n* `nl` - Dutch\n* `en` - English\n* `fi` - Finnish\n* `fr` - French\n* `de` - German\n* `el` - Greek\n* `hi` - Hindi\n* `hu` - Hungarian\n* `id` - Indonesian\n* `it` - Italian\n* `ja` - Japanese\n* `ko` - Korean\n* `ms` - Malay\n* `no` - Norwegian\n* `pl` - Polish\n* `pt` - Portuguese\n* `ro` - Romanian\n* `ru` - Russian\n* `sk` - Slovak\n* `es` - Spanish\n* `sv` - Swedish\n* `tr` - Turkish\n* `uk` - Ukrainian\n* `vi` - Vietnamese"
                     }
                 },
                 "required": [
@@ -15969,12 +16002,10 @@
                     "ar",
                     "bg",
                     "zh",
-                    "hr",
                     "cs",
                     "da",
                     "nl",
                     "en",
-                    "fil",
                     "fi",
                     "fr",
                     "de",
@@ -15994,13 +16025,12 @@
                     "sk",
                     "es",
                     "sv",
-                    "ta",
                     "tr",
                     "uk",
                     "vi"
                 ],
                 "type": "string",
-                "description": "* `ar` - Arabic\n* `bg` - Bulgarian\n* `zh` - Chinese Simplified\n* `hr` - Croatian\n* `cs` - Czech\n* `da` - Danish\n* `nl` - Dutch\n* `en` - English\n* `fil` - Filipino\n* `fi` - Finnish\n* `fr` - French\n* `de` - German\n* `el` - Greek\n* `hi` - Hindi\n* `hu` - Hungarian\n* `id` - Indonesian\n* `it` - Italian\n* `ja` - Japanese\n* `ko` - Korean\n* `ms` - Malay\n* `no` - Norwegian\n* `pl` - Polish\n* `pt` - Portuguese\n* `ro` - Romanian\n* `ru` - Russian\n* `sk` - Slovak\n* `es` - Spanish\n* `sv` - Swedish\n* `ta` - Tamil\n* `tr` - Turkish\n* `uk` - Ukrainian\n* `vi` - Vietnamese"
+                "description": "* `ar` - Arabic\n* `bg` - Bulgarian\n* `zh` - Chinese Simplified\n* `cs` - Czech\n* `da` - Danish\n* `nl` - Dutch\n* `en` - English\n* `fi` - Finnish\n* `fr` - French\n* `de` - German\n* `el` - Greek\n* `hi` - Hindi\n* `hu` - Hungarian\n* `id` - Indonesian\n* `it` - Italian\n* `ja` - Japanese\n* `ko` - Korean\n* `ms` - Malay\n* `no` - Norwegian\n* `pl` - Polish\n* `pt` - Portuguese\n* `ro` - Romanian\n* `ru` - Russian\n* `sk` - Slovak\n* `es` - Spanish\n* `sv` - Swedish\n* `tr` - Turkish\n* `uk` - Ukrainian\n* `vi` - Vietnamese"
             },
             "SchemaGenerateMetricsMetricCreate": {
                 "type": "object",
@@ -16427,6 +16457,10 @@
                         "type": "integer",
                         "default": 1,
                         "description": "The frequency of the scenarios to run"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Label text for the run_scenarios"
                     }
                 }
             },
@@ -16448,7 +16482,7 @@
                     },
                     "personality": {
                         "type": "integer",
-                        "nullable": true
+                        "description": "The personality of the scenario"
                     },
                     "instructions": {
                         "type": "string"
@@ -16462,7 +16496,10 @@
                         "writeOnly": true,
                         "description": "List of metric IDs to associate with this scenario"
                     }
-                }
+                },
+                "required": [
+                    "personality"
+                ]
             },
             "SchemaPostSimulateScenario": {
                 "type": "object",

--- a/openapi.json
+++ b/openapi.json
@@ -15479,6 +15479,10 @@
                         "type": "integer",
                         "readOnly": true
                     },
+                    "name": {
+                        "type": "string",
+                        "maxLength": 255
+                    },
                     "agent": {
                         "type": "integer"
                     },
@@ -15532,6 +15536,10 @@
                     "id": {
                         "type": "integer",
                         "readOnly": true
+                    },
+                    "name": {
+                        "type": "string",
+                        "maxLength": 255
                     },
                     "agent": {
                         "type": "integer"


### PR DESCRIPTION
• Added  name  field in the /test_framework/test-sets/add/{metric_id}/ endpoint in openapi.json
•  name  is an optional parameter for label text in the response