### PR TITLE
docs: add vote metric API reference for call logs and runs

### DIFF
--- a/api-reference/observability/vote-call-log-metric.mdx
+++ b/api-reference/observability/vote-call-log-metric.mdx
@@ -1,0 +1,5 @@
+---
+title: Vote on Call Log Metric
+description: "Submit a thumbs-up or thumbs-down vote on a metric evaluation for a call log"
+openapi: post /observability/v1/call-logs/{id}/mark_metric_vote/
+---

--- a/api-reference/test_framework/vote-run-metric.mdx
+++ b/api-reference/test_framework/vote-run-metric.mdx
@@ -1,0 +1,5 @@
+---
+title: Vote on Run Metric
+description: "Submit a thumbs-up or thumbs-down vote on a metric evaluation for a run"
+openapi: post /test_framework/v1/runs/{id}/mark_metric_vote/
+---

--- a/mint.json
+++ b/mint.json
@@ -217,6 +217,7 @@
             "api-reference/observability/list-calls",
             "api-reference/observability/reevaluate-calls",
             "api-reference/observability/evaluate-metrics",
+            "api-reference/observability/vote-call-log-metric",
             "api-reference/observability/delete-call"
           ]
         },
@@ -372,7 +373,8 @@
             "api-reference/test_framework/runs-improve-prompt-bg",
             "api-reference/test_framework/runs-improve-prompt-progress",
             "api-reference/test_framework/runs-improve-prompt-issues",
-            "api-reference/test_framework/post-test_frameworkruns-end_call"
+            "api-reference/test_framework/post-test_frameworkruns-end_call",
+            "api-reference/test_framework/vote-run-metric"
           ]
         },
         {

--- a/openapi.json
+++ b/openapi.json
@@ -2480,7 +2480,8 @@
         "/observability/v1/call-logs-external/{id}/mark_metric_vote/": {
             "post": {
                 "operationId": "call-logs-external-mark-metric-vote-create",
-                "description": "Call logs mark metric vote",
+                "description": "Record a thumbs-up or thumbs-down vote on a specific metric evaluation for this call log and optionally provide an expected value and free-text feedback. Updates the metric evaluation and marks the call log as reviewed.",
+                "summary": "Submit a metric vote for a call log",
                 "parameters": [
                     {
                         "in": "path",
@@ -2493,23 +2494,23 @@
                     }
                 ],
                 "tags": [
-                    "observability"
+                    "Call Logs"
                 ],
                 "requestBody": {
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/CallLogDetail"
+                                "$ref": "#/components/schemas/MarkMetricVote"
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/CallLogDetail"
+                                "$ref": "#/components/schemas/MarkMetricVote"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/CallLogDetail"
+                                "$ref": "#/components/schemas/MarkMetricVote"
                             }
                         }
                     },
@@ -2525,7 +2526,40 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/CallLogDetail"
+                                    "$ref": "#/components/schemas/MarkMetricVoteCallLogResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "detail": {
+                                            "type": "string"
+                                        }
+                                    }
                                 }
                             }
                         },
@@ -3838,7 +3872,8 @@
         "/observability/v1/call-logs/{id}/mark_metric_vote/": {
             "post": {
                 "operationId": "call-logs-mark-metric-vote-create",
-                "description": "Call logs mark metric vote",
+                "description": "Record a thumbs-up or thumbs-down vote on a specific metric evaluation for this call log and optionally provide an expected value and free-text feedback. Updates the metric evaluation and marks the call log as reviewed.",
+                "summary": "Submit a metric vote for a call log",
                 "parameters": [
                     {
                         "in": "path",
@@ -3851,23 +3886,23 @@
                     }
                 ],
                 "tags": [
-                    "observability"
+                    "Call Logs"
                 ],
                 "requestBody": {
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/CallLogDetail"
+                                "$ref": "#/components/schemas/MarkMetricVote"
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/CallLogDetail"
+                                "$ref": "#/components/schemas/MarkMetricVote"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/CallLogDetail"
+                                "$ref": "#/components/schemas/MarkMetricVote"
                             }
                         }
                     },
@@ -3883,7 +3918,40 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/CallLogDetail"
+                                    "$ref": "#/components/schemas/MarkMetricVoteCallLogResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "detail": {
+                                            "type": "string"
+                                        }
+                                    }
                                 }
                             }
                         },
@@ -7892,6 +7960,53 @@
                             }
                         },
                         "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/billing/payment-history/": {
+            "get": {
+                "operationId": "billing-payment-history",
+                "description": "Returns a paginated list of all payments (auto-pay, one-time, subscription) made by the organization.",
+                "summary": "Get payment history",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "organization_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Organization ID",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/PaymentHistory"
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "description": "organization_id is required"
+                    },
+                    "404": {
+                        "description": "Organization not found"
                     }
                 }
             }
