### PR TITLE
CEK-7099: Update call ended reasons documentation

### DIFF
--- a/documentation/advanced/call-end-reasons.mdx
+++ b/documentation/advanced/call-end-reasons.mdx
@@ -23,34 +23,38 @@ In testing, "Main agent" refers to your agent being tested, and "Testing agent" 
 
 - `Main agent-did-not-answer`: Your agent did not answer within the timeout period.
 - `Main agent-busy`: Your agent's line was busy or at capacity.
-- `voicemail`: The call reached voicemail instead of your agent.
+- `Main agent-voicemail`: The call reached voicemail instead of your agent.
 
 #### Timeouts
 
-- `silence-timed-out`: Call ended due to prolonged silence from both parties.
+- `Main agent-silence-timed-out`: Call ended due to prolonged silence from both parties.
 - `exceeded-max-duration`: Call reached the maximum allowed duration.
 
 #### Testing & User Actions
 
 - `run-cancelled-by-user`: User manually cancelled the test run.
 - `external-user-ended-call`: An external user ended the call.
-- `invalid-phone-number`: Phone number was invalid or unreachable.
+- `Main agent-invalid-phone-number`: Phone number was invalid or unreachable.
+- `Testing agent-run-not-ready`: Test run was not ready when call was initiated.
 
 #### Connection Failures
 
-- `call-not-connected`: Call failed to establish a connection.
+- `Main agent-call-not-connected`: Call failed to establish a connection.
 - `call-canceled`: Call was canceled before connecting.
 - `call-rejected`: Call was explicitly rejected by the destination.
 - `call-failed-unknown-error`: Call failed due to an unknown error.
 - `sip-call-failed`: SIP protocol-specific call failure.
+- `Main agent-twilio-client-error`: Connection error from customer's phone network.
 
 #### Agent & Bot Failures
 
-- `pipecat-agent-did-not-connected`: Agent failed to connect within the timeout period.
-- `dial-out-bot-crashed`: Outbound call bot crashed or became unresponsive.
-- `dial-in-bot-crashed`: Inbound call bot crashed or became unresponsive.
-- `sip-dial-out-bot-crashed`: SIP outbound call bot crashed or became unresponsive.
+- `Testing agent-did-not-connect`: Testing agent failed to connect within the timeout period.
+- `Testing agent-dial-out-bot-crashed`: Outbound call bot crashed or became unresponsive.
+- `Testing agent-dial-in-bot-crashed`: Inbound call bot crashed or became unresponsive.
+- `Testing agent-sip-dial-out-bot-crashed`: SIP outbound call bot crashed or became unresponsive.
 
 #### System Errors
 
-- `pipeline-error`: A system or pipeline error occurred during the call.
+- `Testing agent-pipeline-error`: A system or pipeline error occurred during the call.
+- `Testing agent-recording-absent`: Call recording was not available after the call.
+- `Testing agent-recording-failed`: Call recording failed to process or save.


### PR DESCRIPTION
## Summary
- Updated all call ended reasons to reflect backend conversion logic
- Backend converts "customer" → "Main agent" and "assistant" → "Testing agent"
- Changed vague reasons like "voicemail" to "Main agent-voicemail"
- Added new reasons: Testing agent-run-not-ready, Main agent-twilio-client-error, Testing agent-recording-absent, Testing agent-recording-failed

## Related PRs
- Backend: https://github.com/cekura-ai/vocera.backend/pull/8204
- Patronus: https://github.com/cekura-ai/cekura.patronus/pull/133
- Pipecat: https://github.com/cekura-ai/pipecat-cloud-agents/compare/main...main-local?expand=1

🤖 Generated with [Claude Code](https://claude.com/claude-code)