### PR TITLE
[Auto] Sync docs for backend PR #9116

### DIFF
--- a/api-reference/test_framework/bulk-delete-results-external.mdx
+++ b/api-reference/test_framework/bulk-delete-results-external.mdx
@@ -1,0 +1,6 @@
+---
+title: Bulk Delete Results External
+description: "⚠ Irreversible. Soft-deletes each result (and its non-deleted runs) with the same side-effects as deleting a single result: outbound phone numbers are released when no queued runs remain, capacity-manager slots are freed, and active_sessions / pending_demand counters are decremented in aggregate. Maximum 100 result IDs per request. Results that are already deleted or that the caller cannot access are silently skipped — the response is 204 even when no results are deleted."
+openapi: post /test_framework/v1/results-external/bulk_delete/
+slug: bulk-delete-results-external
+---

--- a/api-reference/test_framework/bulk-delete-results.mdx
+++ b/api-reference/test_framework/bulk-delete-results.mdx
@@ -1,0 +1,6 @@
+---
+title: Bulk Delete Results
+description: "⚠ Irreversible. Soft-deletes each result (and its non-deleted runs) with the same side-effects as deleting a single result: outbound phone numbers are released when no queued runs remain, capacity-manager slots are freed, and active_sessions / pending_demand counters are decremented in aggregate. Maximum 100 result IDs per request. Results that are already deleted or that the caller cannot access are silently skipped — the response is 204 even when no results are deleted."
+openapi: post /test_framework/v1/results/bulk_delete/
+slug: bulk-delete-results
+---

--- a/api-reference/test_framework/bulk-evaluate-results-metrics-external.mdx
+++ b/api-reference/test_framework/bulk-evaluate-results-metrics-external.mdx
@@ -1,0 +1,6 @@
+---
+title: Bulk Evaluate Results Metrics External
+description: "Schedules re-evaluation of the given metrics against every completed/failed, non-deleted run of every selected result. Metrics are validated against each agent's metric scope; balance is checked for the full batch up front before any work is dispatched. Each affected result's status is flipped to RUNNING. Maximum 100 result IDs per request."
+openapi: post /test_framework/v1/results-external/bulk_evaluate_metrics/
+slug: bulk-evaluate-results-metrics-external
+---

--- a/api-reference/test_framework/bulk-evaluate-results-metrics.mdx
+++ b/api-reference/test_framework/bulk-evaluate-results-metrics.mdx
@@ -1,0 +1,6 @@
+---
+title: Bulk Evaluate Results Metrics
+description: "Schedules re-evaluation of the given metrics against every completed/failed, non-deleted run of every selected result. Metrics are validated against each agent's metric scope; balance is checked for the full batch up front before any work is dispatched. Each affected result's status is flipped to RUNNING. Maximum 100 result IDs per request."
+openapi: post /test_framework/v1/results/bulk_evaluate_metrics/
+slug: bulk-evaluate-results-metrics
+---

--- a/mint.json
+++ b/mint.json
@@ -362,7 +362,11 @@
             "api-reference/test_framework/post-test_frameworkresults-delete_runs",
             "api-reference/test_framework/post-test_frameworkresults-end_calls",
             "api-reference/test_framework/post-test_frameworkresults-create_shareable_link_token",
-            "api-reference/test_framework/ask-about-failures"
+            "api-reference/test_framework/ask-about-failures",
+            "api-reference/test_framework/bulk-delete-results-external",
+            "api-reference/test_framework/bulk-evaluate-results-metrics-external",
+            "api-reference/test_framework/bulk-delete-results",
+            "api-reference/test_framework/bulk-evaluate-results-metrics"
           ]
         },
         {

--- a/openapi.json
+++ b/openapi.json
@@ -21993,6 +21993,122 @@
                 }
             }
         },
