### PR TITLE
fix(mcp): stop leaking tracebacks and /app/ paths in tool errors

### DIFF
--- a/cekura-mcp-server/openapi_mcp_server.py
+++ b/cekura-mcp-server/openapi_mcp_server.py
@@ -573,12 +573,11 @@ def setup_dynamic_tool_handlers():
                 return [{"type": "text", "text": json.dumps(result, default=str, ensure_ascii=False)}]
 
             except ValueError as e:
-                error_msg = f"Authentication Error: {str(e)}"
-                return [{"type": "text", "text": error_msg}]
+                return [{"type": "text", "text": f"Authentication Error: {e}"}]
             except Exception as e:
-                import traceback
-                error_msg = f"Error: {str(e)}\n{traceback.format_exc()}"
-                return [{"type": "text", "text": error_msg}]
+                # Log the traceback for ops; return only the actionable message to the LLM.
+                logger.exception("Tool %s failed", name)
+                return [{"type": "text", "text": f"Error: {e}"}]
         else:
             return await original_call_tool(name=name, arguments=arguments)
 


### PR DESCRIPTION
The tool dispatcher embedded `traceback.format_exc()` into every error response, exposing deployment file paths (`/app/http_client.py:143`) and ~500 chars of stack frames to the LLM. Three problems:

- Leaks internal layout to anyone who can trigger a tool error.
- Crowds out the actual actionable message in the LLM context window.
- Chained "During handling of the above exception" sections make the real cause hard to find.

Log the traceback via `logger.exception` for ops, return only the exception message to the caller. Before: ~600 chars including a full Python traceback. After: ~150 chars of just the error.