### PR TITLE
[Auto] Sync docs for backend PR #9121

### DIFF
--- a/api-reference/test_framework/poll-async-clean-description-generation.mdx
+++ b/api-reference/test_framework/poll-async-clean-description-generation.mdx
@@ -1,0 +1,6 @@
+---
+title: Poll Async Clean Description Generation
+description: "Poll the result of a `generate_clean_description_bg` job. `status` is one of: `queued`, `processing`, `completed`, `failed`. On `completed`, `clean_description` and `thinking` are present."
+openapi: get /test_framework/v1/metrics/generate_clean_description_progress/
+slug: poll-async-clean-description-generation
+---

--- a/api-reference/test_framework/re-evaluate-metrics-across-multiple-results.mdx
+++ b/api-reference/test_framework/re-evaluate-metrics-across-multiple-results.mdx
@@ -1,0 +1,6 @@
+---
+title: Re-evaluate Metrics Across Multiple Results
+description: "Schedules re-evaluation of the given metrics against every completed/failed, non-deleted run of every selected result. Metrics are validated against each agent's metric scope; balance is checked for the full batch up front before any work is dispatched. Each affected result's status is flipped to RUNNING. Maximum 100 result IDs per request."
+openapi: post /test_framework/v1/results/bulk_evaluate_metrics/
+slug: re-evaluate-metrics-across-multiple-results
+---

--- a/api-reference/test_framework/soft-delete-multiple-results.mdx
+++ b/api-reference/test_framework/soft-delete-multiple-results.mdx
@@ -1,0 +1,6 @@
+---
+title: Soft-Delete Multiple Results
+description: "⚠ Irreversible. Soft-deletes each result (and its non-deleted runs) with the same side-effects as deleting a single result: outbound phone numbers are released when no queued runs remain, capacity-manager slots are freed, and active_sessions / pending_demand counters are decremented in aggregate. Maximum 100 result IDs per request. Results that are already deleted or that the caller cannot access are silently skipped — the response is 204 even when no results are deleted."
+openapi: post /test_framework/v1/results/bulk_delete/
+slug: soft-delete-multiple-results
+---

--- a/api-reference/test_framework/start-async-clean-description-generation.mdx
+++ b/api-reference/test_framework/start-async-clean-description-generation.mdx
@@ -1,0 +1,6 @@
+---
+title: Start Async Clean Description Generation
+description: "Enqueue a background job to generate a clean metric description. Returns a `progress_id`; poll `generate_clean_description_progress` until `status` is `completed` or `failed`."
+openapi: post /test_framework/v1/metrics/generate_clean_description_bg/
+slug: start-async-clean-description-generation
+---

--- a/cekura-mcp-server/mcp_tools.json
+++ b/cekura-mcp-server/mcp_tools.json
@@ -79,5 +79,8 @@
   },
   "metrics_generate_clean_description_bg_create": {
     "description_suffix": "File uploads not supported via MCP \u2014 the endpoint accepts multipart but MCP callers cannot send file attachments. Async \u2014 poll `metrics_generate_clean_description_progress_retrieve` until `status` is `completed` or `failed`."
+  },
+  "metrics_generate_clean_description_progress_retrieve": {
+    "description_suffix": "Async \u2014 poll this endpoint after calling `metrics_generate_clean_description_bg_create`. When `status` is `completed`, `clean_description` and `thinking` fields are present."
   }
 }

