### PR TITLE
[Auto] Sync docs for backend PR #8818

### DIFF
--- a/documentation/key-concepts/metrics/pre-defined-metrics.mdx
+++ b/documentation/key-concepts/metrics/pre-defined-metrics.mdx
@@ -34,7 +34,7 @@ These metrics evaluate whether your agent provides correct and consistent inform
   </Accordion>
 
   <Accordion title="Hallucination">
-    **Result**: True/False | **Cost**: 0.2 credits per call
+    **Result**: True/False | **Cost**: Variable, typically 0.01-0.1 credits per call
 
     Detects when the Main Agent provides information that contradicts or isn't supported by the uploaded Knowledge Base files. A Knowledge Base is a collection of files uploaded to the agent containing reference information for fact-checking. An LLM compares Main Agent responses against the Knowledge Base content.
 

--- a/openapi.json
+++ b/openapi.json
@@ -49297,6 +49297,7 @@
             },
             "CallLogDetail": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -49483,6 +49484,7 @@
             },
             "CallLogList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -50583,6 +50585,7 @@
             },
             "Dashboard": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -50714,6 +50717,7 @@
             },
             "DashboardList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -52457,6 +52461,7 @@
             },
             "MetricList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -54710,6 +54715,7 @@
             },
             "PatchedCallLogDetail": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -55162,6 +55168,7 @@
             },
             "PatchedDashboard": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -57441,6 +57448,7 @@
             },
             "PatchedSchemaPostScenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "agent": {
                         "type": [
@@ -60251,6 +60259,7 @@
             },
             "RunList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -60650,6 +60659,7 @@
             },
             "Scenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -61524,6 +61534,7 @@
             },
             "ScenarioList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -61743,6 +61754,7 @@
             },
             "ScenarioSerializerV2": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -62922,6 +62934,7 @@
             },
             "SchemaPostRunScenarios": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "agent_id": {
                         "type": "integer",
@@ -63145,6 +63158,7 @@
             },
             "SchemaPostScenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "agent": {
                         "type": [
@@ -63304,6 +63318,7 @@
             },
             "SchemaScenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",


### PR DESCRIPTION
Auto-generated docs sync for backend PR [#8818](https://github.com/cekura-ai/vocera.backend/pull/8818).

Reviewers: @dileep-chagam, @satvik-cek

## Summary

**Spec/overlay:** Schema-only update: 15 component schemas modified (no MCP exposure changes). openapi.json regeneration required.

**Conceptual docs:** Updated Hallucination metric cost from fixed '0.2 credits per call' to 'Variable, typically 0.01-0.1 credits per call' in pre-defined-metrics.mdx to reflect the new two-stage agentic RAG implementation that short-circuits low-cost calls with no verifiable factual claims.

## Changes

- `openapi.json` — regenerate_from_backend
- `documentation/key-concepts/metrics/pre-defined-metrics.mdx` — update

---
*Auto-generated from backend PR #8818.*

<!-- mcp-sync:file-hashes -->
```json
{
  "documentation/key-concepts/metrics/pre-defined-metrics.mdx": "3d19853d379db9a82a96e2b09669be0dda2b9fff3a9c2e13504ef25a46b2db34"
}
```
<!-- /mcp-sync:file-hashes -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cekura-ai/docs/pull/599" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->