### PR TITLE
[CEK-6961] Document {{evaluator.*}} metric variables

### DIFF
--- a/documentation/key-concepts/metrics/metric-variables.mdx
+++ b/documentation/key-concepts/metrics/metric-variables.mdx
@@ -32,6 +32,7 @@ This page is the authoritative reference for that set. If you're looking at one 
 | `{{test_profile.*}}` | ✅ | ❌ |
 | `{{provider_call_data.*}}` | ✅ | ❌ |
 | `{{agent.*}}` | ✅ | ✅ |
+| `{{evaluator.*}}` | ✅ | ❌ |
 
 ## Available Variables
 
@@ -148,6 +149,18 @@ Structured test scenario data configured for simulation runs. Supports nested ob
 This is based on the provider you have integrated on the platform. This variable gives you complete access to call details from your provider platform.
 
 **Example providers:** VAPI, Retell, Elevenlabs, etc.
+
+#### `{{evaluator.*}}`
+**Availability:** ✅ Simulation | ❌ Observability
+
+Access the evaluator (scenario) being run, including its instructions. Useful when a metric or expected outcome prompt needs to reference what the evaluator was supposed to do.
+
+**Available fields:**
+
+| Field | Description | Example Value |
+|-------|-------------|---------------|
+| `{{evaluator.instructions}}` | Evaluator's instructions text. For Conditional Actions evaluators, this is the JSON-serialized conditional actions structure. | `"Call to cancel an appointment scheduled for next Tuesday"` |
+| `{{evaluator.conditional_action_instructions}}` | Conditional action instructions (only populated when the evaluator's type is **Conditional Actions**, otherwise an empty string). JSON string with `conditions` and `role` keys. | `'{"conditions": [{"id": 0, "condition": "...", "action": "...", "type": "standard", "fixed_message": true}], "role": "..."}'` |
 
 #### `{{dynamic_variables.*}}`
 **Availability:** ❌ Simulation | ✅ Observability (via API)


### PR DESCRIPTION
Adds the new evaluator.instructions and evaluator.conditional_action_instructions variables to the metric-variables reference (Simulation only).