--- a/cekura-mcp-server/mcp_tools.json
+++ b/cekura-mcp-server/mcp_tools.json
@@ -1,105 +1,83 @@
 {
   "_comment": "Per-tool MCP enrichments. Applied on top of the OpenAPI-derived schema at registration time. Covers MCP-transport-specific limitations and cross-tool references not meaningful to plain REST callers.",
-
   "aiagents_upload_knowledge_base": {
     "description_suffix": "File uploads are not supported via MCP. Use the Cekura dashboard or Python SDK (`cekura.agents.upload_knowledge_base(id=..., files=[...])`) to upload files. Calling this tool without file parameters returns existing knowledge base metadata only."
   },
-
   "scenarios_run_voice": {
-    "description_suffix": "The run mode (voice / text / WebRTC) is determined by WHICH run endpoint you call — not by the agent config."
+    "description_suffix": "The run mode (voice / text / WebRTC) is determined by WHICH run endpoint you call \u2014 not by the agent config."
   },
-
   "scenarios_run_text": {
-    "description_suffix": "The run mode is determined by WHICH run endpoint you call — not by the agent config. DO NOT USE for voice-specific metrics (latency, pitch) — they will be zero."
+    "description_suffix": "The run mode is determined by WHICH run endpoint you call \u2014 not by the agent config. DO NOT USE for voice-specific metrics (latency, pitch) \u2014 they will be zero."
   },
-
   "scenarios_run_pipecat_v1": {
     "description_suffix": "The run mode is determined by WHICH run endpoint you call, not the agent config. Requires a Pipecat API key configured on the project."
   },
-
   "scenarios_run_websocket": {
     "description_suffix": "The run mode is determined by WHICH run endpoint you call, not the agent config."
   },
-
   "observe_create": {
-    "description_suffix": "File uploads not supported — use `voice_recording_url` instead of `voice_recording`. Do not pass `metric_ids` — causes a 500 error on current staging; use `call_logs_evaluate_metrics_create` after ingestion instead. Wrong roles silently produce an empty transcript with no error returned."
+    "description_suffix": "File uploads not supported \u2014 use `voice_recording_url` instead of `voice_recording`. Do not pass `metric_ids` \u2014 causes a 500 error on current staging; use `call_logs_evaluate_metrics_create` after ingestion instead. Wrong roles silently produce an empty transcript with no error returned."
   },
-
   "runs_bulk_retrieve": {
     "description_suffix": "`run_ids` must be a bare comma-separated string (e.g. `\"86368,86369\"`). Passing a JSON array `[86368, 86369]` or a JSON-quoted string both return `400: run_ids must be comma-separated integers`."
   },
-
   "call_logs_evaluate_metrics_create": {
-    "description_suffix": "Known issue: the `metrics` filter is not enforced — all metrics assigned to the call log are evaluated regardless of which IDs are passed."
+    "description_suffix": "Known issue: the `metrics` filter is not enforced \u2014 all metrics assigned to the call log are evaluated regardless of which IDs are passed."
   },
-
   "metrics_create": {
-    "description_suffix": "**Prefer `metrics_generate`** (AI-authored from agent prompt) over this tool unless the user has explicitly given concrete field values to write. Use `metrics_generate_clean_description_create` to clean up an existing description and `metrics_generate_evaluation_trigger_create` to derive a trigger. The `prompt` field is only active when explicitly setting `llm_provider` to a non-default value — for standard `llm_judge` metrics, the criterion goes in `description`. `assistant_id` is optional despite appearing required in some schema views — omit it entirely; passing an empty string returns a 400 error. `add_to_new_agents`: when omitted or `true`, this metric is automatically assigned to every new agent created in the project — set to `false` to scope to specific agents only. To attach a metric to evaluators after creation, use `scenarios_partial_update` with `metrics: [id1, id2, ...]`; use `metrics_list(agent_id=<id>)` to find available IDs."
+    "description_suffix": "**Prefer `metrics_generate`** (AI-authored from agent prompt) over this tool unless the user has explicitly given concrete field values to write. Use `metrics_generate_clean_description_create` to clean up an existing description and `metrics_generate_evaluation_trigger_create` to derive a trigger. The `prompt` field is only active when explicitly setting `llm_provider` to a non-default value \u2014 for standard `llm_judge` metrics, the criterion goes in `description`. `assistant_id` is optional despite appearing required in some schema views \u2014 omit it entirely; passing an empty string returns a 400 error. `add_to_new_agents`: when omitted or `true`, this metric is automatically assigned to every new agent created in the project \u2014 set to `false` to scope to specific agents only. To attach a metric to evaluators after creation, use `scenarios_partial_update` with `metrics: [id1, id2, ...]`; use `metrics_list(agent_id=<id>)` to find available IDs."
   },
-
   "metrics_partial_update": {
     "description_suffix": "**Prefer `metrics_generate_clean_description_create` / `metrics_generate_evaluation_trigger_create` / `metrics_simplify_prompt_create`** when refining metric fields with AI assistance. Use this raw patch only when the user has given concrete field values to write."
   },
-
   "scenarios_create": {
-    "description_suffix": "**Prefer `scenarios_generate_bg`** for authoring new scenarios — it accepts per-scenario `extra_instructions` so callers can shape each scenario individually. Use this raw create only when the user has given concrete field values to write. To refine an existing scenario, use `scenarios_agent_create` (natural-language improvement) or `scenarios_improve_instructions_create` (rewrites the `instructions` text)."
+    "description_suffix": "**Prefer `scenarios_generate_bg`** for authoring new scenarios \u2014 it accepts per-scenario `extra_instructions` so callers can shape each scenario individually. Use this raw create only when the user has given concrete field values to write. To refine an existing scenario, use `scenarios_agent_create` (natural-language improvement) or `scenarios_improve_instructions_create` (rewrites the `instructions` text)."
   },
-
   "scenarios_partial_update": {
     "description_suffix": "**Prefer `scenarios_agent_create`** (natural-language improvement of one or more scenarios) or `scenarios_improve_instructions_create` (rewrites just the `instructions` text). Use this raw patch only when the user has explicitly given concrete field values to write."
   },
-
   "scenarios_agent_create": {
-    "description_suffix": "Unified scenario-agent endpoint — clarifies (no `scenarios` field in payload) AND improves (with `scenarios` field). The `_create` suffix is a DRF/spectacular naming artifact, NOT a separate create endpoint. Use this whenever the user wants AI-driven scenario refinement; do not reach for `scenarios_create` for that case. Async — poll via `scenarios_agent_progress`."
+    "description_suffix": "Unified scenario-agent endpoint \u2014 clarifies (no `scenarios` field in payload) AND improves (with `scenarios` field). The `_create` suffix is a DRF/spectacular naming artifact, NOT a separate create endpoint. Use this whenever the user wants AI-driven scenario refinement; do not reach for `scenarios_create` for that case. Async \u2014 poll via `scenarios_agent_progress`."
   },
-
   "scenarios_generate_bg": {
-    "description_suffix": "Preferred path for authoring new scenarios. Accepts per-scenario `extra_instructions` so each generated scenario can be shaped individually — use this rather than `scenarios_create` unless the user has given concrete field values to write. Async — poll via `scenarios_generate_progress`."
+    "description_suffix": "Preferred path for authoring new scenarios. Accepts per-scenario `extra_instructions` so each generated scenario can be shaped individually \u2014 use this rather than `scenarios_create` unless the user has given concrete field values to write. Async \u2014 poll via `scenarios_generate_progress`."
   },
-
   "scenarios_improve_instructions_create": {
-    "description_suffix": "Lower-level instruction refiner: takes `agent` + `extra_instructions` and rewrites a scenario's `instructions` text. For multi-scenario or higher-level natural-language refinement use `scenarios_agent_create` instead. Async — poll via `scenarios_instructions_progress_retrieve`."
+    "description_suffix": "Lower-level instruction refiner: takes `agent` + `extra_instructions` and rewrites a scenario's `instructions` text. For multi-scenario or higher-level natural-language refinement use `scenarios_agent_create` instead. Async \u2014 poll via `scenarios_instructions_progress_retrieve`."
   },
-
   "aiagents_create": {
     "description_suffix": "When the goal is to *improve* an existing agent based on test results or natural-language feedback, prefer `scenarios_agent_create` (it can update agent fields as part of the improvement loop). Use this raw create only when the user has given concrete field values to write."
   },
-
   "aiagents_partial_update": {
     "description_suffix": "When refining an existing agent based on test results or natural-language feedback, prefer `scenarios_agent_create` or `runs_improve_prompt_create` / `runs_improve_prompt_bg_create` (run-driven prompt improvement). Use this raw patch only when the user has explicitly given concrete field values to write."
   },
-
   "metrics_list": {
-    "description_suffix": "Always pass `agent_id` or `project_id` — omitting both returns all metrics in your account (potentially hundreds, exceeding response limits). `metrics_list(agent_id=1234)` returns metrics accessible to that agent including both agent-level and project-level metrics."
+    "description_suffix": "Always pass `agent_id` or `project_id` \u2014 omitting both returns all metrics in your account (potentially hundreds, exceeding response limits). `metrics_list(agent_id=1234)` returns metrics accessible to that agent including both agent-level and project-level metrics."
   },
-
   "metrics_bulk_create": {
     "description_suffix": "Pass the array of metric objects as the `items` parameter. Each item accepts the same fields as `metrics_create`. Example: `items: [{\"name\": \"Empathy\", \"type\": \"llm_judge\", \"eval_type\": \"binary_qualitative\", \"description\": \"Did the agent show empathy?\", \"project\": 1234}]`. For `llm_judge` metrics, put the evaluation criterion in `description`, not `prompt`."
   },
-
   "test_profiles_partial_update": {
-    "description_suffix": "The `information` dict is replaced in full on every update — re-send the complete dict. Any key omitted will be deleted from the stored profile."
+    "description_suffix": "The `information` dict is replaced in full on every update \u2014 re-send the complete dict. Any key omitted will be deleted from the stored profile."
   },
-
   "scenarios_folder_move": {
     "description_suffix": "To assign a scenario to a folder, use `scenarios_partial_update` with the `folder_path` field instead."
   },
-
   "call_logs_create_scenarios_progress": {
     "description_suffix": "Done when `completed_scenarios + failed_scenarios >= total_scenarios`. The `scenarios_list` field is populated only after completion."
   },
-
   "scenarios_folder_delete": {
     "destructive": true,
     "description_suffix": "Recursively deletes the folder and all scenarios beneath it. Cannot be undone."
   },
-
   "scenarios_bulk_delete": {
     "destructive": true,
     "description_suffix": "Bulk delete affects every ID in the `scenarios` array. Always confirm the exact list with the user before calling."
   },
-
   "scenarios_bulk_update": {
-    "description_suffix": "Affects every ID in the `scenarios` array in one transaction. `append_instruction` is non-idempotent — re-running with the same value appends it again. For single-scenario edits prefer `scenarios_partial_update`."
+    "description_suffix": "Affects every ID in the `scenarios` array in one transaction. `append_instruction` is non-idempotent \u2014 re-running with the same value appends it again. For single-scenario edits prefer `scenarios_partial_update`."
+  },
+  "metrics_generate_clean_description_bg_create": {
+    "description_suffix": "File uploads not supported via MCP \u2014 the endpoint accepts multipart but MCP callers cannot send file attachments. Async \u2014 poll `metrics_generate_clean_description_progress_retrieve` until `status` is `completed` or `failed`."
   }
 }

