### PR TITLE
Add walkthrough video to ElevenLabs testing guide

### DIFF
--- a/documentation/integrations/elevenlabs/testing.mdx
+++ b/documentation/integrations/elevenlabs/testing.mdx
@@ -10,6 +10,8 @@ import { CopyPageButton } from "/snippets/copy-page-button.mdx";
 
 <CopyPageButton />
 
+<iframe src="https://www.youtube.com/embed/o7ZqAGMuYQY" title="YouTube video player" frameborder="0" className="w-full aspect-video rounded-xl" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen />
+
 ## Overview
 
 Test your ElevenLabs agents using multiple methods: phone numbers, websockets, or chat interfaces. Choose the testing method that best fits your use case.


### PR DESCRIPTION
## Summary
- Embed the YouTube walkthrough (https://youtu.be/o7ZqAGMuYQY) just above the Overview section of the ElevenLabs testing guide.

## Test plan
- [ ] Verify the iframe renders correctly on the live docs site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)