@@ -15564,6 +15679,170 @@
                 }
             }
         },
+        "/test_framework/v1/metrics-external/{id}/history/": {
+            "get": {
+                "operationId": "metrics-external-history-list",
+                "description": "Return paginated change history for a metric, including agents snapshot at each point.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric.",
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "page",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "page_size",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedMetricHistoryList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/metrics-external/{id}/history/edit/": {
+            "patch": {
+                "operationId": "metrics-external-history-edit-partial-update",
+                "description": "Metrics history edit",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedMetricEditHistoryRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedMetricEditHistoryRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedMetricEditHistoryRequest"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricHistory"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/metrics-external/{id}/restore/": {
+            "post": {
+                "operationId": "metrics-external-restore-create",
+                "description": "Restore a metric to a previous historical state, creating a new history record.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricRestoreRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricRestoreRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricRestoreRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricDetailV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/test_framework/v1/metrics-external/{id}/run_reviews/": {
             "post": {
                 "operationId": "metrics-external-run-reviews-create",
@@ -16888,6 +17167,170 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/EvaluateLlmJudgeMetricResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/metrics/{id}/history/": {
+            "get": {
+                "operationId": "metrics-history-list",
+                "description": "Return paginated change history for a metric, including agents snapshot at each point.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric.",
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "page",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "page_size",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedMetricHistoryList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/metrics/{id}/history/edit/": {
+            "patch": {
+                "operationId": "metrics-history-edit-partial-update",
+                "description": "Metrics history edit",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedMetricEditHistoryRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedMetricEditHistoryRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedMetricEditHistoryRequest"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricHistory"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/metrics/{id}/restore/": {
+            "post": {
+                "operationId": "metrics-restore-create",
+                "description": "Restore a metric to a previous historical state, creating a new history record.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricRestoreRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricRestoreRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricRestoreRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricDetailV2"
                                 }
                             }
                         },
@@ -23771,7 +24214,8 @@
         "/test_framework/v1/runs-external/{id}/mark_metric_vote/": {
             "post": {
                 "operationId": "runs-external-mark-metric-vote-create",
-                "description": "Runs mark metric vote",
+                "description": "Record a thumbs-up or thumbs-down vote on a specific metric evaluation for this run and optionally provide an expected value and free-text feedback. Updates the metric evaluation and marks the run as reviewed.",
+                "summary": "Submit a metric vote for a run",
                 "parameters": [
                     {
                         "in": "path",
@@ -23784,26 +24228,27 @@
                     }
                 ],
                 "tags": [
-                    "test_framework"
+                    "Runs"
                 ],
                 "requestBody": {
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/Run"
+                                "$ref": "#/components/schemas/MarkMetricVote"
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/Run"
+                                "$ref": "#/components/schemas/MarkMetricVote"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/Run"
+                                "$ref": "#/components/schemas/MarkMetricVote"
                             }
                         }
-                    }
+                    },
+                    "required": true
                 },
                 "security": [
                     {
@@ -23815,7 +24260,40 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Run"
+                                    "$ref": "#/components/schemas/MarkMetricVoteRunResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "detail": {
+                                            "type": "string"
+                                        }
+                                    }
                                 }
                             }
                         },
@@ -24617,7 +25095,8 @@
         "/test_framework/v1/runs/{id}/mark_metric_vote/": {
             "post": {
                 "operationId": "runs-mark-metric-vote-create",
-                "description": "Runs mark metric vote",
+                "description": "Record a thumbs-up or thumbs-down vote on a specific metric evaluation for this run and optionally provide an expected value and free-text feedback. Updates the metric evaluation and marks the run as reviewed.",
+                "summary": "Submit a metric vote for a run",
                 "parameters": [
                     {
                         "in": "path",
@@ -24630,26 +25109,27 @@
                     }
                 ],
                 "tags": [
-                    "test_framework"
+                    "Runs"
                 ],
                 "requestBody": {
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/Run"
+                                "$ref": "#/components/schemas/MarkMetricVote"
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/Run"
+                                "$ref": "#/components/schemas/MarkMetricVote"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/Run"
+                                "$ref": "#/components/schemas/MarkMetricVote"
                             }
                         }
-                    }
+                    },
+                    "required": true
                 },
                 "security": [
                     {
@@ -24661,7 +25141,40 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Run"
+                                    "$ref": "#/components/schemas/MarkMetricVoteRunResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "detail": {
+                                            "type": "string"
+                                        }
+                                    }
                                 }
                             }
                         },