--- a/mint.json
+++ b/mint.json
@@ -264,7 +264,9 @@
             "api-reference/test_framework/list-critical-metric-scenarios",
             "api-reference/test_framework/update-critical-metric-scenario",
             "api-reference/test_framework/metric-preview",
-            "api-reference/test_framework/metric-preview-progress"
+            "api-reference/test_framework/metric-preview-progress",
+            "api-reference/test_framework/start-async-clean-description-generation",
+            "api-reference/test_framework/poll-async-clean-description-generation"
           ]
         },
         {
@@ -362,7 +364,9 @@
             "api-reference/test_framework/post-test_frameworkresults-delete_runs",
             "api-reference/test_framework/post-test_frameworkresults-end_calls",
             "api-reference/test_framework/post-test_frameworkresults-create_shareable_link_token",
-            "api-reference/test_framework/ask-about-failures"
+            "api-reference/test_framework/ask-about-failures",
+            "api-reference/test_framework/soft-delete-multiple-results",
+            "api-reference/test_framework/re-evaluate-metrics-across-multiple-results"
           ]
         },
         {

--- a/openapi.json
+++ b/openapi.json
@@ -16382,6 +16382,91 @@
                 }
             }
         },
+        "/test_framework/v1/metrics-external/generate_clean_description_bg/": {
+            "post": {
+                "operationId": "metrics-external-generate-clean-description-bg-create",
+                "description": "Enqueue a background job to generate a clean metric description. Returns a `progress_id`; poll `generate_clean_description_progress` until `status` is `completed` or `failed`.",
+                "summary": "Start async clean description generation",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CleanMetricDescriptionRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CleanMetricDescriptionRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CleanMetricDescriptionRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GenerateCleanDescriptionBgResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/metrics-external/generate_clean_description_progress/": {
+            "get": {
+                "operationId": "metrics-external-generate-clean-description-progress-retrieve",
+                "description": "Poll the result of a `generate_clean_description_bg` job. `status` is one of: `queued`, `processing`, `completed`, `failed`. On `completed`, `clean_description` and `thinking` are present.",
+                "summary": "Poll async clean description generation",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "progress_id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "progress_id returned from generate_clean_description_bg",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GenerateCleanDescriptionProgressResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/test_framework/v1/metrics-external/generate_evaluation_trigger/": {
             "post": {
                 "operationId": "metrics-external-generate-evaluation-trigger-create",
@@ -17898,6 +17983,107 @@
                         "enabled": true,
                         "name": "metrics-generate-clean-description-create",
                         "description": "Generate a clean metric description based on agent description and metric description."
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/metrics/generate_clean_description_bg/": {
+            "post": {
+                "operationId": "metrics-generate-clean-description-bg-create",
+                "description": "Enqueue a background job to generate a clean metric description. Returns a `progress_id`; poll `generate_clean_description_progress` until `status` is `completed` or `failed`.",
+                "summary": "Start async clean description generation",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CleanMetricDescriptionRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CleanMetricDescriptionRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CleanMetricDescriptionRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GenerateCleanDescriptionBgResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "metrics-generate-clean-description-bg-create",
+                        "description": "Enqueue a background job to generate a clean metric description. Returns a `progress_id`; poll `generate_clean_description_progress` until `status` is `completed` or `failed`."
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/metrics/generate_clean_description_progress/": {
+            "get": {
+                "operationId": "metrics-generate-clean-description-progress-retrieve",
+                "description": "Poll the result of a `generate_clean_description_bg` job. `status` is one of: `queued`, `processing`, `completed`, `failed`. On `completed`, `clean_description` and `thinking` are present.",
+                "summary": "Poll async clean description generation",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "progress_id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "progress_id returned from generate_clean_description_bg",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GenerateCleanDescriptionProgressResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "metrics-generate-clean-description-progress-retrieve",
+                        "description": "Poll the result of a `generate_clean_description_bg` job. `status` is one of: `queued`, `processing`, `completed`, `failed`. On `completed`, `clean_description` and `thinking` are present."
                     }
                 }
             }
@@ -21993,6 +22179,122 @@
                 }
             }
         },
+        "/test_framework/v1/results-external/bulk_delete/": {
+            "post": {
+                "operationId": "bulk-delete-results",
+                "description": "⚠ Irreversible. Soft-deletes each result (and its non-deleted runs) with the same side-effects as deleting a single result: outbound phone numbers are released when no queued runs remain, capacity-manager slots are freed, and active_sessions / pending_demand counters are decremented in aggregate. Maximum 100 result IDs per request. Results that are already deleted or that the caller cannot access are silently skipped — the response is 204 even when no results are deleted.",
+                "summary": "Soft-delete multiple results",
+                "tags": [
+                    "Results"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostBulkDeleteResults"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostBulkDeleteResults"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostBulkDeleteResults"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No response body"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/results-external/bulk_evaluate_metrics/": {
+            "post": {
+                "operationId": "bulk-evaluate-result-metrics",
+                "description": "Schedules re-evaluation of the given metrics against every completed/failed, non-deleted run of every selected result. Metrics are validated against each agent's metric scope; balance is checked for the full batch up front before any work is dispatched. Each affected result's status is flipped to RUNNING. Maximum 100 result IDs per request.",
+                "summary": "Re-evaluate metrics across multiple results",
+                "tags": [
+                    "Results"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostBulkEvaluateResultMetrics"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostBulkEvaluateResultMetrics"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostBulkEvaluateResultMetrics"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No response body"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/test_framework/v1/results-external/bulk_export_progress/": {
             "get": {
                 "operationId": "results-external-bulk-export-progress-retrieve",
@@ -22985,6 +23287,122 @@
                         "enabled": true,
                         "name": "results-rerun-create",
                         "description": "Re-run a test result evaluation"
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/results/bulk_delete/": {
+            "post": {
+                "operationId": "bulk-delete-results_2",
+                "description": "⚠ Irreversible. Soft-deletes each result (and its non-deleted runs) with the same side-effects as deleting a single result: outbound phone numbers are released when no queued runs remain, capacity-manager slots are freed, and active_sessions / pending_demand counters are decremented in aggregate. Maximum 100 result IDs per request. Results that are already deleted or that the caller cannot access are silently skipped — the response is 204 even when no results are deleted.",
+                "summary": "Soft-delete multiple results",
+                "tags": [
+                    "Results"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostBulkDeleteResults"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostBulkDeleteResults"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostBulkDeleteResults"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No response body"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/results/bulk_evaluate_metrics/": {
+            "post": {
+                "operationId": "bulk-evaluate-result-metrics_2",
+                "description": "Schedules re-evaluation of the given metrics against every completed/failed, non-deleted run of every selected result. Metrics are validated against each agent's metric scope; balance is checked for the full batch up front before any work is dispatched. Each affected result's status is flipped to RUNNING. Maximum 100 result IDs per request.",
+                "summary": "Re-evaluate metrics across multiple results",
+                "tags": [
+                    "Results"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostBulkEvaluateResultMetrics"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostBulkEvaluateResultMetrics"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostBulkEvaluateResultMetrics"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No response body"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
                     }
                 }
             }
@@ -36032,7 +36450,7 @@
                                 "schema": {
                                     "type": "array",
                                     "items": {
-                                        "$ref": "#/components/schemas/AIAgentTestProfile"
+                                        "$ref": "#/components/schemas/AIAgentTestProfileList"
                                     }
                                 },
                                 "examples": {
@@ -36211,7 +36629,7 @@
                                 "schema": {
                                     "type": "array",
                                     "items": {
-                                        "$ref": "#/components/schemas/AIAgentTestProfile"
+                                        "$ref": "#/components/schemas/AIAgentTestProfileList"
                                     }
                                 },
                                 "examples": {
@@ -48288,10 +48706,68 @@
                         },
                         "description": "\nInformation fields for the test profile\nExample:\n```json\n{\n    \"user_name\": \"John Doe\",\n    \"user_email\": \"john.doe@example.com\",\n}\n```\n"
                     },
-                    "scenarios": {
+                    "created_by": {
+                        "type": "integer",
+                        "readOnly": true,
+                        "description": "ID of the user who created this test profile"
+                    },
+                    "last_updated_by": {
+                        "type": "integer",
+                        "readOnly": true,
+                        "description": "ID of the user who last updated this test profile"
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "description": "Timestamp when the test profile was created"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "description": "Timestamp when the test profile was last updated"
+                    }
+                },
+                "required": [
+                    "name"
+                ]
+            },
+            "AIAgentTestProfileList": {
+                "type": "object",
+                "description": "List variant that also embeds the scenarios attached to each profile.\n\nOnly used by `TestProfileViewSet.list` — retrieve/create/update and any\nnested usage (e.g. `ScenarioSerializer.test_profile_data`) should keep\nusing `AIAgentTestProfileSerializer`.",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "project": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
+                    },
+                    "agent": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
+                    },
+                    "agent_name": {
                         "type": "string",
                         "readOnly": true,
-                        "description": "List of scenarios using this test profile"
+                        "description": "\nName of the agent associated with this test profile\nExample: `\"Customer Support Agent\"`\n"
+                    },
+                    "name": {
+                        "type": "string",
+                        "maxLength": 255
+                    },
+                    "information": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "\nInformation fields for the test profile\nExample:\n```json\n{\n    \"user_name\": \"John Doe\",\n    \"user_email\": \"john.doe@example.com\",\n}\n```\n"
                     },
                     "created_by": {
                         "type": "integer",
@@ -48314,6 +48790,11 @@
                         "format": "date-time",
                         "readOnly": true,
                         "description": "Timestamp when the test profile was last updated"
+                    },
+                    "scenarios": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "List of scenarios using this test profile"
                     }
                 },
                 "required": [
@@ -49297,6 +49778,7 @@
             },
             "CallLogDetail": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -49483,6 +49965,7 @@
             },
             "CallLogList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -49868,6 +50351,33 @@
                         "readOnly": true
                     }
                 }
