### PR TITLE
Add generate_metrics_progress endpoint docs

### DIFF
--- a/api-reference/test_framework/generate-metrics-progress.mdx
+++ b/api-reference/test_framework/generate-metrics-progress.mdx
@@ -1,0 +1,5 @@
+---
+title: Get Generate Metrics Progress
+openapi: get /test_framework/v1/metrics/generate_metrics_progress/
+slug: generate-metrics-progress
+---

--- a/api-reference/test_framework/generate-metrics-progress.mdx
+++ b/api-reference/test_framework/generate-metrics-progress.mdx
@@ -3,3 +3,7 @@ title: Get Generate Metrics Progress
 openapi: get /test_framework/v1/metrics/generate_metrics_progress/
 slug: generate-metrics-progress
 ---
+
+<Note>
+When `status` is `"completed"`, the response includes a `metrics` array with the generated metric definitions. These metrics are **not yet saved** — pass them to [Create Metrics in Bulk](/api-reference/test_framework/create-metrics-in-bulk) to persist them.
+</Note>

--- a/api-reference/test_framework/generate-metrics.mdx
+++ b/api-reference/test_framework/generate-metrics.mdx
@@ -3,3 +3,12 @@ title: Generate Metrics
 openapi: post /test_framework/v1/metrics/generate_metrics/
 slug: generate-metrics
 ---
+
+<Note>
+This endpoint returns a `progress_id` — it does not create metrics directly.
+
+**Full workflow:**
+1. Call this endpoint to start metric generation → receive a `progress_id`
+2. Poll [Generate Metrics Progress](/api-reference/test_framework/generate-metrics-progress) with the `progress_id` until `status` is `"completed"`
+3. Take the `metrics` array from the progress response and pass it to [Create Metrics in Bulk](/api-reference/test_framework/create-metrics-in-bulk) to save them
+</Note>

--- a/mint.json
+++ b/mint.json
@@ -233,6 +233,7 @@
             "api-reference/test_framework/update-metric",
             "api-reference/test_framework/delete-metric",
             "api-reference/test_framework/generate-metrics",
+            "api-reference/test_framework/generate-metrics-progress",
             "api-reference/test_framework/create-metrics-in-bulk",
             "api-reference/test_framework/list-critical-metric-scenarios",
             "api-reference/test_framework/update-critical-metric-scenario",

