### PR TITLE
feat: Add API endpoint to create cron jobs for evaluators

### DIFF
--- a/api-reference/schedules/post-schedulesv1-cronjob-external.mdx
+++ b/api-reference/schedules/post-schedulesv1-cronjob-external.mdx
@@ -1,0 +1,4 @@
+---
+title: Creating a cronjob for evaluators
+openapi: post /schedules/v1/cron-jobs-external/
+---

--- a/mint.json
+++ b/mint.json
@@ -150,7 +150,8 @@
             "api-reference/test_framework/patch-test_frameworkv1scenarios-external-",
             "api-reference/test_framework/post-test_frameworkv1scenarios-externalrun_scenarios",
             "api-reference/test_framework/post-test_frameworkv1scenarios-externalgenerate",
-            "api-reference/test_framework/post-test_frameworkv1scenarios-externalcreate_scenario_from_transcript"
+            "api-reference/test_framework/post-test_frameworkv1scenarios-externalcreate_scenario_from_transcript",
+            "api-reference/schedules/post-schedulesv1-cronjob-external"
           ]
         },
         {

--- a/openapi.json
+++ b/openapi.json
@@ -1985,6 +1985,245 @@
                 }
             }
         },
+        "/schedules/v1/cron-jobs-external/": {
+            "get": {
+                "operationId": "schedules_v1_cron_jobs_external_list",
+                "description": "List all cron jobs",
+                "tags": [
+                    "schedules"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/CronJob"
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "post": {
+                "operationId": "schedules_v1_cron_jobs_external_create",
+                "description": "Create a new cron job for scheduled Evaluators execution",
+                "tags": [
+                    "schedules"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostCronJob"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostCronJob"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostCronJob"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CronJob"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/schedules/v1/cron-jobs-external/{id}/": {
+            "get": {
+                "operationId": "schedules_v1_cron_jobs_external_retrieve",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "schedules"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CronJob"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "put": {
+                "operationId": "schedules_v1_cron_jobs_external_update",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "schedules"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CronJob"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CronJob"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CronJob"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CronJob"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "patch": {
+                "operationId": "schedules_v1_cron_jobs_external_partial_update",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "schedules"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedCronJob"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedCronJob"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedCronJob"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CronJob"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "schedules_v1_cron_jobs_external_destroy",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "schedules"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No response body"
+                    }
+                }
+            }
+        },
         "/slack/interact/": {
             "post": {
                 "operationId": "slack_interact_create",
@@ -18987,6 +19226,26 @@
                     "call_id"
                 ]
             },
+            "SchemaPostCronJob": {
+                "type": "object",
+                "properties": {
+                    "scenarios": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        },
+                        "description": "List of scenario IDs to execute"
+                    },
+                    "crontab_expression": {
+                        "type": "string",
+                        "description": "Cron expression for scheduling (e.g. '0 9 * * 1-5' for weekdays at 9am)"
+                    }
+                },
+                "required": [
+                    "crontab_expression",
+                    "scenarios"
+                ]
+            },
             "SchemaPostMetricEdit": {
                 "type": "object",
                 "properties": {
@@ -19195,7 +19454,7 @@
                         },
                         "description": "List of tags to filter scenarios to run. Either scenarios or tags must be provided."
                     },
-                    "freq": {
+                    "frequency": {
                         "type": "integer",
                         "default": 1,
                         "description": "The frequency of the scenarios to run"


### PR DESCRIPTION
• Added new API endpoint  /schedules/v1/cron-jobs-external/  for creating cron jobs
• Included  post  operation to create a new cron job for scheduled