### PR TITLE
docs: document DTMF transcript visibility for IVR scenarios

### DIFF
--- a/documentation/api/evaluators/llm-websocket-server-example.mdx
+++ b/documentation/api/evaluators/llm-websocket-server-example.mdx
@@ -71,3 +71,66 @@ ngrok config add-authtoken <your-token>
 ```bash
 ngrok http 127.0.0.1:8765
 ```
+
+## Keeping the Connection Alive
+
+Cekura's test framework closes a WebSocket connection after **5 minutes of inactivity** (no messages exchanged). Under normal operation this never fires because the agent is actively responding. However, when your LLM is slow to respond — for example during a long inference call or a transient rate-limit retry — the connection can appear idle and get dropped.
+
+### Send keepalive metadata frames
+
+While your server is processing a request, periodically send a metadata-only frame to signal that the connection is still active:
+
+```json
+{"metadata": {"keepalive": true}}
+```
+
+Cekura ignores the content of `metadata`-only frames (no `role` or `content` key) but still counts them as activity, resetting the inactivity timer.
+
+### Implementation pattern
+
+Start a background task when you begin processing each message and cancel it when you send the reply:
+
+```python
+async def chat_response(message, session_id, websocket=None):
+    async def keepalive():
+        while True:
+            await asyncio.sleep(8)   # send every 8 seconds
+            try:
+                if websocket:
+                    await websocket.send(json.dumps({"metadata": {"keepalive": True}}))
+            except Exception:
+                break  # connection already closed
+
+    ka_task = asyncio.create_task(keepalive()) if websocket else None
+    try:
+        # ... your LLM call here ...
+        return json.dumps({"content": assistant_response})
+    finally:
+        if ka_task:
+            ka_task.cancel()
+```
+
+<Warning>
+Only one task should ever call `websocket.send()` at a time. Do **not** start a second keepalive loop inside a retry helper — two concurrent senders can corrupt WebSocket frames and silently drop the connection.
+</Warning>
+
+### Choosing an interval
+
+| Interval | Behaviour |
+|----------|-----------|
+| Too short (< 3s) | Floods the tunnel with frames; can congest ngrok and delay real messages |
+| 5–10s | Recommended — well under the 5-minute window, low overhead |
+| > 60s | Risky if your LLM calls are slow |
+
+### Disabling server-side pings
+
+Set `ping_interval=None` when starting `websockets.serve` to stop the server from sending its own WebSocket ping frames. These add unnecessary control-frame traffic through the tunnel:
+
+```python
+server = await websockets.serve(
+    handle_websocket,
+    "0.0.0.0",
+    8765,
+    ping_interval=None,
+)
+```

--- a/documentation/integrations/chat-testing.mdx
+++ b/documentation/integrations/chat-testing.mdx
@@ -269,11 +269,16 @@ Use voice testing for ASR/TTS validation and final production checks.
 
     Either side can end the conversation. Cekura sends `{"type": "end_call"}` to your server and waits 1 second before closing the connection — your server does not need to close the connection itself. To end the conversation from your side, simply close the WebSocket connection; Cekura treats an unexpected close as the main agent ending the call.
 
-    Cekura closes the connection after 5 minutes without a content message. It also sends a WebSocket ping periodically and considers the connection dropped if no pong is received. Ping/pong are handled automatically at the WebSocket protocol layer by most libraries, so no explicit handling is required in your application code.
+    Cekura enforces two inactivity timeouts:
+
+    - **30 seconds** without any message (including metadata frames) — connection is closed
+    - **5 minutes** without a real content message — connection is closed regardless of metadata activity
+
+    It also sends a WebSocket ping periodically and considers the connection dropped if no pong is received. Ping/pong are handled automatically at the WebSocket protocol layer by most libraries, so no explicit handling is required in your application code.
 
     **Keeping the connection alive during long LLM calls**
 
