### PR TITLE
Add Retell integration video tutorial to documentation

### DIFF
--- a/documentation/integrations/retell/testing.mdx
+++ b/documentation/integrations/retell/testing.mdx
@@ -207,6 +207,12 @@ To enable auto-sync, toggle on **Auto-sync Prompt** in the Retell voice integrat
 Auto-sync requires a valid Retell API Key and Assistant ID. If credentials become invalid or the assistant is deleted, auto-sync will automatically disable itself.
 </Note>
 
+## Video Tutorial
+
+Watch this video to see the Retell integration in action:
+
+<iframe width="100%" height="600" src="https://www.tella.tv/video/cekura-retell-integration-90mo" title="Cekura Retell Integration" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
 ## Next Steps
 
 - Learn about [custom metrics](/documentation/key-concepts/metrics/custom-metrics)

--- a/documentation/integrations/retell/testing.mdx
+++ b/documentation/integrations/retell/testing.mdx
@@ -6,6 +6,12 @@ iconType: "regular"
 description: "This guide will walk you through the process of setting up and testing voice agents using Retell integration in Cekura. When creating a new agent, you can select Retell as your provider from the available options in the agent creation interface."
 ---
 
+## Video Tutorial
+
+Watch this video to see the Retell integration in action:
+
+<iframe width="100%" height="600" src="https://www.tella.tv/video/cekura-retell-integration-90mo" title="Cekura Retell Integration" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
 ## Prerequisites
 
 - A Cekura account
@@ -206,12 +212,6 @@ To enable auto-sync, toggle on **Auto-sync Prompt** in the Retell voice integrat
 <Note>
 Auto-sync requires a valid Retell API Key and Assistant ID. If credentials become invalid or the assistant is deleted, auto-sync will automatically disable itself.
 </Note>
-
-## Video Tutorial
-
-Watch this video to see the Retell integration in action:
-
-<iframe width="100%" height="600" src="https://www.tella.tv/video/cekura-retell-integration-90mo" title="Cekura Retell Integration" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Next Steps
 

--- a/documentation/video_tutorials.mdx
+++ b/documentation/video_tutorials.mdx
@@ -19,7 +19,7 @@ description: "Explore our video tutorials to master AI voice agent testing and i
   <Card title="VAPI Integration Guide" icon="plug" color="#A6A7EA" href="https://www.tella.tv/video/testing-agents-built-on-vapi-apwk">
     Learn how to test agents built on the VAPI platform
   </Card>
-  <Card title="Retell Integration Setup" icon="link" color="#A6A7EA" href="https://www.tella.tv/video/retell-integration-2al4">
+  <Card title="Retell Integration Setup" icon="link" color="#A6A7EA" href="https://www.tella.tv/video/cekura-retell-integration-90mo">
     Connect and test your Retell-powered voice agents
   </Card>
   <Card title="LiveKit Integration Guide" icon="/logo/livekit_icon.svg" color="#A6A7EA" href="https://www.tella.tv/video/vid_cmmti31kk00hu04jm0ua3d0qg/view">


### PR DESCRIPTION
## Summary
This PR adds a video tutorial for the Retell integration to the documentation and updates the video tutorials reference page with the correct video link.

## Key Changes
- Added an embedded video tutorial section at the top of the Retell testing guide (`documentation/integrations/retell/testing.mdx`) to help users visualize the integration setup process
- Updated the Retell Integration Setup card link in the video tutorials index (`documentation/video_tutorials.mdx`) from the old video URL to the new Cekura-specific Retell integration video

## Implementation Details
- The video tutorial iframe is embedded with full width and 600px height for optimal viewing
- The iframe includes standard accessibility and feature attributes (accelerometer, autoplay, clipboard-write, encrypted-media, gyroscope, picture-in-picture, fullscreen)
- Both documentation files now reference the same updated video URL (`https://www.tella.tv/video/cekura-retell-integration-90mo`), ensuring consistency across the documentation

https://claude.ai/code/session_01SrxjtHfAbvFn4Du8MNCzPB