### PR TITLE
docs(mcp): add Claude Desktop setup guide

### DIFF
--- a/mcp/claude-desktop-guide.mdx
+++ b/mcp/claude-desktop-guide.mdx
@@ -1,0 +1,147 @@
+---
+title: "Using Cekura with Claude Desktop"
+sidebarTitle: "Claude Desktop Guide"
+description: "End-to-end setup: install the Cekura plugin in Claude Desktop, connect the MCP, and add your own custom skills"
+icon: "desktop"
+---
+
+import { CopyPageButton } from "/snippets/copy-page-button.mdx";
+
+<CopyPageButton />
+
+
+This is the single-page setup for Claude Desktop. Everything you need — Cekura skills, the MCP server, and your own custom skills — installs in a few minutes through the Claude Desktop plugin marketplace.
+
+<Note>
+**One-line summary:** install the **`cekura`** plugin from `https://github.com/cekura-ai/cekura-skills.git` via **Settings → Plugins**, finish the MCP OAuth sign-in, and you're done. Custom skills live in the **`~/.claude/skills/`** folder or in your own marketplace fork.
+</Note>
+
+## What you'll set up
+
+1. **Cekura plugin** — bundles the nine Cekura skills and auto-configures the MCP server.
+2. **MCP authorization** — one-click OAuth into your Cekura workspace.
+3. **Custom skills** — your own organization-specific playbooks, installed alongside the Cekura ones.
+
+## Prerequisites
+
+- A [Cekura dashboard](https://dashboard.cekura.ai) account.
+- A current Claude Desktop build (Mac or Windows) with **Plugins** enabled. On Team/Enterprise, a workspace admin must enable Plugins and Connectors at the org level first.
+- No Node.js, no API keys, and no manual config-file editing for the default OAuth path.
+
+## 1. Install the Cekura plugin
+
+The plugin ships all nine Cekura skills plus the MCP server configuration in a single install — same `cekura-ai/cekura-skills` marketplace used by Claude Code.
+
+<Steps>
+  <Step title="Open the plugin manager">
+    Claude Desktop → **Settings** → **Plugins**.
+  </Step>
+
+  <Step title="Add the Cekura marketplace">
+    Click **Marketplaces** → **Add marketplace**. Paste:
+
+    ```
+    https://github.com/cekura-ai/cekura-skills.git
+    ```
+
+    Confirm. Claude Desktop fetches the marketplace manifest.
+  </Step>
+
+  <Step title="Install the `cekura` plugin">
+    Switch to the **Discover** (or **Plugins**) tab, search `cekura`, and install. This registers the nine skills and adds the Cekura MCP server to your connector list.
+  </Step>
+
+  <Step title="Authorize the MCP">
+    Open a new chat. On the first Cekura tool call, Claude Desktop opens a browser for OAuth — sign into your Cekura dashboard and click **Authorize**. The session token is managed for you.
+  </Step>
+
+  <Step title="Verify">
+    Ask: *"Use the Cekura MCP to list my agents, then use the Cekura skills to propose 10 workflow evaluators covering the most common flows for the first agent."*
+
+    Claude should call `aiagents_list`, load the `cekura-eval-design` skill, and draft evaluators. If you get `401 Unauthorized`, reconnect from **Settings → Connectors → Cekura**.
+  </Step>
+</Steps>
+
+<Tip>
+**Auto-update.** In the plugin manager, select **cekura-skills → Enable auto-update**. New skill versions and tool overlays land in your next session without re-installing. Same mechanism as Claude Code.
+</Tip>
+
+### What you get out of the box
+
+| Capability | What it does |
+|---|---|
+| 9 Cekura skills | Auto-activate on phrases like *"design a metric for…"* or *"fix this failing run…"* — full catalog in [Skills overview](/mcp/skills). |
+| Cekura MCP server | 84+ tools for agents, evaluators, metrics, runs, and call logs. Configuration in [MCP overview](/mcp/overview). |
+| Skill activation logs | Visible in Claude's chain-of-thought when the matching skill loads. |
+
+<Note>
+**Slash commands** (`/create-metric`, `/run-evals`, etc.) are a Claude Code-only feature today. In Claude Desktop, you describe the task in plain English and Claude auto-activates the matching skill. The end result is the same — Claude calls the same MCP tools under the hood.
+</Note>
+
+## 2. Add your own custom skills
+
+Custom skills encode organization-specific knowledge — naming conventions, compliance checks, internal runbooks — and activate the same way the Cekura ones do.
+
+### Skill structure
+
+A skill is a folder with one required file, `SKILL.md`, plus any supporting files it references.
+
+```
+my-team-eval-conventions/
+├── SKILL.md            ← required
+├── naming-rules.md     ← optional, referenced from SKILL.md
+└── examples/
+    └── good-eval.yaml
+```
+
+`SKILL.md` starts with YAML frontmatter — `name` and a specific `description` (Claude matches your message against the description to decide whether to load the skill).
+
+### Ways to install
+
+| Path | When to use |
+|---|---|
+| Drop into `~/.claude/skills/<name>/` | Solo iteration. Restart Claude Desktop to pick it up. |
+| Fork the marketplace, install the plugin | Team rollout — same **Settings → Plugins → Add marketplace** flow as Cekura, pointing at your fork. |
+| Workspace upload | Team/Enterprise only — admin adds the marketplace at the org level. |
+
+For format details, the `skill-creator` shortcut, and the full authoring guide, see [Anthropic's skills documentation](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/overview) and the [Agent Skills standard](https://agentskills.io).
+
+## 3. End-to-end example
+
+A typical "set up evals for a new agent" loop in Claude Desktop:
+
+1. *"List my Cekura agents."* — MCP returns agents.
+2. *"For agent `support-bot`, generate 10 workflow evaluators following our naming conventions."* — auto-loads `cekura-eval-design` **and** your custom `my-team-eval-conventions` skill, drafts the evaluators, calls the MCP to create them.
+3. *"Run every evaluator on `support-bot` and stream pass/fail."* — MCP runs them concurrently.
+4. *"For the 3 failures, rerun each 4 times and tell me which are real bugs vs. flakes."* — Claude triages with `cekura-fixing-prod-issues`.
+5. *"Draft a fix plan with the suspected prompt or tool changes for each real bug."* — Claude composes the report inline.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| Plugin install fails or marketplace not found | Confirm the URL is exactly `https://github.com/cekura-ai/cekura-skills.git`. Re-run **Marketplace → Refresh**. |
+| `401 Unauthorized` from MCP tools | **Settings → Connectors → Cekura → Reconnect** to re-run OAuth. |
+| Cekura tools don't appear in a chat | Restart Claude Desktop after installing the plugin. Confirm the Cekura connector is **Enabled**. |
+| Skills don't activate | Confirm **Settings → Capabilities → Skills** is on, restart the app, and check that the skill's `description:` matches the phrasing you're using. |
+| Custom skill in `~/.claude/skills/` isn't loading | The folder must contain `SKILL.md` at its root (not nested), and the `name:` frontmatter field must match the folder name. |
+| Team workspace doesn't show Plugins or Connectors | An admin needs to enable them once at the org level. |
+
+Deeper MCP-only troubleshooting (rate limits, header issues, Node.js edge cases) lives in [MCP overview → Troubleshooting](/mcp/overview#troubleshooting).
+
+## References
+
+<CardGroup cols={2}>
+  <Card title="MCP Overview" icon="shield-halved" href="/mcp/overview">
+    Full configuration matrix, auth options, request headers
+  </Card>
+  <Card title="Skills Catalog" icon="sparkles" href="/mcp/skills">
+    All nine Cekura skills and what each one activates on
+  </Card>
+  <Card title="Claude Code Guide" icon="code" href="/mcp/claude-code-guide">
+    The Claude Code equivalent (plugin marketplace + slash commands)
+  </Card>
+  <Card title="Dashboard" icon="gauge" href="https://dashboard.cekura.ai">
+    Manage projects, agents, and API keys
+  </Card>
+</CardGroup>

--- a/mcp/overview.mdx
+++ b/mcp/overview.mdx
@@ -262,7 +262,7 @@ If configured correctly, your assistant returns your agents from the Cekura API.
   </Accordion>
 </AccordionGroup>
 
-For deeper end-to-end walkthroughs, see the [Claude Code Guide](/mcp/claude-code-guide).
+For deeper end-to-end walkthroughs, see the [Claude Code Guide](/mcp/claude-code-guide) or the [Claude Desktop Guide](/mcp/claude-desktop-guide) (covers Connectors, Skills, and authoring custom skills).
 
 ## Request Headers
 

--- a/mcp/skills.mdx
+++ b/mcp/skills.mdx
@@ -209,6 +209,9 @@ Per-user install in most cases — share the install command in your team's onbo
   <Card title="Claude Code Guide" icon="code" href="/mcp/claude-code-guide">
     End-to-end walkthrough using skills + MCP
   </Card>
+  <Card title="Claude Desktop Guide" icon="desktop" href="/mcp/claude-desktop-guide">
+    Connector setup, skill upload, and writing custom skills
+  </Card>
   <Card title="Dashboard" icon="gauge" href="https://dashboard.cekura.ai">
     Manage your Cekura workspace
   </Card>

--- a/mint.json
+++ b/mint.json
@@ -522,6 +522,7 @@
       "group": "Guides",
       "pages": [
         "mcp/claude-code-guide",
+        "mcp/claude-desktop-guide",
         "mcp/cursor-guide",
         "mcp/codex-guide",
         "mcp/auto-optimize-metrics"


### PR DESCRIPTION
## Summary

- New `mcp/claude-desktop-guide.mdx`: single-page setup for Claude Desktop — install the `cekura` plugin from the marketplace (bundles all 9 skills + the MCP server in one), finish OAuth in the browser, verify with a sample prompt.
- Concise **custom skills** section: structure (`SKILL.md`), three install paths (drop into `~/.claude/skills/`, fork the marketplace for a team rollout, or workspace upload on Team/Enterprise), and a link out to Anthropic's official skill authoring docs for the deeper format/tooling details.
- Cross-links from `mcp/overview.mdx` and `mcp/skills.mdx` so existing docs surface the new page.
- Registers the page in `mint.json` under the bottom **Guides** group, right after `claude-code-guide`.

## Why

Claude Code users had a dedicated end-to-end guide; Claude Desktop users were piecing the flow together from the MCP overview + skills page. This page collects everything in one place and is explicit about the parts Claude Desktop does differently from Claude Code (no slash commands — describe the task in natural language).

## Test plan

- [x] Rendered locally with `mintlify dev`; Steps, code blocks, troubleshooting table, and reference cards all render cleanly.
- [x] Confirmed nav placement (MCP → Guides, after Claude Code guide).
- [x] Captured screenshots via Playwright; no console errors from the new page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)