### PR TITLE
Document contact_number caller-ID rule for outbound testing

### DIFF
--- a/documentation/guides/testing-agents/outbound-auto-call.mdx
+++ b/documentation/guides/testing-agents/outbound-auto-call.mdx
@@ -39,10 +39,15 @@ Auto Outbound Call is an automated testing feature where Cekura automatically in
 
 - **Outbound mode enabled**: Agent's `inbound` must be set to `false`
 - **Voice provider configured**: Valid API key and Assistant ID for your provider (Vapi, Retell, or ElevenLabs)
+- **Agent `contact_number` set to your outbound caller ID**: Cekura validates the caller ID (ANI) of every incoming outbound-test call against the agent's `contact_number` field. If the provider dials from `+15551234567`, the agent's `contact_number` must be exactly `+15551234567` in E.164 format. Set this in Agent settings or via the [Update Agent API](/api-reference/test_framework/update-agent-partial).
 - **Evaluators ready**: Created evaluators with valid phone numbers
 
 <Warning>
 **API Key Permissions:** Ensure your API key has outbound call permissions enabled. For ElevenLabs, enable "Conversational AI" and "Phone Number" permissions at https://elevenlabs.io/app/settings/api-keys
+</Warning>
+
+<Warning>
+**Caller ID mismatch causes silent rejects.** If the `contact_number` on your agent is empty or doesn't match the `from_number` your voice provider uses to place the call, Cekura drops the incoming call without returning a SIP error. The symptom on the provider side is `Busy`, `NoAnswer`, or a generic failed dial — no audio, no descriptive error. Confirm `contact_number` matches the provider's outbound caller ID before debugging anything further.
 </Warning>
 
 ## Enabling Auto Outbound Call
@@ -133,6 +138,10 @@ Your webhook should return:
 <AccordionGroup>
   <Accordion title="Calls Not Starting">
     Check that Auto Outbound Call is enabled, agent is in Outbound mode, and voice provider credentials are valid.
+  </Accordion>
+
+  <Accordion title="Calls Placed but Run Times Out (Busy / NoAnswer on Provider Side)">
+    The provider dialed but Cekura never picked up. Cekura rejects incoming outbound-test calls whose caller ID doesn't match a configured `contact_number` on any agent in your project. Open the agent under test and confirm its `contact_number` is set to the exact E.164 number the provider dials from (the `from_number` in the trigger webhook payload). An empty or mismatched `contact_number` causes every outbound attempt to be silently dropped — your provider logs will show `Busy` / `NoAnswer` / no-pickup with no audio and no SIP error explaining why. After correcting `contact_number`, trigger a fresh run; the timed-out runs cannot be recovered.
   </Accordion>
 
   <Accordion title="Failed to Initiate Call / Permission Errors">

--- a/documentation/guides/testing-agents/outbound-evaluators.mdx
+++ b/documentation/guides/testing-agents/outbound-evaluators.mdx
@@ -28,6 +28,16 @@ Testing outbound calls involves two main steps:
 1. Getting the list of evaluators with phone numbers
 2. Running the selected evaluators for outbound testing
 
+## Prerequisites
+
+- **Outbound mode enabled**: Agent's `inbound` must be set to `false`
+- **Agent `contact_number` set to your outbound caller ID**: Cekura validates the caller ID (ANI) of every incoming outbound-test call against the agent's `contact_number` field. If your agent dials from `+15551234567`, the agent's `contact_number` must be exactly `+15551234567` in E.164 format. Set this in Agent settings or via the [Update Agent API](/api-reference/test_framework/update-agent-partial).
+- **Evaluators ready**: Created evaluators with valid phone numbers
+
+<Warning>
+  **Caller ID mismatch causes silent rejects.** If the `contact_number` on your agent is empty or doesn't match the number your agent dials from, Cekura drops the incoming call without returning a SIP error your telephony provider can surface. The symptom on the provider side (Twilio, Telnyx, etc.) is `Busy`, `NoAnswer`, or a generic failed dial — no audio, no answer, no descriptive error. Confirm `contact_number` matches your actual outbound caller ID before debugging anything further downstream.
+</Warning>
+
 ## Getting Evaluators and Phone Numbers
 
 To retrieve the available evaluators and their associated phone numbers:
@@ -177,4 +187,19 @@ Once you have your list of evaluators and phone numbers:
 <Card title="API Reference" icon="link">
 Learn more about the [Running Evaluators API](/api-reference/test_framework/post-test_frameworkv1scenarios-externalrun_scenarios)
 </Card>
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="Calls show Busy / NoAnswer on your telephony provider but never reach Cekura">
+    Cekura rejects incoming outbound-test calls whose caller ID doesn't match a configured `contact_number` on any agent in your project. Open the agent under test and confirm its `contact_number` is set to the exact E.164 number your agent dials from. An empty or mismatched `contact_number` causes every outbound attempt to be silently dropped — the symptom on your provider side is `Busy` / `NoAnswer` / no-pickup, with no audio and no SIP error explaining why. After setting the correct `contact_number`, trigger a new run; existing runs that hit this state will remain in `timeout` and cannot be recovered.
+  </Accordion>
+
+  <Accordion title="Run status stays `timeout` with no transcript">
+    A `timeout` with `duration: 0` and an empty transcript means the call never connected to Cekura. Work through these in order:
+    1. **Caller-ID match** — see the entry above; this is the most common cause.
+    2. **Dial actually happened** — check your telephony provider's logs to confirm the outbound call was placed.
+    3. **Destination number** — confirm the number your agent dialed matches the `outbound_number` returned for that run in the bulk runs API response.
+  </Accordion>
+</AccordionGroup>
 


### PR DESCRIPTION
Cekura validates the caller ID of every incoming outbound-test call against the agent's contact_number; a mismatch causes a silent reject that surfaces as Busy/NoAnswer on the customer's telephony provider. This was an undocumented prerequisite that left customers debugging their provider when the fix was on the Cekura agent config.

Adds a Prerequisites bullet, a Warning callout, and a Troubleshooting accordion entry to both outbound-evaluators.mdx and outbound-auto-call.mdx.