+        "/test_framework/v1/results-external/bulk_delete/": {
+            "post": {
+                "operationId": "bulk-delete-results",
+                "description": "⚠ Irreversible. Soft-deletes each result (and its non-deleted runs) with the same side-effects as deleting a single result: outbound phone numbers are released when no queued runs remain, capacity-manager slots are freed, and active_sessions / pending_demand counters are decremented in aggregate. Maximum 100 result IDs per request. Results that are already deleted or that the caller cannot access are silently skipped — the response is 204 even when no results are deleted.",
+                "summary": "Soft-delete multiple results",
+                "tags": [
+                    "Results"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostBulkDeleteResults"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostBulkDeleteResults"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostBulkDeleteResults"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No response body"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/results-external/bulk_evaluate_metrics/": {
+            "post": {
+                "operationId": "bulk-evaluate-result-metrics",
+                "description": "Schedules re-evaluation of the given metrics against every completed/failed, non-deleted run of every selected result. Metrics are validated against each agent's metric scope; balance is checked for the full batch up front before any work is dispatched. Each affected result's status is flipped to RUNNING. Maximum 100 result IDs per request.",
+                "summary": "Re-evaluate metrics across multiple results",
+                "tags": [
+                    "Results"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostBulkEvaluateResultMetrics"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostBulkEvaluateResultMetrics"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostBulkEvaluateResultMetrics"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No response body"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/test_framework/v1/results-external/bulk_export_progress/": {
             "get": {
                 "operationId": "results-external-bulk-export-progress-retrieve",
@@ -22985,6 +23101,122 @@
                         "enabled": true,
                         "name": "results-rerun-create",
                         "description": "Re-run a test result evaluation"
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/results/bulk_delete/": {
+            "post": {
+                "operationId": "bulk-delete-results_2",
+                "description": "⚠ Irreversible. Soft-deletes each result (and its non-deleted runs) with the same side-effects as deleting a single result: outbound phone numbers are released when no queued runs remain, capacity-manager slots are freed, and active_sessions / pending_demand counters are decremented in aggregate. Maximum 100 result IDs per request. Results that are already deleted or that the caller cannot access are silently skipped — the response is 204 even when no results are deleted.",
+                "summary": "Soft-delete multiple results",
+                "tags": [
+                    "Results"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostBulkDeleteResults"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostBulkDeleteResults"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostBulkDeleteResults"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No response body"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/results/bulk_evaluate_metrics/": {
+            "post": {
+                "operationId": "bulk-evaluate-result-metrics_2",
+                "description": "Schedules re-evaluation of the given metrics against every completed/failed, non-deleted run of every selected result. Metrics are validated against each agent's metric scope; balance is checked for the full batch up front before any work is dispatched. Each affected result's status is flipped to RUNNING. Maximum 100 result IDs per request.",
+                "summary": "Re-evaluate metrics across multiple results",
+                "tags": [
+                    "Results"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostBulkEvaluateResultMetrics"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostBulkEvaluateResultMetrics"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostBulkEvaluateResultMetrics"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No response body"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
                     }
                 }
             }
@@ -36032,7 +36264,7 @@
                                 "schema": {
                                     "type": "array",
                                     "items": {
-                                        "$ref": "#/components/schemas/AIAgentTestProfile"
+                                        "$ref": "#/components/schemas/AIAgentTestProfileList"
                                     }
                                 },
                                 "examples": {
@@ -36211,7 +36443,7 @@
                                 "schema": {
                                     "type": "array",
                                     "items": {
-                                        "$ref": "#/components/schemas/AIAgentTestProfile"
+                                        "$ref": "#/components/schemas/AIAgentTestProfileList"
                                     }
                                 },
                                 "examples": {
@@ -48288,10 +48520,68 @@
                         },
                         "description": "\nInformation fields for the test profile\nExample:\n```json\n{\n    \"user_name\": \"John Doe\",\n    \"user_email\": \"john.doe@example.com\",\n}\n```\n"
                     },
-                    "scenarios": {
+                    "created_by": {
+                        "type": "integer",
+                        "readOnly": true,
+                        "description": "ID of the user who created this test profile"
+                    },
+                    "last_updated_by": {
+                        "type": "integer",
+                        "readOnly": true,
+                        "description": "ID of the user who last updated this test profile"
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "description": "Timestamp when the test profile was created"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "description": "Timestamp when the test profile was last updated"
+                    }
+                },
+                "required": [
+                    "name"
+                ]
+            },
+            "AIAgentTestProfileList": {
+                "type": "object",
+                "description": "List variant that also embeds the scenarios attached to each profile.\n\nOnly used by `TestProfileViewSet.list` — retrieve/create/update and any\nnested usage (e.g. `ScenarioSerializer.test_profile_data`) should keep\nusing `AIAgentTestProfileSerializer`.",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "project": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
+                    },
+                    "agent": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
+                    },
+                    "agent_name": {
                         "type": "string",
                         "readOnly": true,
-                        "description": "List of scenarios using this test profile"
+                        "description": "\nName of the agent associated with this test profile\nExample: `\"Customer Support Agent\"`\n"
+                    },
+                    "name": {
+                        "type": "string",
+                        "maxLength": 255
+                    },
+                    "information": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "\nInformation fields for the test profile\nExample:\n```json\n{\n    \"user_name\": \"John Doe\",\n    \"user_email\": \"john.doe@example.com\",\n}\n```\n"
                     },
                     "created_by": {
                         "type": "integer",
@@ -48314,6 +48604,11 @@
                         "format": "date-time",
                         "readOnly": true,
                         "description": "Timestamp when the test profile was last updated"
+                    },
+                    "scenarios": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "List of scenarios using this test profile"
                     }
                 },
                 "required": [
@@ -62403,6 +62698,49 @@
                 },
                 "required": [
                     "name"
+                ]
+            },
+            "SchemaPostBulkDeleteResults": {
+                "type": "object",
+                "properties": {
+                    "result_ids": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        },
+                        "description": "List of result IDs to soft-delete. Maximum 100 per request.",
+                        "maxItems": 100,
+                        "minItems": 1
+                    }
+                },
+                "required": [
+                    "result_ids"
+                ]
+            },
+            "SchemaPostBulkEvaluateResultMetrics": {
+                "type": "object",
+                "properties": {
+                    "result_ids": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        },
+                        "description": "Result IDs whose completed/failed runs should be re-evaluated. Maximum 100.",
+                        "maxItems": 100,
+                        "minItems": 1
+                    },
+                    "metric_ids": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        },
+                        "description": "Metric IDs to re-evaluate against every eligible run of each result.",
+                        "minItems": 1
+                    }
+                },
+                "required": [
+                    "metric_ids",
+                    "result_ids"
                 ]
             },
             "SchemaPostCopyAgent": {

--- a/openapi.json
+++ b/openapi.json
@@ -49297,6 +49297,7 @@
             },
             "CallLogDetail": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -49483,6 +49484,7 @@
             },
             "CallLogList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -50583,6 +50585,7 @@
             },
             "Dashboard": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -50714,6 +50717,7 @@
             },
             "DashboardList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -52457,6 +52461,7 @@
             },
             "MetricList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -54710,6 +54715,7 @@
             },
             "PatchedCallLogDetail": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -55162,6 +55168,7 @@
             },
             "PatchedDashboard": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -57441,6 +57448,7 @@
             },
             "PatchedSchemaPostScenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "agent": {
                         "type": [
@@ -60251,6 +60259,7 @@
             },
             "RunList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -60650,6 +60659,7 @@
             },
             "Scenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -60694,11 +60704,6 @@
                     },
                     "tool_ids": {
                         "description": "\nList of tool IDs to associate with this scenario\nExample: `[\"TOOL_DTMF\", \"TOOL_END_CALL\"]`\n"
-                    },
-                    "runs": {
-                        "type": "string",
-                        "readOnly": true,
-                        "description": "\nList of IDs for the last run of this scenario\nExample: `[123, 456]`\n"
                     },
                     "metrics": {
                         "writeOnly": true,
@@ -61524,6 +61529,7 @@
             },
             "ScenarioList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -61743,6 +61749,7 @@
             },
             "ScenarioSerializerV2": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -61787,11 +61794,6 @@
                     },
                     "tool_ids": {
                         "description": "\nList of tool IDs to associate with this scenario\nExample: `[\"TOOL_DTMF\", \"TOOL_END_CALL\"]`\n"
-                    },
-                    "runs": {
-                        "type": "string",
-                        "readOnly": true,
-                        "description": "\nList of IDs for the last run of this scenario\nExample: `[123, 456]`\n"
                     },
                     "metrics": {
                         "writeOnly": true,
@@ -62922,6 +62924,7 @@
             },
             "SchemaPostRunScenarios": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "agent_id": {
                         "type": "integer",
@@ -63145,6 +63148,7 @@
             },
             "SchemaPostScenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "agent": {
                         "type": [
@@ -63304,6 +63308,7 @@
             },
             "SchemaScenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -63350,13 +63355,6 @@
                     },
                     "tool_ids": {
                         "description": "\nList of tool IDs to associate with this scenario\nExample: `[\"TOOL_DTMF\", \"TOOL_END_CALL\"]`\n"
-                    },
-                    "runs": {
-                        "type": "array",
-                        "items": {
-                            "type": "integer"
-                        },
-                        "description": "\nList of run IDs\nExample: `[123, 456, 789]`\n"
                     },
                     "metrics": {
                         "type": "array",


### PR DESCRIPTION
Auto-generated docs sync for backend PR [#9116](https://github.com/cekura-ai/vocera.backend/pull/9116).

Reviewers: @dileep-chagam, @om-voceraai

## Summary

**Spec/overlay:** Spec updated with schema changes to scenarios endpoints (removed `runs` field) and 2 new bulk result operations. 1 MCP-exposed operation with schema changes (Bucket A, no overlay needed). 2 not-exposed operations (Bucket C) flagged for exposure consideration. No renames, no MCP exposure changes.

## Changes

- `openapi.json` — regenerate_from_backend

## Exposure suggestions (@mcp_expose candidates)

- **`bulk_delete_results`** (POST `/test_framework/v1/results/bulk_delete/`)
  - Bulk soft-delete for results. Co-located with other exposed result operations (results_list, results_retrieve, delete_runs, end_calls). Note: individual results_destroy is not exposed; evaluate whether bulk deletion should follow the same pattern or be useful for cleanup operations. Consider exposing in a follow-up PR if bulk cleanup is valuable for MCP agents.
- **`bulk_evaluate_result_metrics`** (POST `/test_framework/v1/results/bulk_evaluate_metrics/`)
  - Bulk version of the already-exposed results_evaluate_metrics. Co-located with other exposed result operations. Enables batch metric evaluations across multiple results. Consider exposing in a follow-up PR.

## Duplicate URL variants surviving strip (mcp-hygiene)

- `call-logs-create-scenarios_2` — canonical `/observability/v1/call-logs/create_scenarios/`, duplicates: `/observability/v1/call-logs-external/create_scenarios/`
- `call-logs-create-scenarios-progress_2` — canonical `/observability/v1/call-logs/create_scenarios_progress/`, duplicates: `/observability/v1/call-logs-external/create_scenarios_progress/`
- `aiagents-upload-knowledge-base_2` — canonical `/test_framework/v1/aiagents/{id}/upload_knowledge_base/`, duplicates: `/test_framework/v1/aiagents-external/{id}/upload_knowledge_base/`
- `metrics-bulk-create_2` — canonical `/test_framework/v1/metrics/bulk_create/`, duplicates: `/test_framework/v1/metrics-external/bulk_create/`
- `metrics-generate_2` — canonical `/test_framework/v1/metrics/generate_metrics/`, duplicates: `/test_framework/v1/metrics-external/generate_metrics/`
- `metrics-preview-progress_2` — canonical `/test_framework/v1/metrics/preview-progress/`, duplicates: `/test_framework/v1/metrics-external/preview-progress/`
- `metrics-run-reviews-progress_2` — canonical `/test_framework/v1/metrics/run_reviews_progress/`, duplicates: `/test_framework/v1/metrics-external/run_reviews_progress/`
- `create-shareable-link-token_2` — canonical `/test_framework/v1/results/{id}/create_shareable_link_token/`, duplicates: `/test_framework/v1/results-external/{id}/create_shareable_link_token/`
- `delete-runs_2` — canonical `/test_framework/v1/results/{id}/delete_runs/`, duplicates: `/test_framework/v1/results-external/{id}/delete_runs/`
- `end-calls_2` — canonical `/test_framework/v1/results/{id}/end_calls/`, duplicates: `/test_framework/v1/results-external/{id}/end_calls/`
- `end-call_2` — canonical `/test_framework/v1/runs/{id}/end_call/`, duplicates: `/test_framework/v1/runs-external/{id}/end_call/`
- `scenarios-bulk-update_2` — canonical `/test_framework/v1/scenarios/adv_update/`, duplicates: `/test_framework/v1/scenarios-external/adv_update/`
- `scenarios-folder-create_2` — canonical `/test_framework/v1/scenarios/create_folder/`, duplicates: `/test_framework/v1/scenarios-external/create_folder/`
- `scenarios-create-from-transcript_2` — canonical `/test_framework/v1/scenarios/create_scenario_from_transcript/`, duplicates: `/test_framework/v1/scenarios-external/create_scenario_from_transcript/`
- `scenarios-folder-delete_2` — canonical `/test_framework/v1/scenarios/delete_folder/`, duplicates: `/test_framework/v1/scenarios-external/delete_folder/`
- `scenarios-bulk-delete_2` — canonical `/test_framework/v1/scenarios/delete_scenarios/`, duplicates: `/test_framework/v1/scenarios-external/delete_scenarios/`
- `scenarios-generate-bg_2` — canonical `/test_framework/v1/scenarios/generate-bg/`, duplicates: `/test_framework/v1/scenarios-external/generate-bg/`
- `scenarios-generate-progress_2` — canonical `/test_framework/v1/scenarios/generate-progress/`, duplicates: `/test_framework/v1/scenarios-external/generate-progress/`
- `scenarios-folder-move_2` — canonical `/test_framework/v1/scenarios/move_folder/`, duplicates: `/test_framework/v1/scenarios-external/move_folder/`
- `scenarios-folder-rename_2` — canonical `/test_framework/v1/scenarios/rename_folder/`, duplicates: `/test_framework/v1/scenarios-external/rename_folder/`
- `scenarios-run-voice_2` — canonical `/test_framework/v1/scenarios/run_scenarios/`, duplicates: `/test_framework/v1/scenarios-external/run_scenarios/`
- `scenarios-run-chirp_2` — canonical `/test_framework/v1/scenarios/run_scenarios_chirp/`, duplicates: `/test_framework/v1/scenarios-external/run_scenarios_chirp/`
- `scenarios-run-elevenlabs_2` — canonical `/test_framework/v1/scenarios/run_scenarios_elevenlabs/`, duplicates: `/test_framework/v1/scenarios-external/run_scenarios_elevenlabs/`
- `scenarios-run-livekit-v2_2` — canonical `/test_framework/v1/scenarios/run_scenarios_livekit_v2/`, duplicates: `/test_framework/v1/scenarios-external/run_scenarios_livekit_v2/`
- `scenarios-run-pipecat-v1_2` — canonical `/test_framework/v1/scenarios/run_scenarios_pipecat/`, duplicates: `/test_framework/v1/scenarios-external/run_scenarios_pipecat/`
- `scenarios-run-pipecat-v2_2` — canonical `/test_framework/v1/scenarios/run_scenarios_pipecat_v2/`, duplicates: `/test_framework/v1/scenarios-external/run_scenarios_pipecat_v2/`
- `scenarios-run-retell-webrtc_2` — canonical `/test_framework/v1/scenarios/run_scenarios_retell_webrtc/`, duplicates: `/test_framework/v1/scenarios-external/run_scenarios_retell_webrtc/`
- `scenarios-run-sip_2` — canonical `/test_framework/v1/scenarios/run_scenarios_sip/`, duplicates: `/test_framework/v1/scenarios-external/run_scenarios_sip/`
- `scenarios-run-text_2` — canonical `/test_framework/v1/scenarios/run_scenarios_text/`, duplicates: `/test_framework/v1/scenarios-external/run_scenarios_text/`
- `scenarios-run-vapi-webrtc_2` — canonical `/test_framework/v1/scenarios/run_scenarios_vapi_webrtc/`, duplicates: `/test_framework/v1/scenarios-external/run_scenarios_vapi_webrtc/`
- `scenarios-run-websocket_2` — canonical `/test_framework/v1/scenarios/run_scenarios_with_websockets/`, duplicates: `/test_framework/v1/scenarios-external/run_scenarios_with_websockets/`
- `scenarios-agent-create_2` — canonical `/test_framework/v1/scenarios/scenario-agent/`, duplicates: `/test_framework/v1/scenarios-external/scenario-agent/`
- `scenarios-agent-progress_2` — canonical `/test_framework/v1/scenarios/scenario-agent-progress/`, duplicates: `/test_framework/v1/scenarios-external/scenario-agent-progress/`

---
*Auto-generated from backend PR #9116.*

<!-- mcp-sync:file-hashes -->
```json
{}
```
<!-- /mcp-sync:file-hashes -->