### PR TITLE
Add Failure-Mode Insights guide

### DIFF
--- a/documentation/guides/observability/insights.mdx
+++ b/documentation/guides/observability/insights.mdx
@@ -25,6 +25,8 @@ These insights surface the dominant patterns behind a metric's failures, so you 
 
 Navigate to **Observability → Insights** in the sidebar. The page displays a card for each LLM Judge metric enabled on your project.
 
+Use the **View** dropdown at the top of the page to filter by view. When a view is selected, the page shows only metrics and insights for agents in that view.
+
 Each card shows one of the following:
 - The latest failure-mode audit with identified themes
 - A message indicating not enough failures were found in the analyzed window

--- a/documentation/guides/observability/insights.mdx
+++ b/documentation/guides/observability/insights.mdx
@@ -19,14 +19,14 @@ For every project and every LLM Judge metric, Cekura runs a daily audit that:
 3. Has the agent read a sample of the calls, cluster them by **root cause**, and write a 1-6 theme breakdown.
 4. Saves the result on the metric's Insights card in the dashboard.
 
-The generated insights allow users to better understand the failure modes of their agent.
+These insights surface the dominant patterns behind a metric's failures, so you can fix the agent instead of re-reading every flagged call.
 
 ## Which metrics are eligible
 
 Only supported for LLM Judge type metrics as of now. Code based metrics such as Latency, WPM, Talk Ratio are excluded.
 
 - **Custom metrics** with `type: llm_judge`.
-- The following predefined metrics: **CSAT**, **Critical Deviations Continuous**, **Critical Info Check**, **Critical Info Check bool**, **Expected Outcome**, **Gibberish Detection**, **Hallucination**, **Letterwise Pronunciation Detection**, **Main Agent Early End Call**, **Not Early Termination**, **Pronunciation Analysis**, **Pronunciation test**, **Relevancy**, **Response Consistency**, **STT Errors**, **Tool call Accuracy**, **Unnecessary Repetition Count**, **Unnecessary Repetition Score**.
+- **Predefined metrics** — the following: CSAT, Critical Deviations Continuous, Critical Info Check, Critical Info Check bool, Expected Outcome, Gibberish Detection, Hallucination, Letterwise Pronunciation Detection, Main Agent Early End Call, Not Early Termination, Pronunciation Analysis, Pronunciation test, Relevancy, Response Consistency, STT Errors, Tool call Accuracy, Unnecessary Repetition Count, Unnecessary Repetition Score.
 
 ## How the daily run works
 

