### PR TITLE
Document main_agent_channel_index in custom observability guide

### DIFF
--- a/documentation/guides/observability/custom.mdx
+++ b/documentation/guides/observability/custom.mdx
@@ -113,6 +113,10 @@ Follow these steps to set up custom observability for your voice agents:
       const response = await axios.post(url, data, { headers });
       ```
     </CodeGroup>
+
+    <Info>
+      For stereo recordings, you can optionally pass `main_agent_channel_index` (`0` or `1`) in the request body to indicate which channel belongs to the main agent. The other channel is treated as the customer/testing agent. When omitted, Cekura attempts automatic channel detection. See the [full parameter reference](/api-reference/observability/send-calls#body-main-agent-channel-index-one-of-0).
+    </Info>
   </Tab>
 
   <Tab title="Vapi">


### PR DESCRIPTION
Customer asked where to find this parameter; it was only documented in the api-reference. Adds a callout in the Custom API tab linking back to the full parameter reference.

Slack thread: https://cekura.slack.com/archives/C0AKF1P1QF7/p1779352829189509?thread_ts=1779352826.204989&cid=C0AKF1P1QF7