### PR TITLE
[CEK-7040] Remove deprecated overall evaluation realtime endpoint from docs

### DIFF
--- a/api-reference/observability/get-observabilityoverall_evaluationrealtime.mdx
+++ b/api-reference/observability/get-observabilityoverall_evaluationrealtime.mdx
@@ -1,3 +1,0 @@
----
-openapi: get /observability/overall_evaluation/realtime/
----

--- a/api-reference/observability/get-overall-evaluation.mdx
+++ b/api-reference/observability/get-overall-evaluation.mdx
@@ -1,5 +1,0 @@
----
-title: Get Overall Evaluation
-openapi: get /observability/v1/overall_evaluation/realtime/
-slug: get-overall-evaluation
----

--- a/mint.json
+++ b/mint.json
@@ -196,8 +196,7 @@
             "api-reference/observability/list-calls",
             "api-reference/observability/reevaluate-calls",
             "api-reference/observability/evaluate-metrics",
-            "api-reference/observability/delete-call",
-            "api-reference/observability/get-overall-evaluation"
+            "api-reference/observability/delete-call"
           ]
         },
         {


### PR DESCRIPTION
The GET /observability/v1/overall_evaluation/realtime/ endpoint has been deprecated in the backend. Users should use the Dashboards API instead.