--- a/documentation/guides/observability/insights.mdx
+++ b/documentation/guides/observability/insights.mdx
@@ -34,11 +34,9 @@ A Celery Beat cron fires at **06:00 UTC** daily. For each (project, eligible-met
 
 If a metric has fewer than the minimum failing-call threshold even over 7 days, the card shows **"Not enough metric failure instances in last 7 days."**
 
-## On-demand generation
+## On-demand generation via API
 
-From the Insights page, hit **"Generate all"** to re-run every eligible metric for the current project without waiting for the next daily run. Cards transition through `pending → running → succeeded / failed` and the UI polls for completion.
-
-You can also drive this via the API:
+To re-run a single (project, metric) audit without waiting for the next daily run, call the generate endpoint:
 
 ```bash
 curl -X POST https://api.cekura.ai/api/projects/<project_id>/metric_failure_mode_insights/ \

--- a/documentation/guides/observability/insights.mdx
+++ b/documentation/guides/observability/insights.mdx
@@ -3,7 +3,7 @@ title: "Failure-Mode Insights"
 sidebarTitle: "Insights"
 icon: "lightbulb"
 iconType: "regular"
-description: "Cluster non-passing calls into qualitative failure-mode themes per metric, generated daily by an LLM agent that reads your call logs."
+description: "Cluster failing calls into qualitative failure-mode themes per metric, generated daily by an LLM agent that reads your call logs."
 ---
 
 import { CopyPageButton } from "/snippets/copy-page-button.mdx";
@@ -12,43 +12,25 @@ import { CopyPageButton } from "/snippets/copy-page-button.mdx";
 
 ## What it does
 
-For every project and every metric you've configured that emits a free-text explanation (LLM-judge metrics and a curated set of predefined metrics), Cekura runs a daily audit that:
+For every project and every LLM Judge metric, Cekura runs a daily audit that:
 
-1. Pulls all non-passing calls for that (project, metric) from the last 24 hours (falling back to 7 days if the day's pool is small).
+1. Pulls all failing calls for that (project, metric) from the last 24 hours (falling back to 7 days if the day's pool is small).
 2. Hands the transcripts, the metric card, and an audit prompt to an LLM agent.
-3. Has the agent read a sample of the calls, cluster them by **root cause** (not by score band), and write a 1-6 theme breakdown.
+3. Has the agent read a sample of the calls, cluster them by **root cause**, and write a 1-6 theme breakdown.
 4. Saves the result on the metric's Insights card in the dashboard.
 
-The themes answer **"why is this metric flagging?"** rather than restating the score distribution.
-
-## Where to see it
-
-Open your dashboard, pick a project, and click **Observability → Insights** in the left nav. You'll see one card per eligible metric, grouped into **Custom Metrics** and **Predefined Metrics**. Each card shows:
-
-- The latest headline (one-line summary of the metric's failures)
-- A 1-6 bullet list of failure-mode themes, with title + 1-2 sentence "why" + 2-3 example call IDs per theme
-- How many calls were analyzed and which window was used
-
-Cards auto-refresh after the daily run.
+The generated insights allow users to better understand the failure modes of their agent.
 
 ## Which metrics are eligible
 
-The audit only runs against metrics that produce a written explanation worth clustering. Specifically:
+Only supported for LLM Judge type metrics as of now. Code based metrics such as Latency, WPM, Talk Ratio are excluded.
 
 - **Custom metrics** with `type: llm_judge`.
-- A curated allowlist of predefined metrics: CSAT, Critical Deviations Continuous, Critical Info Check, Critical Info Check bool, Expected Outcome, Gibberish Detection, Hallucination, Letterwise Pronunciation Detection, Main Agent Early End Call, Not Early Termination, Pronunciation Analysis, Pronunciation test, Relevancy, Response Consistency, STT Errors, Tool call Accuracy, Unnecessary Repetition Count, Unnecessary Repetition Score.
-
-Pure numeric metrics that only emit a number (Latency, WPM, Talk Ratio, etc.) are excluded — clustering on a number only produces magnitude buckets, which isn't useful.
+- The following predefined metrics: **CSAT**, **Critical Deviations Continuous**, **Critical Info Check**, **Critical Info Check bool**, **Expected Outcome**, **Gibberish Detection**, **Hallucination**, **Letterwise Pronunciation Detection**, **Main Agent Early End Call**, **Not Early Termination**, **Pronunciation Analysis**, **Pronunciation test**, **Relevancy**, **Response Consistency**, **STT Errors**, **Tool call Accuracy**, **Unnecessary Repetition Count**, **Unnecessary Repetition Score**.
 
 ## How the daily run works
 
-A Celery Beat cron fires at **06:00 UTC** daily. For each (project, eligible-metric) pair, it:
-
-1. Scans the most recent 24 hours of call logs.
-2. If fewer than 500 calls flagged the metric, expands the window to the last 7 days.
-3. Random-samples up to 500 failing calls and ships their transcripts + metadata into an isolated cloud sandbox.
-4. Runs the audit prompt; the agent grep+reads its way through the data and writes a `failure_modes.json` file with the themes.
-5. Persists the result on the metric's Insights card.
+A Celery Beat cron fires at **06:00 UTC** daily. For each (project, eligible-metric) pair, our agent analyses the failing calls and writes the resulting themes to the metric's Insights card.
 
 If a metric has fewer than the minimum failing-call threshold even over 7 days, the card shows **"Not enough metric failure instances in last 7 days."**
 
@@ -77,11 +59,3 @@ curl https://api.cekura.ai/api/projects/<project_id>/metric_failure_mode_insight
 ```
 
 When `status` is `succeeded`, the `failure_modes` array contains the themes.
-
-## Privacy + data flow
-
-The audit ships call transcripts and metric scores into a third-party LLM provider (Cursor / Composer 2.5). Sensitive payloads (PII redaction, tool outputs) follow the same rules as the rest of the platform's LLM-evaluation pipeline. Contact [support@cekura.ai](mailto:support@cekura.ai) if you need to opt your organization out.
-
-## Costs
-
-Each per-(project, metric) audit costs roughly $0.05 in LLM provider tokens. At ~20 eligible metrics per project, the daily cron costs ~$1/project/day. On-demand "Generate all" runs charge the same per audit.

--- a/documentation/guides/observability/insights.mdx
+++ b/documentation/guides/observability/insights.mdx
@@ -21,6 +21,19 @@ For every project and every LLM Judge metric, Cekura runs a daily audit that:
 
 These insights surface the dominant patterns behind a metric's failures, so you can fix the agent instead of re-reading every flagged call.
 
+## Viewing and generating insights in the dashboard
+
+Navigate to **Observability → Insights** in the sidebar. The page displays a card for each LLM Judge metric enabled on your project.
+
+Each card shows one of the following:
+- The latest failure-mode audit with identified themes
+- A message indicating not enough failures were found in the analyzed window
+- A **Generate** button if no audit has run yet
+
+Click **Generate** (or **Regenerate** for an existing audit) to run a new analysis on demand. The page polls automatically until the audit completes.
+
+Each failure theme includes a title, a brief description, and clickable call IDs that link directly to the corresponding call logs.
+
 ## Which metrics are eligible
 
 Only supported for LLM Judge type metrics as of now. Code based metrics such as Latency, WPM, Talk Ratio are excluded.
@@ -36,7 +49,7 @@ If a metric has fewer than the minimum failing-call threshold even over 7 days, 
 
 ## On-demand generation via API
 
-To re-run a single (project, metric) audit without waiting for the next daily run, call the generate endpoint:
+For programmatic access, you can trigger an audit without waiting for the next daily run by calling the generate endpoint:
 
 ```bash
 curl -X POST https://api.cekura.ai/api/projects/<project_id>/metric_failure_mode_insights/ \

--- a/documentation/guides/observability/insights.mdx
+++ b/documentation/guides/observability/insights.mdx
@@ -1,0 +1,87 @@
+---
+title: "Failure-Mode Insights"
+sidebarTitle: "Insights"
+icon: "lightbulb"
+iconType: "regular"
+description: "Cluster non-passing calls into qualitative failure-mode themes per metric, generated daily by an LLM agent that reads your call logs."
+---
+
+import { CopyPageButton } from "/snippets/copy-page-button.mdx";
+
+<CopyPageButton />
+
+## What it does
+
+For every project and every metric you've configured that emits a free-text explanation (LLM-judge metrics and a curated set of predefined metrics), Cekura runs a daily audit that:
+
+1. Pulls all non-passing calls for that (project, metric) from the last 24 hours (falling back to 7 days if the day's pool is small).
+2. Hands the transcripts, the metric card, and an audit prompt to an LLM agent.
+3. Has the agent read a sample of the calls, cluster them by **root cause** (not by score band), and write a 1-6 theme breakdown.
+4. Saves the result on the metric's Insights card in the dashboard.
+
+The themes answer **"why is this metric flagging?"** rather than restating the score distribution.
+
+## Where to see it
+
+Open your dashboard, pick a project, and click **Observability → Insights** in the left nav. You'll see one card per eligible metric, grouped into **Custom Metrics** and **Predefined Metrics**. Each card shows:
+
+- The latest headline (one-line summary of the metric's failures)
+- A 1-6 bullet list of failure-mode themes, with title + 1-2 sentence "why" + 2-3 example call IDs per theme
+- How many calls were analyzed and which window was used
+
+Cards auto-refresh after the daily run.
+
+## Which metrics are eligible
+
+The audit only runs against metrics that produce a written explanation worth clustering. Specifically:
+
+- **Custom metrics** with `type: llm_judge`.
+- A curated allowlist of predefined metrics: CSAT, Critical Deviations Continuous, Critical Info Check, Critical Info Check bool, Expected Outcome, Gibberish Detection, Hallucination, Letterwise Pronunciation Detection, Main Agent Early End Call, Not Early Termination, Pronunciation Analysis, Pronunciation test, Relevancy, Response Consistency, STT Errors, Tool call Accuracy, Unnecessary Repetition Count, Unnecessary Repetition Score.
+
+Pure numeric metrics that only emit a number (Latency, WPM, Talk Ratio, etc.) are excluded — clustering on a number only produces magnitude buckets, which isn't useful.
+
+## How the daily run works
+
+A Celery Beat cron fires at **06:00 UTC** daily. For each (project, eligible-metric) pair, it:
+
+1. Scans the most recent 24 hours of call logs.
+2. If fewer than 500 calls flagged the metric, expands the window to the last 7 days.
+3. Random-samples up to 500 failing calls and ships their transcripts + metadata into an isolated cloud sandbox.
+4. Runs the audit prompt; the agent grep+reads its way through the data and writes a `failure_modes.json` file with the themes.
+5. Persists the result on the metric's Insights card.
+
+If a metric has fewer than the minimum failing-call threshold even over 7 days, the card shows **"Not enough metric failure instances in last 7 days."**
+
+## On-demand generation
+
+From the Insights page, hit **"Generate all"** to re-run every eligible metric for the current project without waiting for the next daily run. Cards transition through `pending → running → succeeded / failed` and the UI polls for completion.
+
+You can also drive this via the API:
+
+```bash
+curl -X POST https://api.cekura.ai/api/projects/<project_id>/metric_failure_mode_insights/ \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "metric_name": "Hallucination",
+    "window_days": 7,
+    "max_calls": 100
+  }'
+```
+
+Poll the returned row's `status` field until it's `succeeded` or `failed`:
+
+```bash
+curl https://api.cekura.ai/api/projects/<project_id>/metric_failure_mode_insights/<id>/ \
+  -H "Authorization: Bearer $API_KEY"
+```
+
+When `status` is `succeeded`, the `failure_modes` array contains the themes.
+
+## Privacy + data flow
+
+The audit ships call transcripts and metric scores into a third-party LLM provider (Cursor / Composer 2.5). Sensitive payloads (PII redaction, tool outputs) follow the same rules as the rest of the platform's LLM-evaluation pipeline. Contact [support@cekura.ai](mailto:support@cekura.ai) if you need to opt your organization out.
+
+## Costs
+
+Each per-(project, metric) audit costs roughly $0.05 in LLM provider tokens. At ~20 eligible metrics per project, the daily cron costs ~$1/project/day. On-demand "Generate all" runs charge the same per audit.

--- a/mint.json
+++ b/mint.json
@@ -138,7 +138,8 @@
           "pages": [
             "documentation/guides/observability/custom",
             "documentation/guides/observability/dynamic-prompting",
-            "documentation/guides/observability/pii-redaction"
+            "documentation/guides/observability/pii-redaction",
+            "documentation/guides/observability/insights"
           ]
         },
         "documentation/guides/dashboards",


### PR DESCRIPTION
## Summary
- New page at `documentation/guides/observability/insights.mdx` documenting the daily failure-mode insights surface.
- Covers eligibility (LLM-judge custom + curated predefined allowlist), the 24h→7d window expansion, the daily cron at 06:00 UTC, the on-demand "Generate all" / API path, data flow, and rough costs.

## Files
- `documentation/guides/observability/insights.mdx`: new guide
- `mint.json`: registers the new page under the Observability group

## Notes
Companion docs for cekura-ai/vocera.backend#9190.