### PR TITLE
Add Verbosity to pre-defined metrics

### DIFF
--- a/documentation/key-concepts/metrics/pre-defined-metrics.mdx
+++ b/documentation/key-concepts/metrics/pre-defined-metrics.mdx
@@ -159,6 +159,19 @@ These metrics evaluate the flow and dynamics of the conversation.
     **Interpretation**: Lower is better. Repetition wastes time and can frustrate the Testing Agent.
   </Accordion>
 
+  <Accordion title="Verbosity">
+    **Result**: Score (1-5) | **Cost**: 0.2 credits per call
+
+    Evaluates how appropriately concise the Main Agent is across the conversation. An LLM classifies each Main Agent turn as Concise, Padded (filler, restated questions, repeated information, disclaimer spam), or Overloaded (more information, options, or follow-up questions than the user asked for), then aggregates to a 1-5 score. Necessary detail the user explicitly asked for is not penalised.
+
+    **Interpretation**:
+    - **5**: Consistently concise and well-calibrated to user intent
+    - **4**: Mostly concise; a few overlong turns
+    - **3**: Mixed; several turns are too long
+    - **2**: Verbosity is the dominant issue across most turns
+    - **1**: Agent is bloated throughout
+  </Accordion>
+
   <Accordion title="Detect Silence in Conversation">
     **Result**: True/False | **Cost**: 0 credits
 


### PR DESCRIPTION
## Summary
Documents the new Verbosity predefined metric introduced in backend PR cekura-ai/vocera.backend#9020.

Adds a Verbosity accordion under **Conversation Quality Metrics** (next to Unnecessary Repetition Count) describing the 1-5 score and what each level means.