### PR TITLE
[Auto] Sync docs for backend PR #9007

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -48086,6 +48086,7 @@
             },
             "CallLogDetail": {
                 "type": "object",
+                "description": "Mixin for parsing restql query from request.\n\nNOTE: We are using `request.GET` instead of\n`request.query_params` because this might be\ncalled before DRF request is created(i.e from dispatch).\nThis means `request.query_params` might not be available\nwhen this mixin is used.",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -48272,6 +48273,7 @@
             },
             "CallLogList": {
                 "type": "object",
+                "description": "Mixin for parsing restql query from request.\n\nNOTE: We are using `request.GET` instead of\n`request.query_params` because this might be\ncalled before DRF request is created(i.e from dispatch).\nThis means `request.query_params` might not be available\nwhen this mixin is used.",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -49372,6 +49374,7 @@
             },
             "Dashboard": {
                 "type": "object",
+                "description": "Mixin for parsing restql query from request.\n\nNOTE: We are using `request.GET` instead of\n`request.query_params` because this might be\ncalled before DRF request is created(i.e from dispatch).\nThis means `request.query_params` might not be available\nwhen this mixin is used.",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -49503,6 +49506,7 @@
             },
             "DashboardList": {
                 "type": "object",
+                "description": "Mixin for parsing restql query from request.\n\nNOTE: We are using `request.GET` instead of\n`request.query_params` because this might be\ncalled before DRF request is created(i.e from dispatch).\nThis means `request.query_params` might not be available\nwhen this mixin is used.",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -50871,6 +50875,7 @@
             },
             "MetricList": {
                 "type": "object",
+                "description": "Mixin for parsing restql query from request.\n\nNOTE: We are using `request.GET` instead of\n`request.query_params` because this might be\ncalled before DRF request is created(i.e from dispatch).\nThis means `request.query_params` might not be available\nwhen this mixin is used.",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -53051,6 +53056,7 @@
             },
             "PatchedCallLogDetail": {
                 "type": "object",
+                "description": "Mixin for parsing restql query from request.\n\nNOTE: We are using `request.GET` instead of\n`request.query_params` because this might be\ncalled before DRF request is created(i.e from dispatch).\nThis means `request.query_params` might not be available\nwhen this mixin is used.",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -53503,6 +53509,7 @@
             },
             "PatchedDashboard": {
                 "type": "object",
+                "description": "Mixin for parsing restql query from request.\n\nNOTE: We are using `request.GET` instead of\n`request.query_params` because this might be\ncalled before DRF request is created(i.e from dispatch).\nThis means `request.query_params` might not be available\nwhen this mixin is used.",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -55754,6 +55761,7 @@
             },
             "PatchedSchemaPostScenario": {
                 "type": "object",
+                "description": "Mixin for parsing restql query from request.\n\nNOTE: We are using `request.GET` instead of\n`request.query_params` because this might be\ncalled before DRF request is created(i.e from dispatch).\nThis means `request.query_params` might not be available\nwhen this mixin is used.",
                 "properties": {
                     "agent": {
                         "type": [
@@ -58629,6 +58637,7 @@
             },
             "RunList": {
                 "type": "object",
+                "description": "Mixin for parsing restql query from request.\n\nNOTE: We are using `request.GET` instead of\n`request.query_params` because this might be\ncalled before DRF request is created(i.e from dispatch).\nThis means `request.query_params` might not be available\nwhen this mixin is used.",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -59028,6 +59037,7 @@
             },
             "Scenario": {
                 "type": "object",
+                "description": "Mixin for parsing restql query from request.\n\nNOTE: We are using `request.GET` instead of\n`request.query_params` because this might be\ncalled before DRF request is created(i.e from dispatch).\nThis means `request.query_params` might not be available\nwhen this mixin is used.",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -59651,6 +59661,7 @@
             },
             "ScenarioList": {
                 "type": "object",
+                "description": "Mixin for parsing restql query from request.\n\nNOTE: We are using `request.GET` instead of\n`request.query_params` because this might be\ncalled before DRF request is created(i.e from dispatch).\nThis means `request.query_params` might not be available\nwhen this mixin is used.",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -59859,6 +59870,7 @@
             },
             "ScenarioSerializerV2": {
                 "type": "object",
+                "description": "Mixin for parsing restql query from request.\n\nNOTE: We are using `request.GET` instead of\n`request.query_params` because this might be\ncalled before DRF request is created(i.e from dispatch).\nThis means `request.query_params` might not be available\nwhen this mixin is used.",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -61038,6 +61050,7 @@
             },
             "SchemaPostRunScenarios": {
                 "type": "object",
+                "description": "Mixin for parsing restql query from request.\n\nNOTE: We are using `request.GET` instead of\n`request.query_params` because this might be\ncalled before DRF request is created(i.e from dispatch).\nThis means `request.query_params` might not be available\nwhen this mixin is used.",
                 "properties": {
                     "agent_id": {
                         "type": "integer",
@@ -61261,6 +61274,7 @@
             },
             "SchemaPostScenario": {
                 "type": "object",
+                "description": "Mixin for parsing restql query from request.\n\nNOTE: We are using `request.GET` instead of\n`request.query_params` because this might be\ncalled before DRF request is created(i.e from dispatch).\nThis means `request.query_params` might not be available\nwhen this mixin is used.",
                 "properties": {
                     "agent": {
                         "type": [
@@ -61420,6 +61434,7 @@
             },
             "SchemaScenario": {
                 "type": "object",
+                "description": "Mixin for parsing restql query from request.\n\nNOTE: We are using `request.GET` instead of\n`request.query_params` because this might be\ncalled before DRF request is created(i.e from dispatch).\nThis means `request.query_params` might not be available\nwhen this mixin is used.",
                 "properties": {
                     "id": {
                         "type": "integer",

--- a/openapi.json
+++ b/openapi.json
@@ -109,7 +109,7 @@
         "/app/v1/product-chat/cancel/": {
             "post": {
                 "operationId": "app-v1-product-chat-cancel-create",
-                "description": "Cancel an in-progress AI assistant task. The Celery worker stops on its next iteration.",
+                "description": "App v1 product chat cancel",
                 "tags": [
                     "app"
                 ],
@@ -9148,7 +9148,7 @@
             },
             "patch": {
                 "operationId": "test-framework-project-default-metrics-partial-update",
-                "description": "ViewSet for managing user's default metrics preferences.\nAllows users to set which metrics should be added by default to their new agents.",
+                "description": "Update a project default metric",
                 "parameters": [
                     {
                         "in": "path",
@@ -9201,7 +9201,7 @@
             },
             "delete": {
                 "operationId": "test-framework-project-default-metrics-destroy",
-                "description": "ViewSet for managing user's default metrics preferences.\nAllows users to set which metrics should be added by default to their new agents.",
+                "description": "Delete a project default metric",
                 "parameters": [
                     {
                         "in": "path",
@@ -11928,7 +11928,7 @@
         "/test_framework/v1/aiagents/{agent_id}/tools/auto-fetch/": {
             "post": {
                 "operationId": "aiagents-tools-auto-fetch-create",
-                "description": "Auto-fetch tools from provider and generate mock data asynchronously.\n\nValidates inputs, fires a background Celery task for the slow provider API calls\nand LLM mock-data generation, and returns a progress_id immediately.\nPoll auto-fetch-progress/ with the progress_id to check completion.\nThis does NOT enable mock mode in the provider. Use the enable-mock endpoint for that.",
+                "description": "Aiagents tools auto fetch",
                 "parameters": [
                     {
                         "in": "path",
@@ -19542,7 +19542,7 @@
         "/test_framework/v1/phone-numbers/providers/plivo/bulk-import/": {
             "post": {
                 "operationId": "phone-numbers-providers-plivo-bulk-import-create",
-                "description": "Unified API viewset for BYOP (Bring Your Own Telephony Provider).\n\nHandles importing and managing phone numbers from various providers:\n- Twilio\n- Future: Vonage, Bandwidth, Telnyx, etc.\n\nURL Structure: /v1/phone-numbers/providers/{provider}/{action}\n\nHow to add a new provider:\n1. Add provider to PhoneNumberProviderChoices enum\n2. Create {Provider}Service class (e.g., VonageService)\n3. Create Import{Provider}NumberSerializer\n4. Add action method with @action(url_path=\"{provider}/import\")\n5. Update get_serializer_class() mapping",
+                "description": "Phone numbers providers plivo bulk import",
                 "tags": [
                     "test_framework"
                 ],
@@ -19588,7 +19588,7 @@
         "/test_framework/v1/phone-numbers/providers/plivo/import/": {
             "post": {
                 "operationId": "phone-numbers-providers-plivo-import-create",
-                "description": "Unified API viewset for BYOP (Bring Your Own Telephony Provider).\n\nHandles importing and managing phone numbers from various providers:\n- Twilio\n- Future: Vonage, Bandwidth, Telnyx, etc.\n\nURL Structure: /v1/phone-numbers/providers/{provider}/{action}\n\nHow to add a new provider:\n1. Add provider to PhoneNumberProviderChoices enum\n2. Create {Provider}Service class (e.g., VonageService)\n3. Create Import{Provider}NumberSerializer\n4. Add action method with @action(url_path=\"{provider}/import\")\n5. Update get_serializer_class() mapping",
+                "description": "Phone numbers providers plivo import",
                 "tags": [
                     "test_framework"
                 ],
@@ -42951,7 +42951,7 @@
         "/user/v1/audit-logs/{id}/": {
             "get": {
                 "operationId": "audit-logs-retrieve",
-                "description": "ViewSet for AuditLog - Read-only access\nOnly accessible by AdminOfOrganization and OrganizationAPIKey",
+                "description": "Retrieve an audit log by ID",
                 "parameters": [
                     {
                         "in": "path",
@@ -43705,7 +43705,7 @@
         "/user/v1/projects-external/{id}/get-topic-names/": {
             "get": {
                 "operationId": "projects-external-get-topic-names-retrieve",
-                "description": "Get unique topic names from all agents in the project.\n\nReturns:\n    Response: {\"topic_names\": [\"topic1\", \"topic2\", ...]}\n\nExample:\n    GET /api/projects/1/get-topic-names/\n\n    Response:\n    {\n        \"topic_names\": [\n            \"Appointment Preparation Requirements\",\n            \"Escalating to a Manager\",\n            \"Initial Greeting and Rapport\",\n            \"Scheduling Onboarding Appointment\"\n        ]\n    }",
+                "description": "Projects get topic names",
                 "parameters": [
                     {
                         "in": "path",
@@ -44642,7 +44642,7 @@
         "/user/v1/projects/{id}/get-topic-names/": {
             "get": {
                 "operationId": "projects-get-topic-names-retrieve",
-                "description": "Get unique topic names from all agents in the project.\n\nReturns:\n    Response: {\"topic_names\": [\"topic1\", \"topic2\", ...]}\n\nExample:\n    GET /api/projects/1/get-topic-names/\n\n    Response:\n    {\n        \"topic_names\": [\n            \"Appointment Preparation Requirements\",\n            \"Escalating to a Manager\",\n            \"Initial Greeting and Rapport\",\n            \"Scheduling Onboarding Appointment\"\n        ]\n    }",
+                "description": "Projects get topic names",
                 "parameters": [
                     {
                         "in": "path",


### PR DESCRIPTION
Auto-generated docs sync for backend PR [#9007](https://github.com/cekura-ai/vocera.backend/pull/9007).

Reviewers: @dileep-chagam, @app/devin-ai-integration

## Summary

**Spec/overlay:** Spec refresh — no MCP changes. Schema descriptions updated (RestQL mixin docstrings now appear in CallLogDetail, Dashboard, Metric, Run, Scenario component schemas). 9 non-exposed operation descriptions simplified to generic CRUD templates. No exposed operations affected. No overlay patches needed.

**Conceptual docs:** No conceptual documentation changes required. PR #9007 is a pure performance optimization to the internal Django admin interface (`user/admin.py`), fixing N+1 queries in the OrganizationAdmin changelist. The change refactors query logic to use annotated subqueries instead of per-row queries, but has no impact on user-facing API behavior, observable data, or public endpoints. Internal admin interface changes are explicitly out of scope per the docs routing map.

## Changes

- `openapi.json` — regenerate_from_backend

---
*Auto-generated from backend PR #9007.*

<!-- mcp-sync:file-hashes -->
```json
{}
```
<!-- /mcp-sync:file-hashes -->