### PR TITLE
MCP Fix: Stop sending body as query params

### DIFF
--- a/cekura-mcp-server/http_client.py
+++ b/cekura-mcp-server/http_client.py
@@ -1,6 +1,5 @@
 import httpx
 from typing import Dict, Any, Optional
-import re
 import json
 
 
@@ -24,77 +23,50 @@ class CekuraAPIClient:
         self,
         method: str,
         path: str,
-        params: Optional[Dict[str, Any]] = None,
-        body: Optional[Dict[str, Any]] = None,
+        query_params: Optional[Dict[str, Any]] = None,
+        body: Any = None,
         property_types: Optional[Dict[str, str]] = None,
     ) -> Dict[str, Any]:
-        params = params or {}
-        resolved_path, query_params = self._prepare_request(path, params)
-        url = f"{self.base_url}{resolved_path}"
-        request_body = self._build_request_body(body, params, property_types) if body else None
+        url = f"{self.base_url}{path}"
+        request_body = self._coerce_body(body, property_types) if body is not None else None
 
         try:
             response = await self.client.request(
                 method=method,
                 url=url,
-                params=query_params,
+                params=self._serialize_query(query_params or {}),
                 json=request_body,
             )
             return self._handle_response(response)
-
         except httpx.TimeoutException:
             raise Exception(f"Request timeout: {method} {url}")
         except httpx.RequestError as e:
             raise Exception(f"Request failed: {method} {url} - {str(e)}")
 
-    def _prepare_request(self, path: str, params: Dict[str, Any]) -> tuple[str, Dict[str, Any]]:
-        path_params = re.findall(r'\{(\w+)\}', path)
-        resolved_path = path
-        query_params = {}
-
-        for key, value in params.items():
-            if key in path_params:
-                resolved_path = resolved_path.replace(f"{{{key}}}", str(value))
-            else:
-                if value is not None:
-                    if isinstance(value, list):
-                        # Comma-separate lists for query params (e.g. run_ids, call_ids)
-                        query_params[key] = ",".join(str(v) for v in value)
-                    elif isinstance(value, dict):
-                        # JSON-serialize dicts for query params (e.g. filters_v2, filters)
-                        query_params[key] = json.dumps(value)
-                    else:
-                        query_params[key] = value
-
-        return resolved_path, query_params
-
-    def _build_request_body(
-        self,
-        body_schema: Optional[Dict[str, Any]],
-        params: Dict[str, Any],
-        property_types: Optional[Dict[str, str]] = None,
-    ) -> Any:
-        types = property_types or {}
-        if not body_schema:
-            body = {}
-            for k, v in params.items():
-                if v is not None:
-                    body[k] = self._parse_json_field(k, v, types.get(k))
-            return body
-
-        # Detect top-level array schemas (e.g. bulk_create endpoints).
-        # The parser exposes these as a single `items` parameter; unwrap it
-        # and send the array directly as the JSON body.
-        content = body_schema.get("content", {})
-        json_schema = content.get("application/json", {}).get("schema", {})
-        if json_schema.get("type") == "array" and "items" in params:
-            raw = params["items"]
-            return self._parse_json_field("items", raw, "array") if isinstance(raw, str) else raw
-
-        body = {}
+    @staticmethod
+    def _serialize_query(params: Dict[str, Any]) -> Dict[str, Any]:
+        out = {}
         for k, v in params.items():
-            if v is not None:
-                body[k] = self._parse_json_field(k, v, types.get(k))
+            if v is None:
+                continue
+            if isinstance(v, list):
+                out[k] = ",".join(str(x) for x in v)
+            elif isinstance(v, dict):
+                out[k] = json.dumps(v)
+            else:
+                out[k] = v
+        return out
+
+    def _coerce_body(self, body: Any, property_types: Optional[Dict[str, str]]) -> Any:
+        # Claude occasionally serializes dict/list arguments as strings; recover
+        # them based on the field's declared schema type. Strings declared as
+        # `type: string` are passed through verbatim (e.g. scenarios.instructions
+        # stores a stringified JSON payload that the backend reads literally).
+        types = property_types or {}
+        if isinstance(body, dict):
+            return {k: self._parse_json_field(k, v, types.get(k)) for k, v in body.items()}
+        if isinstance(body, str):
+            return self._parse_json_field("items", body, "array")
         return body
 
     # Schemas with a declared primitive type must never have their value coerced —