@@ -26154,6 +26667,170 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/Scenario"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/scenarios-external/{id}/history/": {
+            "get": {
+                "operationId": "scenarios-external-history-list",
+                "description": "Scenarios history",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this scenario.",
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "page",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "page_size",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedScenarioHistoryList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/scenarios-external/{id}/history/edit/": {
+            "patch": {
+                "operationId": "scenarios-external-history-edit-partial-update",
+                "description": "Scenarios history edit",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this scenario.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedScenarioEditHistoryRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedScenarioEditHistoryRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedScenarioEditHistoryRequest"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ScenarioHistory"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/scenarios-external/{id}/restore/": {
+            "post": {
+                "operationId": "scenarios-external-restore-create",
+                "description": "Scenarios restore",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this scenario.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ScenarioRestoreRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ScenarioRestoreRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ScenarioRestoreRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ScenarioSerializerV2"
                                 }
                             }
                         },
@@ -30648,6 +31325,170 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/Scenario"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/scenarios/{id}/history/": {
+            "get": {
+                "operationId": "scenarios-history-list",
+                "description": "Scenarios history",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this scenario.",
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "page",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "page_size",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedScenarioHistoryList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/scenarios/{id}/history/edit/": {
+            "patch": {
+                "operationId": "scenarios-history-edit-partial-update",
+                "description": "Scenarios history edit",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this scenario.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedScenarioEditHistoryRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedScenarioEditHistoryRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedScenarioEditHistoryRequest"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ScenarioHistory"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/scenarios/{id}/restore/": {
+            "post": {
+                "operationId": "scenarios-restore-create",
+                "description": "Scenarios restore",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this scenario.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ScenarioRestoreRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ScenarioRestoreRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ScenarioRestoreRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ScenarioSerializerV2"
                                 }
                             }
                         },
@@ -36635,6 +37476,170 @@
                         "multipart/form-data": {
                             "schema": {
                                 "$ref": "#/components/schemas/ScenarioSerializerV2"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ScenarioSerializerV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/scenarios/{id}/history/": {
+            "get": {
+                "operationId": "test-framework-v2-scenarios-history-list",
+                "description": "Scenarios history",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this scenario.",
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "page",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "page_size",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedScenarioHistoryList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/scenarios/{id}/history/edit/": {
+            "patch": {
+                "operationId": "test-framework-v2-scenarios-history-edit-partial-update",
+                "description": "Scenarios history edit",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this scenario.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedScenarioEditHistoryRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedScenarioEditHistoryRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedScenarioEditHistoryRequest"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ScenarioHistory"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/scenarios/{id}/restore/": {
+            "post": {
+                "operationId": "test-framework-v2-scenarios-restore-create",
+                "description": "Scenarios restore",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this scenario.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ScenarioRestoreRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ScenarioRestoreRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ScenarioRestoreRequest"
                             }
                         }
                     },
@@ -46944,6 +47949,10 @@
                         "type": "string",
                         "readOnly": true
                     },
+                    "synthflow_data": {
+                        "type": "string",
+                        "description": "\nSynthflow additional configuration data\nExample: `{\"synthflow_base_url_override\": \"https://api.synthflow.ai\"}`\n"
+                    },
                     "enabled_personalities": {
                         "type": "array",
                         "items": {
@@ -48186,7 +49195,6 @@
             },
             "CallLogDetail": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -48373,7 +49381,6 @@
             },
             "CallLogList": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -49474,7 +50481,6 @@
             },
             "Dashboard": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -49606,7 +50612,6 @@
             },
             "DashboardList": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -50549,6 +51554,65 @@
                     "scenario"
                 ]
             },
+            "MarkMetricVote": {
+                "type": "object",
+                "properties": {
+                    "metric_id": {
+                        "type": "integer",
+                        "description": "ID of the metric to vote on"
+                    },
+                    "thumbs_up": {
+                        "type": [
+                            "boolean",
+                            "null"
+                        ],
+                        "description": "True for thumbs up, False for thumbs down"
+                    },
+                    "expected_value": {
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Expected value for the metric"
+                    },
+                    "feedback": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "Feedback for the metric review"
+                    }
+                },
+                "required": [
+                    "expected_value",
+                    "metric_id",
+                    "thumbs_up"
+                ]
+            },
+            "MarkMetricVoteCallLogResponse": {
+                "type": "object",
+                "properties": {
+                    "detail": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "detail"
+                ]
+            },
+            "MarkMetricVoteRunResponse": {
+                "type": "object",
+                "properties": {
+                    "success": {
+                        "type": "boolean"
+                    }
+                },
+                "required": [
+                    "success"
+                ]
+            },
             "MembershipInline": {
                 "type": "object",
                 "properties": {
@@ -50973,9 +52037,324 @@
                     "name"
                 ]
             },
