### PR TITLE
[CEK-7373] docs: add A/B, multilingual, and tool call testing pages

### DIFF
--- a/documentation/guides/testing-agents/ab-testing.mdx
+++ b/documentation/guides/testing-agents/ab-testing.mdx
@@ -1,0 +1,80 @@
+---
+title: "A/B Testing"
+sidebarTitle: "A/B Testing"
+icon: "code-compare"
+iconType: "regular"
+description: "Compare two versions of your agent side-by-side to measure prompt, model, or configuration changes."
+---
+
+## Overview
+
+A/B testing on Cekura lets you compare two (or more) runs of your agent against the same set of evaluators — so you can see whether a prompt change, model swap, or configuration tweak actually improves behavior before shipping it.
+
+The flow is simple:
+
+1. Run the same set of evaluators against **Version A** of your agent.
+2. Make your change (update the prompt, switch the model, adjust tools, etc.).
+3. Run the **same** evaluators against **Version B**.
+4. Select both runs on the Results page and compare metric-by-metric.
+
+<Note>
+  Always run both versions against the **same evaluators** with the **same test profile**. Otherwise you're measuring noise from different test inputs rather than the change itself.
+</Note>
+
+## Prerequisites
+
+Before running an A/B test, make sure you have:
+
+- An agent configured on Cekura — see the [Testing Overview](/documentation/guides/testing-agents/overview) for the basic testing flow
+- A stable set of evaluators that pass reliably for your baseline — see the [Suggested Testing Approach](/documentation/guides/testing-agents/suggested-testing-approach)
+- A clear hypothesis about what you expect the change to improve (pass rate, latency, adherence to a specific metric, etc.)
+
+## Running an A/B Test
+
+<Steps>
+  <Step title="Run Version A (baseline)">
+    Select your evaluators and run them against your current agent configuration. Wait for the run to complete and record the run name or ID.
+  </Step>
+  <Step title="Apply your change">
+    Update the agent's prompt, model, voice, tool configuration, or any other parameter you want to test. Change **one variable at a time** — otherwise you won't know which change caused the difference.
+  </Step>
+  <Step title="Run Version B">
+    Run the **same evaluators** against the updated agent. Use the same test profile, personalities, and frequency so the only difference between the two runs is your change.
+  </Step>
+  <Step title="Select both runs and compare">
+    On the Results page, select the checkboxes next to both runs and click **Compare**. Cekura shows a side-by-side breakdown of every metric and evaluator across the two runs.
+
+    <img src="/images/compare-runs.png" alt="Selecting multiple runs to compare" />
+
+    Look for:
+
+    - **Overall pass rate** — did B improve or regress?
+    - **Per-metric deltas** — which specific metrics moved, and by how much?
+    - **Individual evaluator diffs** — open any evaluator to see the transcripts side-by-side and read why one passed and the other failed.
+  </Step>
+</Steps>
+
+## Best Practices
+
+### Change One Variable at a Time
+
+If you change the prompt **and** swap the model in the same run, you can't attribute any improvement (or regression) to either change. Test changes in isolation.
+
+### Use Frequency \> 1 to De-Noise
+
+Voice agents are non-deterministic. A single run can pass or fail by chance. Set frequency to 3–5 so each evaluator runs multiple times — the aggregate result is far more reliable than any single call. See [Load Testing](/documentation/guides/testing-agents/load-testing) for how frequency works.
+
+### Keep the Test Set Fixed
+
+Don't add or remove evaluators between A and B. If you want to expand coverage, do that first, re-establish the baseline, and then run the A/B test.
+
+### Compare More Than Pass Rate
+
+Two runs can have the same pass rate while differing dramatically on latency, talk ratio, or a specific workflow metric. The compare view surfaces all of these — don't stop at the headline number.
+
+## Related Resources
+
+- [Testing Overview](/documentation/guides/testing-agents/overview) — Run your first evaluators
+- [Suggested Testing Approach](/documentation/guides/testing-agents/suggested-testing-approach) — Build a reliable evaluator suite
+- [Load Testing](/documentation/guides/testing-agents/load-testing) — Use frequency to run each evaluator multiple times
+- [Metrics Overview](/documentation/key-concepts/metrics/overview) — Understand what each metric measures