--- a/openapi.json
+++ b/openapi.json
@@ -15501,7 +15501,7 @@
         "/test_framework/v1/metrics-external/generate_metrics/": {
             "post": {
                 "operationId": "metrics-external-generate-metrics-create",
-                "description": "Generate metrics for an AI agent. Returns a progress_id that should be polled via the generate_metrics_progress endpoint.",
+                "description": "Generate metrics for an AI agent. Returns a progress_id that should be polled via the generate_metrics_progress endpoint. Once generation is complete, use the bulk_create endpoint to save the generated metrics.",
                 "tags": [
                     "test_framework"
                 ],
@@ -15565,7 +15565,7 @@
         "/test_framework/v1/metrics-external/generate_metrics_progress/": {
             "get": {
                 "operationId": "metrics-external-generate-metrics-progress-retrieve",
-                "description": "Poll the progress of metric generation. Returns current state including status and generated metrics.",
+                "description": "Poll the progress of metric generation. Returns current state including status and generated metrics. Once status is completed, pass the metrics array to the bulk_create endpoint to save them.",
                 "parameters": [
                     {
                         "in": "query",
@@ -16993,7 +16993,7 @@
         "/test_framework/v1/metrics/generate_metrics/": {
             "post": {
                 "operationId": "metrics-generate-metrics-create",
-                "description": "Generate metrics for an AI agent. Returns a progress_id that should be polled via the generate_metrics_progress endpoint.",
+                "description": "Generate metrics for an AI agent. Returns a progress_id that should be polled via the generate_metrics_progress endpoint. Once generation is complete, use the bulk_create endpoint to save the generated metrics.",
                 "tags": [
                     "test_framework"
                 ],
@@ -17056,7 +17056,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "metrics-generate-metrics-create",
-                        "description": "Generate metrics for an AI agent. Returns a progress_id that should be polled via the generate_metrics_progress endpoint."
+                        "description": "Generate metrics for an AI agent. Returns a progress_id that should be polled via the generate_metrics_progress endpoint. Once generation is complete, use the bulk_create endpoint to save the generated metrics."
                     }
                 }
             }
@@ -17064,7 +17064,7 @@
         "/test_framework/v1/metrics/generate_metrics_progress/": {
             "get": {
                 "operationId": "metrics-generate-metrics-progress-retrieve",
-                "description": "Poll the progress of metric generation. Returns current state including status and generated metrics.",
+                "description": "Poll the progress of metric generation. Returns current state including status and generated metrics. Once status is completed, pass the metrics array to the bulk_create endpoint to save them.",
                 "parameters": [
                     {
                         "in": "query",

--- a/openapi.json
+++ b/openapi.json
@@ -15501,6 +15501,7 @@
         "/test_framework/v1/metrics-external/generate_metrics/": {
             "post": {
                 "operationId": "metrics-external-generate-metrics-create",
+                "description": "Generate metrics for an AI agent. Returns a progress_id that should be polled via the generate_metrics_progress endpoint.",
                 "tags": [
                     "test_framework"
                 ],
@@ -15534,8 +15535,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "object",
-                                    "additionalProperties": {}
+                                    "$ref": "#/components/schemas/SchemaGenerateMetricsResponse"
                                 }
                             }
                         },
@@ -15565,7 +15565,18 @@
         "/test_framework/v1/metrics-external/generate_metrics_progress/": {
             "get": {
                 "operationId": "metrics-external-generate-metrics-progress-retrieve",
-                "description": "Polls the progress of background metrics generation.\nReturns current progress state including status and generated metrics.",
+                "description": "Poll the progress of metric generation. Returns current state including status and generated metrics.",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "progress_id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Progress ID returned from the generate_metrics endpoint",
+                        "required": true
+                    }
+                ],
                 "tags": [
                     "test_framework"
                 ],
@@ -16982,6 +16993,7 @@
         "/test_framework/v1/metrics/generate_metrics/": {
             "post": {
                 "operationId": "metrics-generate-metrics-create",
+                "description": "Generate metrics for an AI agent. Returns a progress_id that should be polled via the generate_metrics_progress endpoint.",
                 "tags": [
                     "test_framework"
                 ],
@@ -17015,8 +17027,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "object",
-                                    "additionalProperties": {}
+                                    "$ref": "#/components/schemas/SchemaGenerateMetricsResponse"
                                 }
                             }
                         },
@@ -17045,7 +17056,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "metrics-generate-metrics-create",
-                        "description": "POST /test_framework/v1/metrics/generate_metrics/"
+                        "description": "Generate metrics for an AI agent. Returns a progress_id that should be polled via the generate_metrics_progress endpoint."
                     }
                 }
             }
@@ -17053,7 +17064,18 @@
         "/test_framework/v1/metrics/generate_metrics_progress/": {
             "get": {
                 "operationId": "metrics-generate-metrics-progress-retrieve",
-                "description": "Polls the progress of background metrics generation.\nReturns current progress state including status and generated metrics.",
+                "description": "Poll the progress of metric generation. Returns current state including status and generated metrics.",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "progress_id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Progress ID returned from the generate_metrics endpoint",
+                        "required": true
+                    }
+                ],
                 "tags": [
                     "test_framework"
                 ],
@@ -55120,6 +55142,19 @@
                         "description": "Whether the organization has whitelabel custom domain enabled for branded links"
                     }
                 }
+            },
+            "SchemaGenerateMetricsResponse": {
+                "type": "object",
+                "properties": {
+                    "progress_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "UUID to poll the generate_metrics_progress endpoint for status and results"
+                    }
+                },
+                "required": [
+                    "progress_id"
+                ]
             },
             "SchemaGenerateMetricsMetricCreate": {
                 "type": "object",

--- a/openapi.json
+++ b/openapi.json
@@ -15861,7 +15861,7 @@
         "/test_framework/v1/metrics-external/generate_metrics/": {
             "post": {
                 "operationId": "metrics-external-generate-metrics-create",
-                "description": "Generate metrics for an AI agent. Returns a progress_id that should be polled via the generate_metrics_progress endpoint. Once generation is complete, use the bulk_create endpoint to save the generated metrics.",
+                "description": "Generate metrics for an AI agent. Returns a progress_id that should be polled via the generate_metrics_progress endpoint.",
                 "tags": [
                     "test_framework"
                 ],
@@ -15925,7 +15925,7 @@
         "/test_framework/v1/metrics-external/generate_metrics_progress/": {
             "get": {
                 "operationId": "metrics-external-generate-metrics-progress-retrieve",
-                "description": "Poll the progress of metric generation. Returns current state including status and generated metrics. Once status is completed, pass the metrics array to the bulk_create endpoint to save them.",
+                "description": "Poll the progress of metric generation. Returns current state including status and generated metrics.",
                 "parameters": [
                     {
                         "in": "query",
@@ -17354,7 +17354,7 @@
         "/test_framework/v1/metrics/generate_metrics/": {
             "post": {
                 "operationId": "metrics-generate-metrics-create",
-                "description": "Generate metrics for an AI agent. Returns a progress_id that should be polled via the generate_metrics_progress endpoint. Once generation is complete, use the bulk_create endpoint to save the generated metrics.",
+                "description": "Generate metrics for an AI agent. Returns a progress_id that should be polled via the generate_metrics_progress endpoint.",
                 "tags": [
                     "test_framework"
                 ],
@@ -17417,7 +17417,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "metrics-generate-metrics-create",
-                        "description": "Generate metrics for an AI agent. Returns a progress_id that should be polled via the generate_metrics_progress endpoint. Once generation is complete, use the bulk_create endpoint to save the generated metrics."
+                        "description": "Generate metrics for an AI agent. Returns a progress_id that should be polled via the generate_metrics_progress endpoint."
                     }
                 }
             }
@@ -17425,7 +17425,7 @@
         "/test_framework/v1/metrics/generate_metrics_progress/": {
             "get": {
                 "operationId": "metrics-generate-metrics-progress-retrieve",
-                "description": "Poll the progress of metric generation. Returns current state including status and generated metrics. Once status is completed, pass the metrics array to the bulk_create endpoint to save them.",
+                "description": "Poll the progress of metric generation. Returns current state including status and generated metrics.",
                 "parameters": [
                     {
                         "in": "query",

--- a/openapi.json
+++ b/openapi.json
@@ -55826,16 +55826,6 @@
                     "assistant_id"
                 ]
             },
-            "SchemaGenerateMetricsResponse": {
-                "type": "object",
-                "properties": {
-                    "progress_id": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "UUID to poll the generate_metrics_progress endpoint for status and results"
-                    }
-                }
-            },
             "SchemaGenerateScenarios": {
                 "type": "object",
                 "properties": {

--- a/openapi.json
+++ b/openapi.json
@@ -15947,6 +15947,13 @@
                 ],
                 "responses": {
                     "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GenerateMetricsProgressResponse"
+                                }
+                            }
+                        },
                         "description": "Returns generation state with status and generated metrics"
                     }
                 }
@@ -17447,6 +17454,13 @@
                 ],
                 "responses": {
                     "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GenerateMetricsProgressResponse"
+                                }
+                            }
+                        },
                         "description": "Returns generation state with status and generated metrics"
                     }
                 },
