### PR TITLE
docs: remove Provider Support sections from conditional-actions tags

### DIFF
--- a/documentation/key-concepts/evaluators/conditional-actions.mdx
+++ b/documentation/key-concepts/evaluators/conditional-actions.mdx
@@ -327,8 +327,6 @@ Only tags from the supported set are allowed. Using an unrecognized XML tag retu
 
     **Attributes:**
     - `text`: The IVR message to play (required)
-
-    **Provider Support:** Works with all TTS providers
   </Accordion>
 
   <Accordion title="<voicemail> - Voicemail Greeting" icon="voicemail">
@@ -350,8 +348,6 @@ Only tags from the supported set are allowed. Using an unrecognized XML tag retu
 
     **Attributes:**
     - `text`: Voicemail greeting message (optional) - if omitted, only plays beep
-
-    **Provider Support:** Works with all TTS providers
   </Accordion>
 
   <Accordion title="<endcall> - End Call" icon="phone-slash">
@@ -364,8 +360,6 @@ Only tags from the supported set are allowed. Using an unrecognized XML tag retu
     ```
 
     **Attributes:** None
-
-    **Provider Support:** Works with all TTS providers
   </Accordion>
 </AccordionGroup>
 
@@ -386,11 +380,6 @@ Only tags from the supported set are allowed. Using an unrecognized XML tag retu
 
     **Attributes:**
     - `time`: Duration of silence (required) - format: "Xs" where X is a number (e.g., "1s", "2.5s")
-
-    **Provider Support:**
-    - **Cartesia**: Supported on all models
-    - **ElevenLabs**: Only supported on `eleven_turbo_v2` and `eleven_turbo_v2_5` models
-    - **Other providers**: Not supported
   </Accordion>
 
   <Accordion title="<hold> - Hold Between Messages" icon="pause">
@@ -412,8 +401,6 @@ Only tags from the supported set are allowed. Using an unrecognized XML tag retu
 
     **Attributes:**
     - `time`: Duration to wait before next message (required) - format: "Xs" where X is a number (e.g., "5s", "10s")
-
-    **Provider Support:** Works with all TTS providers
   </Accordion>
 
   <Accordion title="<spell> - Spell Out Text" icon="font">
@@ -426,11 +413,6 @@ Only tags from the supported set are allowed. Using an unrecognized XML tag retu
     ```
 
     **Attributes:** None - this is a wrapping tag that encloses the text to be spelled
-
-    **Provider Support:**
-    - **Cartesia**: Full native support
-    - **ElevenLabs**: Supported
-    - **Other providers**: Supported
   </Accordion>
 
   <Accordion title="<speed> - Control Speech Speed" icon="gauge-high">
@@ -450,11 +432,6 @@ Only tags from the supported set are allowed. Using an unrecognized XML tag retu
 
     **Attributes:**
     - `ratio`: Speed multiplier (required) - e.g., "1.5" for 50% faster, "0.8" for 20% slower
-
-    **Provider Support:**
-    - **Cartesia**: Supported
-    - **ElevenLabs**: Supported
-    - **Other providers**: Not supported
   </Accordion>
 
   <Accordion title="<volume> - Control Volume" icon="volume-up">
@@ -471,11 +448,6 @@ Only tags from the supported set are allowed. Using an unrecognized XML tag retu
     **Attributes:**
     - `ratio`: Volume multiplier (required) - Valid range: 0.5 to 2.0.<br />
       Examples: "1.3" for 30% louder, "0.8" for 20% quieter
-
-    **Provider Support:**
-    - **Cartesia**: Supported
-    - **ElevenLabs**: Not supported
-    - **Other providers**: Not supported
   </Accordion>
 </AccordionGroup>
 
@@ -498,8 +470,6 @@ Only tags from the supported set are allowed. Using an unrecognized XML tag retu
 
     **Attributes:**
     - `digits`: DTMF digits to send (required) - e.g., "123", "456#", "*9"
-
-    **Provider Support:** Works with all TTS providers
   </Accordion>
 
   <Accordion title="<send_sms> - Send SMS" icon="message">
@@ -513,8 +483,6 @@ Only tags from the supported set are allowed. Using an unrecognized XML tag retu
 
     **Attributes:**
     - `text`: SMS message content to send (required)
-
-    **Provider Support:** Works with all TTS providers
   </Accordion>
 
   <Accordion title="<interruption> - Interrupt After Timeout" icon="hand">
@@ -530,8 +498,6 @@ Only tags from the supported set are allowed. Using an unrecognized XML tag retu
 
     **Attributes:**
     - `time`: Duration to wait before interrupting (required) - format: "Xs" where X is a number (e.g., "3s", "5.5s")
-
-    **Provider Support:** Works with all TTS providers
   </Accordion>
 </AccordionGroup>
 
@@ -560,8 +526,6 @@ Only tags from the supported set are allowed. Using an unrecognized XML tag retu
     **Attributes:**
     - `sound`: Sound name (required) - e.g., `office`, `cough`
     - `volume`: Volume level (optional) - default applies if not specified
-
-    **Provider Support:** Works with all TTS providers
   </Accordion>
 
   <Accordion title="<noise> - Play Sound Effects" icon="music">
@@ -585,8 +549,6 @@ Only tags from the supported set are allowed. Using an unrecognized XML tag retu
     - `sound`: Sound name (required)
     - `volume`: Volume level (optional)
     - `time`: Duration in ms (optional)
-
-    **Provider Support:** Works with all TTS providers
   </Accordion>
 
   <Accordion title="<network_simulation> - Simulate Network Issues" icon="wifi">
@@ -612,8 +574,6 @@ Only tags from the supported set are allowed. Using an unrecognized XML tag retu
     - `packet_loss`: Percentage (e.g., "5" = 5%)
     - `jitter`: Milliseconds (e.g., "50")
     - `latency`: Milliseconds (e.g., "100")
-
-    **Provider Support:** Works with all TTS providers
   </Accordion>
 </AccordionGroup>
 
@@ -953,7 +913,6 @@ Use `action_followup` for complex multi-part responses:
 
     **Solutions**:
     - Check tag syntax (spelling, attributes, closing format)
-    - Verify provider compatibility (e.g., Cartesia for `<volume>`)
     - Check tag placement (some tags must be at the start)
     - Confirm `fixed_message: true` is set — tags don't work with instruction-based actions
   </Accordion>


### PR DESCRIPTION
Removes all **Provider Support** blocks from every tag accordion in the Conditional Actions page (14 occurrences across Communication, Speech Control, Interaction, and Environmental tag sections).

Also removed the stale "Verify provider compatibility" hint from the Tags Not Working troubleshooting entry.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cekura-ai/docs/pull/530" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