--- a/documentation/guides/testing-agents/multilingual-testing.mdx
+++ b/documentation/guides/testing-agents/multilingual-testing.mdx
@@ -1,0 +1,87 @@
+---
+title: "Multilingual Testing"
+sidebarTitle: "Multilingual Testing"
+icon: "language"
+iconType: "regular"
+description: "Test your voice AI agent across multiple languages, accents, and code-switching scenarios."
+---
+
+## Overview
+
+If your agent serves users in more than one language — or handles code-switching (e.g. Spanglish, Hinglish) — you can't rely on English-only tests to tell you whether it actually works. Multilingual testing on Cekura uses language-specific **personalities** to drive evaluators in the target language and surface issues that only show up outside English, like:
+
+- ASR (speech-to-text) mis-transcriptions on non-English audio
+- TTS (text-to-speech) pronouncing names or numbers incorrectly in the target language
+- The agent silently falling back to English mid-conversation
+- Workflow metrics passing in one language but failing in another
+
+## How It Works
+
+Multilingual testing is driven by two primitives:
+
+1. **Personalities** — each personality has a configured language (and optionally an accent, pace, or code-switching pattern). The evaluator speaks to your agent using that personality, in that language.
+2. **Per-language evaluator runs** — the same evaluator can be run against multiple personalities to test whether your agent handles the same workflow identically across languages.
+
+See the [Personality](/documentation/key-concepts/evaluators/personality) docs for the full list of configuration options, and [Creating Custom Personalities](/documentation/advanced/creating-custom-personalities) for how to add a language or accent that isn't in the default set.
+
+## Running a Multilingual Test
+
+<Steps>
+  <Step title="Confirm your agent supports the target languages">
+    Check your agent's STT, LLM, and TTS configuration for each language you want to test. A common failure mode is that the LLM prompt is multilingual but the STT is locked to `en-US` — the agent will never "hear" the non-English turns correctly.
+  </Step>
+  <Step title="Pick or create a personality per language">
+    Use a built-in personality (e.g. `Spanglish`) or create a [custom personality](/documentation/advanced/creating-custom-personalities) for the specific language, accent, or code-switching pattern you want to test.
+
+    Common patterns:
+
+    - **Pure target language** — caller speaks only Spanish for the whole call
+    - **Code-switching** — caller mixes English and the target language within sentences
+    - **Accented English** — caller speaks English with a non-native accent (tests ASR robustness)
+  </Step>
+  <Step title="Attach the personality to your evaluators">
+    You have two options — pick whichever fits your workflow:
+
+    - **Duplicate the evaluator per language** — take an evaluator that already passes in English, duplicate it, and assign the language-specific personality to each copy. Good when you want the per-language variants saved as distinct evaluators you can re-run independently.
+    - **Override personality at runtime** — keep a single evaluator and override the personality when you run it. On the evaluators page, select the evaluators you want to run and use the **Override Personality** option to pick one or more personalities for this run. Cekura executes each selected evaluator against every selected personality. Good when you want to sweep the same workflow across many languages without creating N copies.
+
+    Either way, keep the **scenario instructions** and **expected outcomes** identical so you're measuring the same workflow across languages.
+  </Step>
+  <Step title="Run and compare per language">
+    Run each language's evaluator set and compare pass rates side-by-side. Use the [A/B Testing](/documentation/guides/testing-agents/ab-testing) compare view to diff two language runs of the same evaluator.
+  </Step>
+</Steps>
+
+## What to Watch For
+
+| Symptom | Likely Cause |
+|---|---|
+| Expected outcome fails, transcript looks garbled | STT not configured for the target language |
+| Agent responds in English even though caller is speaking Spanish | LLM prompt isn't instructing the agent to mirror the caller's language |
+| Names, dates, or numbers sound wrong on playback | TTS voice or language setting mismatched |
+| Works in pure Spanish but fails on code-switching | Agent is language-locking on first turn; prompt needs to handle mid-call switches |
+
+## Best Practices
+
+### Hold the Workflow Constant, Vary the Language
+
+When isolating language-related issues, keep scenario instructions and expected outcomes identical across language variants. If you change the workflow and the language at the same time, you won't know which one caused a regression.
+
+### Test the Seams, Not Just the Middle
+
+Most multilingual bugs live at transitions: the opening turn (before language is established), the handoff to a tool call, and the farewell. Make sure your evaluators exercise all three.
+
+### Include Code-Switching Explicitly
+
+Many real users mix languages. If your product is used in markets where this is common, add at least one code-switching personality per language pair — don't assume pure-language tests cover it.
+
+### Measure Per Language, Not Just Overall
+
+A 90% pass rate that's 99% in English and 70% in Spanish is hiding a real problem. Break down results per personality (and therefore per language) rather than relying on the aggregate number.
+
+## Related Resources
+
+- [Personality](/documentation/key-concepts/evaluators/personality) — How personalities control language and behavior
+- [Creating Custom Personalities](/documentation/advanced/creating-custom-personalities) — Add a new language, accent, or code-switching pattern
+- [A/B Testing](/documentation/guides/testing-agents/ab-testing) — Compare per-language runs side-by-side
+- [Testing Overview](/documentation/guides/testing-agents/overview) — Basic testing flow