@@ -55788,6 +55802,62 @@
                         "description": "Whether the organization has whitelabel custom domain enabled for branded links"
                     }
                 }
+            },
+            "GenerateMetricsProgressResponse": {
+                "type": "object",
+                "properties": {
+                    "agent_id": {
+                        "type": "integer",
+                        "description": "ID of the agent metrics are being generated for"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["queued", "in_progress", "completed", "failed"],
+                        "description": "Current status of the generation task"
+                    },
+                    "current_step": {
+                        "type": "string",
+                        "description": "Human-readable description of the current processing step"
+                    },
+                    "metrics": {
+                        "type": "array",
+                        "description": "Generated metrics (populated when status is completed)",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "description": "Name of the generated metric"
+                                },
+                                "description": {
+                                    "type": "string",
+                                    "description": "Description of what the metric evaluates"
+                                },
+                                "agent": {
+                                    "type": "integer",
+                                    "description": "Agent ID"
+                                },
+                                "eval_type": {
+                                    "type": "string",
+                                    "description": "Evaluation type"
+                                },
+                                "scenarios": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "integer"
+                                    },
+                                    "description": "Scenario IDs associated with this metric"
+                                }
+                            }
+                        }
+                    },
+                    "error": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "Error message if status is failed"
+                    }
+                },
+                "required": ["agent_id", "status", "current_step", "metrics", "error"]
             },
             "SchemaGenerateMetricsResponse": {
                 "type": "object",


### PR DESCRIPTION
## Summary
- Added MDX page for `generate_metrics_progress` polling endpoint
- Added it to mint.json navigation (right after `generate-metrics`)
- Regenerated openapi.json with updated schema (progress_id parameter docs, response serializer)

**Context:** Customers calling `generate_metrics` were polling the wrong endpoint (`preview-progress`) because `generate_metrics_progress` was undocumented. Companion backend PR: cekura-ai/vocera.backend#8449