### PR TITLE
docs: tag constraints, ranges, and supported sound lists

### DIFF
--- a/documentation/key-concepts/evaluators/conditional-actions.mdx
+++ b/documentation/key-concepts/evaluators/conditional-actions.mdx
@@ -351,6 +351,10 @@ Conditional Actions supports a variety of special tags in the `action` field to 
 
     The agent cannot interrupt while this message plays.
 
+    <Warning>
+    `<ivr>` must be the **entire action** — it cannot be combined with other text or tags in the same action string.
+    </Warning>
+
     **Attributes:**
     - `text`: The IVR message to play (required)
   </Accordion>
@@ -371,6 +375,10 @@ Conditional Actions supports a variety of special tags in the `action` field to 
       "action": "<voicemail />"
     }
     ```
+
+    <Warning>
+    `<voicemail>` must be the **entire action** — it cannot be combined with other text or tags in the same action string.
+    </Warning>
 
     **Attributes:**
     - `text`: Voicemail greeting message (optional) - if omitted, only plays beep; if provided, cannot be empty
@@ -447,18 +455,15 @@ Conditional Actions supports a variety of special tags in the `action` field to 
 
     ```json
     {
-      "action": "<speed ratio=\"1.5\" /> I need to talk quickly about this"
+      "action": "<speed ratio=\"1.2\" /> I need to talk quickly about this"
     }
     ```
-
-    - `1.0` = normal speed
-    - `1.5` = 50% faster
-    - `0.8` = 20% slower
 
     Must be at the start of the message.
 
     **Attributes:**
-    - `ratio`: Speed multiplier (required) - e.g., "1.5" for 50% faster, "0.8" for 20% slower
+    - `ratio`: Speed multiplier (required) - Valid range: **0.8 to 1.2**<br />
+      Examples: `"1.2"` for 20% faster, `"0.8"` for 20% slower
   </Accordion>
 
   <Accordion title="<volume> - Control Volume" icon="volume-up">
@@ -466,15 +471,15 @@ Conditional Actions supports a variety of special tags in the `action` field to 
 
     ```json
     {
-      "action": "<volume ratio=\"1.3\" /> This is important!"
+      "action": "<volume ratio=\"1.5\" /> This is important!"
     }
     ```
 
     Must be at the start of the message.
 
     **Attributes:**
-    - `ratio`: Volume multiplier (required) - Valid range: 0.5 to 2.0.<br />
-      Examples: "1.3" for 30% louder, "0.8" for 20% quieter
+    - `ratio`: Volume multiplier (required) - Valid range: **0 to 2**<br />
+      Examples: `"1.5"` for 50% louder, `"0.5"` for 50% quieter, `"0"` for silence
   </Accordion>
 </AccordionGroup>
 
@@ -518,11 +523,21 @@ Conditional Actions supports a variety of special tags in the `action` field to 
 
     ```json
     {
-      "action": "<interruption time=\"3s\" /> Please listen carefully to these instructions"
+      "id": 2,
+      "type": "action_followup",
+      "condition": 1,
+      "action": "<interruption time=\"3s\" /> Please listen carefully to these instructions",
+      "fixed_message": true
     }
     ```
 
     The testing agent will interrupt the main agent after 3 seconds and speak this message.
+
+    <Warning>
+    `<interruption>` has two requirements:
+    1. The condition must have `type: "action_followup"`
+    2. The tag must appear at the **very start** of the action string
+    </Warning>
 
     **Attributes:**
     - `time`: Duration to wait before interrupting (required) - format: "Xs" where X is a number (e.g., "3s", "5.5s")
@@ -533,75 +548,80 @@ Conditional Actions supports a variety of special tags in the `action` field to 
 
 <AccordionGroup>
   <Accordion title="<background_noise> - Background Sounds" icon="waveform-lines">
-    Add background sounds during specific portions of speech.
-
-    With volume control:
+    Add continuous background sounds during a portion of speech.
 
     ```json
     {
-      "action": "Let me check <background_noise sound=\"office\" volume=\"0.05\">I'm looking at the system now</background_noise> found it"
-    }
-    ```
-
-    Or with default volume:
-
-    ```json
-    {
-      "action": "<background_noise sound=\"cough\">Excuse me</background_noise> sorry about that"
+      "action": "<background_noise sound=\"coffee-shop\" volume=\"0.3\">Hi, I'm calling about my order</background_noise>"
     }
     ```
 
     **Attributes:**
-    - `sound`: Sound name (required) - e.g., `office`, `cough`
+    - `sound`: Sound name (required) - see supported sounds below
     - `volume`: Volume level (optional) - default applies if not specified
+
+    **Supported sounds:**
+
+    | Sound name | Description |
+    |---|---|
+    | `office-ambience` | Office environment |
+    | `coffee-shop` | Coffee shop chatter |
+    | `kitchen-noise` | Kitchen sounds |
+    | `home-chatter` | Home background voices |
+    | `vacuum-cleaner` | Vacuum cleaner |
+    | `dog-barking` | Dog barking |
+    | `baby-crying` | Baby crying |
+    | `keyboard-typing` | Keyboard typing |
+    | `coughing` | Coughing sounds |
+    | `background-printer` | Printer noise |
+    | `quiet-room` | Near-silent room |
+    | `air-conditioner` | AC hum |
+    | `construction-site` | Construction noise |
+    | `busy-street` | Street traffic |
+    | `airport-boarding` | Airport gate |
+    | `inside-car` | Moving car interior |
+    | `inside-train` | Moving train interior |
+    | `public-park` | Park ambience |
+    | `rain-thunder` | Rain and thunder |
+    | `windy-day` | Wind |
+    | `restaurant` | Restaurant ambience |
+    | `shopping-mall` | Shopping mall |
+    | `stadium-crowd` | Crowd noise |
+    | `standard-hiss` | White noise hiss |
+    | `static-radio` | Radio static |
+    | `fan-buzz` | Fan buzz |
+    | `ship-humming` | Low ship hum |
+    | `two-people-talking` | Background conversation |
+    | `train-station` | Train station hall |
+    | `holding-on-song` | Hold music |
   </Accordion>
 
   <Accordion title="<noise> - Play Sound Effects" icon="music">
-    Play a sound effect once without speech.
+    Play a one-shot sound effect (does not loop).
 
     ```json
     {
-      "action": "Hold on <noise sound=\"typing\" volume=\"0.8\" time=\"500\" /> thanks for waiting"
-    }
-    ```
-
-    Or with just sound:
-
-    ```json
-    {
-      "action": "Please wait <noise sound=\"beep\" /> one moment"
+      "action": "Hold on <noise sound=\"beep\" /> one moment"
     }
     ```
 
     **Attributes:**
-    - `sound`: Sound name (required)
+    - `sound`: Sound name (required) - supported: `office`, `beep`, `cough1`, `cough2`
     - `volume`: Volume level (optional)
     - `time`: Duration in ms (optional)
   </Accordion>
 
   <Accordion title="<network_simulation> - Simulate Network Issues" icon="wifi">
-    Simulate network conditions like packet loss, jitter, or latency.
-
-    All parameters together:
+    Simulate packet loss on the network connection.
 
     ```json
     {
-      "action": "<network_simulation packet_loss=\"5\" jitter=\"50\" latency=\"100\" /> Testing under poor network"
+      "action": "<network_simulation packet_loss=\"5\" /> Testing under poor network"
     }
     ```
 
-    Or individual parameters:
-
-    ```json
-    {
-      "action": "<network_simulation latency=\"200\" /> Testing with high latency"
-    }
-    ```
-
-    **Attributes (all optional):**
-    - `packet_loss`: Percentage (e.g., "5" = 5%)
-    - `jitter`: Milliseconds (e.g., "50")
-    - `latency`: Milliseconds (e.g., "100")
+    **Attributes:**
+    - `packet_loss`: Packet loss percentage (required) - e.g., `"5"` = 5% loss
   </Accordion>
 </AccordionGroup>
 
@@ -770,14 +790,14 @@ Conditional Actions supports a variety of special tags in the `action` field to 
     {
       "id": 0,
       "condition": "FIRST_MESSAGE",
-      "action": "<background_noise sound=\"office\" volume=\"0.05\">Hi, I'm calling about my order</background_noise>",
+      "action": "<background_noise sound=\"coffee-shop\" volume=\"0.3\">Hi, I'm calling about my order</background_noise>",
       "type": "standard",
       "fixed_message": true
     },
     {
       "id": 1,
       "condition": "The agent asks you to repeat",
-      "action": "<volume ratio=\"1.3\" />I said I'm calling about my order, <spell>ABC</spell> 123",
+      "action": "<volume ratio=\"1.5\" />I said I'm calling about my order, <spell>ABC</spell> 123",
       "type": "standard",
       "fixed_message": true
     },
@@ -992,7 +1012,7 @@ Use `action_followup` for complex multi-part responses:
 
     **Solutions**:
     - Check tag syntax (spelling, attributes, closing format)
-    - Check tag placement (some tags must be at the start)
+    - Check tag placement (some tags must be at the start or span the entire action)
     - Confirm `fixed_message: true` is set — tags don't work with instruction-based actions
   </Accordion>
 

--- a/documentation/key-concepts/evaluators/conditional-actions.mdx
+++ b/documentation/key-concepts/evaluators/conditional-actions.mdx
@@ -479,7 +479,7 @@ Conditional Actions supports a variety of special tags in the `action` field to 
 
     **Attributes:**
     - `ratio`: Volume multiplier (required) - Valid range: **0 to 2**<br />
-      Examples: `"1.5"` for 50% louder, `"0.5"` for 50% quieter, `"0"` for silence
+      Examples: `"1.5"` for 50% louder, `"0.5"` for 50% quieter
   </Accordion>
 </AccordionGroup>
 


### PR DESCRIPTION
Updates the Supported Tags section of the conditional-actions page with new constraints and accurate data.

## Changes

| Tag | Change |
|-----|--------|
| `<ivr>` | Must be the entire action — cannot be combined with other text/tags |
| `<voicemail>` | Must be the entire action — cannot be combined with other text/tags |
| `<interruption>` | Requires `type: "action_followup"` AND must appear at the very start of the action |
| `<speed>` | Ratio range corrected to **0.8–1.2** |
| `<volume>` | Ratio range corrected to **0–2** |
| `<background_noise>` | Full list of 29 supported sound names added |
| `<noise>` | Supported sounds documented: `office`, `beep`, `cough1`, `cough2` |
| `<network_simulation>` | Removed `jitter` and `latency`; `packet_loss` is the only supported attribute |

Also updated Example 4 to use `coffee-shop` (valid sound name) instead of the generic `office` reference.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cekura-ai/docs/pull/535" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