--- a/cekura-mcp-server/openapi_mcp_server.py
+++ b/cekura-mcp-server/openapi_mcp_server.py
@@ -2,10 +2,11 @@ import asyncio
 import json
 import logging
 import os
+import re
 import sys
 from contextvars import ContextVar
 from datetime import datetime, timezone
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple
 
 import httpx
 from mcp.server.fastmcp import FastMCP
@@ -469,6 +470,51 @@ def get_request_credential() -> tuple[str, str]:
         "No credential found. Connect via X-CEKURA-API-KEY header, Bearer token, or OAuth."
     )
 
+_PATH_PARAM_RE = re.compile(r'\{(\w+)\}')
+
+
+def _dispatch_args(op, arguments: Dict[str, Any]) -> Tuple[str, Dict[str, Any], Any]:
+    """Classify tool args into (resolved_path, query_params, body_payload).
+
+    Classification rules:
+    - Path params (matched against `{name}` placeholders) substituted into the URL.
+    - Query params (declared in OpenAPI `parameters` with `in: query`) sent in the URL.
+    - Everything else: routed to JSON body if the op has a requestBody, else to query.
+
+    For top-level array bodies (bulk endpoints), the `items` arg is unwrapped so
+    the body is sent as a bare JSON array.
+    """
+    path_param_names = set(_PATH_PARAM_RE.findall(op.path))
+    query_param_names = {
+        p["name"] for p in (op.parameters or [])
+        if p.get("in") == "query" and "name" in p
+    }
+    has_body = bool(op.request_body)
+
+    resolved_path = op.path
+    query_args: Dict[str, Any] = {}
+    body_args: Dict[str, Any] = {}
+
+    for key, value in arguments.items():
+        if value is None:
+            continue
+        if key in path_param_names:
+            resolved_path = resolved_path.replace(f"{{{key}}}", str(value))
+        elif key in query_param_names:
+            query_args[key] = value
+        elif has_body:
+            body_args[key] = value
+        else:
+            query_args[key] = value
+
+    if has_body:
+        schema = op.request_body.get("content", {}).get("application/json", {}).get("schema", {})
+        if schema.get("type") == "array" and "items" in body_args:
+            return resolved_path, query_args, body_args["items"]
+
+    return resolved_path, query_args, (body_args if has_body else None)
+
+
 def setup_dynamic_tool_handlers():
     from mcp.types import Tool as MCPTool
 
@@ -513,11 +559,13 @@ def setup_dynamic_tool_handlers():
                     k: v.get('type') for k, v in schema_properties.items() if isinstance(v, dict)
                 }
 
+                resolved_path, query_args, body_payload = _dispatch_args(op, arguments)
+
                 result = await user_api_client.execute_request(
                     method=op.method,
-                    path=op.path,
-                    params=arguments,
-                    body=op.request_body,
+                    path=resolved_path,
+                    query_params=query_args,
+                    body=body_payload,
                     property_types=property_types,
                 )
 