+            },
+            "CleanMetricDescriptionRequest": {
+                "type": "object",
+                "properties": {
+                    "agent": {
+                        "type": "integer"
+                    },
+                    "metric_description": {
+                        "type": "string"
+                    },
+                    "eval_type": {
+                        "enum": [
+                            "boolean",
+                            "numeric",
+                            "rating",
+                            "enum"
+                        ],
+                        "type": "string",
+                        "description": "* `boolean` - boolean\n* `numeric` - numeric\n* `rating` - rating\n* `enum` - enum",
+                        "x-spec-enum-id": "ae756482f906eddf"
+                    }
+                },
+                "required": [
+                    "agent",
+                    "eval_type",
+                    "metric_description"
+                ]
             },
             "Condition": {
                 "type": "object",
@@ -50583,6 +51093,7 @@
             },
             "Dashboard": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -50714,6 +51225,7 @@
             },
             "DashboardList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -51181,6 +51693,37 @@
                     "explanation",
                     "outcome_alignments",
                     "score"
+                ]
+            },
+            "GenerateCleanDescriptionBgResponse": {
+                "type": "object",
+                "properties": {
+                    "progress_id": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "progress_id"
+                ]
+            },
+            "GenerateCleanDescriptionProgressResponse": {
+                "type": "object",
+                "properties": {
+                    "status": {
+                        "type": "string"
+                    },
+                    "clean_description": {
+                        "type": "string"
+                    },
+                    "thinking": {
+                        "type": "string"
+                    },
+                    "error": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "status"
                 ]
             },
             "ImportPlivoNumber": {
@@ -52457,6 +53000,7 @@
             },
             "MetricList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -54710,6 +55254,7 @@
             },
             "PatchedCallLogDetail": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -55162,6 +55707,7 @@
             },
             "PatchedDashboard": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -57441,6 +57987,7 @@
             },
             "PatchedSchemaPostScenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "agent": {
                         "type": [
@@ -60251,6 +60798,7 @@
             },
             "RunList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -60650,6 +61198,7 @@
             },
             "Scenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -61524,6 +62073,7 @@
             },
             "ScenarioList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -61743,6 +62293,7 @@
             },
             "ScenarioSerializerV2": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -62403,6 +62954,49 @@
                     "name"
                 ]
             },
