### PR TITLE
docs(mcp): recommend TOOL_END_CALL by default for scenario authoring

### DIFF
--- a/cekura-mcp-server/mcp_tools.json
+++ b/cekura-mcp-server/mcp_tools.json
@@ -42,7 +42,7 @@
   },
 
   "scenarios_create": {
-    "description_suffix": "**Prefer `scenarios_generate_bg`** for authoring new scenarios — it accepts per-scenario `extra_instructions` so callers can shape each scenario individually. Use this raw create only when the user has given concrete field values to write. To refine an existing scenario, use `scenarios_agent_create` (natural-language improvement) or `scenarios_improve_instructions_create` (rewrites the `instructions` text)."
+    "description_suffix": "**Prefer `scenarios_generate_bg`** for authoring new scenarios — it accepts per-scenario `extra_instructions` so callers can shape each scenario individually. Use this raw create only when the user has given concrete field values to write. To refine an existing scenario, use `scenarios_agent_create` (natural-language improvement) or `scenarios_improve_instructions_create` (rewrites the `instructions` text).\n\n**Tools (`tool_ids`):** it is recommended to include `TOOL_END_CALL` by default so the testing agent can hang up once it has completed its objective — leave it out only if the user does not want the agent to end the call. Other commonly used tool IDs include `TOOL_END_CALL_ONLY_ON_TRANSFER` (use instead of `TOOL_END_CALL` when the expected outcome is a transfer to a human/IVR, so the agent does not sit through hold music) and `TOOL_DTMF` (send keypad tones for IVR navigation). Example: `\"tool_ids\": [\"TOOL_END_CALL\"]`."
   },
 
   "scenarios_partial_update": {
@@ -54,7 +54,7 @@
   },
 
   "scenarios_generate_bg": {
-    "description_suffix": "Preferred path for authoring new scenarios. Accepts per-scenario `extra_instructions` so each generated scenario can be shaped individually — use this rather than `scenarios_create` unless the user has given concrete field values to write. Async — poll via `scenarios_generate_progress`."
+    "description_suffix": "Preferred path for authoring new scenarios. Accepts per-scenario `extra_instructions` so each generated scenario can be shaped individually — use this rather than `scenarios_create` unless the user has given concrete field values to write. Async — poll via `scenarios_generate_progress`.\n\n**Tools (`tool_ids`):** it is recommended to include `TOOL_END_CALL` by default so the generated testing agents can hang up once they have completed their objective — leave it out only if the user does not want the agent to end the call. Other commonly used tool IDs include `TOOL_END_CALL_ONLY_ON_TRANSFER` (use instead of `TOOL_END_CALL` when the expected outcome is a transfer to a human/IVR, so the agent does not sit through hold music) and `TOOL_DTMF` (send keypad tones for IVR navigation). Example: `\"tool_ids\": [\"TOOL_END_CALL\"]`."
   },
 
   "scenarios_improve_instructions_create": {


### PR DESCRIPTION
## Problem

Scenarios authored via the Claude MCP frequently end up **without the end-call tool enabled**, so the testing agent can't hang up and calls run until timeout (wasted credits). Two gaps drive this:

1. **No "whether" signal** — nothing told the model that `TOOL_END_CALL` is the recommended default, so it was routinely omitted.
2. **No "how" signal** — `tool_ids` in the spec was a free-form `array[string]` with only an illustrative example and no semantics.

## Change (guidance only — nothing enforced or restricted)

Extend the MCP overlays for the two authoring tools that expose `tool_ids`:
- `scenarios_create`
- `scenarios_generate_bg`

Each `description_suffix` now:
- **Recommends** including `TOOL_END_CALL` by default (omit only if the user doesn't want the agent to end the call).
- Mentions other commonly used tool IDs — `TOOL_END_CALL_ONLY_ON_TRANSFER` (transfer scenarios), `TOOL_DTMF` (IVR keypad) — as **examples, not a closed/enforced list**, since the valid set can change.
- Gives a literal example.

Purely advisory — the model is told *whether* and *how*, but nothing force-adds the tool, nothing rejects scenarios without it, and no value set is restricted. `scenarios_agent_create` is not covered (no `tool_ids` field).

## Validation

- `python3 cekura-mcp-server/validate_overlays.py` — no new drift (2 pre-existing unrelated warnings).
- `python3 -m pytest tests/test_overlays.py` — 14 passed.

## Related

Skills-side companion (recommend-default wording + `TOOL_END_CALL_ON_TRANSFER` → `TOOL_END_CALL_ONLY_ON_TRANSFER` alias fix) in cekura-ai/cekura-skills#47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)