### PR TITLE
docs: document silence vs hold tag behaviour difference

### DIFF
--- a/documentation/key-concepts/evaluators/conditional-actions.mdx
+++ b/documentation/key-concepts/evaluators/conditional-actions.mdx
@@ -351,10 +351,6 @@ Conditional Actions supports a variety of special tags in the `action` field to 
 
     The agent cannot interrupt while this message plays.
 
-    <Warning>
-    `<ivr>` must be the **entire action** — it cannot be combined with other text or tags in the same action string.
-    </Warning>
-
     **Attributes:**
     - `text`: The IVR message to play (required)
   </Accordion>
@@ -376,10 +372,6 @@ Conditional Actions supports a variety of special tags in the `action` field to 
     }
     ```
 
-    <Warning>
-    `<voicemail>` must be the **entire action** — it cannot be combined with other text or tags in the same action string.
-    </Warning>
-
     **Attributes:**
     - `text`: Voicemail greeting message (optional) - if omitted, only plays beep; if provided, cannot be empty
   </Accordion>
@@ -399,9 +391,21 @@ Conditional Actions supports a variety of special tags in the `action` field to 
 
 ### Speech Control Tags
 
+<Note>
+**`<silence>` vs `<hold>`** — both add pauses, but behave differently:
+
+| | `<silence>` | `<hold>` |
+|---|---|---|
+| Interruptible | ✅ Yes — main agent can interrupt | ❌ No — testing agent won't be interrupted |
+| After interruption | Condition matching restarts after main agent stops speaking | N/A |
+| Background noise | Continues to play during the pause | Does **not** play during the pause |
+
+Use `<silence>` when you want the conversation to feel natural and allow the main agent to jump in. Use `<hold>` when you need a guaranteed delay before the next message.
+</Note>
+
 <AccordionGroup>
-  <Accordion title="<silence> - Add Pauses" icon="clock">
-    Add silence/pauses in speech.
+  <Accordion title="<silence> - Add Pauses (interruptible)" icon="clock">
+    Add a pause in speech. **Interruptible** — if the main agent speaks during the silence, the testing agent stops immediately and condition matching restarts once the main agent finishes. Background noise continues to play during the pause.
 
     ```json
     {
@@ -417,8 +421,8 @@ Conditional Actions supports a variety of special tags in the `action` field to 
     - `time`: Duration of silence (required) - format: "Xs" where X is a number (e.g., "1s", "2.5s")
   </Accordion>
 
-  <Accordion title="<hold> - Hold Between Messages" icon="pause">
-    Wait before sending the next message.
+  <Accordion title="<hold> - Hold Between Messages (not interruptible)" icon="pause">
+    Wait before sending the next message. **Not interruptible** — the testing agent will not be interrupted during a hold, regardless of what the main agent says. Background noise does not play during a hold.
 
     ```json
     {
@@ -455,15 +459,18 @@ Conditional Actions supports a variety of special tags in the `action` field to 
 
     ```json
     {
-      "action": "<speed ratio=\"1.2\" /> I need to talk quickly about this"
+      "action": "<speed ratio=\"1.5\" /> I need to talk quickly about this"
     }
     ```
+
+    - `1.0` = normal speed
+    - `1.5` = 50% faster
+    - `0.8` = 20% slower
 
     Must be at the start of the message.
 
     **Attributes:**
-    - `ratio`: Speed multiplier (required) - Valid range: **0.8 to 1.2**<br />
-      Examples: `"1.2"` for 20% faster, `"0.8"` for 20% slower
+    - `ratio`: Speed multiplier (required) - e.g., "1.5" for 50% faster, "0.8" for 20% slower
   </Accordion>
 
   <Accordion title="<volume> - Control Volume" icon="volume-up">
@@ -471,15 +478,15 @@ Conditional Actions supports a variety of special tags in the `action` field to 
 
     ```json
     {
-      "action": "<volume ratio=\"1.5\" /> This is important!"
+      "action": "<volume ratio=\"1.3\" /> This is important!"
     }
     ```
 
     Must be at the start of the message.
 
     **Attributes:**
-    - `ratio`: Volume multiplier (required) - Valid range: **0 to 2**<br />
-      Examples: `"1.5"` for 50% louder, `"0.5"` for 50% quieter
+    - `ratio`: Volume multiplier (required) - Valid range: 0.5 to 2.0.<br />
+      Examples: "1.3" for 30% louder, "0.8" for 20% quieter
   </Accordion>
 </AccordionGroup>
 
@@ -523,21 +530,11 @@ Conditional Actions supports a variety of special tags in the `action` field to 
 
     ```json
     {
-      "id": 2,
-      "type": "action_followup",
-      "condition": 1,
-      "action": "<interruption time=\"3s\" /> Please listen carefully to these instructions",
-      "fixed_message": true
+      "action": "<interruption time=\"3s\" /> Please listen carefully to these instructions"
     }
     ```
 
     The testing agent will interrupt the main agent after 3 seconds and speak this message.
-
-    <Warning>
-    `<interruption>` has two requirements:
-    1. The condition must have `type: "action_followup"`
-    2. The tag must appear at the **very start** of the action string
-    </Warning>
 
     **Attributes:**
     - `time`: Duration to wait before interrupting (required) - format: "Xs" where X is a number (e.g., "3s", "5.5s")
@@ -548,80 +545,75 @@ Conditional Actions supports a variety of special tags in the `action` field to 
 
 <AccordionGroup>
   <Accordion title="<background_noise> - Background Sounds" icon="waveform-lines">
-    Add continuous background sounds during a portion of speech.
+    Add background sounds during specific portions of speech.
+
+    With volume control:
 
     ```json
     {
-      "action": "<background_noise sound=\"coffee-shop\" volume=\"0.3\">Hi, I'm calling about my order</background_noise>"
+      "action": "Let me check <background_noise sound=\"office\" volume=\"0.05\">I'm looking at the system now</background_noise> found it"
+    }
+    ```
+
+    Or with default volume:
+
+    ```json
+    {
+      "action": "<background_noise sound=\"cough\">Excuse me</background_noise> sorry about that"
     }
     ```
 
     **Attributes:**
-    - `sound`: Sound name (required) - see supported sounds below
+    - `sound`: Sound name (required) - e.g., `office`, `cough`
     - `volume`: Volume level (optional) - default applies if not specified
-
-    **Supported sounds:**
-
-    | Sound name | Description |
-    |---|---|
-    | `office-ambience` | Office environment |
-    | `coffee-shop` | Coffee shop chatter |
-    | `kitchen-noise` | Kitchen sounds |
-    | `home-chatter` | Home background voices |
-    | `vacuum-cleaner` | Vacuum cleaner |
-    | `dog-barking` | Dog barking |
-    | `baby-crying` | Baby crying |
-    | `keyboard-typing` | Keyboard typing |
-    | `coughing` | Coughing sounds |
-    | `background-printer` | Printer noise |
-    | `quiet-room` | Near-silent room |
-    | `air-conditioner` | AC hum |
-    | `construction-site` | Construction noise |
-    | `busy-street` | Street traffic |
-    | `airport-boarding` | Airport gate |
-    | `inside-car` | Moving car interior |
-    | `inside-train` | Moving train interior |
-    | `public-park` | Park ambience |
-    | `rain-thunder` | Rain and thunder |
-    | `windy-day` | Wind |
-    | `restaurant` | Restaurant ambience |
-    | `shopping-mall` | Shopping mall |
-    | `stadium-crowd` | Crowd noise |
-    | `standard-hiss` | White noise hiss |
-    | `static-radio` | Radio static |
-    | `fan-buzz` | Fan buzz |
-    | `ship-humming` | Low ship hum |
-    | `two-people-talking` | Background conversation |
-    | `train-station` | Train station hall |
-    | `holding-on-song` | Hold music |
   </Accordion>
 
   <Accordion title="<noise> - Play Sound Effects" icon="music">
-    Play a one-shot sound effect (does not loop).
+    Play a sound effect once without speech.
 
     ```json
     {
-      "action": "Hold on <noise sound=\"beep\" /> one moment"
+      "action": "Hold on <noise sound=\"typing\" volume=\"0.8\" time=\"500\" /> thanks for waiting"
+    }
+    ```
+
+    Or with just sound:
+
+    ```json
+    {
+      "action": "Please wait <noise sound=\"beep\" /> one moment"
     }
     ```
 
     **Attributes:**
-    - `sound`: Sound name (required) - supported: `office`, `beep`, `cough1`, `cough2`
+    - `sound`: Sound name (required)
     - `volume`: Volume level (optional)
     - `time`: Duration in ms (optional)
   </Accordion>
 
   <Accordion title="<network_simulation> - Simulate Network Issues" icon="wifi">
-    Simulate packet loss on the network connection.
+    Simulate network conditions like packet loss, jitter, or latency.
+
+    All parameters together:
 
     ```json
     {
-      "action": "<network_simulation packet_loss=\"5\" /> Testing under poor network"
+      "action": "<network_simulation packet_loss=\"5\" jitter=\"50\" latency=\"100\" /> Testing under poor network"
     }
     ```
 
-    **Attributes:**
-    - `packet_loss`: Packet loss percentage (required) - e.g., `"5"` = 5% loss
+    Or individual parameters:
+
+    ```json
+    {
+      "action": "<network_simulation latency=\"200\" /> Testing with high latency"
+    }
+    ```
+
+    **Attributes (all optional):**
+    - `packet_loss`: Percentage (e.g., "5" = 5%)
+    - `jitter`: Milliseconds (e.g., "50")
+    - `latency`: Milliseconds (e.g., "100")
   </Accordion>
 </AccordionGroup>
 
@@ -790,14 +782,14 @@ Conditional Actions supports a variety of special tags in the `action` field to 
     {
       "id": 0,
       "condition": "FIRST_MESSAGE",
-      "action": "<background_noise sound=\"coffee-shop\" volume=\"0.3\">Hi, I'm calling about my order</background_noise>",
+      "action": "<background_noise sound=\"office\" volume=\"0.05\">Hi, I'm calling about my order</background_noise>",
       "type": "standard",
       "fixed_message": true
     },
     {
       "id": 1,
       "condition": "The agent asks you to repeat",
-      "action": "<volume ratio=\"1.5\" />I said I'm calling about my order, <spell>ABC</spell> 123",
+      "action": "<volume ratio=\"1.3\" />I said I'm calling about my order, <spell>ABC</spell> 123",
       "type": "standard",
       "fixed_message": true
     },
@@ -1012,7 +1004,7 @@ Use `action_followup` for complex multi-part responses:
 
     **Solutions**:
     - Check tag syntax (spelling, attributes, closing format)
-    - Check tag placement (some tags must be at the start or span the entire action)
+    - Check tag placement (some tags must be at the start)
     - Confirm `fixed_message: true` is set — tags don't work with instruction-based actions
   </Accordion>
 

--- a/documentation/key-concepts/evaluators/conditional-actions.mdx
+++ b/documentation/key-concepts/evaluators/conditional-actions.mdx
@@ -351,6 +351,10 @@ Conditional Actions supports a variety of special tags in the `action` field to 
 
     The agent cannot interrupt while this message plays.
 
+    <Warning>
+    `<ivr>` must be the **entire action** — it cannot be combined with other text or tags in the same action string.
+    </Warning>
+
     **Attributes:**
     - `text`: The IVR message to play (required)
   </Accordion>
@@ -371,6 +375,10 @@ Conditional Actions supports a variety of special tags in the `action` field to 
       "action": "<voicemail />"
     }
     ```
+
+    <Warning>
+    `<voicemail>` must be the **entire action** — it cannot be combined with other text or tags in the same action string.
+    </Warning>
 
     **Attributes:**
     - `text`: Voicemail greeting message (optional) - if omitted, only plays beep; if provided, cannot be empty
@@ -396,7 +404,7 @@ Conditional Actions supports a variety of special tags in the `action` field to 
 
 | | `<silence>` | `<hold>` |
 |---|---|---|
-| Interruptible | ✅ Yes — main agent can interrupt | ❌ No — testing agent won't be interrupted |
+| Interruptible | ✅ Yes — main agent can interrupt | ❌ No — testing agent won’t be interrupted |
 | After interruption | Condition matching restarts after main agent stops speaking | N/A |
 | Background noise | Continues to play during the pause | Does **not** play during the pause |
 
@@ -459,18 +467,15 @@ Use `<silence>` when you want the conversation to feel natural and allow the mai
 
     ```json
     {
-      "action": "<speed ratio=\"1.5\" /> I need to talk quickly about this"
+      "action": "<speed ratio=\"1.2\" /> I need to talk quickly about this"
     }
     ```
-
-    - `1.0` = normal speed
-    - `1.5` = 50% faster
-    - `0.8` = 20% slower
 
     Must be at the start of the message.
 
     **Attributes:**
-    - `ratio`: Speed multiplier (required) - e.g., "1.5" for 50% faster, "0.8" for 20% slower
+    - `ratio`: Speed multiplier (required) - Valid range: **0.8 to 1.2**<br />
+      Examples: `"1.2"` for 20% faster, `"0.8"` for 20% slower
   </Accordion>
 
   <Accordion title="<volume> - Control Volume" icon="volume-up">
@@ -478,15 +483,15 @@ Use `<silence>` when you want the conversation to feel natural and allow the mai
 
     ```json
     {
-      "action": "<volume ratio=\"1.3\" /> This is important!"
+      "action": "<volume ratio=\"1.5\" /> This is important!"
     }
     ```
 
     Must be at the start of the message.
 
     **Attributes:**
-    - `ratio`: Volume multiplier (required) - Valid range: 0.5 to 2.0.<br />
-      Examples: "1.3" for 30% louder, "0.8" for 20% quieter
+    - `ratio`: Volume multiplier (required) - Valid range: **0 to 2**<br />
+      Examples: `"1.5"` for 50% louder, `"0.5"` for 50% quieter
   </Accordion>
 </AccordionGroup>
 
@@ -530,11 +535,21 @@ Use `<silence>` when you want the conversation to feel natural and allow the mai
 
     ```json
     {
-      "action": "<interruption time=\"3s\" /> Please listen carefully to these instructions"
+      "id": 2,
+      "type": "action_followup",
+      "condition": 1,
+      "action": "<interruption time=\"3s\" /> Please listen carefully to these instructions",
+      "fixed_message": true
     }
     ```
 
     The testing agent will interrupt the main agent after 3 seconds and speak this message.
+
+    <Warning>
+    `<interruption>` has two requirements:
+    1. The condition must have `type: "action_followup"`
+    2. The tag must appear at the **very start** of the action string
+    </Warning>
 
     **Attributes:**
     - `time`: Duration to wait before interrupting (required) - format: "Xs" where X is a number (e.g., "3s", "5.5s")
@@ -545,75 +560,80 @@ Use `<silence>` when you want the conversation to feel natural and allow the mai
 
 <AccordionGroup>
   <Accordion title="<background_noise> - Background Sounds" icon="waveform-lines">
-    Add background sounds during specific portions of speech.
-
-    With volume control:
+    Add continuous background sounds during a portion of speech.
 
     ```json
     {
-      "action": "Let me check <background_noise sound=\"office\" volume=\"0.05\">I'm looking at the system now</background_noise> found it"
-    }
-    ```
-
-    Or with default volume:
-
-    ```json
-    {
-      "action": "<background_noise sound=\"cough\">Excuse me</background_noise> sorry about that"
+      "action": "<background_noise sound=\"coffee-shop\" volume=\"0.3\">Hi, I'm calling about my order</background_noise>"
     }
     ```
 
     **Attributes:**
-    - `sound`: Sound name (required) - e.g., `office`, `cough`
+    - `sound`: Sound name (required) - see supported sounds below
     - `volume`: Volume level (optional) - default applies if not specified
+
+    **Supported sounds:**
+
+    | Sound name | Description |
+    |---|---|
+    | `office-ambience` | Office environment |
+    | `coffee-shop` | Coffee shop chatter |
+    | `kitchen-noise` | Kitchen sounds |
+    | `home-chatter` | Home background voices |
+    | `vacuum-cleaner` | Vacuum cleaner |
+    | `dog-barking` | Dog barking |
+    | `baby-crying` | Baby crying |
+    | `keyboard-typing` | Keyboard typing |
+    | `coughing` | Coughing sounds |
+    | `background-printer` | Printer noise |
+    | `quiet-room` | Near-silent room |
+    | `air-conditioner` | AC hum |
+    | `construction-site` | Construction noise |
+    | `busy-street` | Street traffic |
+    | `airport-boarding` | Airport gate |
+    | `inside-car` | Moving car interior |
+    | `inside-train` | Moving train interior |
+    | `public-park` | Park ambience |
+    | `rain-thunder` | Rain and thunder |
+    | `windy-day` | Wind |
+    | `restaurant` | Restaurant ambience |
+    | `shopping-mall` | Shopping mall |
+    | `stadium-crowd` | Crowd noise |
+    | `standard-hiss` | White noise hiss |
+    | `static-radio` | Radio static |
+    | `fan-buzz` | Fan buzz |
+    | `ship-humming` | Low ship hum |
+    | `two-people-talking` | Background conversation |
+    | `train-station` | Train station hall |
+    | `holding-on-song` | Hold music |
   </Accordion>
 
   <Accordion title="<noise> - Play Sound Effects" icon="music">
-    Play a sound effect once without speech.
+    Play a one-shot sound effect (does not loop).
 
     ```json
     {
-      "action": "Hold on <noise sound=\"typing\" volume=\"0.8\" time=\"500\" /> thanks for waiting"
-    }
-    ```
-
-    Or with just sound:
-
-    ```json
-    {
-      "action": "Please wait <noise sound=\"beep\" /> one moment"
+      "action": "Hold on <noise sound=\"beep\" /> one moment"
     }
     ```
 
     **Attributes:**
-    - `sound`: Sound name (required)
+    - `sound`: Sound name (required) - supported: `office`, `beep`, `cough1`, `cough2`
     - `volume`: Volume level (optional)
     - `time`: Duration in ms (optional)
   </Accordion>
 
   <Accordion title="<network_simulation> - Simulate Network Issues" icon="wifi">
-    Simulate network conditions like packet loss, jitter, or latency.
-
-    All parameters together:
+    Simulate packet loss on the network connection.
 
     ```json
     {
-      "action": "<network_simulation packet_loss=\"5\" jitter=\"50\" latency=\"100\" /> Testing under poor network"
+      "action": "<network_simulation packet_loss=\"5\" /> Testing under poor network"
     }
     ```
 
-    Or individual parameters:
-
-    ```json
-    {
-      "action": "<network_simulation latency=\"200\" /> Testing with high latency"
-    }
-    ```
-
-    **Attributes (all optional):**
-    - `packet_loss`: Percentage (e.g., "5" = 5%)
-    - `jitter`: Milliseconds (e.g., "50")
-    - `latency`: Milliseconds (e.g., "100")
+    **Attributes:**
+    - `packet_loss`: Packet loss percentage (required) - e.g., `"5"` = 5% loss
   </Accordion>
 </AccordionGroup>
 
@@ -782,14 +802,14 @@ Use `<silence>` when you want the conversation to feel natural and allow the mai
     {
       "id": 0,
       "condition": "FIRST_MESSAGE",
-      "action": "<background_noise sound=\"office\" volume=\"0.05\">Hi, I'm calling about my order</background_noise>",
+      "action": "<background_noise sound=\"coffee-shop\" volume=\"0.3\">Hi, I'm calling about my order</background_noise>",
       "type": "standard",
       "fixed_message": true
     },
     {
       "id": 1,
       "condition": "The agent asks you to repeat",
-      "action": "<volume ratio=\"1.3\" />I said I'm calling about my order, <spell>ABC</spell> 123",
+      "action": "<volume ratio=\"1.5\" />I said I'm calling about my order, <spell>ABC</spell> 123",
       "type": "standard",
       "fixed_message": true
     },
@@ -1004,7 +1024,7 @@ Use `action_followup` for complex multi-part responses:
 
     **Solutions**:
     - Check tag syntax (spelling, attributes, closing format)
-    - Check tag placement (some tags must be at the start)
+    - Check tag placement (some tags must be at the start or span the entire action)
     - Confirm `fixed_message: true` is set — tags don't work with instruction-based actions
   </Accordion>
 


### PR DESCRIPTION
Adds a comparison table and per-accordion descriptions explaining the key behavioural difference between `<silence>` and `<hold>`.

| | `<silence>` | `<hold>` |
|---|---|---|
| Interruptible | ✅ Yes — main agent can interrupt | ❌ No — testing agent won't be interrupted |
| After interruption | Condition matching restarts after main agent stops | N/A |
| Background noise | Continues to play during the pause | Does **not** play during the pause |

Changes:
- Added a `<Note>` comparison table above the Speech Control Tags accordions
- Updated the `<silence>` accordion title and description to call out it is interruptible and bg noise continues
- Updated the `<hold>` accordion title and description to call out it is not interruptible and bg noise stops
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cekura-ai/docs/pull/536" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