+            "MetricHistory": {
+                "type": "object",
+                "properties": {
+                    "history_id": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "history_date": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "history_type": {
+                        "enum": [
+                            "+",
+                            "~",
+                            "-"
+                        ],
+                        "type": "string",
+                        "description": "* `+` - Created\n* `~` - Changed\n* `-` - Deleted",
+                        "x-spec-enum-id": "c2e35addebb4f5da"
+                    },
+                    "history_change_reason": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "maxLength": 100
+                    },
+                    "history_user": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/UserInline"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "readOnly": true
+                    },
+                    "version_id": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "maxLength": 12
+                    },
+                    "version_name": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "maxLength": 255
+                    },
+                    "agents_snapshot": {
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "id": {
+                        "type": "integer",
+                        "maximum": 9223372036854775807,
+                        "minimum": -9223372036854775808,
+                        "format": "int64"
+                    },
+                    "slug": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "URL-friendly unique identifier in snake_case format. Example: \"customer_satisfaction_1562\"",
+                        "maxLength": 255
+                    },
+                    "project": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
+                    },
+                    "agent": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "\nName of the metric.\nExample: `\"Customer Satisfaction\"` or `\"Appointment Booking\"`\n        ",
+                        "maxLength": 255
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "\nDescription of what the metric measures.\nExample: `\"Measures how satisfied customers are with the service provided\"`\n        "
+                    },
+                    "function_name": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "\nPredefined function name\nExample: `\"get_latency\"` or `\"check_critical_deviations\"`\n",
+                        "maxLength": 255
+                    },
+                    "type": {
+                        "enum": [
+                            "basic",
+                            "custom_prompt",
+                            "custom_code",
+                            "llm_judge"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "b44700c0a6443b40",
+                        "description": "\nType of metric\n\n\n* `basic` - Basic (Deprecated in favor of LLM Judge)\n* `custom_prompt` - Custom Prompt ( Deprecated in favor of LLM Judge)\n* `custom_code` - Custom Code\n* `llm_judge` - LLM Judge"
+                    },
+                    "eval_type": {
+                        "enum": [
+                            "binary_workflow_adherence",
+                            "binary_qualitative",
+                            "continuous_qualitative",
+                            "numeric",
+                            "enum"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "1e3e27b342bfd8ec",
+                        "description": "\nType of evaluation\n\n\n* `binary_workflow_adherence` - Binary Workflow Adherence\n* `binary_qualitative` - Binary Qualitative\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum"
+                    },
+                    "enum_values": {
+                        "description": "\nList of possible enum values for enum type metrics.\nExample: `[\"satisfied\", \"unsatisfied\"]`\n"
+                    },
+                    "audio_enabled": {
+                        "type": "boolean",
+                        "description": "\nWhether this metric requires audio analysis.\nExample: `true` or `false`\n        "
+                    },
+                    "observability_enabled": {
+                        "type": "boolean",
+                        "description": "\nEnable this metric for observability.\nExample: `true` or `false`\n        "
+                    },
+                    "simulation_enabled": {
+                        "type": "boolean",
+                        "description": "\nEnable this metric for simulations.\nExample: `true` or `false`\n        "
+                    },
+                    "sampling_enabled": {
+                        "type": "boolean",
+                        "description": "Enable sampling for this metric using project-level sample rate"
+                    },
+                    "alert_enabled": {
+                        "type": "boolean",
+                        "description": "\nEnable alerts for this metric when it fails (value < 5).\nOnly applicable to binary metrics (binary_workflow_adherence and binary_qualitative).\nFor other metric types, use significant_change_alert_status instead.\nExample: `true` or `false`\n        "
+                    },
+                    "prompt": {
+                        "type": "string",
+                        "description": "\nEvaluation prompt for the metric.\nExample: `\"Evaluate customer satisfaction based on conversation\"`\n"
+                    },
+                    "display_order": {
+                        "type": "integer",
+                        "maximum": 2147483647,
+                        "minimum": -2147483648,
+                        "description": "\nDisplay order for the metric.\nExample: `1`\n"
+                    },
+                    "evaluation_trigger": {
+                        "enum": [
+                            "always",
+                            "automatic",
+                            "custom"
+                        ],
+                        "type": "string",
+                        "description": "* `always` - Always\n* `automatic` - Automatic\n* `custom` - Custom",
+                        "x-spec-enum-id": "ecd3c02e0e393ef5"
+                    },
+                    "trigger_type": {
+                        "enum": [
+                            "llm_judge",
+                            "custom_code"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "2adad4b8df61914f",
+                        "description": "\nType of trigger evaluation: LLM judge or custom code.\nOnly used when evaluation_trigger is CUSTOM.\nExample: `\"llm_judge\"` or `\"custom_code\"`\n\n\n* `llm_judge` - LLM Judge\n* `custom_code` - Custom Code"
+                    },
+                    "evaluation_trigger_prompt": {
+                        "type": "string",
+                        "description": "\nEvaluation trigger prompt for the metric.\nExample: `\"Evaluate metric only if call ended reason is main-agent-ended-call\"`\n"
+                    },
+                    "evaluation_trigger_custom_code": {
+                        "type": "string",
+                        "description": "\nPython custom code to determine metric relevance. Code should set _result (bool) and _explanation (str).\nExample:\n```python\n_result = True\n_explanation = \"Metric is relevant\"\nif \"call_end_reason\" in data and data[\"call_end_reason\"] == \"customer-hung-up\":\n    _result = False\n    _explanation = \"Customer hung up, metric not applicable\"\n```\n"
+                    },
+                    "priority_assignment_prompt": {
+                        "type": "string",
+                        "description": "\nPriority assignment prompt for the metric.\n"
+                    },
+                    "configuration": {
+                        "description": "\nCustom configuration parameters for specific metrics if metric supports it.\nExample:\n- For Infrastructure issues\n```json\n{\n    \"infra_issues_timeout\": 10\n}\n```\n"
+                    },
+                    "alert_type": {
+                        "enum": [
+                            "disabled",
+                            "normal",
+                            "significant_change"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "9e2661f1aeca64cf",
+                        "description": "\nAlert type: disabled, normal alerts, or significant change alerts.\n\n\n* `disabled` - Alerts Disabled\n* `normal` - Normal Alerts\n* `significant_change` - Significant Change Alerts"
+                    },
+                    "significant_change_alert_status": {
+                        "enum": [
+                            "enabled",
+                            "disabled"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "6d6f4d361b4ea1fb",
+                        "description": "\nAlert status: enabled or disabled.\n\n\n* `enabled` - Enabled\n* `disabled` - Disabled"
+                    },
+                    "significant_change_alert_direction": {
+                        "enum": [
+                            "",
+                            "increase",
+                            "decrease"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "1e86e60ca5cfba12",
+                        "description": "Alert direction: increase only, decrease only, or both (empty = both).\nExample: `\"increase\"`, `\"decrease\"`, or `\"both\"`\n\n* `` - Both (Increase and Decrease)\n* `increase` - Increase Only\n* `decrease` - Decrease Only"
+                    },
+                    "window_size": {
+                        "type": "integer",
+                        "maximum": 2147483647,
+                        "minimum": 0,
+                        "description": "\nWindow size for rolling statistics calculation.\nExample: `50`\n"
+                    },
+                    "std_multiplier": {
+                        "type": "number",
+                        "format": "double",
+                        "description": "\nStandard deviation multiplier for threshold calculation.\nExample: `2.0`\n"
+                    },
+                    "ewma_alpha": {
+                        "type": "number",
+                        "format": "double",
+                        "description": "\nAlpha value for exponentially weighted moving average (EWMA) calculation.\nExample: `0.1`\n"
+                    },
+                    "add_to_new_agents": {
+                        "type": [
+                            "boolean",
+                            "null"
+                        ],
+                        "description": "When enabled, this metric is automatically assigned to new agents created in the project."
+                    },
+                    "alert_filters": {
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Filters to apply before computing alerts (CallLogQueryFilter format)"
+                    },
+                    "slack_workspace": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
+                        "description": "Slack workspace to send alerts to"
+                    },
+                    "slack_channel_id": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "Override channel ID for this metric's alerts",
+                        "maxLength": 255
+                    },
+                    "custom_code": {
+                        "type": "string",
+                        "description": "\nPython custom code for the metric.\nExample:\n```python\n_resul = True\n_explanation = None\nif  \"call_end_reason\" in data and data[\"call_end_reason\"] == \"customer_satisfaction\":\n    _result = True\n    _explanation = \"Customer expressed satisfaction with service\"\n```\n"
+                    },
+                    "vocera_defined_metric_code": {
+                        "type": "string",
+                        "description": "\nVocera defined metric code for the metric.\nExample: `\"7fd534f5\"`\n",
+                        "maxLength": 255
+                    },
+                    "llm_provider": {
+                        "enum": [
+                            "openai",
+                            "gemini",
+                            "dspy-gepa-gemini-flash"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "627916df1920819a",
+                        "description": "LLM provider for this metric evaluation.\nExample: \n- `\"gemini\"`\n- `\"openai\"`\n\n\n* `openai` - OpenAI\n* `gemini` - Gemini\n* `dspy-gepa-gemini-flash` - Dspy Gepa Gemini Flash"
+                    },
+                    "relevance_llm_provider": {
+                        "enum": [
+                            "openai",
+                            "gemini",
+                            "dspy-gepa-gemini-flash"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "627916df1920819a",
+                        "description": "LLM provider for this metric relevance.\nExample: \n- `\"gemini\"`\n- `\"openai\"`\n\n\n* `openai` - OpenAI\n* `gemini` - Gemini\n* `dspy-gepa-gemini-flash` - Dspy Gepa Gemini Flash"
+                    },
+                    "metric_description_variables": {
+                        "description": "Dynamic variables for this metric evaluation using DSPy GEPA.\nExample: \n```json\n[\"customer_sentiment\", \"response_time\", \"issue_resolved\"]\n```\n"
+                    },
+                    "evaluation_trigger_variables": {
+                        "description": "Dynamic variables for this metric relevance using DSPy GEPA.\nExample: \n```json\n[\"call_type\", \"customer_tier\", \"issue_complexity\"]\n```\n"
+                    }
+                },
+                "required": [
+                    "alert_type",
+                    "ewma_alpha",
+                    "history_date",
+                    "history_type",
+                    "name",
+                    "std_multiplier",
+                    "window_size"
+                ]
+            },
             "MetricList": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -51363,6 +52742,17 @@
                     "eval_type",
                     "name",
                     "type"
+                ]
+            },
+            "MetricRestoreRequest": {
+                "type": "object",
+                "properties": {
+                    "history_id": {
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "history_id"
                 ]
             },
             "MetricReviewDetail": {
@@ -52851,6 +54241,37 @@
                     }
                 }
             },
+            "PaginatedMetricHistoryList": {
+                "type": "object",
+                "required": [
+                    "count",
+                    "results"
+                ],
+                "properties": {
+                    "count": {
+                        "type": "integer",
+                        "example": 123
+                    },
+                    "next": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "https://api.cekura.ai/example/v1/example-external/?page=4"
+                    },
+                    "previous": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "https://api.cekura.ai/example/v1/example-external/?page=3"
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/MetricHistory"
+                        }
+                    }
+                }
+            },
             "PaginatedMetricRollingStatsList": {
                 "type": "object",
                 "required": [
@@ -52971,6 +54392,37 @@
                         "type": "array",
                         "items": {
                             "$ref": "#/components/schemas/ScenarioFolder"
+                        }
+                    }
+                }
+            },
+            "PaginatedScenarioHistoryList": {
+                "type": "object",
+                "required": [
+                    "count",
+                    "results"
+                ],
+                "properties": {
+                    "count": {
+                        "type": "integer",
+                        "example": 123
+                    },
+                    "next": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "https://api.cekura.ai/example/v1/example-external/?page=4"
+                    },
+                    "previous": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "https://api.cekura.ai/example/v1/example-external/?page=3"
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ScenarioHistory"
                         }
                     }
                 }