--- a/documentation/guides/testing-agents/tool-call-testing.mdx
+++ b/documentation/guides/testing-agents/tool-call-testing.mdx
@@ -1,0 +1,106 @@
+---
+title: "Tool Call Testing"
+sidebarTitle: "Tool Call Testing"
+icon: "wrench"
+iconType: "regular"
+description: "Validate that your agent calls the right tools, with the right arguments, at the right time."
+---
+
+## Overview
+
+Most real voice agents don't just talk — they call tools: look up a customer, schedule an appointment, transfer to a human, end the call. If your agent says "I've booked your appointment" but never actually invoked the booking tool, the call is a failure no matter how good the transcript sounds.
+
+Tool call testing on Cekura is about making sure:
+
+1. Cekura can **see** the tool calls your agent made (names, arguments, results, latency).
+2. You can **assert** against those tool calls — both "did it happen" and "did it happen correctly."
+
+## Step 1 — Make Tool Calls Visible to Cekura
+
+Before you can evaluate tool calls, Cekura needs the tool call events in the transcript and metadata for each call. There are two ways to get this:
+
+### Option A — Use a Native Integration (Recommended)
+
+If you're on one of our supported providers, you don't need to do anything special to capture tool calls from simulated test runs — once your agent is connected to Cekura via the provider integration, we automatically fetch the tool call names, arguments, results, and latency from the provider after each simulation and attach them to the transcript.
+
+Supported providers:
+
+- [VAPI](/documentation/integrations/vapi/testing)
+- [Retell](/documentation/integrations/retell/testing)
+- [ElevenLabs](/documentation/integrations/elevenlabs/testing)
+- [LiveKit](/documentation/integrations/livekit/testing)
+- [Pipecat](/documentation/integrations/pipecat/automated)
+
+### Option B — Send the Transcript Yourself
+
+If you're on a custom stack or a provider we don't natively support, send the call transcript (including tool call invocations and results) to Cekura directly via the observability API. See:
+
+- [Custom Integration](/documentation/integrations/custom-integration) — how to send calls programmatically
+- [Transcript Format](/documentation/advanced/transcript-format) — the exact shape of `tool_call`, `tool_call_invocation`, and `tool_call_result` entries Cekura expects
+
+<Note>
+  The transcript format supports both OpenAI-style (`toolCalls` / `tool_call_result`) and generic (`tool_calls` / `tool_results`) representations. As long as tool names, arguments, and results are included, Cekura can evaluate against them.
+</Note>
+
+## Step 2 — Test Tool Calls in Evaluators
+
+Once tool calls are flowing into Cekura, you can validate them in two ways.
+
+### Assertion Approach 1 — Expected Outcome
+
+The simplest way to test a tool call is to write the expectation into the evaluator's **expected outcome**. For example:
+
+> The agent must call the `book_appointment` tool with the caller's requested date and time before confirming the booking verbally.
+
+Cekura's expected-outcome judge has access to the full transcript including tool calls, and will fail the evaluator if the tool wasn't invoked (or was invoked with the wrong arguments).
+
+**Use this when:**
+
+- The tool call is part of a specific workflow scenario
+- You want a single pass/fail signal per evaluator
+- The assertion is naturally expressible in prose
+
+### Assertion Approach 2 — Custom Metrics
+
+For assertions you want to run across **many** evaluators, or that need structured logic (exact argument matching, ordering, counting, etc.), use a custom metric instead:
+
+- [LLM-Judge Metric](/documentation/key-concepts/metrics/llm-judge-metric) — write a prompt that inspects the tool calls and returns pass/fail or a score
+- [Python Metric](/documentation/key-concepts/metrics/python-metric) — write code that parses `tool_calls` out of the transcript and makes deterministic assertions
+
+**Use this when:**
+
+- You want to enforce "never call `transfer_to_human` before verifying identity" across every call
+- You need exact matching on tool arguments
+- You want to track tool-call reliability as a metric over time on a [Dashboard](/documentation/guides/dashboards)
+
+## Putting It Together
+
+<Steps>
+  <Step title="Wire up visibility">
+    Either connect a native integration or start sending transcripts via the custom integration. Confirm you can see tool call entries in the Cekura transcript viewer for a sample call.
+  </Step>
+  <Step title="Pick the right assertion mechanism">
+    For per-scenario checks, put the tool call requirement into the evaluator's expected outcome. For cross-cutting rules, build a custom LLM-judge or Python metric.
+  </Step>
+  <Step title="Run and iterate">
+    Run the evaluators, inspect failing transcripts, and refine either the agent prompt or the assertion as needed.
+  </Step>
+</Steps>
+
+## Recommended: Set Up Mock Tools
+
+For reliable tool call testing, we strongly recommend configuring [Mock Tools](/documentation/key-concepts/evaluators/mock-tools) before running evaluators at scale. Mock tools let you return predefined responses for each tool call during a simulation, which gives you:
+
+- **Deterministic tests** — the same evaluator produces the same tool responses on every run, so a failure is a real agent failure and not a flaky backend
+- **No backend dependency** — your tests don't hit production systems, don't burn quota on third-party APIs, and don't require network access to internal services
+- **Edge-case coverage** — you can force a tool to return an error, a timeout, or an unusual payload to test how the agent handles it
+
+Without mock tools, tool call testing still works, but every failure becomes ambiguous — was it the agent, or was it the backend? Mocking removes that ambiguity.
+
+## Related Resources
+
+- [Mock Tools](/documentation/key-concepts/evaluators/mock-tools) — Stub tool responses for reproducible tests
+- [Transcript Format](/documentation/advanced/transcript-format) — How tool calls appear in the transcript
+- [LLM-Judge Metric](/documentation/key-concepts/metrics/llm-judge-metric) — Prompt-based assertions over tool calls
+- [Python Metric](/documentation/key-concepts/metrics/python-metric) — Deterministic assertions over tool calls
+- [Custom Integration](/documentation/integrations/custom-integration) — Send transcripts from any stack

