### PR TITLE
feat(mcp): expose KB upload via JSON + preserve nested item schemas

### DIFF
--- a/cekura-mcp-server/mcp_tools.json
+++ b/cekura-mcp-server/mcp_tools.json
@@ -2,7 +2,7 @@
   "_comment": "Per-tool MCP enrichments. Applied on top of the OpenAPI-derived schema at registration time. Covers MCP-transport-specific limitations and cross-tool references not meaningful to plain REST callers.",
 
   "aiagents_upload_knowledge_base": {
-    "description_suffix": "File uploads are not supported via MCP. Use the Cekura dashboard or Python SDK (`cekura.agents.upload_knowledge_base(id=..., files=[...])`) to upload files. Calling this tool without file parameters returns existing knowledge base metadata only."
+    "description_suffix": "Pass each file as `{\"name\": \"manual.pdf\", \"content_base64\": \"...\"}` where `content_base64` is the file content base64-encoded (a raw base64 string or a `data:<mime>;base64,...` data URI both work). Max 50 MB per file. Allowed extensions: pdf, txt, json, csv, xml, md."
   },
 
   "scenarios_run_voice": {

--- a/cekura-mcp-server/openapi_parser.py
+++ b/cekura-mcp-server/openapi_parser.py
@@ -228,9 +228,30 @@ class OpenAPIParser:
                 properties[prop_name]["default"] = prop_schema["default"]
 
             if prop_type == "array" and "items" in prop_schema:
-                properties[prop_name]["items"] = {
-                    "type": self._convert_openapi_type(prop_schema["items"].get("type", "string"))
-                }
+                items_schema = prop_schema["items"]
+                if isinstance(items_schema, dict) and "$ref" in items_schema:
+                    try:
+                        items_schema = self.resolve_schema_ref(items_schema["$ref"])
+                    except (ValueError, KeyError):
+                        items_schema = {}
+                # Preserve nested object-item shape (name/required/properties) so
+                # callers know per-item structure for array-of-object fields.
+                if (
+                    isinstance(items_schema, dict)
+                    and items_schema.get("type") == "object"
+                    and items_schema.get("properties")
+                ):
+                    nested = self._extract_schema_properties(items_schema)
+                    item_entry: Dict[str, Any] = {"type": "object", "properties": nested}
+                    if items_schema.get("required"):
+                        item_entry["required"] = list(items_schema["required"])
+                    properties[prop_name]["items"] = item_entry
+                else:
+                    properties[prop_name]["items"] = {
+                        "type": self._convert_openapi_type(items_schema.get("type", "string"))
+                        if isinstance(items_schema, dict)
+                        else "string"
+                    }
 
         return properties
 

--- a/openapi.json
+++ b/openapi.json
@@ -11291,7 +11291,7 @@
         "/test_framework/v1/aiagents-external/{id}/upload_knowledge_base/": {
             "post": {
                 "operationId": "aiagents-upload-knowledge-base",
-                "description": "Upload one or more files to the agent's knowledge base. Supports multiple file uploads.",
+                "description": "Upload one or more files to the agent's knowledge base. Accepts either a `multipart/form-data` body (used by the web dashboard) or an `application/json` body where each entry carries base64-encoded file content.",
                 "parameters": [
                     {
                         "in": "path",
@@ -11337,6 +11337,38 @@
                                             "format": "binary"
                                         },
                                         "description": "List of files to upload to the knowledge base"
+                                    }
+                                },
+                                "required": [
+                                    "files"
+                                ]
+                            }
+                        },
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "files": {
+                                        "type": "array",
+                                        "description": "List of files to upload, each provided as base64-encoded content.",
+                                        "items": {
+                                            "type": "object",
+                                            "required": [
+                                                "name",
+                                                "content_base64"
+                                            ],
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string",
+                                                    "description": "Filename including extension (e.g. `manual.pdf`)."
+                                                },
+                                                "content_base64": {
+                                                    "type": "string",
+                                                    "contentEncoding": "base64",
+                                                    "description": "Base64-encoded file content. Accepts a raw base64 string or a `data:<mime>;base64,...` data URI."
+                                                }
+                                            }
+                                        }
                                     }
                                 },
                                 "required": [
@@ -13208,7 +13240,7 @@
         "/test_framework/v1/aiagents/{id}/upload_knowledge_base/": {
             "post": {
                 "operationId": "aiagents-upload-knowledge-base_2",
-                "description": "Upload one or more files to the agent's knowledge base. Supports multiple file uploads.",
+                "description": "Upload one or more files to the agent's knowledge base. Accepts either a `multipart/form-data` body (used by the web dashboard) or an `application/json` body where each entry carries base64-encoded file content.",
                 "parameters": [
                     {
                         "in": "path",
@@ -13260,6 +13292,38 @@
                                     "files"
                                 ]
                             }
+                        },
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "files": {
+                                        "type": "array",
+                                        "description": "List of files to upload, each provided as base64-encoded content.",
+                                        "items": {
+                                            "type": "object",
+                                            "required": [
+                                                "name",
+                                                "content_base64"
+                                            ],
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string",
+                                                    "description": "Filename including extension (e.g. `manual.pdf`)."
+                                                },
+                                                "content_base64": {
+                                                    "type": "string",
+                                                    "contentEncoding": "base64",
+                                                    "description": "Base64-encoded file content. Accepts a raw base64 string or a `data:<mime>;base64,...` data URI."
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "required": [
+                                    "files"
+                                ]
+                            }
                         }
                     }
                 },
