### PR TITLE
Add skills repository link to MCP section in docs

### DIFF
--- a/mcp/skills.mdx
+++ b/mcp/skills.mdx
@@ -1,0 +1,6 @@
+---
+title: "Skills Repository"
+sidebarTitle: "Skills"
+icon: "sparkles"
+url: "https://github.com/cekura-ai/cekura-skills"
+---

--- a/mint.json
+++ b/mint.json
@@ -427,7 +427,8 @@
     {
       "group": "MCP",
       "pages": [
-        "mcp/overview"
+        "mcp/overview",
+        "mcp/skills"
       ]
     }
   ],


### PR DESCRIPTION
Added a redirect link to the Cekura Skills repository (https://github.com/cekura-ai/cekura-skills) in the MCP documentation section, following the same pattern as the existing changelog link.

https://cekura.slack.com/archives/D09RP5PBN1L/p1775515528329069?thread_ts=1775515318.029589&cid=D09RP5PBN1L