@@ -53156,7 +54608,6 @@
             },
             "PatchedCallLogDetail": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -53609,7 +55060,6 @@
             },
             "PatchedDashboard": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -53943,6 +55393,20 @@
                         "format": "date-time",
                         "readOnly": true,
                         "description": "When this record was last updated.\nExample: `2024-03-15T10:35:11Z`"
+                    }
+                }
+            },
+            "PatchedMetricEditHistoryRequest": {
+                "type": "object",
+                "properties": {
+                    "history_id": {
+                        "type": "integer"
+                    },
+                    "version_name": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
                     }
                 }
             },
@@ -55490,6 +56954,20 @@
                     }
                 }
             },
+            "PatchedScenarioEditHistoryRequest": {
+                "type": "object",
+                "properties": {
+                    "history_id": {
+                        "type": "integer"
+                    },
+                    "version_name": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    }
+                }
+            },
             "PatchedScenarioImprovementSessionDetail": {
                 "type": "object",
                 "description": "",
@@ -55861,7 +57339,6 @@
             },
             "PatchedSchemaPostScenario": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "agent": {
                         "type": [
@@ -56327,6 +57804,10 @@
                     "synthflow_api_key_configured": {
                         "type": "string",
                         "readOnly": true
+                    },
+                    "synthflow_data": {
+                        "type": "string",
+                        "description": "\nSynthflow additional configuration data\nExample: `{\"synthflow_base_url_override\": \"https://api.synthflow.ai\"}`\n"
                     },
                     "enabled_personalities": {
                         "type": "array",
@@ -57056,6 +58537,61 @@
                         "readOnly": true
                     },
                     "updated_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    }
+                }
+            },
+            "PaymentHistory": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "amount": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "currency": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "Currency code (e.g. USD, INR)",
+                        "maxLength": 10
+                    },
+                    "payment_type": {
+                        "enum": [
+                            "auto_pay",
+                            "one_time_payment",
+                            "self_serve_credits",
+                            "self_serve_member_seat",
+                            "subscription",
+                            "subscription_member_seat",
+                            null
+                        ],
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "x-spec-enum-id": "361bd31b044dd4ca",
+                        "description": "Type of payment (auto_pay or one_time_payment)\n\n* `auto_pay` - Auto Pay\n* `one_time_payment` - One-Time Payment\n* `self_serve_credits` - Self-Serve Credits\n* `self_serve_member_seat` - Self-Serve Member Seat\n* `subscription` - Subscription\n* `subscription_member_seat` - Subscription Member Seat"
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Payment description or notes"
+                    },
+                    "stripe_payment_intent_id": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "Stripe Payment Intent ID for tracking",
+                        "maxLength": 255
+                    },
+                    "created_at": {
                         "type": "string",
                         "format": "date-time",
                         "readOnly": true
@@ -58737,7 +60273,6 @@
             },
             "RunList": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -59137,7 +60672,6 @@
             },
             "Scenario": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -59578,6 +61112,249 @@
                     "project_id"
                 ]
             },
