### PR TITLE
Regenerate openapi.json for custom-MCP flow + new mock-tool response fields

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2050,6 +2050,187 @@
                 }
             }
         },
+        "/observability/v1/alerts/{id}/review_detail/": {
+            "get": {
+                "operationId": "alerts-review-detail-retrieve",
+                "description": "Per-alert review data — config snapshot, timeline, paginated fires.\n\nPowers the per-alert review page. Single-alert version of the bulk\n`review` action. Timeline is computed with a DB-side GROUP BY so the\nendpoint stays fast for noisy alerts (thousands of fires in 7d).\n\nQuery params:\n    hours: optional, defaults to 24. Capped at 7 days.\n    page: optional, defaults to 1.\n    page_size: optional, defaults to 50, capped at 200.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this alert.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "observability"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AlertDetail"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/observability/v1/alerts/{id}/summarize/": {
+            "post": {
+                "operationId": "alerts-summarize-create",
+                "description": "Kick off an LLM summary of the last N hours of fires for this alert.\n\nReturns a progress_id. Frontend polls `summarize_progress` until status\nis 'completed' or 'error'. Cached for 1 hour keyed on (alert, hours,\nlatest fire id) — re-invocations within that window return the same\nprogress_id.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this alert.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "observability"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AlertDetail"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AlertDetail"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AlertDetail"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AlertDetail"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/observability/v1/alerts/review/": {
+            "get": {
+                "operationId": "alerts-review-retrieve",
+                "description": "Aggregate every alert's fire activity over a rolling window. Returns KPI totals (total fires, unique alerts that fired, top firing alert), a time-bucketed timeline (hourly for 24h, 3-hour for 3d, 6-hour for 7d), and a per-alert breakdown with a sparkline of fires-per-bucket. Use to answer 'what alerts fired this week?' or 'is anything noisy right now?'. Pass `hours` (default 24, capped at 168) to widen the window. The response shape lets you compose a written report in a single call.",
+                "summary": "Review alert activity in a project",
+                "tags": [
+                    "observability"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AlertDetail"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "alerts-review-retrieve",
+                        "description": "Aggregate every alert's fire activity over a rolling window. Returns KPI totals (total fires, unique alerts that fired, top firing alert), a time-bucketed timeline (hourly for 24h, 3-hour for 3d, 6-hour for 7d), and a per-alert breakdown with a sparkline of fires-per-bucket. Use to answer 'what alerts fired this week?' or 'is anything noisy right now?'. Pass `hours` (default 24, capped at 168) to widen the window. The response shape lets you compose a written report in a single call."
+                    }
+                }
+            }
+        },
+        "/observability/v1/alerts/summarize_progress/": {
+            "get": {
+                "operationId": "alerts-summarize-progress-retrieve",
+                "description": "Manage alerts that fire when metric thresholds are crossed.",
+                "tags": [
+                    "observability"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AlertDetail"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/observability/v1/alerts/trigger_summary/": {
+            "get": {
+                "operationId": "alerts-trigger-summary-retrieve",
+                "description": "Return fire counts per alert over a time window.\n\nPowers the \"Last 24h\" status pill on the alerts list. Counts CallLogAlert\nrows linked to each alert in the project, scoped to the window.\n\nQuery params:\n    project_id: required, scopes the result to alerts in this project.\n    hours: optional, defaults to 24. Window size in hours.\n\nReturns: { \"<alert_id>\": <fire_count>, ... }",
+                "tags": [
+                    "observability"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AlertDetail"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/observability/v1/call-logs/": {
             "get": {
                 "operationId": "call-logs-list",
@@ -6990,6 +7171,274 @@
                 }
             }
         },
+        "/schedules/v1/metric-optimiser-cron-jobs/": {
+            "get": {
+                "operationId": "metric-optimiser-cron-jobs-list",
+                "description": "List all scheduled metric-optimiser jobs.",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "project_id",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "organization_id",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "tags": [
+                    "schedules"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/MetricOptimiserCronJob"
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "post": {
+                "operationId": "metric-optimiser-cron-jobs-create",
+                "description": "Create a cron job that runs the Metric Lab optimiser against one or more metrics on a recurring schedule. The optimiser uses every test set already in each metric's Lab (every MetricReview row). Set `auto_apply` to overwrite the live metric prompt when the optimised score is at least as good as the baseline on the labelled set — otherwise the run is read-only and emails a diff summary.",
+                "summary": "Schedule a recurring metric optimiser run",
+                "tags": [
+                    "schedules"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricOptimiserCronJob"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricOptimiserCronJob"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricOptimiserCronJob"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricOptimiserCronJob"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/schedules/v1/metric-optimiser-cron-jobs/{id}/": {
+            "get": {
+                "operationId": "metric-optimiser-cron-jobs-retrieve",
+                "description": "Retrieve a scheduled metric-optimiser job by id.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric optimiser cron job.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "schedules"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricOptimiserCronJob"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "put": {
+                "operationId": "metric-optimiser-cron-jobs-update",
+                "description": "Update an existing scheduled metric-optimiser job.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric optimiser cron job.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "schedules"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricOptimiserCronJob"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricOptimiserCronJob"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricOptimiserCronJob"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricOptimiserCronJob"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "patch": {
+                "operationId": "metric-optimiser-cron-jobs-partial-update",
+                "description": "Partially update an existing scheduled metric-optimiser job.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric optimiser cron job.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "schedules"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedMetricOptimiserCronJob"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedMetricOptimiserCronJob"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedMetricOptimiserCronJob"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricOptimiserCronJob"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "metric-optimiser-cron-jobs-destroy",
+                "description": "Irreversible. Deletes the cron job and stops it from firing. Past optimiser runs are retained.",
+                "summary": "Delete a scheduled metric-optimiser job",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric optimiser cron job.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "schedules"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No response body"
+                    },
+                    "404": {
+                        "description": "No response body"
+                    }
+                }
+            }
+        },
         "/slack/events/": {
             "post": {
                 "operationId": "slack-events-create",
@@ -11518,7 +11967,7 @@
         "/test_framework/v1/aiagents-external/{id}/upload_knowledge_base/": {
             "post": {
                 "operationId": "aiagents-upload-knowledge-base",
-                "description": "Aiagents upload knowledge base",
+                "description": "Upload one or more files to the agent's knowledge base. Accepts either a `multipart/form-data` body (used by the web dashboard) or an `application/json` body where each entry carries base64-encoded file content.",
                 "parameters": [
                     {
                         "in": "path",
@@ -11564,6 +12013,38 @@
                                             "format": "binary"
                                         },
                                         "description": "List of files to upload to the knowledge base"
+                                    }
+                                },
+                                "required": [
+                                    "files"
+                                ]
+                            }
+                        },
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "files": {
+                                        "type": "array",
+                                        "description": "List of files to upload, each provided as base64-encoded content.",
+                                        "items": {
+                                            "type": "object",
+                                            "required": [
+                                                "name",
+                                                "content_base64"
+                                            ],
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string",
+                                                    "description": "Filename including extension (e.g. `manual.pdf`)."
+                                                },
+                                                "content_base64": {
+                                                    "type": "string",
+                                                    "contentEncoding": "base64",
+                                                    "description": "Base64-encoded file content. Accepts a raw base64 string or a `data:<mime>;base64,...` data URI."
+                                                }
+                                            }
+                                        }
                                     }
                                 },
                                 "required": [
@@ -12429,7 +12910,8 @@
         "/test_framework/v1/aiagents/{agent_id}/tools/auto-fetch/": {
             "post": {
                 "operationId": "aiagents-tools-auto-fetch-create",
-                "description": "Auto-fetch tools from provider and generate mock data asynchronously.\n\nValidates inputs, fires a background Celery task for the slow provider API calls\nand LLM mock-data generation, and returns a progress_id immediately.\nPoll auto-fetch-progress/ with the progress_id to check completion.\nThis does NOT enable mock mode in the provider. Use the enable-mock endpoint for that.",
+                "description": "Discover the agent's tools (from a managed provider or a customer-hosted MCP server) and LLM-generate mock input/output data for each. Persists Tool rows and records the provider configuration on the agent. ⚠ Overwrites empty Tool rows; existing rows with mock data are kept. For provider=\"custom\", supply `mcp_server_url`; the URL is SSRF-validated (no private/loopback targets).",
+                "summary": "Auto-fetch mock tools for an agent",
                 "parameters": [
                     {
                         "in": "path",
@@ -12451,12 +12933,22 @@
                                 "$ref": "#/components/schemas/AutoFetchToolsRequest"
                             },
                             "examples": {
-                                "Auto-FetchToolsRequest": {
+                                "Auto-FetchToolsRequest(managedProvider)": {
                                     "value": {
                                         "provider": "retell",
                                         "assistant_id": "agent_abc123"
                                     },
-                                    "summary": "Auto-Fetch Tools Request"
+                                    "summary": "Auto-Fetch Tools Request (managed provider)"
+                                },
+                                "Auto-FetchToolsRequest(customMCPServer)": {
+                                    "value": {
+                                        "provider": "custom",
+                                        "mcp_server_url": "https://customer.example.com/mcp",
+                                        "mcp_server_headers": {
+                                            "Authorization": "Bearer ..."
+                                        }
+                                    },
+                                    "summary": "Auto-Fetch Tools Request (custom MCP server)"
                                 }
                             }
                         },
@@ -12568,7 +13060,8 @@
         "/test_framework/v1/aiagents/{agent_id}/tools/disable-mock/": {
             "post": {
                 "operationId": "aiagents-tools-disable-mock-create",
-                "description": "Kick off a background task to disable mock tools for this agent.\nReturns a progress_id to poll disable-mock-progress/ for status.",
+                "description": "Restore the agent's tools to their original (non-mock) state. For managed providers this PATCHes the provider assistant back to its `original_tool_ids` and deletes the cloned tools. For provider=\"custom\" this only flips `mock_enabled` off; the `mcp_server_url` is preserved so re-enable works.",
+                "summary": "Disable mock tools for an agent",
                 "parameters": [
                     {
                         "in": "path",
@@ -12635,6 +13128,7 @@
             "get": {
                 "operationId": "aiagents-tools-disable-mock-progress-retrieve",
                 "description": "Poll the status of a background disable-mock task.",
+                "summary": "Poll status of a disable-mock task",
                 "parameters": [
                     {
                         "in": "path",
@@ -12642,6 +13136,14 @@
                         "schema": {
                             "type": "string",
                             "pattern": "^\\d+$"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "progress_id",
+                        "schema": {
+                            "type": "string"
                         },
                         "required": true
                     }
@@ -12659,7 +13161,17 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Tool"
+                                    "$ref": "#/components/schemas/DisableMockProgressResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/DisableMockProgressErrorResponse"
                                 }
                             }
                         },
@@ -12671,7 +13183,8 @@
         "/test_framework/v1/aiagents/{agent_id}/tools/enable-mock/": {
             "post": {
                 "operationId": "aiagents-tools-enable-mock-create",
-                "description": "Kick off a background task to enable mock tools for this agent.\nReturns a progress_id to poll enable-mock-progress/ for status.\nAuto-fetch must be run first to populate tool mock data.",
+                "description": "Activate mock-tool mode using the data created by `auto-fetch`. For managed providers (vapi/retell/elevenlabs) this clones the provider's tools at the provider and swaps URLs to Cekura-hosted endpoints. For provider=\"custom\" it just registers `mcp_sub_tool_map` so MockMCPView can serve `/mcp/N/` calls. Returns a `progress_id`; poll `enable-mock-progress/` for the resulting `mcp_endpoints`. Run `auto-fetch` first.",
+                "summary": "Enable mock tools for an agent",
                 "parameters": [
                     {
                         "in": "path",
@@ -12738,6 +13251,7 @@
             "get": {
                 "operationId": "aiagents-tools-enable-mock-progress-retrieve",
                 "description": "Poll the status of a background enable-mock task.",
+                "summary": "Poll status of an enable-mock task",
                 "parameters": [
                     {
                         "in": "path",
@@ -12745,6 +13259,14 @@
                         "schema": {
                             "type": "string",
                             "pattern": "^\\d+$"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "progress_id",
+                        "schema": {
+                            "type": "string"
                         },
                         "required": true
                     }
@@ -12762,7 +13284,17 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Tool"
+                                    "$ref": "#/components/schemas/EnableMockProgressResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/EnableMockProgressErrorResponse"
                                 }
                             }
                         },
@@ -12774,7 +13306,8 @@
         "/test_framework/v1/aiagents/{agent_id}/tools/mock-status/": {
             "get": {
                 "operationId": "aiagents-tools-mock-status-retrieve",
-                "description": "Get the current mock tools status for this agent.",
+                "description": "Single source of truth for \"what mock-tool runtime URLs do I have, and what are they configured for?\". `mcp_endpoints[]` lists each Cekura-hosted MCP JSON-RPC endpoint with the sub-tools it serves; `tool_endpoints[]` lists standalone (non-MCP) per-tool webhook URLs. URLs are computed from `settings.CEKURA_BASE_URL`, so each environment renders the correct host.",
+                "summary": "Current mock-tools state for an agent",
                 "parameters": [
                     {
                         "in": "path",
@@ -12799,7 +13332,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Tool"
+                                    "$ref": "#/components/schemas/MockStatusResponse"
                                 }
                             }
                         },
@@ -13480,7 +14013,7 @@
         "/test_framework/v1/aiagents/{id}/upload_knowledge_base/": {
             "post": {
                 "operationId": "aiagents-upload-knowledge-base_2",
-                "description": "Aiagents upload knowledge base",
+                "description": "Upload one or more files to the agent's knowledge base. Accepts either a `multipart/form-data` body (used by the web dashboard) or an `application/json` body where each entry carries base64-encoded file content.",
                 "parameters": [
                     {
                         "in": "path",
@@ -13526,6 +14059,38 @@
                                             "format": "binary"
                                         },
                                         "description": "List of files to upload to the knowledge base"
+                                    }
+                                },
+                                "required": [
+                                    "files"
+                                ]
+                            }
+                        },
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "files": {
+                                        "type": "array",
+                                        "description": "List of files to upload, each provided as base64-encoded content.",
+                                        "items": {
+                                            "type": "object",
+                                            "required": [
+                                                "name",
+                                                "content_base64"
+                                            ],
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string",
+                                                    "description": "Filename including extension (e.g. `manual.pdf`)."
+                                                },
+                                                "content_base64": {
+                                                    "type": "string",
+                                                    "contentEncoding": "base64",
+                                                    "description": "Base64-encoded file content. Accepts a raw base64 string or a `data:<mime>;base64,...` data URI."
+                                                }
+                                            }
+                                        }
                                     }
                                 },
                                 "required": [
@@ -15866,6 +16431,68 @@
                 }
             }
         },
+        "/test_framework/v1/metrics-external/{id}/apply_optimisation_proposal/": {
+            "post": {
+                "operationId": "metrics-external-apply-optimisation-proposal-create",
+                "description": "Copies the fields from `pending_optimisation_proposal` (description, evaluation_trigger, type, custom_code) into the live metric columns and clears the proposal. 400 if no pending proposal exists.",
+                "summary": "Apply a pending optimisation proposal",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Metric updated; pending proposal cleared."
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/metrics-external/{id}/dismiss_optimisation_proposal/": {
+            "post": {
+                "operationId": "metrics-external-dismiss-optimisation-proposal-create",
+                "description": "Discards the metric's `pending_optimisation_proposal` without applying. Idempotent — a metric with no pending proposal returns 200.",
+                "summary": "Dismiss a pending optimisation proposal",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Proposal cleared."
+                    }
+                }
+            }
+        },
         "/test_framework/v1/metrics-external/{id}/evaluate_advance_metric/": {
             "post": {
                 "operationId": "metrics-external-evaluate-advance-metric-create",
@@ -17443,6 +18070,68 @@
                             }
                         },
                         "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/metrics/{id}/apply_optimisation_proposal/": {
+            "post": {
+                "operationId": "metrics-apply-optimisation-proposal-create",
+                "description": "Copies the fields from `pending_optimisation_proposal` (description, evaluation_trigger, type, custom_code) into the live metric columns and clears the proposal. 400 if no pending proposal exists.",
+                "summary": "Apply a pending optimisation proposal",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Metric updated; pending proposal cleared."
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/metrics/{id}/dismiss_optimisation_proposal/": {
+            "post": {
+                "operationId": "metrics-dismiss-optimisation-proposal-create",
+                "description": "Discards the metric's `pending_optimisation_proposal` without applying. Idempotent — a metric with no pending proposal returns 200.",
+                "summary": "Dismiss a pending optimisation proposal",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Proposal cleared."
                     }
                 }
             }
@@ -25805,7 +26494,7 @@
         "/test_framework/v1/runs/{run_id}/datadog-logs/": {
             "get": {
                 "operationId": "runs-datadog-logs-retrieve",
-                "description": "Fetch Datadog logs for a given simulation run ID.\n\nRestricted to OAuth tokens minted by the `cekura-support-bot` client via\nthe client_credentials grant. Even though the support-bot client can\nimpersonate any user, the token's subject user must be a member of the\nrun's organization — so support agents only see logs for runs belonging\nto the customer they're currently helping.",
+                "description": "Fetch Datadog logs for a given simulation run ID.\n\nRestricted to OAuth tokens minted by the `cekura-support-bot` client via\nthe client_credentials grant. Even though the support-bot client can\nimpersonate any user, the token's subject user must have access to the\nrun's project — either as an org-admin or via a direct project membership.\nOrg-level membership alone is not enough: a user added to project A\nshould not see logs for runs in project B in the same org.",
                 "parameters": [
                     {
                         "in": "path",
@@ -36373,6 +37062,35 @@
                 }
             }
         },
+        "/test_framework/v1/share-tokens/{token}/resolve/": {
+            "get": {
+                "operationId": "share-tokens-resolve-retrieve",
+                "description": "Resolve a shareable-link token to the underlying source object(s).\n\nGiven the opaque token from a `https://<host>/share/results/<token>` URL,\nreturns the result_id (or other source object IDs) the token grants access\nto, plus org/agent context and expiry state.\n\nRestricted to OAuth tokens minted by the `cekura-support-bot` client via\nthe client_credentials grant. The support-bot's subject user must be a\nmember of the source object's organization — so support agents can only\nresolve tokens for results belonging to the customer they're helping.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "token",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No response body"
+                    }
+                }
+            }
+        },
         "/test_framework/v1/test-profiles/": {
             "get": {
                 "operationId": "test-profiles-list",
@@ -38547,7 +39265,7 @@
         "/test_framework/v2/aiagents/{id}/upload_knowledge_base/": {
             "post": {
                 "operationId": "aiagents-upload-knowledge-base_3",
-                "description": "Aiagents upload knowledge base",
+                "description": "Upload one or more files to the agent's knowledge base. Accepts either a `multipart/form-data` body (used by the web dashboard) or an `application/json` body where each entry carries base64-encoded file content.",
                 "parameters": [
                     {
                         "in": "path",
@@ -38599,6 +39317,38 @@
                                     "files"
                                 ]
                             }
+                        },
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "files": {
+                                        "type": "array",
+                                        "description": "List of files to upload, each provided as base64-encoded content.",
+                                        "items": {
+                                            "type": "object",
+                                            "required": [
+                                                "name",
+                                                "content_base64"
+                                            ],
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string",
+                                                    "description": "Filename including extension (e.g. `manual.pdf`)."
+                                                },
+                                                "content_base64": {
+                                                    "type": "string",
+                                                    "contentEncoding": "base64",
+                                                    "description": "Base64-encoded file content. Accepts a raw base64 string or a `data:<mime>;base64,...` data URI."
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "required": [
+                                    "files"
+                                ]
+                            }
                         }
                     }
                 },
@@ -38642,7 +39392,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "aiagents-upload-knowledge-base",
-                        "description": "Aiagents upload knowledge base"
+                        "description": "Upload one or more files to the agent's knowledge base. Accepts either a `multipart/form-data` body (used by the web dashboard) or an `application/json` body where each entry carries base64-encoded file content."
                     }
                 }
             }
@@ -49332,187 +50082,6 @@
                 },
                 "description": "Delete a workflows workflow"
             }
-        },
-        "/observability/v1/alerts/{id}/review_detail/": {
-            "get": {
-                "operationId": "alerts-review-detail-retrieve",
-                "description": "Per-alert review data — config snapshot, timeline, paginated fires.\n\nPowers the per-alert review page. Single-alert version of the bulk\n`review` action. Timeline is computed with a DB-side GROUP BY so the\nendpoint stays fast for noisy alerts (thousands of fires in 7d).\n\nQuery params:\n    hours: optional, defaults to 24. Capped at 7 days.\n    page: optional, defaults to 1.\n    page_size: optional, defaults to 50, capped at 200.",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "A unique integer value identifying this alert.",
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "observability"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/AlertDetail"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
-        },
-        "/observability/v1/alerts/{id}/summarize/": {
-            "post": {
-                "operationId": "alerts-summarize-create",
-                "description": "Kick off an LLM summary of the last N hours of fires for this alert.\n\nReturns a progress_id. Frontend polls `summarize_progress` until status\nis 'completed' or 'error'. Cached for 1 hour keyed on (alert, hours,\nlatest fire id) — re-invocations within that window return the same\nprogress_id.",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "A unique integer value identifying this alert.",
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "observability"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/AlertDetail"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/AlertDetail"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/AlertDetail"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/AlertDetail"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
-        },
-        "/observability/v1/alerts/review/": {
-            "get": {
-                "operationId": "alerts-review-retrieve",
-                "description": "Aggregate every alert's fire activity over a rolling window. Returns KPI totals (total fires, unique alerts that fired, top firing alert), a time-bucketed timeline (hourly for 24h, 3-hour for 3d, 6-hour for 7d), and a per-alert breakdown with a sparkline of fires-per-bucket. Use to answer 'what alerts fired this week?' or 'is anything noisy right now?'. Pass `hours` (default 24, capped at 168) to widen the window. The response shape lets you compose a written report in a single call.",
-                "summary": "Review alert activity in a project",
-                "tags": [
-                    "observability"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/AlertDetail"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "alerts-review-retrieve",
-                        "description": "Aggregate every alert's fire activity over a rolling window. Returns KPI totals (total fires, unique alerts that fired, top firing alert), a time-bucketed timeline (hourly for 24h, 3-hour for 3d, 6-hour for 7d), and a per-alert breakdown with a sparkline of fires-per-bucket. Use to answer 'what alerts fired this week?' or 'is anything noisy right now?'. Pass `hours` (default 24, capped at 168) to widen the window. The response shape lets you compose a written report in a single call."
-                    }
-                }
-            }
-        },
-        "/observability/v1/alerts/summarize_progress/": {
-            "get": {
-                "operationId": "alerts-summarize-progress-retrieve",
-                "description": "Manage alerts that fire when metric thresholds are crossed.",
-                "tags": [
-                    "observability"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/AlertDetail"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
-        },
-        "/observability/v1/alerts/trigger_summary/": {
-            "get": {
-                "operationId": "alerts-trigger-summary-retrieve",
-                "description": "Return fire counts per alert over a time window.\n\nPowers the \"Last 24h\" status pill on the alerts list. Counts CallLogAlert\nrows linked to each alert in the project, scoped to the window.\n\nQuery params:\n    project_id: required, scopes the result to alerts in this project.\n    hours: optional, defaults to 24. Window size in hours.\n\nReturns: { \"<alert_id>\": <fire_count>, ... }",
-                "tags": [
-                    "observability"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/AlertDetail"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
         }
     },
     "components": {
@@ -51122,23 +51691,32 @@
                         "enum": [
                             "vapi",
                             "retell",
-                            "elevenlabs"
+                            "elevenlabs",
+                            "custom"
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "ff667bd2cd27b9d3",
-                        "description": "Provider to fetch tools from\n\n* `vapi` - vapi\n* `retell` - retell\n* `elevenlabs` - elevenlabs"
+                        "x-spec-enum-id": "e3f60d118bb06f46",
+                        "description": "Provider to fetch tools from. Use \"custom\" for self-hosted agents that expose an MCP server directly.\n\n* `vapi` - vapi\n* `retell` - retell\n* `elevenlabs` - elevenlabs\n* `custom` - custom"
                     },
                     "assistant_id": {
                         "type": "string",
-                        "description": "Assistant/Agent ID from the provider (e.g., VAPI Assistant ID)"
+                        "description": "Provider assistant/agent ID. Required for vapi/retell/elevenlabs; ignored for custom."
                     },
                     "api_key": {
                         "type": "string",
-                        "description": "Optional API key for the provider. If not provided, will use stored credentials."
+                        "description": "Optional API key for the managed provider. Ignored for custom. If not provided, stored credentials are used."
+                    },
+                    "mcp_server_url": {
+                        "type": "string",
+                        "description": "Required when provider=\"custom\". URL of the customer-hosted MCP server (JSON-RPC 2.0)."
+                    },
+                    "mcp_server_headers": {
+                        "type": "object",
+                        "additionalProperties": {},
+                        "description": "Optional auth/custom headers forwarded to the MCP server during tool discovery (provider=\"custom\" only)."
                     }
                 },
                 "required": [
-                    "assistant_id",
                     "provider"
                 ]
             },
@@ -53446,6 +54024,56 @@
                     "detail"
                 ]
             },
+            "DisableMockProgressErrorResponse": {
+                "type": "object",
+                "properties": {
+                    "detail": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "detail"
+                ]
+            },
+            "DisableMockProgressResponse": {
+                "type": "object",
+                "properties": {
+                    "status": {
+                        "enum": [
+                            "in_progress",
+                            "completed",
+                            "failed"
+                        ],
+                        "type": "string",
+                        "description": "* `in_progress` - in_progress\n* `completed` - completed\n* `failed` - failed",
+                        "x-spec-enum-id": "6e9575e5767aaee0"
+                    },
+                    "mock_enabled": {
+                        "type": [
+                            "boolean",
+                            "null"
+                        ]
+                    },
+                    "message": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "error": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    }
+                },
+                "required": [
+                    "error",
+                    "message",
+                    "mock_enabled",
+                    "status"
+                ]
+            },
             "DisableMockToolsRequest": {
                 "type": "object",
                 "properties": {
@@ -53581,6 +54209,63 @@
                 },
                 "required": [
                     "detail"
+                ]
+            },
+            "EnableMockProgressErrorResponse": {
+                "type": "object",
+                "properties": {
+                    "detail": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "detail"
+                ]
+            },
+            "EnableMockProgressResponse": {
+                "type": "object",
+                "properties": {
+                    "status": {
+                        "enum": [
+                            "in_progress",
+                            "completed",
+                            "failed"
+                        ],
+                        "type": "string",
+                        "description": "* `in_progress` - in_progress\n* `completed` - completed\n* `failed` - failed",
+                        "x-spec-enum-id": "6e9575e5767aaee0"
+                    },
+                    "mock_enabled": {
+                        "type": [
+                            "boolean",
+                            "null"
+                        ]
+                    },
+                    "mcp_endpoints": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/MockMCPEndpoint"
+                        },
+                        "description": "MCP mock endpoints registered for this agent (one per MCP-typed tool). Empty for agents without MCP tools."
+                    },
+                    "message": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "error": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    }
+                },
+                "required": [
+                    "error",
+                    "message",
+                    "mock_enabled",
+                    "status"
                 ]
             },
             "EnableMockToolsRequest": {
@@ -54813,6 +55498,16 @@
                             "null"
                         ],
                         "description": "When enabled, this metric is automatically assigned to new agents created in the project."
+                    },
+                    "pending_optimisation_proposal": {
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "readOnly": true,
+                        "description": "Unsaved proposal from a metric-optimiser cron run. Shape: {description, evaluation_trigger, type, custom_code, score, baseline_score, cron_job_id, cron_job_name, proposed_at}."
                     }
                 },
                 "required": [
@@ -54868,11 +55563,12 @@
                             "pending",
                             "running",
                             "succeeded",
-                            "failed"
+                            "failed",
+                            "skipped_no_failures"
                         ],
                         "type": "string",
-                        "description": "* `pending` - Pending\n* `running` - Running\n* `succeeded` - Succeeded\n* `failed` - Failed",
-                        "x-spec-enum-id": "7a7ee2ea425ee5c6",
+                        "description": "* `pending` - Pending\n* `running` - Running\n* `succeeded` - Succeeded\n* `failed` - Failed\n* `skipped_no_failures` - Skipped No Failures",
+                        "x-spec-enum-id": "7052652d8ca01a2a",
                         "readOnly": true
                     },
                     "headline": {
@@ -55529,6 +56225,98 @@
                     "name"
                 ]
             },
+            "MetricOptimiserCronJob": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "project": {
+                        "type": "integer",
+                        "description": "Project ID this cron job belongs to."
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Display name for the cronjob.",
+                        "maxLength": 255
+                    },
+                    "metrics": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        },
+                        "description": "Metric IDs the cron job will optimise on each firing."
+                    },
+                    "crontab_expression": {
+                        "type": "string",
+                        "description": "Standard 5-field cron expression (minute hour dom mon dow).",
+                        "maxLength": 255
+                    },
+                    "timezone": {
+                        "type": "string",
+                        "description": "IANA timezone name (e.g. America/Los_Angeles). Defaults to UTC."
+                    },
+                    "auto_apply": {
+                        "type": "boolean",
+                        "description": "If true, overwrite the live metric prompt with the optimised one whenever the optimised score is >= baseline on the labelled set. Defaults to false (read-only)."
+                    },
+                    "skip_evaluation": {
+                        "type": "boolean",
+                        "description": "Skip the post-optimisation evaluation pass to speed up the cron."
+                    },
+                    "is_active": {
+                        "type": "boolean"
+                    },
+                    "notify_on": {
+                        "enum": [
+                            "never",
+                            "success",
+                            "failure",
+                            "both"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "d06ae6855e4121c0",
+                        "description": "When to email project members about the run outcome.\n\n* `never` - Never\n* `success` - Success\n* `failure` - Failure\n* `both` - Both"
+                    },
+                    "created_by": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "created_via": {
+                        "enum": [
+                            "user",
+                            "api",
+                            "mcp",
+                            "cli",
+                            "sdk",
+                            null
+                        ],
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "* `user` - User\n* `api` - API\n* `mcp` - MCP\n* `cli` - CLI\n* `sdk` - SDK",
+                        "x-spec-enum-id": "360ac7f2b69a95cc",
+                        "readOnly": true
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    }
+                },
+                "required": [
+                    "crontab_expression",
+                    "metrics",
+                    "project"
+                ]
+            },
             "MetricPreview": {
                 "type": "object",
                 "properties": {
@@ -55911,6 +56699,106 @@
                 },
                 "required": [
                     "metric"
+                ]
+            },
+            "MockMCPEndpoint": {
+                "type": "object",
+                "properties": {
+                    "mock_index": {
+                        "type": "integer"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "tool_names": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "required": [
+                    "mock_index",
+                    "tool_names",
+                    "url"
+                ]
+            },
+            "MockStatusMCPEndpoint": {
+                "type": "object",
+                "properties": {
+                    "mock_index": {
+                        "type": "integer"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "tool_names": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "required": [
+                    "mock_index",
+                    "tool_names",
+                    "url"
+                ]
+            },
+            "MockStatusResponse": {
+                "type": "object",
+                "properties": {
+                    "mock_enabled": {
+                        "type": "boolean"
+                    },
+                    "provider": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "assistant_id": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "mcp_endpoints": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/MockStatusMCPEndpoint"
+                        },
+                        "description": "MCP JSON-RPC endpoints registered on the agent. Empty if no MCP-typed tools are mocked."
+                    },
+                    "tool_endpoints": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/MockStatusToolEndpoint"
+                        },
+                        "description": "Per-tool webhook endpoints for standalone (non-MCP) tools. Excludes MCP sub-tools, which are listed under mcp_endpoints[].tool_names."
+                    }
+                },
+                "required": [
+                    "assistant_id",
+                    "mcp_endpoints",
+                    "mock_enabled",
+                    "provider",
+                    "tool_endpoints"
+                ]
+            },
+            "MockStatusToolEndpoint": {
+                "type": "object",
+                "properties": {
+                    "tool_name": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "tool_name",
+                    "url"
                 ]
             },
             "MoveFolderRequest": {
@@ -56697,6 +57585,15 @@
                         "type": "boolean",
                         "description": "Allow VIEW_ONLY role for memberships/invites on this pack. When False, view-only seats are blocked."
                     },
