### PR TITLE
Set Hallucination metric cost to 0.6 credits/call

### DIFF
--- a/documentation/key-concepts/metrics/pre-defined-metrics.mdx
+++ b/documentation/key-concepts/metrics/pre-defined-metrics.mdx
@@ -34,7 +34,7 @@ These metrics evaluate whether your agent provides correct and consistent inform
   </Accordion>
 
   <Accordion title="Hallucination">
-    **Result**: True/False | **Cost**: Variable, typically 0.01-0.1 credits per call
+    **Result**: True/False | **Cost**: 0.6 credits per call
 
     Detects when the Main Agent provides information that contradicts or isn't supported by the uploaded Knowledge Base files. A Knowledge Base is a collection of files uploaded to the agent containing reference information for fact-checking. An LLM compares Main Agent responses against the Knowledge Base content.
 


### PR DESCRIPTION
## Summary

Corrects the Hallucination metric cost in the predefined-metrics reference.

The cost field had been changed in PR #599 to `Variable, typically 0.01-0.1 credits per call`, which is inaccurate. The agentic RAG-accuracy implementation (backend PR cekura-ai/vocera.backend#8818) prices a single flat rate of **0.6 credits per call**.

## Change

- `documentation/key-concepts/metrics/pre-defined-metrics.mdx`: Hallucination Accordion cost line → `0.6 credits per call`

Companion updates:
- Skills: cekura-ai/cekura-skills (PR to follow)
- UI: cekura-ai/vocera.frontend.product (PR to follow)