### PR TITLE
feat(mcp): capture Mcp-Session-Id, forward as X-MCP-Session-Id

### DIFF
--- a/cekura-mcp-server/http_client.py
+++ b/cekura-mcp-server/http_client.py
@@ -15,6 +15,7 @@ class CekuraAPIClient:
         mcp_tool: Optional[str] = None,
         mcp_skill: Optional[str] = None,
         conversation_id: Optional[str] = None,
+        mcp_session_id: Optional[str] = None,
     ):
         self.base_url = base_url
         auth_header = (
@@ -30,6 +31,7 @@ class CekuraAPIClient:
                 ("X-MCP-Tool", mcp_tool),
                 ("X-MCP-Skill", mcp_skill),
                 ("X-Cekura-Conversation-Id", conversation_id),
+                ("X-MCP-Session-Id", mcp_session_id),
             )
             if value
         }
@@ -182,6 +184,7 @@ def create_client(
     mcp_tool: Optional[str] = None,
     mcp_skill: Optional[str] = None,
     conversation_id: Optional[str] = None,
+    mcp_session_id: Optional[str] = None,
 ) -> CekuraAPIClient:
     return CekuraAPIClient(
         base_url,
@@ -193,4 +196,5 @@ def create_client(
         mcp_tool=mcp_tool,
         mcp_skill=mcp_skill,
         conversation_id=conversation_id,
+        mcp_session_id=mcp_session_id,
     )

--- a/cekura-mcp-server/openapi_mcp_server.py
+++ b/cekura-mcp-server/openapi_mcp_server.py
@@ -59,6 +59,10 @@ request_base_url: ContextVar[str] = ContextVar('request_base_url', default=None)
 # wires its conversation_id here). Per-call `_meta["com.cekura/conversation_id"]`
 # wins when both are present.
 request_conversation_id: ContextVar[str] = ContextVar('request_conversation_id', default=None)
+# MCP streamable-http session id (``Mcp-Session-Id``). Captured so external
+# analytics can group an external client's tool calls into a chat session
+# without relying on a per-call conversation id.
+request_mcp_session_id: ContextVar[str] = ContextVar('request_mcp_session_id', default=None)
 
 # X-CEKURA-BASE-URL override is only allowed when explicitly enabled (dev/staging only)
 _ALLOW_BASE_URL_OVERRIDE = os.environ.get("ALLOW_BASE_URL_OVERRIDE", "").lower() in ("1", "true", "yes")
@@ -754,11 +758,13 @@ def _resolve_telemetry() -> Dict[str, Optional[str]]:
     meta = _read_request_meta()
     skill = meta.get("com.cekura/skill")
     conversation_id = meta.get("com.cekura/conversation_id") or request_conversation_id.get()
+    mcp_session_id = request_mcp_session_id.get()
     return {
         "call_id": f"call_{uuid.uuid4().hex[:16]}",
         "client_id": _resolve_client_identifier(),
         "skill": skill if isinstance(skill, str) and skill else None,
         "conversation_id": conversation_id if isinstance(conversation_id, str) and conversation_id else None,
+        "mcp_session_id": mcp_session_id if isinstance(mcp_session_id, str) and mcp_session_id else None,
     }
 
 
@@ -858,6 +864,7 @@ def setup_dynamic_tool_handlers():
                 mcp_tool=name,
                 mcp_skill=telemetry["skill"],
                 conversation_id=telemetry["conversation_id"],
+                mcp_session_id=telemetry["mcp_session_id"],
             )
 
             # Forward the resolved per-property types so the HTTP client can respect
@@ -968,6 +975,14 @@ def main():
             )
             if conversation_header:
                 request_conversation_id.set(conversation_header)
+
+            # MCP protocol session identifier (issued on `initialize`).
+            mcp_session_header = (
+                request.headers.get('Mcp-Session-Id')
+                or request.headers.get('mcp-session-id')
+            )
+            if mcp_session_header:
+                request_mcp_session_id.set(mcp_session_header)
 
             # Enforce auth at the transport layer for MCP traffic. Without this,
             # FastMCP's `initialize` and `tools/list` succeed unauthenticated,


### PR DESCRIPTION
Streamable-http clients (Claude Code, Claude.ai) receive an Mcp-Session-Id from the server on `initialize` and echo it on every subsequent call — a protocol-native chat-session boundary. We now capture it in middleware, expose it via _resolve_telemetry(), and forward as X-MCP-Session-Id on backend HTTP calls.

The backend (vocera.backend) folds the header into api_request_events.metadata.mcp.session_id, which the new self-observe exporter uses to group an external user's tool calls into coherent sessions without needing a per-call conversation_id (only the Cekura sandbox sets that today).

Stdio MCP callers without a session header are still handled analytics-side via a (user_hash, client) + idle-gap fallback.