+                    "data_retention_days": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
+                        "maximum": 2147483647,
+                        "minimum": -2147483648,
+                        "description": "Data retention period in days. Leave blank to skip archival for this plan."
+                    },
                     "created_at": {
                         "type": "string",
                         "format": "date-time",
@@ -56870,6 +57767,15 @@
                     "allow_view_only_role": {
                         "type": "boolean",
                         "description": "Allow VIEW_ONLY role for memberships/invites on this pack. When False, view-only seats are blocked."
+                    },
+                    "data_retention_days": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
+                        "maximum": 2147483647,
+                        "minimum": -2147483648,
+                        "description": "Data retention period in days. Leave blank to skip archival for this plan."
                     },
                     "extra_member_price": {
                         "type": "string",
@@ -58528,6 +59434,93 @@
                             "string",
                             "null"
                         ]
+                    }
+                }
+            },
+            "PatchedMetricOptimiserCronJob": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "project": {
+                        "type": "integer",
+                        "description": "Project ID this cron job belongs to."
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Display name for the cronjob.",
+                        "maxLength": 255
+                    },
+                    "metrics": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        },
+                        "description": "Metric IDs the cron job will optimise on each firing."
+                    },
+                    "crontab_expression": {
+                        "type": "string",
+                        "description": "Standard 5-field cron expression (minute hour dom mon dow).",
+                        "maxLength": 255
+                    },
+                    "timezone": {
+                        "type": "string",
+                        "description": "IANA timezone name (e.g. America/Los_Angeles). Defaults to UTC."
+                    },
+                    "auto_apply": {
+                        "type": "boolean",
+                        "description": "If true, overwrite the live metric prompt with the optimised one whenever the optimised score is >= baseline on the labelled set. Defaults to false (read-only)."
+                    },
+                    "skip_evaluation": {
+                        "type": "boolean",
+                        "description": "Skip the post-optimisation evaluation pass to speed up the cron."
+                    },
+                    "is_active": {
+                        "type": "boolean"
+                    },
+                    "notify_on": {
+                        "enum": [
+                            "never",
+                            "success",
+                            "failure",
+                            "both"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "d06ae6855e4121c0",
+                        "description": "When to email project members about the run outcome.\n\n* `never` - Never\n* `success` - Success\n* `failure` - Failure\n* `both` - Both"
+                    },
+                    "created_by": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "created_via": {
+                        "enum": [
+                            "user",
+                            "api",
+                            "mcp",
+                            "cli",
+                            "sdk",
+                            null
+                        ],
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "* `user` - User\n* `api` - API\n* `mcp` - MCP\n* `cli` - CLI\n* `sdk` - SDK",
+                        "x-spec-enum-id": "360ac7f2b69a95cc",
+                        "readOnly": true
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
                     }
                 }
             },