+            "SchemaPostBulkDeleteResults": {
+                "type": "object",
+                "properties": {
+                    "result_ids": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        },
+                        "description": "List of result IDs to soft-delete. Maximum 100 per request.",
+                        "maxItems": 100,
+                        "minItems": 1
+                    }
+                },
+                "required": [
+                    "result_ids"
+                ]
+            },
+            "SchemaPostBulkEvaluateResultMetrics": {
+                "type": "object",
+                "properties": {
+                    "result_ids": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        },
+                        "description": "Result IDs whose completed/failed runs should be re-evaluated. Maximum 100.",
+                        "maxItems": 100,
+                        "minItems": 1
+                    },
+                    "metric_ids": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        },
+                        "description": "Metric IDs to re-evaluate against every eligible run of each result.",
+                        "minItems": 1
+                    }
+                },
+                "required": [
+                    "metric_ids",
+                    "result_ids"
+                ]
+            },
             "SchemaPostCopyAgent": {
                 "type": "object",
                 "properties": {
@@ -62922,6 +63516,7 @@
             },
             "SchemaPostRunScenarios": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "agent_id": {
                         "type": "integer",
@@ -63145,6 +63740,7 @@
             },
             "SchemaPostScenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "agent": {
                         "type": [
@@ -63304,6 +63900,7 @@
             },
             "SchemaScenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",


### PR DESCRIPTION
Auto-generated docs sync for backend PR [#9121](https://github.com/cekura-ai/vocera.backend/pull/9121).

Reviewers: @dileep-chagam, @om-voceraai

## Summary

**Spec/overlay:** Buckets: A=1, B-new=2, B-retract=0, C=5. Confirmed renames: 0. SDK/CLI follow-ups: 2.

## Changes

- `openapi.json` — regenerate_from_backend
- `cekura-mcp-server/mcp_tools.json` — patch_json
- `cekura-mcp-server/mcp_tools.json` — patch_json

## Exposure suggestions (@mcp_expose candidates)

- **`bulk_delete_results`** (POST `/test_framework/v1/results/bulk_delete/`)
  - Bulk destructive operation on results. Co-located with other exposed result operations (`results_list`, `results_retrieve`, etc.). Consider adding `@mcp_expose()` if bulk management is user-facing.
- **`bulk_evaluate_result_metrics`** (POST `/test_framework/v1/results/bulk_evaluate_metrics/`)
  - Bulk metric re-evaluation across multiple results. Co-located with other exposed result operations. Consider adding `@mcp_expose()` if bulk re-evaluation is user-facing.

## SDK / CLI parity follow-ups

- `metrics_generate_clean_description_bg_create` (POST `/test_framework/v1/metrics/generate_clean_description_bg/`) — add
- `metrics_generate_clean_description_progress_retrieve` (GET `/test_framework/v1/metrics/generate_clean_description_progress/`) — add

## Duplicate URL variants surviving strip (mcp-hygiene)

- `call-logs-create-scenarios_2` — canonical `/observability/v1/call-logs/create_scenarios/`, duplicates: `/observability/v1/call-logs-external/create_scenarios/`
- `call-logs-create-scenarios-progress_2` — canonical `/observability/v1/call-logs/create_scenarios_progress/`, duplicates: `/observability/v1/call-logs-external/create_scenarios_progress/`
- `aiagents-upload-knowledge-base_2` — canonical `/test_framework/v1/aiagents/{id}/upload_knowledge_base/`, duplicates: `/test_framework/v1/aiagents-external/{id}/upload_knowledge_base/`
- `metrics-bulk-create_2` — canonical `/test_framework/v1/metrics/bulk_create/`, duplicates: `/test_framework/v1/metrics-external/bulk_create/`
- `metrics-generate_2` — canonical `/test_framework/v1/metrics/generate_metrics/`, duplicates: `/test_framework/v1/metrics-external/generate_metrics/`
- `metrics-preview-progress_2` — canonical `/test_framework/v1/metrics/preview-progress/`, duplicates: `/test_framework/v1/metrics-external/preview-progress/`
- `metrics-run-reviews-progress_2` — canonical `/test_framework/v1/metrics/run_reviews_progress/`, duplicates: `/test_framework/v1/metrics-external/run_reviews_progress/`
- `create-shareable-link-token_2` — canonical `/test_framework/v1/results/{id}/create_shareable_link_token/`, duplicates: `/test_framework/v1/results-external/{id}/create_shareable_link_token/`
- `delete-runs_2` — canonical `/test_framework/v1/results/{id}/delete_runs/`, duplicates: `/test_framework/v1/results-external/{id}/delete_runs/`
- `end-calls_2` — canonical `/test_framework/v1/results/{id}/end_calls/`, duplicates: `/test_framework/v1/results-external/{id}/end_calls/`
- `end-call_2` — canonical `/test_framework/v1/runs/{id}/end_call/`, duplicates: `/test_framework/v1/runs-external/{id}/end_call/`
- `scenarios-bulk-update_2` — canonical `/test_framework/v1/scenarios/adv_update/`, duplicates: `/test_framework/v1/scenarios-external/adv_update/`
- `scenarios-folder-create_2` — canonical `/test_framework/v1/scenarios/create_folder/`, duplicates: `/test_framework/v1/scenarios-external/create_folder/`
- `scenarios-create-from-transcript_2` — canonical `/test_framework/v1/scenarios/create_scenario_from_transcript/`, duplicates: `/test_framework/v1/scenarios-external/create_scenario_from_transcript/`
- `scenarios-folder-delete_2` — canonical `/test_framework/v1/scenarios/delete_folder/`, duplicates: `/test_framework/v1/scenarios-external/delete_folder/`
- `scenarios-bulk-delete_2` — canonical `/test_framework/v1/scenarios/delete_scenarios/`, duplicates: `/test_framework/v1/scenarios-external/delete_scenarios/`
- `scenarios-generate-bg_2` — canonical `/test_framework/v1/scenarios/generate-bg/`, duplicates: `/test_framework/v1/scenarios-external/generate-bg/`
- `scenarios-generate-progress_2` — canonical `/test_framework/v1/scenarios/generate-progress/`, duplicates: `/test_framework/v1/scenarios-external/generate-progress/`
- `scenarios-folder-move_2` — canonical `/test_framework/v1/scenarios/move_folder/`, duplicates: `/test_framework/v1/scenarios-external/move_folder/`
- `scenarios-folder-rename_2` — canonical `/test_framework/v1/scenarios/rename_folder/`, duplicates: `/test_framework/v1/scenarios-external/rename_folder/`
- `scenarios-run-voice_2` — canonical `/test_framework/v1/scenarios/run_scenarios/`, duplicates: `/test_framework/v1/scenarios-external/run_scenarios/`
- `scenarios-run-chirp_2` — canonical `/test_framework/v1/scenarios/run_scenarios_chirp/`, duplicates: `/test_framework/v1/scenarios-external/run_scenarios_chirp/`
- `scenarios-run-elevenlabs_2` — canonical `/test_framework/v1/scenarios/run_scenarios_elevenlabs/`, duplicates: `/test_framework/v1/scenarios-external/run_scenarios_elevenlabs/`
- `scenarios-run-livekit-v2_2` — canonical `/test_framework/v1/scenarios/run_scenarios_livekit_v2/`, duplicates: `/test_framework/v1/scenarios-external/run_scenarios_livekit_v2/`
- `scenarios-run-pipecat-v1_2` — canonical `/test_framework/v1/scenarios/run_scenarios_pipecat/`, duplicates: `/test_framework/v1/scenarios-external/run_scenarios_pipecat/`
- `scenarios-run-pipecat-v2_2` — canonical `/test_framework/v1/scenarios/run_scenarios_pipecat_v2/`, duplicates: `/test_framework/v1/scenarios-external/run_scenarios_pipecat_v2/`
- `scenarios-run-retell-webrtc_2` — canonical `/test_framework/v1/scenarios/run_scenarios_retell_webrtc/`, duplicates: `/test_framework/v1/scenarios-external/run_scenarios_retell_webrtc/`
- `scenarios-run-sip_2` — canonical `/test_framework/v1/scenarios/run_scenarios_sip/`, duplicates: `/test_framework/v1/scenarios-external/run_scenarios_sip/`
- `scenarios-run-text_2` — canonical `/test_framework/v1/scenarios/run_scenarios_text/`, duplicates: `/test_framework/v1/scenarios-external/run_scenarios_text/`
- `scenarios-run-vapi-webrtc_2` — canonical `/test_framework/v1/scenarios/run_scenarios_vapi_webrtc/`, duplicates: `/test_framework/v1/scenarios-external/run_scenarios_vapi_webrtc/`
- `scenarios-run-websocket_2` — canonical `/test_framework/v1/scenarios/run_scenarios_with_websockets/`, duplicates: `/test_framework/v1/scenarios-external/run_scenarios_with_websockets/`
- `scenarios-agent-create_2` — canonical `/test_framework/v1/scenarios/scenario-agent/`, duplicates: `/test_framework/v1/scenarios-external/scenario-agent/`
- `scenarios-agent-progress_2` — canonical `/test_framework/v1/scenarios/scenario-agent-progress/`, duplicates: `/test_framework/v1/scenarios-external/scenario-agent-progress/`

---
*Auto-generated from backend PR #9121.*

<!-- mcp-sync:file-hashes -->
```json
{}
```
<!-- /mcp-sync:file-hashes -->