-    If your server takes a long time to respond — for example during a slow LLM inference or a rate-limit retry — the connection can appear idle and get dropped by the inactivity timeout. To prevent this, send a metadata-only frame every few seconds while processing:
+    If your server takes a long time to respond — for example during a slow LLM inference or a rate-limit retry — the 30-second inactivity timeout will drop the connection. To prevent this, send a metadata-only frame every few seconds while processing:
 
     ```json
     {"metadata": {"keepalive": true}}

--- a/documentation/integrations/chat-testing.mdx
+++ b/documentation/integrations/chat-testing.mdx
@@ -269,16 +269,16 @@ Use voice testing for ASR/TTS validation and final production checks.
 
     Either side can end the conversation. Cekura sends `{"type": "end_call"}` to your server and waits 1 second before closing the connection — your server does not need to close the connection itself. To end the conversation from your side, simply close the WebSocket connection; Cekura treats an unexpected close as the main agent ending the call.
 
-    Cekura enforces two inactivity timeouts:
+    Cekura closes the connection if your server goes silent:
 
-    - **30 seconds** without any message (including metadata frames) — connection is closed
-    - **5 minutes** without a real content message — connection is closed regardless of metadata activity
+    - **30 seconds** without any frame — connection is closed. Send keepalive metadata frames (see below) to extend this window.
+    - **5 minutes** without a real content message — absolute maximum, even if keepalive frames are being sent.
 
     It also sends a WebSocket ping periodically and considers the connection dropped if no pong is received. Ping/pong are handled automatically at the WebSocket protocol layer by most libraries, so no explicit handling is required in your application code.
 
     **Keeping the connection alive during long LLM calls**
 
-    If your server takes a long time to respond — for example during a slow LLM inference or a rate-limit retry — the 30-second inactivity timeout will drop the connection. To prevent this, send a metadata-only frame every few seconds while processing:
+    If your server takes a long time to respond — for example during a slow LLM inference or a rate-limit retry — the 30-second timeout will drop the connection. Send a metadata-only frame every few seconds to reset the 30-second clock while processing:
 
     ```json
     {"metadata": {"keepalive": true}}

--- a/documentation/integrations/chat-testing.mdx
+++ b/documentation/integrations/chat-testing.mdx
@@ -269,7 +269,52 @@ Use voice testing for ASR/TTS validation and final production checks.
 
     Either side can end the conversation. Cekura sends `{"type": "end_call"}` to your server and waits 1 second before closing the connection — your server does not need to close the connection itself. To end the conversation from your side, simply close the WebSocket connection; Cekura treats an unexpected close as the main agent ending the call.
 
-    Cekura closes the connection after 5 minutes without a content message. It also sends a WebSocket ping every 30 seconds and considers the connection dropped if no pong is received within 10 seconds. Ping/pong are handled automatically at the WebSocket protocol layer by most libraries, so no explicit handling is required in your application code.
+    Cekura closes the connection after 5 minutes without a content message. It also sends a WebSocket ping periodically and considers the connection dropped if no pong is received. Ping/pong are handled automatically at the WebSocket protocol layer by most libraries, so no explicit handling is required in your application code.
+
+    **Keeping the connection alive during long LLM calls**
+
+    If your server takes a long time to respond — for example during a slow LLM inference or a rate-limit retry — the connection can appear idle and get dropped by the inactivity timeout. To prevent this, send a metadata-only frame every few seconds while processing:
+
+    ```json
+    {"metadata": {"keepalive": true}}
+    ```
+
+    Cekura treats any incoming frame (including metadata-only frames) as activity, so this resets the inactivity timer without triggering a response from the testing agent.
+
+    ```python
+    async def chat_response(message, session_id, websocket=None):
+        async def keepalive():
+            while True:
+                await asyncio.sleep(8)  # send every 8 seconds
+                try:
+                    if websocket:
+                        await websocket.send(json.dumps({"metadata": {"keepalive": True}}))
+                except Exception:
+                    break  # connection already closed
+
+        ka_task = asyncio.create_task(keepalive()) if websocket else None
+        try:
+            # ... your LLM call here ...
+            return json.dumps({"content": assistant_response})
+        finally:
+            if ka_task:
+                ka_task.cancel()
+    ```
+
+    <Warning>
+    Only one task should ever call `websocket.send()` at a time. Do **not** start a second keepalive loop inside a retry helper — two concurrent senders can corrupt WebSocket frames and silently drop the connection.
+    </Warning>
+
+    Also set `ping_interval=None` on `websockets.serve` to disable server-initiated pings, which add unnecessary control-frame traffic through tunnels like ngrok:
+
+    ```python
+    server = await websockets.serve(
+        handle_websocket,
+        "0.0.0.0",
+        8765,
+        ping_interval=None,
+    )
+    ```
   </Step>
 
   <Step title="Expose Server">

