### PR TITLE
docs: fix ivr-voicemail voicemail example missing FIRST_MESSAGE condition

### DIFF
--- a/documentation/advanced/ivr-voicemail.mdx
+++ b/documentation/advanced/ivr-voicemail.mdx
@@ -37,7 +37,7 @@ Navigate to the evaluator creation form and click on "Create Evaluator" to begin
 
 In the conditions configuration:
 
-**First Message (Optional):** You can add the greeting here only which is shown in next line or You can leave this field empty if you want your agent to speak first.
+**First Message (FIRST_MESSAGE):** The first condition must always have `condition: "FIRST_MESSAGE"` and `id: 0`. For voicemail scenarios where the main agent speaks first, leave the `action` empty.
 
 **Condition 1 - Voicemail Greeting:**
 When the main agent starts the conversation, add a voicemail greeting using the `<voicemail>` XML tag with the following syntax:
@@ -73,6 +73,13 @@ Here's a complete JSON configuration example for a personal voicemail system:
 {
   "conditions": [
     {
+      "id": 0,
+      "condition": "FIRST_MESSAGE",
+      "action": "",
+      "type": "standard",
+      "fixed_message": true
+    },
+    {
       "id": 1,
       "condition": "The main agent starts the conversation and says \"Hello\".",
       "action": "<voicemail text=\"Hello, Adarsh is not available right now please record your message after this message and please press 0 button after you have finished speaking the message to mark the end of message.\" />",
@@ -94,7 +101,7 @@ Here's a complete JSON configuration example for a personal voicemail system:
 **Key Configuration Points:**
 - **conditions**: Array of condition-action pairs that define the voicemail flow
 - **role**: Defines the agent's behavior as a voicemail receiver
-- **fixed_message**: Set to `true` when using XML tags (`<voicemail>`, `<endcall />`)
+- **fixed_message**: Required on every condition — set to `true` when using XML tags (`<voicemail>`, `<endcall />`), `false` for natural language instructions
 - **action**: Contains either XML tags for structured responses or natural language instructions
 
 ### Key Voicemail Features
@@ -179,7 +186,7 @@ IVR scenarios are configured using a JSON structure with conditions and actions:
 | `condition` | string | Yes | Description of when this condition applies (e.g., "FIRST_MESSAGE", specific DTMF tones) |
 | `action` | string | Yes | Action to take (XML tag for IVR prompt or natural response instruction) |
 | `type` | string | Yes | Type of condition (typically "standard") |
-| `fixed_message` | boolean | Yes | Whether the message is fixed. **Must be `true` when using XML tags** like `<ivr>`. Set to `false` only for natural conversation responses. |
+| `fixed_message` | boolean | Yes | Required on every condition. Set to `true` when using XML tags like `<ivr>`. Set to `false` for natural conversation responses. |
 
 ### IVR XML Tags
 


### PR DESCRIPTION
The voicemail complete JSON example was missing the required `id: 0 / condition: "FIRST_MESSAGE"` condition — it started at `id: 1`, which now fails backend validation (vocera.backend#8754).

**Changes:**
- Added `FIRST_MESSAGE` condition (id: 0, empty action) at the top of the voicemail example
- Updated Step 2 description to clarify that FIRST_MESSAGE is required, not optional
- Updated `fixed_message` description in the condition table to say "Required on every condition"
- IVR example was already correct — no changes needed there
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cekura-ai/docs/pull/532" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