+            "ScenarioHistory": {
+                "type": "object",
+                "properties": {
+                    "history_id": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "history_date": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "history_type": {
+                        "enum": [
+                            "+",
+                            "~",
+                            "-"
+                        ],
+                        "type": "string",
+                        "description": "* `+` - Created\n* `~` - Changed\n* `-` - Deleted",
+                        "x-spec-enum-id": "c2e35addebb4f5da"
+                    },
+                    "history_change_reason": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "maxLength": 100
+                    },
+                    "history_user": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/UserInline"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "readOnly": true
+                    },
+                    "version_id": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "maxLength": 12
+                    },
+                    "version_name": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "maxLength": 255
+                    },
+                    "metrics_snapshot": {
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "id": {
+                        "type": "integer",
+                        "maximum": 9223372036854775807,
+                        "minimum": -9223372036854775808,
+                        "format": "int64"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Name of the scenario",
+                        "maxLength": 80
+                    },
+                    "project": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
+                    },
+                    "agent": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
+                    },
+                    "personality": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
+                    },
+                    "tags": {
+                        "description": "\nTags associated with the scenario\nExample: `[\"tag1\", \"tag2\"]`\n"
+                    },
+                    "tool_ids": {
+                        "description": "\nList of tool IDs to associate with this scenario\nExample: `[\"TOOL_DTMF\", \"TOOL_END_CALL\"]`\n"
+                    },
+                    "first_message": {
+                        "type": "string",
+                        "description": "First message to be sent to the Main Agent"
+                    },
+                    "instructions": {
+                        "type": "string",
+                        "description": "Scenario Instructions"
+                    },
+                    "simulation_description": {
+                        "type": "string",
+                        "description": "Simulation Description"
+                    },
+                    "information_fields": {
+                        "description": "\nInformation fields associated with the scenario\nExample: `{\"user_name\": \"John Doe\", \"user_email\": \"john.doe@example.com\", \"order_id\": \"1234567890\"}`\n"
+                    },
+                    "expected_outcome_prompt": {
+                        "type": "string",
+                        "description": "\nExpected Outcome Prompt\nExample: `\"The user should be able to complete the order\"`\n"
+                    },
+                    "scenario_language": {
+                        "enum": [
+                            "af",
+                            "ar",
+                            "bn",
+                            "bg",
+                            "zh",
+                            "cs",
+                            "da",
+                            "nl",
+                            "en",
+                            "et",
+                            "fi",
+                            "fr",
+                            "de",
+                            "el",
+                            "gu",
+                            "hi",
+                            "he",
+                            "hu",
+                            "id",
+                            "it",
+                            "ja",
+                            "kn",
+                            "ko",
+                            "ms",
+                            "ml",
+                            "mr",
+                            "multi",
+                            "no",
+                            "pl",
+                            "pa",
+                            "pt",
+                            "ro",
+                            "ru",
+                            "sk",
+                            "es",
+                            "sv",
+                            "th",
+                            "tr",
+                            "tl",
+                            "ta",
+                            "te",
+                            "uk",
+                            "vi",
+                            "",
+                            null
+                        ],
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "x-spec-enum-id": "b822ad429c7b7fec",
+                        "description": "Language of the scenario\n\n* `af` - Afrikaans\n* `ar` - Arabic\n* `bn` - Bengali\n* `bg` - Bulgarian\n* `zh` - Chinese Simplified\n* `cs` - Czech\n* `da` - Danish\n* `nl` - Dutch\n* `en` - English\n* `et` - Estonian\n* `fi` - Finnish\n* `fr` - French\n* `de` - German\n* `el` - Greek\n* `gu` - Gujarati\n* `hi` - Hindi\n* `he` - Hebrew\n* `hu` - Hungarian\n* `id` - Indonesian\n* `it` - Italian\n* `ja` - Japanese\n* `kn` - Kannada\n* `ko` - Korean\n* `ms` - Malay\n* `ml` - Malayalam\n* `mr` - Marathi\n* `multi` - Multilingual\n* `no` - Norwegian\n* `pl` - Polish\n* `pa` - Punjabi\n* `pt` - Portuguese\n* `ro` - Romanian\n* `ru` - Russian\n* `sk` - Slovak\n* `es` - Spanish\n* `sv` - Swedish\n* `th` - Thai\n* `tr` - Turkish\n* `tl` - Tagalog\n* `ta` - Tamil\n* `te` - Telugu\n* `uk` - Ukrainian\n* `vi` - Vietnamese"
+                    },
+                    "scenario_type": {
+                        "enum": [
+                            "instruction",
+                            "real_world_smart",
+                            "real_world_fixed",
+                            "conditional_actions"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "db62e37bb530b602",
+                        "description": "Type of scenario\n\n* `instruction` - Instruction\n* `real_world_smart` - Real World Smart\n* `real_world_fixed` - Real World Fixed\n* `conditional_actions` - Conditional Actions"
+                    },
+                    "suite_type": {
+                        "enum": [
+                            "undefined",
+                            "infrastructure"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "643f6a8cdc799a77",
+                        "description": "Type of predefined suite (e.g., infrastructure)\n\n* `undefined` - Undefined\n* `infrastructure` - Infrastructure"
+                    },
+                    "is_predefined": {
+                        "type": "boolean",
+                        "description": "Whether this is a predefined scenario (template)"
+                    },
+                    "max_duration": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
+                        "maximum": 2147483647,
+                        "minimum": -2147483648,
+                        "description": "\nMax call duration in seconds for this scenario. If not set, uses the project's max_call_duration setting.\nExample: `600` (10 minutes)\n"
+                    },
+                    "dynamic_variable_values": {
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Generated values for the agent's dynamic variables for this scenario. Keys are variable names; values are the generated values."
+                    },
+                    "phone_number": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
+                    },
+                    "inbound_phone_number": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
+                    },
+                    "test_profile": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
+                    },
+                    "folder": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
+                    }
+                },
+                "required": [
+                    "history_date",
+                    "history_type",
+                    "scenario_type"
+                ]
+            },
             "ScenarioImprovementSessionCreate": {
                 "type": "object",
                 "description": "",
@@ -59761,7 +61538,6 @@
             },
             "ScenarioList": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -59968,9 +61744,19 @@
                     "name"
                 ]
             },