--- a/documentation/key-concepts/evaluators/conditional-actions.mdx
+++ b/documentation/key-concepts/evaluators/conditional-actions.mdx
@@ -366,6 +366,10 @@ Conditional Actions supports a variety of special tags in the `action` field to 
     `<ivr>` must be the **entire action** — it cannot be combined with other text or tags in the same action string.
     </Warning>
 
+    <Note>
+    **DTMF digits appear in the transcript when using `<ivr>`.** When a scenario contains the `<ivr>` tag, any DTMF digits pressed by the main agent (the agent being tested) are captured and appear in the transcript. This lets you write conditions that detect the exact digit pressed — for example, `"The main agent pressed 1"` — rather than relying on speech detection alone.
+    </Note>
+
     **Attributes:**
     - `text`: The IVR message to play (required)
   </Accordion>
@@ -728,9 +732,11 @@ Use `<silence>` when you want the conversation to feel natural and allow the mai
 
 </CodeGroup>
 
-### Example 2: IVR (Interactive Voice Response) Navigation
+### Example 2: IVR Navigation
 
-```json
+<CodeGroup>
+
+```json Inbound IVR (main agent is the IVR)
 {
   "role": "You are a customer calling support",
   "conditions": [
@@ -765,6 +771,50 @@ Use `<silence>` when you want the conversation to feel natural and allow the mai
   ]
 }
 ```
+
+```json Outbound IVR (testing agent simulates an external IVR)
+{
+  "role": "You are simulating a third-party IVR that the agent will call into",
+  "conditions": [
+    {
+      "id": 0,
+      "condition": "FIRST_MESSAGE",
+      "action": "<ivr text=\"Thank you for calling Acme Corp. Press 1 for sales, press 2 for support.\" />",
+      "type": "standard",
+      "fixed_message": true
+    },
+    {
+      "id": 1,
+      "condition": "The main agent pressed 1",
+      "action": "Connecting you to sales now. Please hold.",
+      "type": "standard",
+      "fixed_message": true
+    },
+    {
+      "id": 2,
+      "condition": "The main agent pressed 2",
+      "action": "Connecting you to support now. Please hold.",
+      "type": "standard",
+      "fixed_message": true
+    },
+    {
+      "id": 3,
+      "condition": "The agent states their reason for calling",
+      "action": "Thank you. Routing your call now. <endcall />",
+      "type": "standard",
+      "fixed_message": true
+    }
+  ]
+}
+```
+
+</CodeGroup>
+
+<Note>
+**Inbound vs outbound IVR patterns differ:**
+- **Inbound** (main agent IS the IVR): Set `id: 0` `action: ""` and use `<dtmf>` on later conditions to navigate the main agent's IVR menu. Do **not** use `<ivr>`.
+- **Outbound** (testing agent simulates an external IVR): Use `<ivr text="..." />` as the entire `id: 0` action. When the scenario contains `<ivr>`, DTMF digits pressed by the main agent appear in the transcript — write your conditions using the specific digit (e.g., `"The main agent pressed 1"`).
+</Note>
 
 ### Example 3: Multi-Part Response with Followup
 


### PR DESCRIPTION
## Summary

- Adds a `<Note>` block inside the `<ivr>` accordion explaining that DTMF digits pressed by the main agent appear in the transcript when the scenario uses `<ivr>`
- Expands Example 2 from a single inbound IVR snippet to a `<CodeGroup>` with both inbound and outbound patterns
- The outbound example shows digit-specific conditions (`"The main agent pressed 1"`) and includes a `<Note>` clarifying the inbound vs outbound distinction

## Test plan

- [ ] Check the `<ivr>` accordion renders the new Note correctly
- [ ] Check the outbound IVR code tab renders in the CodeGroup
- [ ] Verify the inbound/outbound Note renders below the CodeGroup

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cekura-ai/docs/pull/577" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->