@@ -13303,7 +13367,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "aiagents-upload-knowledge-base",
-                        "description": "Upload one or more files to the agent's knowledge base. Supports multiple file uploads."
+                        "description": "Upload one or more files to the agent's knowledge base. Accepts either a `multipart/form-data` body (used by the web dashboard) or an `application/json` body where each entry carries base64-encoded file content."
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Three coordinated changes alongside the backend PR https://github.com/cekura-ai/vocera.backend/pull/9247:

- **`mcp_tools.json`** — replace the "not supported via MCP" suffix on `aiagents_upload_knowledge_base` with a usage hint describing the `{name, content_base64}` shape.
- **`openapi_parser.py`** — preserve nested item shape for array-of-object body params. Previously these were collapsed to `items: {type: object}` (or worse, `items: {type: string}` when the OpenAPI spec used `$ref`-resolved nested schemas). Now we emit the full `properties` + `required` from the spec.
- **`openapi.json`** — regenerated to include `application/json` content on both `aiagents-upload-knowledge-base` paths.

## Cross-tool impact of the parser change

I dumped all 145 registered tool schemas before and after, then diffed:

- **108 tools**: byte-identical schema and description.
- **18 tools**: only difference is `required` array ordering (Python `set()` non-determinism in pre-existing parser code).
- **19 tools**: real schema differences — all the same pattern. Previously their array-of-object body fields had `items: {type: string}` (a pre-existing bug — those items are objects). Now they have the correct nested object shape from the spec.

No tool's runtime behavior changes (the schema is advisory metadata, not wire validation). Functionally verified by exercising every read-only tool (47 of them) through MCP → backend → MCP — zero roundtrip failures, zero schema-related parse errors.

Tools whose `items` schema is now corrected:

`aiagents_upload_knowledge_base` (new field), `call_logs_improve_prompt_bg_create`, `call_logs_improve_prompt_create`, `call_logs_improve_prompt_issues_create`, `dashboards_create`, `dashboards_partial_update`, `metrics_generate_clean_description_create`, `metrics_generate_evaluation_trigger_create`, `projects_create`, `projects_partial_update`, `runs_improve_prompt_bg_create`, `runs_improve_prompt_issues_create`, `scenarios_create_from_transcript`, `scenarios_run_livekit_v2`, `scenarios_run_pipecat_v1`, `scenarios_run_pipecat_v2`, `scenarios_run_websocket`, `test_sets_create_from_call_log`, `test_sets_create_from_run`.

## Test plan

- [x] Existing MCP server tests still pass (69/75; the 5 failures pre-existed and are config-loading / description-truncation issues unrelated to this).
- [x] End-to-end MCP smoke: tool schema exposes `files: [{name, content_base64}]` correctly; validation errors propagate through MCP; happy path uploads a file and creates a `KnowledgeBaseFile` row (verified with `FileSystemStorage` locally because the dev env's Supabase storage is unconfigured).
- [x] Schema diff before/after change for all 145 tools, with cross-tool functional regression check via every read-only tool.
- [ ] Backend PR merged so the `application/json` content type is available in production.