+            "ScenarioRestoreRequest": {
+                "type": "object",
+                "properties": {
+                    "history_id": {
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "history_id"
+                ]
+            },
             "ScenarioSerializerV2": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -61150,7 +62936,6 @@
             },
             "SchemaPostRunScenarios": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "agent_id": {
                         "type": "integer",
@@ -61374,7 +63159,6 @@
             },
             "SchemaPostScenario": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "agent": {
                         "type": [
@@ -61534,7 +63318,6 @@
             },
             "SchemaScenario": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -62128,6 +63911,10 @@
                     "synthflow_api_key_configured": {
                         "type": "string",
                         "readOnly": true
+                    },
+                    "synthflow_data": {
+                        "type": "string",
+                        "description": "\nSynthflow additional configuration data\nExample: `{\"synthflow_base_url_override\": \"https://api.synthflow.ai\"}`\n"
                     },
                     "enabled_personalities": {
                         "type": "array",

--- a/openapi.json
+++ b/openapi.json
@@ -3957,6 +3957,14 @@
                         },
                         "description": ""
                     }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "call-logs-mark-metric-vote-create",
+                        "description": "Record a thumbs-up or thumbs-down vote on a specific metric evaluation for this call log and optionally provide an expected value and free-text feedback. Updates the metric evaluation and marks the call log as reviewed."
+                    }
                 }
             }
         },
@@ -25179,6 +25187,14 @@
                             }
                         },
                         "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "runs-mark-metric-vote-create",
+                        "description": "Record a thumbs-up or thumbs-down vote on a specific metric evaluation for this run and optionally provide an expected value and free-text feedback. Updates the metric evaluation and marks the run as reviewed."
                     }
                 }
             }


### PR DESCRIPTION
Backend PR: https://github.com/cekura-ai/vocera.backend/pull/9056

## Summary
- Add `openapi.json` updated with `@extend_schema` on `mark_metric_vote` for call logs and runs (request schema via `MarkMetricVoteSerializer`, accurate response schemas)
- Add `api-reference/observability/vote-call-log-metric.mdx` for `POST /observability/v1/call-logs/{id}/mark_metric_vote/`
- Add `api-reference/test_framework/vote-run-metric.mdx` for `POST /test_framework/v1/runs/{id}/mark_metric_vote/`
- Register both pages in `mint.json` under Calls and Runs groups respectively

🤖 Generated with [Claude Code](https://claude.com/claude-code)