@@ -61082,6 +62075,16 @@
                     },
                     "freetext_params": {
                         "description": "Parameter names skipped during mock matching because they are free-text (e.g. [\"notes\", \"reason\"])"
+                    },
+                    "mock_url": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "Per-tool webhook URL. None if this Tool is served through an MCP endpoint."
+                    },
+                    "served_via": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "How this tool is accessed at runtime. `{'type': 'direct'}` for standalone tools; `{'type': 'mcp', 'mock_index': N, 'url': '.../mcp/N/'}` for MCP sub-tools."
                     }
                 }
             },
@@ -62053,8 +63056,7 @@
                         "items": {
                             "type": "integer"
                         },
-                        "description": "List of test set IDs to process feedbacks from",
-                        "minItems": 1
+                        "description": "Test set IDs whose feedback drives the optimization. If omitted, defaults to every test set already added to this metric's Lab."
                     },
                     "simplified_prompt": {
                         "type": "string",
@@ -62067,8 +63069,7 @@
                     }
                 },
                 "required": [
-                    "metric_id",
-                    "test_set_ids"
+                    "metric_id"
                 ]
             },
             "ProcessFeedbacksResponse": {
@@ -63909,6 +64910,7 @@
                     "folder_path": {
                         "type": [
                             "string",
+                            "null",
                             "null"
                         ],
                         "description": "Dot-separated path of the folder to assign this evaluator to (e.g. \"Sales.Inbound\"). Folders must be created before use — they are not auto-created. Use `scenarios_create_folder_create` to create each level before assigning evaluators. Example: to use \"Sales.Inbound\", first create \"Sales\", then create \"Inbound\" inside it."
@@ -64763,6 +65765,7 @@
                     "folder_path": {
                         "type": [
                             "string",
+                            "null",
                             "null"
                         ],
                         "description": "Dot-separated path of the folder to assign this evaluator to (e.g. \"Sales.Inbound\"). Folders must be created before use — they are not auto-created. Use `scenarios_create_folder_create` to create each level before assigning evaluators. Example: to use \"Sales.Inbound\", first create \"Sales\", then create \"Inbound\" inside it."
@@ -64998,6 +66001,7 @@
                     "folder_path": {
                         "type": [
                             "string",
+                            "null",
                             "null"
                         ],
                         "description": "Dot-separated path of the folder to assign this evaluator to (e.g. \"Sales.Inbound\"). Folders must be created before use — they are not auto-created. Use `scenarios_create_folder_create` to create each level before assigning evaluators. Example: to use \"Sales.Inbound\", first create \"Sales\", then create \"Inbound\" inside it."
@@ -66593,6 +67597,7 @@
                     "folder_path": {
                         "type": [
                             "string",
+                            "null",
                             "null"
                         ],
                         "description": "Dot-separated path of the folder to assign this evaluator to (e.g. \"Sales.Inbound\"). Folders must be created before use — they are not auto-created. Use `scenarios_create_folder_create` to create each level before assigning evaluators. Example: to use \"Sales.Inbound\", first create \"Sales\", then create \"Inbound\" inside it."
@@ -67741,6 +68746,16 @@
                     },
                     "freetext_params": {
                         "description": "Parameter names skipped during mock matching because they are free-text (e.g. [\"notes\", \"reason\"])"
+                    },
+                    "mock_url": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "Per-tool webhook URL. None if this Tool is served through an MCP endpoint."
+                    },
+                    "served_via": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "How this tool is accessed at runtime. `{'type': 'direct'}` for standalone tools; `{'type': 'mcp', 'mock_index': N, 'url': '.../mcp/N/'}` for MCP sub-tools."
                     }
                 },
                 "required": [


### PR DESCRIPTION
Companion docs PR for backend PR cekura-ai/vocera.backend#9297. Strictly an `openapi.json` regen — no narrative MDX changes.

**Changes:**
- **`openapi.json`** — regenerated via `python manage.py spectacular` on the backend PR's branch (+1460 / -513 lines).

## ⚠️ About the large diff size

Roughly **~50 lines** of this diff are from my PR. The remaining **~1900 lines** are **drift catch-up** from 18 brand-new endpoints that other engineers merged to `main` without regenerating `openapi.json` (per [CLAUDE.md guidance](../vocera.backend/CLAUDE.md): *"After adding or removing a decorator, regenerate the spec... and commit the diff"*). My regen catches all of it up at once.

**Drift endpoints (not introduced by this PR):**
- `alerts-review-detail-retrieve`, `alerts-review-retrieve`, `alerts-summarize-create`, `alerts-summarize-progress-retrieve`, `alerts-trigger-summary-retrieve` — observability alerts
- `app-otel-validate-retrieve` — OTel auth
- `call-logs-trace-retrieve`, `runs-trace-retrieve`, `runs-datadog-logs-retrieve` — tracing pages
- `metric-failure-mode-insights-list`, `metric-failure-mode-insights-retrieve`, `metric-failure-mode-insights-destroy`, `metric-failure-mode-insights-generate-create` — metric insights
- `metrics-generate-clean-description-bg-create`, `metrics-generate-clean-description-progress-retrieve`, `metrics-external-generate-clean-description-bg-create`, `metrics-external-generate-clean-description-progress-retrieve` — metric description LLM
- `share-tokens-resolve-retrieve`

These additions are real, in-prod backend code that was merged but never had its spec entry committed here.

## What the regen actually picks up (this PR's actual scope, ~50 lines)

- `AutoFetchToolsRequest` — `provider` enum now includes `"custom"`; new optional `mcp_server_url` and `mcp_server_headers` request fields for the self-hosted-agent flow.
- `MockStatusResponse` — new `mcp_endpoints[]` (each `{mock_index, url, tool_names}`) and `tool_endpoints[]` (each `{tool_name, url}`) fields. Clients now read URLs from the API instead of reconstructing path templates client-side.
- `EnableMockProgressResponse` — new `mcp_endpoints[]` field so the URL is available atomically at activation.
- `Tool` schema — new read-only `mock_url` and `served_via` (`{type: "direct"}` or `{type: "mcp", mock_index, url}`) fields on every Tool serialization (list / create / get / update / post).
- `x-mcp-expose: true` markers on `auto-fetch`, `enable-mock`, `disable-mock`, their `*-progress` endpoints, and `mock-status` so the Cekura MCP server picks them up automatically.

## Impact

- Backward compatible — all changes are additive; no removed fields.
- Existing api-reference MDX files (`list-mock-tools`, `create-mock-tool`, etc.) auto-render the new fields because they read from `openapi.json` frontmatter — no per-page MDX edits needed.
- Narrative `documentation/key-concepts/evaluators/mock-tools.mdx` intentionally untouched.

**Preview**: `mintlify dev`, then visit any of the existing mock-tool API reference pages to see the new fields in the schemas.