--- a/cekura-mcp-server/tests/test_dispatch_args.py
+++ b/cekura-mcp-server/tests/test_dispatch_args.py
@@ -1,0 +1,128 @@
+"""Tests for the dispatch-layer classifier that routes tool args into
+path / query / body buckets based on the OpenAPI operation shape."""
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from openapi_mcp_server import _dispatch_args
+
+
+@dataclass
+class FakeOp:
+    path: str
+    parameters: Optional[List[Dict[str, Any]]] = None
+    request_body: Optional[Dict[str, Any]] = None
+
+
+JSON_OBJECT_BODY = {
+    "content": {
+        "application/json": {
+            "schema": {"$ref": "#/components/schemas/PatchedAgent"}
+        }
+    }
+}
+
+JSON_ARRAY_BODY = {
+    "content": {
+        "application/json": {
+            "schema": {"type": "array", "items": {"type": "object"}}
+        }
+    }
+}
+
+
+class TestDispatchArgs:
+    def test_get_routes_everything_to_query(self):
+        op = FakeOp(
+            path="/aiagents/",
+            parameters=[{"name": "page", "in": "query"}, {"name": "project_id", "in": "query"}],
+        )
+        path, query, body = _dispatch_args(op, {"page": 1, "project_id": 5})
+        assert path == "/aiagents/"
+        assert query == {"page": 1, "project_id": 5}
+        assert body is None
+
+    def test_patch_routes_body_fields_to_body_not_query(self):
+        # The actual bug: PATCH with a $ref body schema. `description` must NOT
+        # land in the URL — only path params do.
+        op = FakeOp(
+            path="/aiagents/{id}/",
+            parameters=[{"name": "id", "in": "path"}],
+            request_body=JSON_OBJECT_BODY,
+        )
+        path, query, body = _dispatch_args(
+            op, {"id": 16959, "description": "A" * 8000, "agent_name": "Bot"}
+        )
+        assert path == "/aiagents/16959/"
+        assert query == {}
+        assert body == {"description": "A" * 8000, "agent_name": "Bot"}
+
+    def test_patch_with_explicit_query_param_preserved(self):
+        # POST/PATCH endpoints can declare query params (e.g. `project_id` on
+        # create). Those still belong in the URL.
+        op = FakeOp(
+            path="/aiagents/",
+            parameters=[{"name": "project_id", "in": "query"}],
+            request_body=JSON_OBJECT_BODY,
+        )
+        path, query, body = _dispatch_args(
+            op, {"project_id": 99, "description": "agent description"}
+        )
+        assert path == "/aiagents/"
+        assert query == {"project_id": 99}
+        assert body == {"description": "agent description"}
+
+    def test_top_level_array_body_unwrapped(self):
+        op = FakeOp(
+            path="/metrics/bulk_create/",
+            request_body=JSON_ARRAY_BODY,
+        )
+        path, query, body = _dispatch_args(
+            op, {"items": [{"name": "m1"}, {"name": "m2"}]}
+        )
+        assert path == "/metrics/bulk_create/"
+        assert query == {}
+        assert body == [{"name": "m1"}, {"name": "m2"}]
+
+    def test_path_substitution_multiple_params(self):
+        op = FakeOp(path="/aiagents/{agent_id}/tool/{tool_name}/")
+        path, _, _ = _dispatch_args(op, {"agent_id": 1, "tool_name": "search"})
+        assert path == "/aiagents/1/tool/search/"
+
+    def test_none_values_dropped(self):
+        op = FakeOp(
+            path="/aiagents/{id}/",
+            parameters=[{"name": "id", "in": "path"}],
+            request_body=JSON_OBJECT_BODY,
+        )
+        _, _, body = _dispatch_args(op, {"id": 1, "description": "x", "agent_name": None})
+        assert body == {"description": "x"}
+
+    def test_no_op_parameters_defaults_to_empty(self):
+        # op.parameters may be None or missing — should not crash.
+        op = FakeOp(path="/aiagents/{id}/", parameters=None, request_body=JSON_OBJECT_BODY)
+        path, query, body = _dispatch_args(op, {"id": 1, "description": "x"})
+        assert path == "/aiagents/1/"
+        assert query == {}
+        assert body == {"description": "x"}
+
+    def test_get_with_unknown_param_still_goes_to_query(self):
+        # If the caller passes a param not declared in `parameters` and there's
+        # no body, fall through to query (legacy permissive behaviour).
+        op = FakeOp(path="/aiagents/", parameters=[])
+        _, query, body = _dispatch_args(op, {"some_filter": "x"})
+        assert query == {"some_filter": "x"}
+        assert body is None
+
+    def test_large_payload_keeps_url_small(self):
+        # The regression test for the nginx 4094-byte Request-Line cap.
+        op = FakeOp(
+            path="/aiagents/{id}/",
+            parameters=[{"name": "id", "in": "path"}],
+            request_body=JSON_OBJECT_BODY,
+        )
+        path, query, _ = _dispatch_args(op, {"id": 1, "description": "X" * 100_000})
+        # URL contains only path; no query params.
+        assert path == "/aiagents/1/"
+        assert query == {}