--- a/mint.json
+++ b/mint.json
@@ -113,6 +113,9 @@
             "documentation/guides/testing-agents/outbound-evaluators",
             "documentation/guides/testing-agents/outbound-auto-call",
             "documentation/guides/testing-agents/load-testing",
+            "documentation/guides/testing-agents/ab-testing",
+            "documentation/guides/testing-agents/multilingual-testing",
+            "documentation/guides/testing-agents/tool-call-testing",
             "documentation/guides/testing-agents/sms-during-call",
             "documentation/guides/testing-agents/whatsapp-testing",
             "documentation/guides/testing-agents/dtmf-testing"


### PR DESCRIPTION
## Summary
- Adds 3 new pages under Guides → Testing: A/B Testing, Multilingual Testing, Tool Call Testing
- Registers the new pages in `mint.json` navigation
- Linear: [CEK-7373](https://linear.app/cekura/issue/CEK-7373/docs-ab-testing-multilingual-testing-tool-call-testing)

### A/B Testing
Links to the basic testing flow and walks through selecting multiple runs and comparing. References `/images/compare-runs.png` — drop in the screenshot when ready.

### Multilingual Testing
Personality-driven flow. Explains both options: duplicate evaluators per language **or** override personality at runtime (multi-select) when running.

### Tool Call Testing
Step 1 is getting tool call visibility (native providers auto-fetch after simulation; custom stacks send transcripts via the custom integration). Step 2 is asserting via expected outcome or custom metrics. Ends with a **Recommended: Set Up Mock Tools** section.

## Test plan
- [ ] Preview the Mintlify build
- [ ] Confirm the 3 new pages render in the sidebar under Guides → Testing
- [ ] Verify all internal links resolve
- [ ] Add screenshot at `/images/compare-runs.png` (referenced by A/B Testing page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)