### PR TITLE
feat: Add request body examples for Retell and VAPI in observability …

### DIFF
--- a/documentation/guides/observability/retell.mdx
+++ b/documentation/guides/observability/retell.mdx
@@ -32,3 +32,17 @@ Add the key from Retell with the tag `webhook` to Cekura in the Agent Settings p
 ![images/Screenshot2025-03-17at11.35.20AM.png](/images/Screenshot2025-03-17at11.35.20AM.png)
 
 You should be all set now. Simply make a call from Retell (phone number based or even webcall) to test it out. The calls will start appearing in the observability `Calls` section
+
+## Request Body Example
+
+When using Retell, here's what the request body will look like when creating a new call log entry in Cekura:
+
+```json
+{
+  "agent": <agent_id_in_vocera>,
+  "recording_url": retell_response["recording_url"],
+  "transcript_type": "retell",
+  "transcript_json": retell_response["transcript_with_tool_calls"],
+  "call_id": retell_response["call_id"]
+}
+```

--- a/documentation/guides/observability/vapi.mdx
+++ b/documentation/guides/observability/vapi.mdx
@@ -44,4 +44,16 @@ To obtain your API key from the dashboard.cekura.ai platform:
 
 Keep this key secure and never share it publicly, as it provides access to your VAPI integration.
 
+## Request Body Example
 
+When using VAPI, here's what the request body will look like when creating a new call log entry in Cekura:
+
+```json
+{
+  "agent": <agent_id_in_vocera>,
+  "recording_url": vapi_response["recordingUrl"],
+  "transcript_type": "vapi",
+  "transcript_json": vapi_response["messages"],
+  "call_id": vapi_response["id"]
+}
+```


### PR DESCRIPTION
…guides

• Added a request body example for Retell when creating a new call log entry in Cekura
• Included fields like agent ID, recording URL, transcript type, transcript JSON, and call ID
• Updated the Retell section to provide clarity on how to use the request body • Added a request body example for VAPI when creating a new call log entry in Cekura