### PR TITLE
[Auto] Sync docs for backend PR #9017

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -109,7 +109,7 @@
         "/app/v1/product-chat/cancel/": {
             "post": {
                 "operationId": "app-v1-product-chat-cancel-create",
-                "description": "Cancel an in-progress AI assistant task. The Celery worker stops on its next iteration.",
+                "description": "App v1 product chat cancel",
                 "tags": [
                     "app"
                 ],
@@ -9148,7 +9148,7 @@
             },
             "patch": {
                 "operationId": "test-framework-project-default-metrics-partial-update",
-                "description": "ViewSet for managing user's default metrics preferences.\nAllows users to set which metrics should be added by default to their new agents.",
+                "description": "Update a project default metric",
                 "parameters": [
                     {
                         "in": "path",
@@ -9201,7 +9201,7 @@
             },
             "delete": {
                 "operationId": "test-framework-project-default-metrics-destroy",
-                "description": "ViewSet for managing user's default metrics preferences.\nAllows users to set which metrics should be added by default to their new agents.",
+                "description": "Delete a project default metric",
                 "parameters": [
                     {
                         "in": "path",
@@ -9683,7 +9683,8 @@
         "/test_framework/test-sets/create_from_call_log/": {
             "post": {
                 "operationId": "test-sets-create-from-call-log",
-                "description": "Test sets create from call log",
+                "description": "Promote a real production call into a labeled test set by attaching the specified metrics. The call's transcript, recording, and any existing metric evaluations are copied into the new test set so they can be reviewed and used as labeled ground truth. Returns the created or existing test set.",
+                "summary": "Create a test set from a production call log",
                 "tags": [
                     "test_framework"
                 ],
@@ -9729,7 +9730,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "test-sets-create-from-call-log",
-                        "description": "Test sets create from call log"
+                        "description": "Promote a real production call into a labeled test set by attaching the specified metrics. The call's transcript, recording, and any existing metric evaluations are copied into the new test set so they can be reviewed and used as labeled ground truth. Returns the created or existing test set."
                     }
                 }
             }
@@ -9783,7 +9784,8 @@
         "/test_framework/test-sets/create_from_run/": {
             "post": {
                 "operationId": "test-sets-create-from-run",
-                "description": "Test sets create from run",
+                "description": "Promote a completed test run into a labeled test set by attaching the specified metrics. Existing metric scores from the run are copied as the initial 'actual' values; the caller provides 'expected' values for review. Returns the created or existing test set.",
+                "summary": "Create a test set from a previous test run",
                 "tags": [
                     "test_framework"
                 ],
@@ -9829,7 +9831,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "test-sets-create-from-run",
-                        "description": "Test sets create from run"
+                        "description": "Promote a completed test run into a labeled test set by attaching the specified metrics. Existing metric scores from the run are copied as the initial 'actual' values; the caller provides 'expected' values for review. Returns the created or existing test set."
                     }
                 }
             }
@@ -10482,6 +10484,20 @@
                         "application/json": {
                             "schema": {
                                 "$ref": "#/components/schemas/SchemaUpdateAIAgentExternal"
+                            },
+                            "examples": {
+                                "ReplaceAgent(fullPayload)": {
+                                    "value": {
+                                        "agent_name": "Support Bot v2",
+                                        "description": "Handles inbound support calls for ACME Inc.",
+                                        "inbound": true,
+                                        "project": 1376,
+                                        "contact_number": "+14155551234",
+                                        "language": "en",
+                                        "assistant_provider": "self_hosted"
+                                    },
+                                    "summary": "Replace agent (full payload)"
+                                }
                             }
                         },
                         "application/x-www-form-urlencoded": {
@@ -10535,7 +10551,7 @@
             },
             "patch": {
                 "operationId": "aiagents-external-partial-update",
-                "description": "Partially update an AI agent. Same field shape as create — see `aiagents_create` for details and per-provider examples.\n\n**Common patterns:**\n- Switch provider: set `assistant_provider` + the matching `{provider}_api_key` / `{provider}_data`.\n- Rotate credentials: pass only the `{provider}_api_key` field you want to update.\n- Attach predefined metrics: pass `predefined_metrics` (list of metric slugs).",
+                "description": "Partially update an AI agent. Same field shape as create — see `aiagents_create` for details and per-provider examples.",
                 "summary": "Update an AI voice agent (partial)",
                 "parameters": [
                     {
@@ -10556,6 +10572,15 @@
                         "application/json": {
                             "schema": {
                                 "$ref": "#/components/schemas/PatchedSchemaUpdateAIAgentExternal"
+                            },
+                            "examples": {
+                                "Rename+UpdateDescription": {
+                                    "value": {
+                                        "agent_name": "Support Bot v2",
+                                        "description": "Updated description"
+                                    },
+                                    "summary": "Rename + update description"
+                                }
                             }
                         },
                         "application/x-www-form-urlencoded": {
@@ -11928,7 +11953,7 @@
         "/test_framework/v1/aiagents/{agent_id}/tools/auto-fetch/": {
             "post": {
                 "operationId": "aiagents-tools-auto-fetch-create",
-                "description": "Auto-fetch tools from provider and generate mock data asynchronously.\n\nValidates inputs, fires a background Celery task for the slow provider API calls\nand LLM mock-data generation, and returns a progress_id immediately.\nPoll auto-fetch-progress/ with the progress_id to check completion.\nThis does NOT enable mock mode in the provider. Use the enable-mock endpoint for that.",
+                "description": "Aiagents tools auto fetch",
                 "parameters": [
                     {
                         "in": "path",
@@ -12344,6 +12369,20 @@
                         "application/json": {
                             "schema": {
                                 "$ref": "#/components/schemas/SchemaUpdateAIAgentExternal"
+                            },
+                            "examples": {
+                                "ReplaceAgent(fullPayload)": {
+                                    "value": {
+                                        "agent_name": "Support Bot v2",
+                                        "description": "Handles inbound support calls for ACME Inc.",
+                                        "inbound": true,
+                                        "project": 1376,
+                                        "contact_number": "+14155551234",
+                                        "language": "en",
+                                        "assistant_provider": "self_hosted"
+                                    },
+                                    "summary": "Replace agent (full payload)"
+                                }
                             }
                         },
                         "application/x-www-form-urlencoded": {
@@ -12405,7 +12444,7 @@
             },
             "patch": {
                 "operationId": "aiagents-partial-update",
-                "description": "Partially update an AI agent. Same field shape as create — see `aiagents_create` for details and per-provider examples.\n\n**Common patterns:**\n- Switch provider: set `assistant_provider` + the matching `{provider}_api_key` / `{provider}_data`.\n- Rotate credentials: pass only the `{provider}_api_key` field you want to update.\n- Attach predefined metrics: pass `predefined_metrics` (list of metric slugs).",
+                "description": "Partially update an AI agent. Same field shape as create — see `aiagents_create` for details and per-provider examples.",
                 "summary": "Update an AI voice agent (partial)",
                 "parameters": [
                     {
@@ -12426,6 +12465,15 @@
                         "application/json": {
                             "schema": {
                                 "$ref": "#/components/schemas/PatchedSchemaUpdateAIAgentExternal"
+                            },
+                            "examples": {
+                                "Rename+UpdateDescription": {
+                                    "value": {
+                                        "agent_name": "Support Bot v2",
+                                        "description": "Updated description"
+                                    },
+                                    "summary": "Rename + update description"
+                                }
                             }
                         },
                         "application/x-www-form-urlencoded": {
@@ -12480,7 +12528,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "aiagents-partial-update",
-                        "description": "Partially update an AI agent. Same field shape as create — see `aiagents_create` for details and per-provider examples.\n\n**Common patterns:**\n- Switch provider: set `assistant_provider` + the matching `{provider}_api_key` / `{provider}_data`.\n- Rotate credentials: pass only the `{provider}_api_key` field you want to update.\n- Attach predefined metrics: pass `predefined_metrics` (list of metric slugs)."
+                        "description": "Partially update an AI agent. Same field shape as create — see `aiagents_create` for details and per-provider examples."
                     }
                 }
             },
@@ -15184,6 +15232,15 @@
                         "application/json": {
                             "schema": {
                                 "$ref": "#/components/schemas/PatchedSchemaPostMetricEdit"
+                            },
+                            "examples": {
+                                "UpdatePrompt+CriticalFlag": {
+                                    "value": {
+                                        "description": "Updated rubric",
+                                        "is_critical": true
+                                    },
+                                    "summary": "Update prompt + critical flag"
+                                }
                             }
                         },
                         "application/x-www-form-urlencoded": {
@@ -15688,7 +15745,8 @@
         "/test_framework/v1/metrics-external/bulk_create/": {
             "post": {
                 "operationId": "metrics-bulk-create",
-                "description": "Metrics bulk",
+                "description": "Atomic bulk creation of project-level metrics. Pass a JSON array of metric objects with the same field shape as `metrics_create`. All entries succeed together or the whole request fails validation.",
+                "summary": "Create multiple metrics in a single request",
                 "tags": [
                     "test_framework"
                 ],
@@ -16490,6 +16548,15 @@
                         "application/json": {
                             "schema": {
                                 "$ref": "#/components/schemas/PatchedSchemaPostMetricEdit"
+                            },
+                            "examples": {
+                                "UpdatePrompt+CriticalFlag": {
+                                    "value": {
+                                        "description": "Updated rubric",
+                                        "is_critical": true
+                                    },
+                                    "summary": "Update prompt + critical flag"
+                                }
                             }
                         },
                         "application/x-www-form-urlencoded": {
@@ -17018,7 +17085,8 @@
         "/test_framework/v1/metrics/bulk_create/": {
             "post": {
                 "operationId": "metrics-bulk-create_2",
-                "description": "Metrics bulk",
+                "description": "Atomic bulk creation of project-level metrics. Pass a JSON array of metric objects with the same field shape as `metrics_create`. All entries succeed together or the whole request fails validation.",
+                "summary": "Create multiple metrics in a single request",
                 "tags": [
                     "test_framework"
                 ],
@@ -17094,7 +17162,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "metrics-bulk-create",
-                        "description": "Metrics bulk"
+                        "description": "Atomic bulk creation of project-level metrics. Pass a JSON array of metric objects with the same field shape as `metrics_create`. All entries succeed together or the whole request fails validation."
                     }
                 }
             }
@@ -19542,7 +19610,7 @@
         "/test_framework/v1/phone-numbers/providers/plivo/bulk-import/": {
             "post": {
                 "operationId": "phone-numbers-providers-plivo-bulk-import-create",
-                "description": "Unified API viewset for BYOP (Bring Your Own Telephony Provider).\n\nHandles importing and managing phone numbers from various providers:\n- Twilio\n- Future: Vonage, Bandwidth, Telnyx, etc.\n\nURL Structure: /v1/phone-numbers/providers/{provider}/{action}\n\nHow to add a new provider:\n1. Add provider to PhoneNumberProviderChoices enum\n2. Create {Provider}Service class (e.g., VonageService)\n3. Create Import{Provider}NumberSerializer\n4. Add action method with @action(url_path=\"{provider}/import\")\n5. Update get_serializer_class() mapping",
+                "description": "Phone numbers providers plivo bulk import",
                 "tags": [
                     "test_framework"
                 ],
@@ -19588,7 +19656,7 @@
         "/test_framework/v1/phone-numbers/providers/plivo/import/": {
             "post": {
                 "operationId": "phone-numbers-providers-plivo-import-create",
-                "description": "Unified API viewset for BYOP (Bring Your Own Telephony Provider).\n\nHandles importing and managing phone numbers from various providers:\n- Twilio\n- Future: Vonage, Bandwidth, Telnyx, etc.\n\nURL Structure: /v1/phone-numbers/providers/{provider}/{action}\n\nHow to add a new provider:\n1. Add provider to PhoneNumberProviderChoices enum\n2. Create {Provider}Service class (e.g., VonageService)\n3. Create Import{Provider}NumberSerializer\n4. Add action method with @action(url_path=\"{provider}/import\")\n5. Update get_serializer_class() mapping",
+                "description": "Phone numbers providers plivo import",
                 "tags": [
                     "test_framework"
                 ],
@@ -25059,9 +25127,10 @@
         "/test_framework/v1/scenario-improvement-sessions/": {
             "get": {
                 "operationId": "scenario-improvement-sessions-list",
-                "description": "List ViewSet",
+                "description": "List scenario-improvement sessions for a project. Each session tracks an AI-assisted refinement run over the project's scenarios. Requires `project_id`.",
+                "summary": "List scenario improvement sessions",
                 "tags": [
-                    "test_framework"
+                    "Scenarios"
                 ],
                 "security": [
                     {
@@ -25088,7 +25157,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenario-improvement-sessions-list",
-                        "description": "List ViewSet"
+                        "description": "List scenario-improvement sessions for a project. Each session tracks an AI-assisted refinement run over the project's scenarios. Requires `project_id`."
                     }
                 }
             },
@@ -25932,6 +26001,15 @@
                         "application/json": {
                             "schema": {
                                 "$ref": "#/components/schemas/PatchedSchemaPostScenario"
+                            },
+                            "examples": {
+                                "Rename+TweakInstructions": {
+                                    "value": {
+                                        "name": "Refund flow v2",
+                                        "instructions": "Ask for the order ID before refunding."
+                                    },
+                                    "summary": "Rename + tweak instructions"
+                                }
                             }
                         },
                         "application/x-www-form-urlencoded": {
@@ -30401,6 +30479,15 @@
                         "application/json": {
                             "schema": {
                                 "$ref": "#/components/schemas/PatchedSchemaPostScenario"
+                            },
+                            "examples": {
+                                "Rename+TweakInstructions": {
+                                    "value": {
+                                        "name": "Refund flow v2",
+                                        "instructions": "Ask for the order ID before refunding."
+                                    },
+                                    "summary": "Rename + tweak instructions"
+                                }
                             }
                         },
                         "application/x-www-form-urlencoded": {
@@ -36411,6 +36498,15 @@
                         "application/json": {
                             "schema": {
                                 "$ref": "#/components/schemas/PatchedSchemaPostScenario"
+                            },
+                            "examples": {
+                                "Rename+TweakInstructions": {
+                                    "value": {
+                                        "name": "Refund flow v2",
+                                        "instructions": "Ask for the order ID before refunding."
+                                    },
+                                    "summary": "Rename + tweak instructions"
+                                }
                             }
                         },
                         "application/x-www-form-urlencoded": {
@@ -42951,7 +43047,7 @@
         "/user/v1/audit-logs/{id}/": {
             "get": {
                 "operationId": "audit-logs-retrieve",
-                "description": "ViewSet for AuditLog - Read-only access\nOnly accessible by AdminOfOrganization and OrganizationAPIKey",
+                "description": "Retrieve an audit log by ID",
                 "parameters": [
                     {
                         "in": "path",
@@ -43705,7 +43801,7 @@
         "/user/v1/projects-external/{id}/get-topic-names/": {
             "get": {
                 "operationId": "projects-external-get-topic-names-retrieve",
-                "description": "Get unique topic names from all agents in the project.\n\nReturns:\n    Response: {\"topic_names\": [\"topic1\", \"topic2\", ...]}\n\nExample:\n    GET /api/projects/1/get-topic-names/\n\n    Response:\n    {\n        \"topic_names\": [\n            \"Appointment Preparation Requirements\",\n            \"Escalating to a Manager\",\n            \"Initial Greeting and Rapport\",\n            \"Scheduling Onboarding Appointment\"\n        ]\n    }",
+                "description": "Projects get topic names",
                 "parameters": [
                     {
                         "in": "path",
@@ -44642,7 +44738,7 @@
         "/user/v1/projects/{id}/get-topic-names/": {
             "get": {
                 "operationId": "projects-get-topic-names-retrieve",
-                "description": "Get unique topic names from all agents in the project.\n\nReturns:\n    Response: {\"topic_names\": [\"topic1\", \"topic2\", ...]}\n\nExample:\n    GET /api/projects/1/get-topic-names/\n\n    Response:\n    {\n        \"topic_names\": [\n            \"Appointment Preparation Requirements\",\n            \"Escalating to a Manager\",\n            \"Initial Greeting and Rapport\",\n            \"Scheduling Onboarding Appointment\"\n        ]\n    }",
+                "description": "Projects get topic names",
                 "parameters": [
                     {
                         "in": "path",
@@ -47115,7 +47211,7 @@
             },
             "AlertCreate": {
                 "type": "object",
-                "description": "Serializer for creating alerts with validation",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -47364,7 +47460,7 @@
             },
             "AlertUpdate": {
                 "type": "object",
-                "description": "Serializer for updating alerts (partial updates allowed)",
+                "description": "",
                 "properties": {
                     "name": {
                         "type": "string",
@@ -47812,7 +47908,7 @@
             },
             "BulkImportTelnyxNumber": {
                 "type": "object",
-                "description": "Serializer for bulk importing multiple Telnyx phone numbers.",
+                "description": "",
                 "properties": {
                     "telnyx_api_key": {
                         "type": "string",
@@ -47856,7 +47952,7 @@
             },
             "BulkImportTwilioNumber": {
                 "type": "object",
-                "description": "Serializer for bulk importing multiple Twilio phone numbers.",
+                "description": "",
                 "properties": {
                     "twilio_account_sid": {
                         "type": "string",
@@ -47973,7 +48069,7 @@
             },
             "BulkWidgetOperationRequest": {
                 "type": "object",
-                "description": "Serializer for bulk widget operations request.\n\nAccepts separate lists for create, update, and delete operations.\nAll operations are performed in a single transaction.\nDashboard is provided via query parameter (dashboard_id).\n\nExample request:\n{\n    \"create\": [{\"name\": \"New Widget\", \"field\": \"duration\", \"chart_type\": \"line\"}, ...],\n    \"update\": [{\"id\": 1, \"name\": \"Updated Name\", \"filters\": {}}, ...],\n    \"delete\": [2, 3, 4]\n}",
+                "description": "",
                 "properties": {
                     "create": {
                         "type": "array",
@@ -48086,6 +48182,7 @@
             },
             "CallLogDetail": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -48272,6 +48369,7 @@
             },
             "CallLogList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -48514,7 +48612,7 @@
             },
             "ChatMessage": {
                 "type": "object",
-                "description": "Serializer for individual chat messages.",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -48547,7 +48645,7 @@
             },
             "ChatSessionCreate": {
                 "type": "object",
-                "description": "Serializer for creating a new chat session.",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "string",
@@ -48577,7 +48675,7 @@
             },
             "ChatSessionDetail": {
                 "type": "object",
-                "description": "Serializer for retrieving a chat session with all messages.",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "string",
@@ -48620,7 +48718,7 @@
             },
             "ChatSessionList": {
                 "type": "object",
-                "description": "Serializer for listing chat sessions (without messages).",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "string",
@@ -49293,7 +49391,7 @@
             },
             "CustomDomainDetail": {
                 "type": "object",
-                "description": "Serializer for detailed view of CustomDomain objects including verification token",
+                "description": "",
                 "properties": {
                     "organization": {
                         "type": "integer",
@@ -49325,7 +49423,7 @@
             },
             "CustomDomainList": {
                 "type": "object",
-                "description": "Serializer for listing CustomDomain objects with limited fields",
+                "description": "",
                 "properties": {
                     "organization": {
                         "type": "integer",
@@ -49372,6 +49470,7 @@
             },
             "Dashboard": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -49503,6 +49602,7 @@
             },
             "DashboardList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -50010,7 +50110,7 @@
             },
             "ImportTelnyxNumber": {
                 "type": "object",
-                "description": "Serializer for importing Telnyx phone numbers.",
+                "description": "",
                 "properties": {
                     "telnyx_phone_number": {
                         "type": "string",
@@ -50041,7 +50141,7 @@
             },
             "ImportTwilioNumber": {
                 "type": "object",
-                "description": "Serializer for importing Twilio phone numbers.",
+                "description": "",
                 "properties": {
                     "twilio_phone_number": {
                         "type": "string",
@@ -50434,7 +50534,7 @@
             },
             "LivekitScenario": {
                 "type": "object",
-                "description": "Serializer for scenarios with LiveKit credentials instead of pre-generated URLs",
+                "description": "",
                 "properties": {
                     "scenario": {
                         "type": "integer"
@@ -50871,6 +50971,7 @@
             },
             "MetricList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -51457,7 +51558,7 @@
             },
             "MetricRollingStatsPatch": {
                 "type": "object",
-                "description": "Serializer for updating specific fields in MetricRollingStats model via PUT/PATCH requests.\nOnly allows updating window_size, std_multiplier, and ewma_alpha fields.",
+                "description": "",
                 "properties": {
                     "window_size": {
                         "type": "integer",
@@ -53027,7 +53128,7 @@
             },
             "PatchedAlertUpdate": {
                 "type": "object",
-                "description": "Serializer for updating alerts (partial updates allowed)",
+                "description": "",
                 "properties": {
                     "name": {
                         "type": "string",
@@ -53051,6 +53152,7 @@
             },
             "PatchedCallLogDetail": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -53234,7 +53336,7 @@
             },
             "PatchedChatSessionDetail": {
                 "type": "object",
-                "description": "Serializer for retrieving a chat session with all messages.",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "string",
@@ -53474,7 +53576,7 @@
             },
             "PatchedCustomDomainDetail": {
                 "type": "object",
-                "description": "Serializer for detailed view of CustomDomain objects including verification token",
+                "description": "",
                 "properties": {
                     "organization": {
                         "type": "integer",
@@ -53503,6 +53605,7 @@
             },
             "PatchedDashboard": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -53889,7 +53992,7 @@
             },
             "PatchedMetricRollingStatsPatch": {
                 "type": "object",
-                "description": "Serializer for updating specific fields in MetricRollingStats model via PUT/PATCH requests.\nOnly allows updating window_size, std_multiplier, and ewma_alpha fields.",
+                "description": "",
                 "properties": {
                     "window_size": {
                         "type": "integer",
@@ -55385,7 +55488,7 @@
             },
             "PatchedScenarioImprovementSessionDetail": {
                 "type": "object",
-                "description": "Serializer for detailed scenario improvement session with conversation history.",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -55754,6 +55857,7 @@
             },
             "PatchedSchemaPostScenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "agent": {
                         "type": [
@@ -56486,7 +56590,7 @@
             },
             "PatchedUserConfiguration": {
                 "type": "object",
-                "description": "Serializer for UserConfiguration model to handle user settings.\nSupports key-value data storage for various configuration types.",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -57059,7 +57163,7 @@
             },
             "PhoneNumberDetail": {
                 "type": "object",
-                "description": "Serializer for PhoneNumber with decrypted metadata.\nUse this for detailed views where credentials should be visible.",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -58629,6 +58733,7 @@
             },
             "RunList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -58837,7 +58942,7 @@
             },
             "RunLivekitScenarios": {
                 "type": "object",
-                "description": "Serializer for running scenarios with LiveKit credentials from ProviderCredential model",
+                "description": "",
                 "properties": {
                     "name": {
                         "type": [
@@ -59028,6 +59133,7 @@
             },
             "Scenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -59470,7 +59576,7 @@
             },
             "ScenarioImprovementSessionCreate": {
                 "type": "object",
-                "description": "Serializer for creating a new scenario improvement session.\nAccepts scenario_selection which can be:\n- An array of scenario IDs\n- \"all\" to select all scenarios for the project\n- A number N to select the first N scenarios\nThe selection is resolved to actual scenario IDs for storage.",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -59498,7 +59604,7 @@
             },
             "ScenarioImprovementSessionDetail": {
                 "type": "object",
-                "description": "Serializer for detailed scenario improvement session with conversation history.",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -59553,7 +59659,7 @@
             },
             "ScenarioImprovementSessionList": {
                 "type": "object",
-                "description": "Serializer for listing scenario improvement sessions.",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -59651,6 +59757,7 @@
             },
             "ScenarioList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -59859,6 +59966,7 @@
             },
             "ScenarioSerializerV2": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -61038,6 +61146,7 @@
             },
             "SchemaPostRunScenarios": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "agent_id": {
                         "type": "integer",
@@ -61261,6 +61370,7 @@
             },
             "SchemaPostScenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "agent": {
                         "type": [
@@ -61420,6 +61530,7 @@
             },
             "SchemaScenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -62681,7 +62792,7 @@
             },
             "UserConfiguration": {
                 "type": "object",
-                "description": "Serializer for UserConfiguration model to handle user settings.\nSupports key-value data storage for various configuration types.",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",

--- a/openapi.json
+++ b/openapi.json
@@ -109,7 +109,7 @@
         "/app/v1/product-chat/cancel/": {
             "post": {
                 "operationId": "app-v1-product-chat-cancel-create",
-                "description": "App v1 product chat cancel",
+                "description": "Cancel an in-progress AI assistant task. The Celery worker stops on its next iteration.",
                 "tags": [
                     "app"
                 ],
@@ -11953,7 +11953,7 @@
         "/test_framework/v1/aiagents/{agent_id}/tools/auto-fetch/": {
             "post": {
                 "operationId": "aiagents-tools-auto-fetch-create",
-                "description": "Aiagents tools auto fetch",
+                "description": "Auto-fetch tools from provider and generate mock data asynchronously.\n\nValidates inputs, fires a background Celery task for the slow provider API calls\nand LLM mock-data generation, and returns a progress_id immediately.\nPoll auto-fetch-progress/ with the progress_id to check completion.\nThis does NOT enable mock mode in the provider. Use the enable-mock endpoint for that.",
                 "parameters": [
                     {
                         "in": "path",
@@ -19610,7 +19610,7 @@
         "/test_framework/v1/phone-numbers/providers/plivo/bulk-import/": {
             "post": {
                 "operationId": "phone-numbers-providers-plivo-bulk-import-create",
-                "description": "Phone numbers providers plivo bulk import",
+                "description": "Unified API viewset for BYOP (Bring Your Own Telephony Provider).\n\nHandles importing and managing phone numbers from various providers:\n- Twilio\n- Future: Vonage, Bandwidth, Telnyx, etc.\n\nURL Structure: /v1/phone-numbers/providers/{provider}/{action}\n\nHow to add a new provider:\n1. Add provider to PhoneNumberProviderChoices enum\n2. Create {Provider}Service class (e.g., VonageService)\n3. Create Import{Provider}NumberSerializer\n4. Add action method with @action(url_path=\"{provider}/import\")\n5. Update get_serializer_class() mapping",
                 "tags": [
                     "test_framework"
                 ],
@@ -19656,7 +19656,7 @@
         "/test_framework/v1/phone-numbers/providers/plivo/import/": {
             "post": {
                 "operationId": "phone-numbers-providers-plivo-import-create",
-                "description": "Phone numbers providers plivo import",
+                "description": "Unified API viewset for BYOP (Bring Your Own Telephony Provider).\n\nHandles importing and managing phone numbers from various providers:\n- Twilio\n- Future: Vonage, Bandwidth, Telnyx, etc.\n\nURL Structure: /v1/phone-numbers/providers/{provider}/{action}\n\nHow to add a new provider:\n1. Add provider to PhoneNumberProviderChoices enum\n2. Create {Provider}Service class (e.g., VonageService)\n3. Create Import{Provider}NumberSerializer\n4. Add action method with @action(url_path=\"{provider}/import\")\n5. Update get_serializer_class() mapping",
                 "tags": [
                     "test_framework"
                 ],
@@ -43801,7 +43801,7 @@
         "/user/v1/projects-external/{id}/get-topic-names/": {
             "get": {
                 "operationId": "projects-external-get-topic-names-retrieve",
-                "description": "Projects get topic names",
+                "description": "Get unique topic names from all agents in the project.\n\nReturns:\n    Response: {\"topic_names\": [\"topic1\", \"topic2\", ...]}\n\nExample:\n    GET /api/projects/1/get-topic-names/\n\n    Response:\n    {\n        \"topic_names\": [\n            \"Appointment Preparation Requirements\",\n            \"Escalating to a Manager\",\n            \"Initial Greeting and Rapport\",\n            \"Scheduling Onboarding Appointment\"\n        ]\n    }",
                 "parameters": [
                     {
                         "in": "path",
@@ -44738,7 +44738,7 @@
         "/user/v1/projects/{id}/get-topic-names/": {
             "get": {
                 "operationId": "projects-get-topic-names-retrieve",
-                "description": "Projects get topic names",
+                "description": "Get unique topic names from all agents in the project.\n\nReturns:\n    Response: {\"topic_names\": [\"topic1\", \"topic2\", ...]}\n\nExample:\n    GET /api/projects/1/get-topic-names/\n\n    Response:\n    {\n        \"topic_names\": [\n            \"Appointment Preparation Requirements\",\n            \"Escalating to a Manager\",\n            \"Initial Greeting and Rapport\",\n            \"Scheduling Onboarding Appointment\"\n        ]\n    }",
                 "parameters": [
                     {
                         "in": "path",


### PR DESCRIPTION
Auto-generated docs sync for backend PR [#9017](https://github.com/cekura-ai/vocera.backend/pull/9017).

Reviewers: @dileep-chagam, @app/devin-ai-integration

## Summary

**Spec/overlay:** OpenAPI spec differs from main (42 schema changes detected) but no MCP exposure changes. PR #9017 only modified Django admin list_filter settings in dashboards/admin.py — no API endpoints were added, removed, or had their x-mcp-expose status changed. The spec differences likely reflect drift from other changes merged to main. Regenerating openapi.json to sync with current backend state. Buckets: A=0, B-new=0, B-retract=0, C=0. Confirmed renames: 0. SDK/CLI follow-ups: 0.

## Changes

- `openapi.json` — regenerate_from_backend

---
*Auto-generated from backend PR #9017.*

<!-- mcp-sync:file-hashes -->
```json
{}
```
<!-- /mcp-sync:file-hashes -->