### PR TITLE
Add Claude Code + Cekura MCP guide with Gradient Bam video

### DIFF
--- a/mcp/claude-code-guide.mdx
+++ b/mcp/claude-code-guide.mdx
@@ -5,7 +5,7 @@ description: "End-to-end walkthrough: evaluate complex voice agents using Claude
 icon: "code"
 ---
 
-Watch how we evaluated [Gradient Bang](https://www.tella.tv/video/evaluating-gradient-bang-agents-gr1g)—an open-source multiplayer space game by the Daily and Pipecat team, with voice agents running 25+ tools across multiple coordinating agents—using Claude Code, the Cekura MCP, and Cekura Skills end-to-end.
+Watch how we evaluated [Gradient Bang](https://www.gradient-bang.com/)—an open-source multiplayer space game by the Daily and Pipecat team, with voice agents running 25+ tools across multiple coordinating agents—using Claude Code, the Cekura MCP, and Cekura Skills end-to-end.
 
 <iframe
   style={{

--- a/mcp/claude-code-guide.mdx
+++ b/mcp/claude-code-guide.mdx
@@ -5,7 +5,7 @@ description: "End-to-end walkthrough: evaluate complex voice agents using Claude
 icon: "code"
 ---
 
-Watch how we evaluated [Gradient Bam](https://www.tella.tv/video/evaluating-gradient-bang-agents-gr1g)—an open-source multiplayer space game by the Daily and Pipecat team, with voice agents running 25+ tools across multiple coordinating agents—using Claude Code, the Cekura MCP, and Cekura Skills end-to-end.
+Watch how we evaluated [Gradient Bang](https://www.tella.tv/video/evaluating-gradient-bang-agents-gr1g)—an open-source multiplayer space game by the Daily and Pipecat team, with voice agents running 25+ tools across multiple coordinating agents—using Claude Code, the Cekura MCP, and Cekura Skills end-to-end.
 
 <iframe
   style={{
@@ -19,7 +19,7 @@ Watch how we evaluated [Gradient Bam](https://www.tella.tv/video/evaluating-grad
   frameborder="0"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
   allowfullscreen
-  title="Evaluating Gradient Bam Agents with Cekura"
+  title="Evaluating Gradient Bang Agents with Cekura"
 />
 
 ## Quick Guide
@@ -37,10 +37,6 @@ Watch how we evaluated [Gradient Bam](https://www.tella.tv/video/evaluating-grad
     Ask Claude Code to read your database schema and agent tools through the Cekura MCP. Once it has the lay of the land, prompt it to generate scenario coverage—for example: *"Using the Cekura skill, create 10 test cases covering ship movement, corp joins, and credit transfers."*
   </Step>
 
-  <Step title="Isolate concurrent runs">
-    For agents that mutate shared state, instruct Claude to assign a **unique character ID (or tenant ID) per test case** and seed the matching mock data. This lets you fan out runs in parallel without tests stepping on each other.
-  </Step>
-
   <Step title="Run the full suite">
     Kick off all evaluators at once through the MCP. Cekura executes them concurrently and surfaces pass/fail with full transcripts and traces.
   </Step>
@@ -55,5 +51,5 @@ Watch how we evaluated [Gradient Bam](https://www.tella.tv/video/evaluating-grad
 </Steps>
 
 <Tip>
-A good first prompt: *"Use the Cekura MCP to list my agents, then use the Cekura skill to generate 10 workflow evaluators covering the most common user flows. Give each test a unique character ID."*
+A good first prompt: *"Use the Cekura MCP to list my agents, then use the Cekura skill to generate 10 workflow evaluators covering the most common user flows."*
 </Tip>

--- a/mcp/claude-code-guide.mdx
+++ b/mcp/claude-code-guide.mdx
@@ -1,0 +1,59 @@
+---
+title: "Using Cekura with Claude Code"
+sidebarTitle: "Claude Code Guide"
+description: "End-to-end walkthrough: evaluate complex voice agents using Claude Code, the Cekura MCP, and Cekura Skills"
+icon: "code"
+---
+
+Watch how we evaluated [Gradient Bam](https://www.tella.tv/video/evaluating-gradient-bang-agents-gr1g)—an open-source multiplayer space game by the Daily and Pipecat team, with voice agents running 25+ tools across multiple coordinating agents—using Claude Code, the Cekura MCP, and Cekura Skills end-to-end.
+
+<iframe
+  style={{
+    aspectRatio: "16 / 9",
+    border: "1px solid #ccc",
+    borderRadius: "8px",
+    marginBottom: "20px",
+  }}
+  src="https://www.tella.tv/video/evaluating-gradient-bang-agents-gr1g/embed"
+  width="100%"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowfullscreen
+  title="Evaluating Gradient Bam Agents with Cekura"
+/>
+
+## Quick Guide
+
+<Steps>
+  <Step title="Connect Claude Code to Cekura">
+    Install the Cekura MCP server (see the [Claude Code tab in the MCP overview](/mcp/overview#2-configure-mcp-server)) and install the [Cekura Skills repository](https://github.com/cekura-ai/cekura-skills). Skills give Claude Code the playbook for creating evaluators, running tests, and analyzing results through Cekura.
+  </Step>
+
+  <Step title="Set up mock data and cleanup hooks">
+    Complex agents depend on database state—ships, credits, sectors, user metadata. Stand up a lightweight webhook server that seeds mock data before a run and listens for Cekura's post-run webhook to reset the database. This keeps concurrent tests isolated and repeatable.
+  </Step>
+
+  <Step title="Let Claude Code learn the schema">
+    Ask Claude Code to read your database schema and agent tools through the Cekura MCP. Once it has the lay of the land, prompt it to generate scenario coverage—for example: *"Using the Cekura skill, create 10 test cases covering ship movement, corp joins, and credit transfers."*
+  </Step>
+
+  <Step title="Isolate concurrent runs">
+    For agents that mutate shared state, instruct Claude to assign a **unique character ID (or tenant ID) per test case** and seed the matching mock data. This lets you fan out runs in parallel without tests stepping on each other.
+  </Step>
+
+  <Step title="Run the full suite">
+    Kick off all evaluators at once through the MCP. Cekura executes them concurrently and surfaces pass/fail with full transcripts and traces.
+  </Step>
+
+  <Step title="Triage with Claude">
+    Ask Claude Code to pull failing runs and classify them: *"Analyze these 4 failures and tell me which are real bugs vs. flakes."* Because runs are non-deterministic, **rerun each failing test 3–4 times** and ask Claude to compute a pass rate. One pass out of four usually points to a prompt or tool-routing bug, not infra.
+  </Step>
+
+  <Step title="Get a root-cause report">
+    Claude Code stitches together Cekura run links, Pipecat session IDs, transcripts, and a per-scenario root cause into a final report—coverage summary, failure breakdown, and recommended prompt or tool fixes.
+  </Step>
+</Steps>
+
+<Tip>
+A good first prompt: *"Use the Cekura MCP to list my agents, then use the Cekura skill to generate 10 workflow evaluators covering the most common user flows. Give each test a unique character ID."*
+</Tip>

--- a/mcp/overview.mdx
+++ b/mcp/overview.mdx
@@ -190,48 +190,6 @@ Ask your AI: "List my Cekura agents"
 
 If configured correctly, your assistant will be able to interact with Cekura's API.
 
-## Using Cekura with Claude Code
-
-Watch how we evaluated [Gradient Bam](https://www.tella.tv/video/evaluating-gradient-bang-agents-gr1g)—an open-source multiplayer space game by the Daily and Pipecat team, with voice agents running 25+ tools across multiple coordinating agents—using Claude Code, the Cekura MCP, and Cekura Skills end-to-end.
-
-<iframe width="100%" height="600" src="https://www.tella.tv/video/evaluating-gradient-bang-agents-gr1g" title="Evaluating Gradient Bam Agents with Cekura" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
-### Quick Guide
-
-<Steps>
-  <Step title="Connect Claude Code to Cekura">
-    Install the Cekura MCP server (see the Claude Code tab above) and install the [Cekura Skills repository](https://github.com/cekura-ai/cekura-skills). Skills give Claude Code the playbook for creating evaluators, running tests, and analyzing results through Cekura.
-  </Step>
-
-  <Step title="Set up mock data and cleanup hooks">
-    Complex agents depend on database state—ships, credits, sectors, user metadata. Stand up a lightweight webhook server that seeds mock data before a run and listens for Cekura's post-run webhook to reset the database. This keeps concurrent tests isolated and repeatable.
-  </Step>
-
-  <Step title="Let Claude Code learn the schema">
-    Ask Claude Code to read your database schema and agent tools through the Cekura MCP. Once it has the lay of the land, prompt it to generate scenario coverage—for example: *"Using the Cekura skill, create 10 test cases covering ship movement, corp joins, and credit transfers."*
-  </Step>
-
-  <Step title="Isolate concurrent runs">
-    For agents that mutate shared state, instruct Claude to assign a **unique character ID (or tenant ID) per test case** and seed the matching mock data. This lets you fan out runs in parallel without tests stepping on each other.
-  </Step>
-
-  <Step title="Run the full suite">
-    Kick off all evaluators at once through the MCP. Cekura executes them concurrently and surfaces pass/fail with full transcripts and traces.
-  </Step>
-
-  <Step title="Triage with Claude">
-    Ask Claude Code to pull failing runs and classify them: *"Analyze these 4 failures and tell me which are real bugs vs. flakes."* Because runs are non-deterministic, **rerun each failing test 3–4 times** and ask Claude to compute a pass rate. One pass out of four usually points to a prompt or tool-routing bug, not infra.
-  </Step>
-
-  <Step title="Get a root-cause report">
-    Claude Code stitches together Cekura run links, Pipecat session IDs, transcripts, and a per-scenario root cause into a final report—coverage summary, failure breakdown, and recommended prompt or tool fixes.
-  </Step>
-</Steps>
-
-<Tip>
-A good first prompt: *"Use the Cekura MCP to list my agents, then use the Cekura skill to generate 10 workflow evaluators covering the most common user flows. Give each test a unique character ID."*
-</Tip>
-
 ## How MCP Works
 
 When you connect to Cekura's MCP server, you get instant access to both documentation and APIs:

--- a/mcp/overview.mdx
+++ b/mcp/overview.mdx
@@ -190,6 +190,48 @@ Ask your AI: "List my Cekura agents"
 
 If configured correctly, your assistant will be able to interact with Cekura's API.
 
+## Using Cekura with Claude Code
+
+Watch how we evaluated [Gradient Bam](https://www.tella.tv/video/evaluating-gradient-bang-agents-gr1g)—an open-source multiplayer space game by the Daily and Pipecat team, with voice agents running 25+ tools across multiple coordinating agents—using Claude Code, the Cekura MCP, and Cekura Skills end-to-end.
+
+<iframe width="100%" height="600" src="https://www.tella.tv/video/evaluating-gradient-bang-agents-gr1g" title="Evaluating Gradient Bam Agents with Cekura" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+### Quick Guide
+
+<Steps>
+  <Step title="Connect Claude Code to Cekura">
+    Install the Cekura MCP server (see the Claude Code tab above) and install the [Cekura Skills repository](https://github.com/cekura-ai/cekura-skills). Skills give Claude Code the playbook for creating evaluators, running tests, and analyzing results through Cekura.
+  </Step>
+
+  <Step title="Set up mock data and cleanup hooks">
+    Complex agents depend on database state—ships, credits, sectors, user metadata. Stand up a lightweight webhook server that seeds mock data before a run and listens for Cekura's post-run webhook to reset the database. This keeps concurrent tests isolated and repeatable.
+  </Step>
+
+  <Step title="Let Claude Code learn the schema">
+    Ask Claude Code to read your database schema and agent tools through the Cekura MCP. Once it has the lay of the land, prompt it to generate scenario coverage—for example: *"Using the Cekura skill, create 10 test cases covering ship movement, corp joins, and credit transfers."*
+  </Step>
+
+  <Step title="Isolate concurrent runs">
+    For agents that mutate shared state, instruct Claude to assign a **unique character ID (or tenant ID) per test case** and seed the matching mock data. This lets you fan out runs in parallel without tests stepping on each other.
+  </Step>
+
+  <Step title="Run the full suite">
+    Kick off all evaluators at once through the MCP. Cekura executes them concurrently and surfaces pass/fail with full transcripts and traces.
+  </Step>
+
+  <Step title="Triage with Claude">
+    Ask Claude Code to pull failing runs and classify them: *"Analyze these 4 failures and tell me which are real bugs vs. flakes."* Because runs are non-deterministic, **rerun each failing test 3–4 times** and ask Claude to compute a pass rate. One pass out of four usually points to a prompt or tool-routing bug, not infra.
+  </Step>
+
+  <Step title="Get a root-cause report">
+    Claude Code stitches together Cekura run links, Pipecat session IDs, transcripts, and a per-scenario root cause into a final report—coverage summary, failure breakdown, and recommended prompt or tool fixes.
+  </Step>
+</Steps>
+
+<Tip>
+A good first prompt: *"Use the Cekura MCP to list my agents, then use the Cekura skill to generate 10 workflow evaluators covering the most common user flows. Give each test a unique character ID."*
+</Tip>
+
 ## How MCP Works
 
 When you connect to Cekura's MCP server, you get instant access to both documentation and APIs:

--- a/mint.json
+++ b/mint.json
@@ -438,6 +438,12 @@
         "mcp/overview",
         "mcp/skills"
       ]
+    },
+    {
+      "group": "Guides",
+      "pages": [
+        "mcp/claude-code-guide"
+      ]
     }
   ],
   "footerSocials": {


### PR DESCRIPTION
## Summary

- Embeds the [Gradient Bam evaluation walkthrough](https://www.tella.tv/video/evaluating-gradient-bang-agents-gr1g) video in the MCP overview page.
- Adds a new **"Using Cekura with Claude Code"** section with a 7-step quick guide distilled from the walkthrough: MCP + Skills setup, mock-data/cleanup webhook, schema discovery, unique character IDs for concurrent runs, parallel execution, flakiness triage via reruns, and root-cause reporting.
- Placed right after "Verify Connection" so users see it immediately after configuring the Claude Code MCP tab.

## Why

Showcases a real end-to-end workflow (Pipecat/Daily's Gradient Bam agent with 25+ tools) so users understand how Claude Code + the Cekura MCP + Skills work together for complex agent evaluation, not just isolated API calls.

## Test plan

- [ ] Preview the MCP overview page and confirm the iframe renders.
- [ ] Verify the Steps block renders correctly in Mintlify.
- [ ] Confirm all "Cekura" (not "Secura") spellings are correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)