### PR TITLE
fix(mcp): coerce pipecat_data to object on agent create/patch (no backend change)

### DIFF
--- a/cekura-mcp-server/mcp_tools.json
+++ b/cekura-mcp-server/mcp_tools.json
@@ -62,11 +62,13 @@
   },
 
   "aiagents_create": {
-    "description_suffix": "When the goal is to *improve* an existing agent based on test results or natural-language feedback, prefer `scenarios_agent_create` (it can update agent fields as part of the improvement loop). Use this raw create only when the user has given concrete field values to write."
+    "description_suffix": "When the goal is to *improve* an existing agent based on test results or natural-language feedback, prefer `scenarios_agent_create` (it can update agent fields as part of the improvement loop). Use this raw create only when the user has given concrete field values to write.",
+    "property_types": {"pipecat_data": "object"}
   },
 
   "aiagents_partial_update": {
-    "description_suffix": "When refining an existing agent based on test results or natural-language feedback, prefer `scenarios_agent_create` or `runs_improve_prompt_create` / `runs_improve_prompt_bg_create` (run-driven prompt improvement). Use this raw patch only when the user has explicitly given concrete field values to write."
+    "description_suffix": "When refining an existing agent based on test results or natural-language feedback, prefer `scenarios_agent_create` or `runs_improve_prompt_create` / `runs_improve_prompt_bg_create` (run-driven prompt improvement). Use this raw patch only when the user has explicitly given concrete field values to write.",
+    "property_types": {"pipecat_data": "object"}
   },
 
   "metrics_list": {

--- a/cekura-mcp-server/mcp_tools.json
+++ b/cekura-mcp-server/mcp_tools.json
@@ -63,11 +63,13 @@
 
   "aiagents_create": {
     "description_suffix": "When the goal is to *improve* an existing agent based on test results or natural-language feedback, prefer `scenarios_agent_create` (it can update agent fields as part of the improvement loop). Use this raw create only when the user has given concrete field values to write.",
+    "_property_types_note": "pipecat_data is a JSON object the spec mistypes as string; coerced to object so the client sends a dict. Only needed for Pipecat agents — other providers omit pipecat_data, so it's a no-op for them.",
     "property_types": {"pipecat_data": "object"}
   },
 
   "aiagents_partial_update": {
     "description_suffix": "When refining an existing agent based on test results or natural-language feedback, prefer `scenarios_agent_create` or `runs_improve_prompt_create` / `runs_improve_prompt_bg_create` (run-driven prompt improvement). Use this raw patch only when the user has explicitly given concrete field values to write.",
+    "_property_types_note": "pipecat_data is a JSON object the spec mistypes as string; coerced to object so the client sends a dict. Only needed for Pipecat agents — other providers omit pipecat_data, so it's a no-op for them.",
     "property_types": {"pipecat_data": "object"}
   },
 

--- a/cekura-mcp-server/tests/test_overlays.py
+++ b/cekura-mcp-server/tests/test_overlays.py
@@ -138,3 +138,25 @@ def test_generate_improve_tools_have_clarifying_suffix(tool):
     )
     suffix = overlays[tool].get("description_suffix", "")
     assert suffix, f"{tool} overlay must define a non-empty description_suffix."
+
+
+def test_pipecat_data_overlaid_to_object_for_agent_tools():
+    """pipecat_data is typed `string` in the spec but the backend wants an
+    object. The overlay forces it to `object` on the agent create/patch tools
+    so the HTTP client coerces the model's stringified JSON to a dict."""
+    from tool_generator import apply_overlay_to_schema
+
+    for tool in ("aiagents_create", "aiagents_partial_update"):
+        schema = {
+            "type": "object",
+            "properties": {
+                "pipecat_data": {"type": "string", "description": "x"},
+                "name": {"type": "string"},
+            },
+            "required": [],
+        }
+        out = apply_overlay_to_schema(tool, schema)
+        assert out["properties"]["pipecat_data"]["type"] == "object", tool
+        assert out["properties"]["pipecat_data"].get("additionalProperties") is True, tool
+        # unrelated fields are untouched
+        assert out["properties"]["name"]["type"] == "string", tool

--- a/cekura-mcp-server/tool_generator.py
+++ b/cekura-mcp-server/tool_generator.py
@@ -97,6 +97,18 @@ def apply_overlay_to_schema(tool_name: str, schema: Dict[str, Any]) -> Dict[str,
         existing.update(overlay['required'])
         schema['required'] = sorted(existing)
 
+    # Force specific body fields to a given JSON-schema type. For fields the
+    # backend stores as JSON objects but the OpenAPI spec types as `string`
+    # (e.g. AIAgent.pipecat_data), declaring `object` makes the HTTP client
+    # coerce the model's stringified value to a dict before sending — the
+    # backend rejects a raw string. Scoped per-tool via mcp_tools.json.
+    for field_name, ptype in (overlay.get('property_types') or {}).items():
+        prop = (schema.get('properties') or {}).get(field_name)
+        if isinstance(prop, dict):
+            prop['type'] = ptype
+            if ptype == 'object':
+                prop.setdefault('additionalProperties', True)
+
     # Examples precedence (JSON-Schema draft-07 `examples` array, one per request body):
     #   1. Overlay `examples: [...]` → use verbatim; openapi examples ignored.
     #   2. Else, merge openapi-spec examples with overlay.example_request. Overlay filters:


### PR DESCRIPTION
## Problem
The onboarding agent can't set `pipecat_data` via the MCP `aiagents_create` / `aiagents_partial_update` tools. `APIDataField` is typed `string` in the OpenAPI schema, so the MCP client forwards the model's value verbatim as a **string**, but the backend requires a dict → `"Expected a dictionary"`. Backend/spec can't change right now.

## Fix (MCP-only, scoped to agent creation)
Add a `property_types` overlay key to `apply_overlay_to_schema` that forces a body field's JSON-schema type. In `mcp_tools.json`, mark **`pipecat_data` → `object`** on `aiagents_create` and `aiagents_partial_update`. The MCP HTTP client already coerces stringified JSON for `type: object`/`array` fields (`_parse_json_field`), so the model's `'{"pipecat_agent_name": "..."}'` is parsed into a dict before the request is sent → backend accepts.

- No backend change, no `openapi.json` regen.
- Respects the client's "trust the declared type" design — we correct the (overlaid) type rather than hacking the parser.
- Scoped to the two agent write tools; other providers' `*_data` fields can be added to `property_types` the same way if needed.

## Tests
`test_pipecat_data_overlaid_to_object_for_agent_tools` — pins the override sets `object` + `additionalProperties` on both tools and leaves other fields untouched. (Note: the pre-existing `test_generate_description_truncation` failure is unrelated — fails on `main` too.)

## Pairs with
- cekura-skills PR #48 (correct pipecat config shape + WebRTC run tool).
- Supersedes the user-facing-curl fallback idea; the agent now sets `pipecat_data` itself through the normal MCP tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)