### PR TITLE
fix(mcp): suppress OAuth discovery when API key is configured

### DIFF
--- a/cekura-mcp-server/http_client.py
+++ b/cekura-mcp-server/http_client.py
@@ -18,6 +18,7 @@ class CekuraAPIClient:
         mcp_session_id: Optional[str] = None,
     ):
         self.base_url = base_url
+        self.credential_type = credential_type
         auth_header = (
             {"Authorization": f"Bearer {credential}"}
             if credential_type == "bearer"
@@ -152,7 +153,22 @@ class CekuraAPIClient:
                 return {"result": response.text}
 
         if response.status_code == 401:
-            raise Exception("Authentication failed (401). Check your CEKURA_API_KEY.")
+            if self.credential_type == "bearer":
+                message = (
+                    "Authentication failed (401). Your OAuth/Bearer token was rejected — "
+                    "it may have expired or been revoked. Re-authenticate and retry."
+                )
+            else:
+                message = (
+                    "Authentication failed (401). Your API key was rejected for this endpoint. "
+                    "Verify CEKURA_API_KEY is valid and authorized for this operation."
+                )
+            return {
+                "error": "authentication_failed",
+                "status_code": 401,
+                "credential_type": self.credential_type,
+                "message": message,
+            }
 
         if response.status_code == 403:
             raise Exception("Access forbidden (403). You may not have permission for this endpoint.")

--- a/cekura-mcp-server/http_client.py
+++ b/cekura-mcp-server/http_client.py
@@ -166,7 +166,6 @@ class CekuraAPIClient:
             return {
                 "error": "authentication_failed",
                 "status_code": 401,
-                "credential_type": self.credential_type,
                 "message": message,
             }
 

--- a/cekura-mcp-server/openapi_mcp_server.py
+++ b/cekura-mcp-server/openapi_mcp_server.py
@@ -906,7 +906,7 @@ def main():
 
     import uvicorn
     from starlette.middleware.base import BaseHTTPMiddleware
-    from starlette.responses import JSONResponse
+    from starlette.responses import JSONResponse, Response
     from starlette.routing import Route
 
     parser = argparse.ArgumentParser(description="Cekura OpenAPI MCP Server")
@@ -1088,15 +1088,23 @@ def main():
         logger.info(f"observe: forwarded session {session_id} as call_id={call_id} (skill={skill}, turns={len(transcript)})")
         return JSONResponse({"status": "ok", "call_id": call_id, "upstream_status": resp.status_code})
 
+    def _has_api_key(request) -> bool:
+        return bool(
+            request.headers.get('X-CEKURA-API-KEY')
+            or request.headers.get('x-cekura-api-key')
+        )
+
     async def oauth_protected_resource(request):
-        # RFC 9728 — resource server advertises its authorization server
+        if _has_api_key(request):
+            return Response(status_code=404)
         return JSONResponse({
             "resource": MCP_SERVER_URL,
             "authorization_servers": [MCP_ISSUER_URL],
         })
 
     async def oauth_as_metadata(request):
-        # Convenience fallback for clients that check AS metadata directly on resource server
+        if _has_api_key(request):
+            return Response(status_code=404)
         return JSONResponse({
             "issuer": MCP_ISSUER_URL,
             "authorization_endpoint": f"{MCP_ISSUER_URL}/user/oauth/authorize",


### PR DESCRIPTION
## Summary
- API-key MCP clients no longer trigger OAuth browser re-auth on backend 401s.
- `oauth_protected_resource` / `oauth_as_metadata` return `404` when the request carries `X-CEKURA-API-KEY`, so Claude Code can't discover an authorization server for those connections.
- `http_client._handle_response` converts a backend `401` into a tool-error result (dict) instead of raising, so it surfaces as a tool failure rather than a transport-level `401`. The error message is tailored: API-key users are told to check `CEKURA_API_KEY`; bearer/OAuth users are told to re-authenticate.

## Why
Some MCP-exposed backend ViewSets don't include `APIKeyAuthentication` in their `authentication_classes`, so calls to those endpoints `401` even when a valid API key is configured. Because the MCP server advertises OAuth at `/.well-known/oauth-*`, Claude Code interprets the `401` as "needs auth" and kicks a browser flow — even though the user explicitly chose API-key auth.

This change keeps OAuth fully functional for clients that don't send an API key, while making it invisible (and unkickable) for clients that do.

## Test plan
- [ ] `python3 cekura-mcp-server/validate_overlays.py` — no new drift.
- [ ] `cd cekura-mcp-server && python3 -m pytest tests/test_http_client.py tests/test_overlays.py -q` — passes (38/38 locally).
- [ ] Manual: configure Claude Code with `--header "X-CEKURA-API-KEY: <key>"`, call a tool whose backend ViewSet omits `APIKeyAuthentication`, confirm Claude Code shows a tool error instead of a browser re-auth prompt.
- [ ] Manual: configure Claude Code without an API-key header (OAuth path), confirm `/.well-known/oauth-protected-resource` and `/.well-known/oauth-authorization-server` still return metadata and the browser flow works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)