--- a/cekura-mcp-server/tests/test_http_client.py
+++ b/cekura-mcp-server/tests/test_http_client.py
@@ -88,67 +88,58 @@ class TestParseJsonField:
         assert out == "[1, 2, 3]"
 
 
-class TestBuildRequestBodyPropertyTypes:
-    def test_property_types_routed_to_parse_json_field(self, client):
-        # Body with `instructions: string` should not be auto-parsed even when
-        # the value looks like JSON.
-        body_schema = {
-            "content": {
-                "application/json": {
-                    "schema": {"type": "object", "properties": {}}
-                }
-            }
-        }
-        instructions_payload = json.dumps({"role": "x"})
-        result = client._build_request_body(
-            body_schema,
-            {"name": "n", "instructions": instructions_payload},
+class TestCoerceBody:
+    """The HTTP client only applies field-level JSON coercion now. Classification
+    (path/query/body) is done upstream in the MCP server."""
+
+    def test_string_typed_field_not_coerced(self, client):
+        # `instructions` is `type: string` — even a JSON-looking value stays a string.
+        payload = json.dumps({"role": "x"})
+        result = client._coerce_body(
+            {"name": "n", "instructions": payload},
             property_types={"name": "string", "instructions": "string"},
         )
-        assert result["instructions"] == instructions_payload
+        assert result["instructions"] == payload
         assert isinstance(result["instructions"], str)
 
-    def test_property_types_allow_object_parse(self, client):
-        body_schema = {
-            "content": {
-                "application/json": {
-                    "schema": {"type": "object", "properties": {}}
-                }
-            }
-        }
+    def test_object_typed_field_coerced_from_string(self, client):
         payload = json.dumps({"role": "x"})
-        result = client._build_request_body(
-            body_schema,
+        result = client._coerce_body(
             {"conditional_actions": payload},
             property_types={"conditional_actions": "object"},
         )
         assert result["conditional_actions"] == {"role": "x"}
 
-    def test_top_level_array_body_still_unwrapped(self, client):
-        body_schema = {
-            "content": {
-                "application/json": {
-                    "schema": {"type": "array", "items": {"type": "object"}}
-                }
-            }
-        }
-        result = client._build_request_body(
-            body_schema,
-            {"items": json.dumps([{"a": 1}])},
-            property_types={"items": "array"},
+    def test_array_body_string_coerced(self, client):
+        # Top-level array body — caller unwrapped `items`, so we get a string here.
+        result = client._coerce_body(
+            json.dumps([{"a": 1}, {"b": 2}]),
+            property_types=None,
         )
+        assert result == [{"a": 1}, {"b": 2}]
+
+    def test_array_body_list_passthrough(self, client):
+        result = client._coerce_body([{"a": 1}], property_types=None)
         assert result == [{"a": 1}]
 
-    def test_no_property_types_falls_back_to_legacy_behavior(self, client):
-        body_schema = {
-            "content": {
-                "application/json": {
-                    "schema": {"type": "object", "properties": {}}
-                }
-            }
-        }
-        # Without type info, JSON-looking strings still get parsed (existing behaviour).
-        result = client._build_request_body(
-            body_schema, {"instructions": '{"role": "x"}'}, property_types=None
+    def test_no_property_types_legacy_parse(self, client):
+        # Without type info, JSON-looking strings still get parsed (legacy heuristic).
+        result = client._coerce_body(
+            {"instructions": '{"role": "x"}'}, property_types=None
         )
         assert result["instructions"] == {"role": "x"}
+
+
+class TestSerializeQuery:
+    def test_list_comma_separated(self, client):
+        assert client._serialize_query({"run_ids": [1, 2, 3]}) == {"run_ids": "1,2,3"}
+
+    def test_dict_json_serialized(self, client):
+        result = client._serialize_query({"filters": {"x": 1}})
+        assert result == {"filters": '{"x": 1}'}
+
+    def test_none_dropped(self, client):
+        assert client._serialize_query({"page": None, "size": 10}) == {"size": 10}
+
+    def test_scalar_passthrough(self, client):
+        assert client._serialize_query({"page": 1, "name": "x"}) == {"page": 1, "name": "x"}

--- a/mcp/codex-guide.mdx
+++ b/mcp/codex-guide.mdx
@@ -1,0 +1,59 @@
+---
+title: "Using Cekura with Codex"
+sidebarTitle: "Codex Guide"
+description: "End-to-end walkthrough: evaluate complex voice agents using OpenAI Codex CLI and the Cekura MCP"
+icon: "code"
+---
+
+import { CopyPageButton } from "/snippets/copy-page-button.mdx";
+
+<CopyPageButton />
+
+
+Use OpenAI's Codex CLI together with the Cekura MCP to design evaluators, run them against your voice agents, and triage the results — all from your terminal.
+
+## Quick Guide
+
+<Steps>
+  <Step title="Connect Codex to Cekura">
+    Add the Cekura MCP server to Codex. Edit `~/.codex/config.toml` and add:
+
+    ```toml
+    [mcp_servers.cekura]
+    url = "https://api.cekura.ai/mcp"
+    ```
+
+    On first use Codex opens a browser to authorize against your Cekura dashboard. For API-key-based auth (project-scoped credentials, shared CI access), use the CLI form instead:
+
+    ```bash
+    codex mcp add cekura --env CEKURA_API_KEY=YOUR_API_KEY_HERE -- \
+      sh -c 'npx -y mcp-remote https://api.cekura.ai/mcp --header "X-CEKURA-API-KEY:$CEKURA_API_KEY"'
+    ```
+
+    Verify by starting Codex and asking: *"List my Cekura agents."*
+  </Step>
+
+  <Step title="Set up mock data and cleanup hooks">
+    Complex agents depend on database state — users, accounts, sessions, entitlements. Stand up a lightweight webhook server that seeds mock data before a run and listens for Cekura's post-run webhook to reset the database. This keeps concurrent tests isolated and repeatable.
+  </Step>
+
+  <Step title="Let Codex learn the schema">
+    Run Codex from your agent's repo so it can read your tool definitions, prompts, and database schema directly. Then prompt it to generate scenario coverage through the Cekura MCP — for example: *"Read the agent's tools and prompts in this repo, then create 10 Cekura evaluators covering the most common user flows."*
+  </Step>
+
+  <Step title="Run the full suite">
+    Kick off all evaluators at once through the MCP: *"Run every evaluator on agent X and report pass/fail."* Cekura executes them concurrently and surfaces pass/fail with full transcripts and traces.
+  </Step>
+
+  <Step title="Triage with Codex">
+    Ask Codex to pull failing runs and classify them: *"Fetch the failures from the last run and tell me which are real bugs vs. flakes."* Because runs are non-deterministic, **rerun each failing test 3–4 times** and ask Codex to compute a pass rate. One pass out of four usually points to a prompt or tool-routing bug, not infra.
+  </Step>
+
+  <Step title="Fix in-place and re-run">
+    With both your codebase and the Cekura MCP in the same Codex session, you can go from failing transcript → suspected prompt or tool bug → edit → re-run the failing evaluator without leaving the terminal.
+  </Step>
+</Steps>
+
+<Tip>
+A good first prompt: *"Use the Cekura MCP to list my agents, then read the prompt for the first one and propose 10 workflow evaluators covering the most common user flows."*
+</Tip>

--- a/mcp/cursor-guide.mdx
+++ b/mcp/cursor-guide.mdx
@@ -1,0 +1,60 @@
+---
+title: "Using Cekura with Cursor"
+sidebarTitle: "Cursor Guide"
+description: "End-to-end walkthrough: evaluate complex voice agents using Cursor and the Cekura MCP"
+icon: "code"
+---
+
+import { CopyPageButton } from "/snippets/copy-page-button.mdx";
+
+<CopyPageButton />
+
+
+Use Cursor's agent mode together with the Cekura MCP to design evaluators, run them against your voice agents, and triage the results — all without leaving the editor.
+
+## Quick Guide
+
+<Steps>
+  <Step title="Connect Cursor to Cekura">
+    Add the Cekura MCP server to Cursor. Open **Cursor Settings → MCP → Add new MCP server** (or edit `~/.cursor/mcp.json` directly) and paste:
+
+    ```json
+    {
+      "mcpServers": {
+        "cekura": {
+          "command": "npx",
+          "args": ["mcp-remote", "https://api.cekura.ai/mcp"]
+        }
+      }
+    }
+    ```
+
+    On first use Cursor opens a browser to authorize against your Cekura dashboard. For API-key-based auth (project-scoped credentials, shared CI access), see the [MCP overview](/mcp/overview#configure-mcp-server-full-matrix).
+
+    Verify by asking Cursor's agent: *"List my Cekura agents."*
+  </Step>
+
+  <Step title="Set up mock data and cleanup hooks">
+    Complex agents depend on database state — users, accounts, sessions, entitlements. Stand up a lightweight webhook server that seeds mock data before a run and listens for Cekura's post-run webhook to reset the database. This keeps concurrent tests isolated and repeatable.
+  </Step>
+
+  <Step title="Let Cursor learn the schema">
+    Open your agent's repo in Cursor and ask the agent to read your tool definitions, prompts, and database schema. Then prompt it to generate scenario coverage through the Cekura MCP — for example: *"Read the agent's tools in `src/agent/tools.ts`, then create 10 Cekura evaluators covering the most common user flows."*
+  </Step>
+
+  <Step title="Run the full suite">
+    Kick off all evaluators at once through the MCP: *"Run every evaluator on agent X and stream the results."* Cekura executes them concurrently and surfaces pass/fail with full transcripts and traces.
+  </Step>
+
+  <Step title="Triage with Cursor">
+    Ask Cursor's agent to pull failing runs and classify them: *"Fetch the failures from the last run and tell me which are real bugs vs. flakes."* Because runs are non-deterministic, **rerun each failing test 3–4 times** and ask Cursor to compute a pass rate. One pass out of four usually points to a prompt or tool-routing bug, not infra.
+  </Step>
+
+  <Step title="Fix in-place and re-run">
+    Because Cursor has both your codebase and the Cekura MCP in the same context, you can go from failing transcript → suspected prompt or tool bug → edit → re-run the failing evaluator in a single thread.
+  </Step>
+</Steps>
+
+<Tip>
+A good first prompt: *"Use the Cekura MCP to list my agents, then read the prompt for the first one and propose 10 workflow evaluators covering the most common user flows."*
+</Tip>

--- a/mint.json
+++ b/mint.json
@@ -520,7 +520,9 @@
     {
       "group": "Guides",
       "pages": [
-        "mcp/claude-code-guide"
+        "mcp/claude-code-guide",
+        "mcp/cursor-guide",
+        "mcp/codex-guide"
       ]
     }
   ],


### PR DESCRIPTION
## Summary
- Add `mcp/cursor-guide.mdx` and `mcp/codex-guide.mdx`, mirroring the existing Claude Code MCP walkthrough so Cursor and Codex users each have a setup-to-triage flow tailored to their tooling (no embedded video, per request).
- Wire both pages into the Guides nav group in `mint.json`.

## Test plan
- [ ] `mintlify dev` renders both new pages under **Guides** without nav warnings.
- [ ] Setup snippets (Cursor `~/.cursor/mcp.json`, Codex `~/.codex/config.toml`, API-key CLI form) match the MCP overview matrix.
- [ ] Internal link `/mcp/overview#configure-mcp-server-full-matrix` resolves on preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)