### PR TITLE
[CEK-7373] docs: drop screenshot placeholder from A/B testing page

### DIFF
--- a/documentation/guides/testing-agents/ab-testing.mdx
+++ b/documentation/guides/testing-agents/ab-testing.mdx
@@ -44,8 +44,6 @@ Before running an A/B test, make sure you have:
   <Step title="Select both runs and compare">
     On the Results page, select the checkboxes next to both runs and click **Compare**. Cekura shows a side-by-side breakdown of every metric and evaluator across the two runs.
 
-    <img src="/images/compare-runs.png" alt="Selecting multiple runs to compare" />
-
     Look for:
 
     - **Overall pass rate** — did B improve or regress?


### PR DESCRIPTION
## Summary
- Removes the `/images/compare-runs.png` image reference from the A/B testing page (no screenshot needed)
- Follow-up to [#483](https://github.com/cekura-ai/docs/pull/483)
- Linear: [CEK-7373](https://linear.app/cekura/issue/CEK-7373/docs-ab-testing-multilingual-testing-tool-call-testing)

## Test plan
- [ ] Preview the A/B testing page and confirm no broken image tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)