### PR TITLE
fix(mcp): clean auth separation — API key, Supabase, OAuth

### DIFF
--- a/cekura-mcp-server/http_client.py
+++ b/cekura-mcp-server/http_client.py
@@ -18,6 +18,7 @@ class CekuraAPIClient:
         mcp_session_id: Optional[str] = None,
     ):
         self.base_url = base_url
+        self.credential_type = credential_type
         auth_header = (
             {"Authorization": f"Bearer {credential}"}
             if credential_type == "bearer"
@@ -152,7 +153,22 @@ class CekuraAPIClient:
                 return {"result": response.text}
 
         if response.status_code == 401:
-            raise Exception("Authentication failed (401). Check your CEKURA_API_KEY.")
+            if self.credential_type == "bearer":
+                message = (
+                    "Authentication failed (401). Your OAuth/Bearer token was rejected — "
+                    "it may have expired or been revoked. Re-authenticate and retry."
+                )
+            else:
+                message = (
+                    "Authentication failed (401). Your API key was rejected for this endpoint. "
+                    "Verify CEKURA_API_KEY is valid and authorized for this operation."
+                )
+            return {
+                "error": "authentication_failed",
+                "status_code": 401,
+                "credential_type": self.credential_type,
+                "message": message,
+            }
 
         if response.status_code == 403:
             raise Exception("Access forbidden (403). You may not have permission for this endpoint.")

--- a/cekura-mcp-server/http_client.py
+++ b/cekura-mcp-server/http_client.py
@@ -2,6 +2,8 @@ import httpx
 from typing import Dict, Any, Optional
 import json
 
+import jwt
+
 
 class CekuraAPIClient:
     def __init__(
@@ -19,6 +21,7 @@ class CekuraAPIClient:
     ):
         self.base_url = base_url
         self.credential_type = credential_type
+        self._bearer_token = credential if credential_type == "bearer" else None
         auth_header = (
             {"Authorization": f"Bearer {credential}"}
             if credential_type == "bearer"
@@ -48,6 +51,17 @@ class CekuraAPIClient:
 
     async def close(self):
         await self.client.aclose()
+
+    def _is_oauth_access_token(self) -> bool:
+        if not self._bearer_token:
+            return False
+        try:
+            payload = jwt.decode(
+                self._bearer_token, options={"verify_signature": False}
+            )
+        except jwt.PyJWTError:
+            return False
+        return payload.get("type") == "oauth_access"
 
     async def execute_request(
         self,
@@ -153,21 +167,29 @@ class CekuraAPIClient:
                 return {"result": response.text}
 
         if response.status_code == 401:
-            if self.credential_type == "bearer":
-                message = (
-                    "Authentication failed (401). Your OAuth/Bearer token was rejected — "
+            payload: Dict[str, Any] = {
+                "error": "authentication_failed",
+                "status_code": 401,
+            }
+            if self._is_oauth_access_token():
+                payload["message"] = (
+                    "OAuth access token rejected. The client should refresh "
+                    "the token and retry."
+                )
+                # Marker scanned by OAuthRefreshSignalMiddleware to convert this
+                # tool-level error into a transport-level 401 with WWW-Authenticate.
+                payload["oauth_refresh_required"] = True
+            elif self.credential_type == "bearer":
+                payload["message"] = (
+                    "Authentication failed (401). Bearer token rejected — "
                     "it may have expired or been revoked. Re-authenticate and retry."
                 )
             else:
-                message = (
-                    "Authentication failed (401). Your API key was rejected for this endpoint. "
+                payload["message"] = (
+                    "Authentication failed (401). API key rejected for this endpoint. "
                     "Verify CEKURA_API_KEY is valid and authorized for this operation."
                 )
-            return {
-                "error": "authentication_failed",
-                "status_code": 401,
-                "message": message,
-            }
+            return payload
 
         if response.status_code == 403:
             raise Exception("Access forbidden (403). You may not have permission for this endpoint.")

--- a/cekura-mcp-server/http_client.py
+++ b/cekura-mcp-server/http_client.py
@@ -166,7 +166,6 @@ class CekuraAPIClient:
             return {
                 "error": "authentication_failed",
                 "status_code": 401,
-                "credential_type": self.credential_type,
                 "message": message,
             }
 

--- a/cekura-mcp-server/http_client.py
+++ b/cekura-mcp-server/http_client.py
@@ -5,6 +5,13 @@ import json
 import jwt
 
 
+class OAuthRefreshNeeded(Exception):
+    """Raised when the backend rejects an oauth_access JWT. The MCP tool wrapper
+    catches this and emits a sentinel string in the response body; an ASGI
+    middleware then converts the response to HTTP 401 + WWW-Authenticate so the
+    MCP client refreshes its token."""
+
+
 class CekuraAPIClient:
     def __init__(
         self,
@@ -167,29 +174,19 @@ class CekuraAPIClient:
                 return {"result": response.text}
 
         if response.status_code == 401:
-            payload: Dict[str, Any] = {
-                "error": "authentication_failed",
-                "status_code": 401,
-            }
             if self._is_oauth_access_token():
-                payload["message"] = (
-                    "OAuth access token rejected. The client should refresh "
-                    "the token and retry."
+                raise OAuthRefreshNeeded(
+                    "OAuth access token rejected. Refresh required."
                 )
-                # Marker scanned by OAuthRefreshSignalMiddleware to convert this
-                # tool-level error into a transport-level 401 with WWW-Authenticate.
-                payload["oauth_refresh_required"] = True
-            elif self.credential_type == "bearer":
-                payload["message"] = (
+            if self.credential_type == "bearer":
+                raise Exception(
                     "Authentication failed (401). Bearer token rejected — "
                     "it may have expired or been revoked. Re-authenticate and retry."
                 )
-            else:
-                payload["message"] = (
-                    "Authentication failed (401). API key rejected for this endpoint. "
-                    "Verify CEKURA_API_KEY is valid and authorized for this operation."
-                )
-            return payload
+            raise Exception(
+                "Authentication failed (401). API key rejected for this endpoint. "
+                "Verify CEKURA_API_KEY is valid and authorized for this operation."
+            )
 
         if response.status_code == 403:
             raise Exception("Access forbidden (403). You may not have permission for this endpoint.")

--- a/cekura-mcp-server/http_client.py
+++ b/cekura-mcp-server/http_client.py
@@ -2,14 +2,6 @@ import httpx
 from typing import Dict, Any, Optional
 import json
 
-import jwt
-
-
-class OAuthRefreshNeeded(Exception):
-    """Raised when the backend rejects an oauth_access JWT. The MCP tool wrapper
-    catches this and emits a sentinel string in the response body; an ASGI
-    middleware then converts the response to HTTP 401 + WWW-Authenticate so the
-    MCP client refreshes its token."""
 
 
 class CekuraAPIClient:
@@ -28,7 +20,6 @@ class CekuraAPIClient:
     ):
         self.base_url = base_url
         self.credential_type = credential_type
-        self._bearer_token = credential if credential_type == "bearer" else None
         auth_header = (
             {"Authorization": f"Bearer {credential}"}
             if credential_type == "bearer"
@@ -58,17 +49,6 @@ class CekuraAPIClient:
 
     async def close(self):
         await self.client.aclose()
-
-    def _is_oauth_access_token(self) -> bool:
-        if not self._bearer_token:
-            return False
-        try:
-            payload = jwt.decode(
-                self._bearer_token, options={"verify_signature": False}
-            )
-        except jwt.PyJWTError:
-            return False
-        return payload.get("type") == "oauth_access"
 
     async def execute_request(
         self,
@@ -174,10 +154,6 @@ class CekuraAPIClient:
                 return {"result": response.text}
 
         if response.status_code == 401:
-            if self._is_oauth_access_token():
-                raise OAuthRefreshNeeded(
-                    "OAuth access token rejected. Refresh required."
-                )
             if self.credential_type == "bearer":
                 raise Exception(
                     "Authentication failed (401). Bearer token rejected — "

--- a/cekura-mcp-server/http_client.py
+++ b/cekura-mcp-server/http_client.py
@@ -3,7 +3,6 @@ from typing import Dict, Any, Optional
 import json
 
 
-
 class CekuraAPIClient:
     def __init__(
         self,

--- a/cekura-mcp-server/openapi_mcp_server.py
+++ b/cekura-mcp-server/openapi_mcp_server.py
@@ -25,15 +25,13 @@ if os.getenv("AWS_SECRET_NAME"):
     os.environ.update({key: str(value) for key, value in _config.items()})
 
 from config import load_config
-from http_client import create_client, OAuthRefreshNeeded
+from http_client import create_client
 
-# Private sentinel emitted by the tool wrapper when the backend rejects an
-# oauth_access JWT. OAuthRefreshSignalMiddleware scans the response body for
-# this byte sequence and converts the response into HTTP 401 + WWW-Authenticate
-# so the MCP client refreshes its OAuth token. The string is deliberately
-# verbose and version-tagged to avoid colliding with any legitimate tool output.
-OAUTH_REFRESH_SENTINEL = "__cekura_mcp_internal_oauth_refresh_required_v1__"
-OAUTH_REFRESH_SENTINEL_BYTES = OAUTH_REFRESH_SENTINEL.encode()
+import jwt as _jwt
+import time as _time
+
+# Clock-skew grace for local oauth_access JWT expiry check.
+OAUTH_EXP_SKEW_SECONDS = 10
 from openapi_parser import load_openapi_spec
 from tool_generator import (
     apply_overlay_to_description,
@@ -900,8 +898,6 @@ def setup_dynamic_tool_handlers():
 
         except ValueError as e:
             return [{"type": "text", "text": f"Authentication Error: {e}{call_id_suffix}"}]
-        except OAuthRefreshNeeded:
-            return [{"type": "text", "text": OAUTH_REFRESH_SENTINEL}]
         except Exception as e:
             # Log the traceback for ops; return only the actionable message to
             # the LLM (no /app/ paths, no Python stack frames).
@@ -959,9 +955,30 @@ def main():
             has_bearer = False
             auth_header = request.headers.get('Authorization') or request.headers.get('authorization')
             if auth_header and auth_header.lower().startswith('bearer '):
-                request_bearer_token.set(auth_header[7:])
+                token = auth_header[7:]
+                request_bearer_token.set(token)
                 has_bearer = True
                 logger.debug("Bearer token credential set for request")
+
+                # Local expiry check for oauth_access JWTs. Unsigned peek;
+                # signature/audience validation stays the backend's job. Catching
+                # expiry here short-circuits the request and emits 401 +
+                # WWW-Authenticate so the MCP client refreshes the token.
+                try:
+                    claims = _jwt.decode(token, options={"verify_signature": False})
+                except _jwt.PyJWTError:
+                    claims = None
+                if claims is not None and claims.get("type") == "oauth_access":
+                    exp = claims.get("exp")
+                    if isinstance(exp, (int, float)) and exp < _time.time() - OAUTH_EXP_SKEW_SECONDS:
+                        return JSONResponse(
+                            {
+                                "error": "invalid_token",
+                                "error_description": "OAuth access token expired",
+                            },
+                            status_code=401,
+                            headers={"WWW-Authenticate": WWW_AUTH_HEADER},
+                        )
 
             # API key header — legacy mcp-remote / Claude Desktop
             has_api_key = False
@@ -1009,96 +1026,6 @@ def main():
                 )
 
             return await call_next(request)
-
-    class OAuthRefreshSignalMiddleware:
-        """Pure-ASGI middleware. Scans POST responses for the OAuth refresh
-        sentinel and replaces matching responses with HTTP 401 + WWW-Authenticate
-        so MCP clients trigger reactive OAuth token refresh.
-
-        Scoped to keep memory cost bounded:
-          - Only POST requests carrying `Authorization: Bearer …` are buffered.
-            API-key, anonymous, and GET (SSE long-poll) traffic passes through
-            unbuffered.
-          - Buffer is capped at MAX_SCAN_BYTES. Larger responses flush early
-            and pass through; a tool-result body large enough to exceed the
-            cap can't be the small auth-error payload that carries the sentinel.
-        """
-
-        MAX_SCAN_BYTES = 64 * 1024
-
-        def __init__(self, app):
-            self.app = app
-
-        async def __call__(self, scope, receive, send):
-            if scope["type"] != "http" or scope.get("method") != "POST":
-                return await self.app(scope, receive, send)
-
-            auth = b""
-            for k, v in scope.get("headers", []):
-                if k.lower() == b"authorization":
-                    auth = v
-                    break
-            if not auth.lower().startswith(b"bearer "):
-                return await self.app(scope, receive, send)
-
-            start_msg = None
-            chunks: List[bytes] = []
-            buffered_bytes = 0
-            flushed = False
-            cap = self.MAX_SCAN_BYTES
-
-            async def flush_buffered():
-                nonlocal flushed
-                if flushed:
-                    return
-                flushed = True
-                if start_msg is not None:
-                    await send(start_msg)
-                for chunk in chunks:
-                    await send({"type": "http.response.body", "body": chunk, "more_body": True})
-
-            async def wrapped_send(message):
-                nonlocal start_msg, buffered_bytes, flushed
-                if flushed:
-                    return await send(message)
-                if message["type"] == "http.response.start":
-                    start_msg = message
-                    return
-                if message["type"] != "http.response.body":
-                    return await send(message)
-
-                chunk = message.get("body", b"")
-                chunks.append(chunk)
-                buffered_bytes += len(chunk)
-
-                if not message.get("more_body"):
-                    body = b"".join(chunks)
-                    if OAUTH_REFRESH_SENTINEL_BYTES in body:
-                        refresh_body = json.dumps({
-                            "error": "invalid_token",
-                            "error_description": "OAuth access token rejected — refresh required",
-                        }).encode()
-                        await send({
-                            "type": "http.response.start",
-                            "status": 401,
-                            "headers": [
-                                (b"content-type", b"application/json"),
-                                (b"www-authenticate", WWW_AUTH_HEADER.encode()),
-                                (b"content-length", str(len(refresh_body)).encode()),
-                            ],
-                        })
-                        await send({"type": "http.response.body", "body": refresh_body})
-                    else:
-                        if start_msg is not None:
-                            await send(start_msg)
-                        await send({"type": "http.response.body", "body": body})
-                    return
-
-                if buffered_bytes > cap:
-                    await flush_buffered()
-                    chunks.clear()
-
-            await self.app(scope, receive, wrapped_send)
 
     async def health_check(request):
         return JSONResponse({
@@ -1228,10 +1155,6 @@ def main():
     app.router.routes.insert(5, Route("/mcp/healthz", health_check))
     app.router.routes.insert(6, Route("/mcp/monitoring/sessions", monitoring_session_create, methods=["POST"]))
 
-    # Starlette stacks middleware so the last added is outermost. We want
-    # CredentialMiddleware outer (reject unauth requests early) and
-    # OAuthRefreshSignalMiddleware inner (wrap the tool dispatch response).
-    app.add_middleware(OAuthRefreshSignalMiddleware)
     app.add_middleware(CredentialMiddleware)
     logger.info("Credential middleware added (API key + Bearer token support)")
     logger.info(f"OAuth discovery: {MCP_SERVER_URL}/.well-known/oauth-protected-resource → {MCP_ISSUER_URL}")

--- a/cekura-mcp-server/openapi_mcp_server.py
+++ b/cekura-mcp-server/openapi_mcp_server.py
@@ -25,7 +25,15 @@ if os.getenv("AWS_SECRET_NAME"):
     os.environ.update({key: str(value) for key, value in _config.items()})
 
 from config import load_config
-from http_client import create_client
+from http_client import create_client, OAuthRefreshNeeded
+
+# Private sentinel emitted by the tool wrapper when the backend rejects an
+# oauth_access JWT. OAuthRefreshSignalMiddleware scans the response body for
+# this byte sequence and converts the response into HTTP 401 + WWW-Authenticate
+# so the MCP client refreshes its OAuth token. The string is deliberately
+# verbose and version-tagged to avoid colliding with any legitimate tool output.
+OAUTH_REFRESH_SENTINEL = "__cekura_mcp_internal_oauth_refresh_required_v1__"
+OAUTH_REFRESH_SENTINEL_BYTES = OAUTH_REFRESH_SENTINEL.encode()
 from openapi_parser import load_openapi_spec
 from tool_generator import (
     apply_overlay_to_description,
@@ -892,6 +900,8 @@ def setup_dynamic_tool_handlers():
 
         except ValueError as e:
             return [{"type": "text", "text": f"Authentication Error: {e}{call_id_suffix}"}]
+        except OAuthRefreshNeeded:
+            return [{"type": "text", "text": OAUTH_REFRESH_SENTINEL}]
         except Exception as e:
             # Log the traceback for ops; return only the actionable message to
             # the LLM (no /app/ paths, no Python stack frames).
@@ -1000,46 +1010,93 @@ def main():
 
             return await call_next(request)
 
-    OAUTH_REFRESH_MARKER = b"oauth_refresh_required"
-
     class OAuthRefreshSignalMiddleware:
+        """Pure-ASGI middleware. Scans POST responses for the OAuth refresh
+        sentinel and replaces matching responses with HTTP 401 + WWW-Authenticate
+        so MCP clients trigger reactive OAuth token refresh.
+
+        Scoped to keep memory cost bounded:
+          - Only POST requests carrying `Authorization: Bearer …` are buffered.
+            API-key, anonymous, and GET (SSE long-poll) traffic passes through
+            unbuffered.
+          - Buffer is capped at MAX_SCAN_BYTES. Larger responses flush early
+            and pass through; a tool-result body large enough to exceed the
+            cap can't be the small auth-error payload that carries the sentinel.
+        """
+
+        MAX_SCAN_BYTES = 64 * 1024
+
         def __init__(self, app):
             self.app = app
 
         async def __call__(self, scope, receive, send):
-            if scope["type"] != "http":
+            if scope["type"] != "http" or scope.get("method") != "POST":
                 return await self.app(scope, receive, send)
 
-            start = None
-            chunks: list[bytes] = []
+            auth = b""
+            for k, v in scope.get("headers", []):
+                if k.lower() == b"authorization":
+                    auth = v
+                    break
+            if not auth.lower().startswith(b"bearer "):
+                return await self.app(scope, receive, send)
+
+            start_msg = None
+            chunks: List[bytes] = []
+            buffered_bytes = 0
+            flushed = False
+            cap = self.MAX_SCAN_BYTES
+
+            async def flush_buffered():
+                nonlocal flushed
+                if flushed:
+                    return
+                flushed = True
+                if start_msg is not None:
+                    await send(start_msg)
+                for chunk in chunks:
+                    await send({"type": "http.response.body", "body": chunk, "more_body": True})
 
             async def wrapped_send(message):
-                nonlocal start
+                nonlocal start_msg, buffered_bytes, flushed
+                if flushed:
+                    return await send(message)
                 if message["type"] == "http.response.start":
-                    start = message
+                    start_msg = message
                     return
-                chunks.append(message.get("body", b""))
-                if message.get("more_body"):
+                if message["type"] != "http.response.body":
+                    return await send(message)
+
+                chunk = message.get("body", b"")
+                chunks.append(chunk)
+                buffered_bytes += len(chunk)
+
+                if not message.get("more_body"):
+                    body = b"".join(chunks)
+                    if OAUTH_REFRESH_SENTINEL_BYTES in body:
+                        refresh_body = json.dumps({
+                            "error": "invalid_token",
+                            "error_description": "OAuth access token rejected — refresh required",
+                        }).encode()
+                        await send({
+                            "type": "http.response.start",
+                            "status": 401,
+                            "headers": [
+                                (b"content-type", b"application/json"),
+                                (b"www-authenticate", WWW_AUTH_HEADER.encode()),
+                                (b"content-length", str(len(refresh_body)).encode()),
+                            ],
+                        })
+                        await send({"type": "http.response.body", "body": refresh_body})
+                    else:
+                        if start_msg is not None:
+                            await send(start_msg)
+                        await send({"type": "http.response.body", "body": body})
                     return
-                body = b"".join(chunks)
-                if OAUTH_REFRESH_MARKER in body:
-                    refresh_body = json.dumps({
-                        "error": "invalid_token",
-                        "error_description": "OAuth access token rejected — refresh required",
-                    }).encode()
-                    await send({
-                        "type": "http.response.start",
-                        "status": 401,
-                        "headers": [
-                            (b"content-type", b"application/json"),
-                            (b"www-authenticate", WWW_AUTH_HEADER.encode()),
-                            (b"content-length", str(len(refresh_body)).encode()),
-                        ],
-                    })
-                    await send({"type": "http.response.body", "body": refresh_body})
-                else:
-                    await send(start)
-                    await send({"type": "http.response.body", "body": body})
+
+                if buffered_bytes > cap:
+                    await flush_buffered()
+                    chunks.clear()
 
             await self.app(scope, receive, wrapped_send)
 
@@ -1171,6 +1228,9 @@ def main():
     app.router.routes.insert(5, Route("/mcp/healthz", health_check))
     app.router.routes.insert(6, Route("/mcp/monitoring/sessions", monitoring_session_create, methods=["POST"]))
 
+    # Starlette stacks middleware so the last added is outermost. We want
+    # CredentialMiddleware outer (reject unauth requests early) and
+    # OAuthRefreshSignalMiddleware inner (wrap the tool dispatch response).
     app.add_middleware(OAuthRefreshSignalMiddleware)
     app.add_middleware(CredentialMiddleware)
     logger.info("Credential middleware added (API key + Bearer token support)")

--- a/cekura-mcp-server/openapi_mcp_server.py
+++ b/cekura-mcp-server/openapi_mcp_server.py
@@ -1000,6 +1000,49 @@ def main():
 
             return await call_next(request)
 
+    OAUTH_REFRESH_MARKER = b"oauth_refresh_required"
+
+    class OAuthRefreshSignalMiddleware:
+        def __init__(self, app):
+            self.app = app
+
+        async def __call__(self, scope, receive, send):
+            if scope["type"] != "http":
+                return await self.app(scope, receive, send)
+
+            start = None
+            chunks: list[bytes] = []
+
+            async def wrapped_send(message):
+                nonlocal start
+                if message["type"] == "http.response.start":
+                    start = message
+                    return
+                chunks.append(message.get("body", b""))
+                if message.get("more_body"):
+                    return
+                body = b"".join(chunks)
+                if OAUTH_REFRESH_MARKER in body:
+                    refresh_body = json.dumps({
+                        "error": "invalid_token",
+                        "error_description": "OAuth access token rejected — refresh required",
+                    }).encode()
+                    await send({
+                        "type": "http.response.start",
+                        "status": 401,
+                        "headers": [
+                            (b"content-type", b"application/json"),
+                            (b"www-authenticate", WWW_AUTH_HEADER.encode()),
+                            (b"content-length", str(len(refresh_body)).encode()),
+                        ],
+                    })
+                    await send({"type": "http.response.body", "body": refresh_body})
+                else:
+                    await send(start)
+                    await send({"type": "http.response.body", "body": body})
+
+            await self.app(scope, receive, wrapped_send)
+
     async def health_check(request):
         return JSONResponse({
             "status": "healthy",
@@ -1128,6 +1171,7 @@ def main():
     app.router.routes.insert(5, Route("/mcp/healthz", health_check))
     app.router.routes.insert(6, Route("/mcp/monitoring/sessions", monitoring_session_create, methods=["POST"]))
 
+    app.add_middleware(OAuthRefreshSignalMiddleware)
     app.add_middleware(CredentialMiddleware)
     logger.info("Credential middleware added (API key + Bearer token support)")
     logger.info(f"OAuth discovery: {MCP_SERVER_URL}/.well-known/oauth-protected-resource → {MCP_ISSUER_URL}")

--- a/cekura-mcp-server/openapi_mcp_server.py
+++ b/cekura-mcp-server/openapi_mcp_server.py
@@ -12,6 +12,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
 import httpx
+import jwt
 from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
 from mcp.types import ToolAnnotations
@@ -26,12 +27,6 @@ if os.getenv("AWS_SECRET_NAME"):
 
 from config import load_config
 from http_client import create_client
-
-import jwt as _jwt
-import time as _time
-
-# Clock-skew grace for local oauth_access JWT expiry check.
-OAUTH_EXP_SKEW_SECONDS = 10
 from openapi_parser import load_openapi_spec
 from tool_generator import (
     apply_overlay_to_description,
@@ -75,6 +70,9 @@ _ALLOW_BASE_URL_OVERRIDE = os.environ.get("ALLOW_BASE_URL_OVERRIDE", "").lower()
 
 MCP_ISSUER_URL = os.environ.get("MCP_ISSUER_URL", "https://api.cekura.ai")
 MCP_SERVER_URL = os.environ.get("MCP_SERVER_URL", "https://api.cekura.ai/mcp")
+
+# Clock-skew grace (seconds) for the local oauth_access JWT expiry check.
+OAUTH_EXP_SKEW_SECONDS = 10
 
 # Derive allowed hosts from MCP_ISSUER_URL and MCP_SERVER_URL (covers prod, ngrok, local).
 from urllib.parse import urlparse as _urlparse
@@ -960,22 +958,19 @@ def main():
                 has_bearer = True
                 logger.debug("Bearer token credential set for request")
 
-                # Local expiry check for oauth_access JWTs. Unsigned peek;
-                # signature/audience validation stays the backend's job. Catching
-                # expiry here short-circuits the request and emits 401 +
+                # Short-circuit expired oauth_access JWTs with 401 +
                 # WWW-Authenticate so the MCP client refreshes the token.
+                # Signature validation stays the backend's job.
                 try:
-                    claims = _jwt.decode(token, options={"verify_signature": False})
-                except _jwt.PyJWTError:
+                    claims = jwt.decode(token, options={"verify_signature": False})
+                except jwt.PyJWTError:
                     claims = None
-                if claims is not None and claims.get("type") == "oauth_access":
+                if claims and claims.get("type") == "oauth_access":
                     exp = claims.get("exp")
-                    if isinstance(exp, (int, float)) and exp < _time.time() - OAUTH_EXP_SKEW_SECONDS:
+                    if isinstance(exp, (int, float)) and exp < time.time() - OAUTH_EXP_SKEW_SECONDS:
                         return JSONResponse(
-                            {
-                                "error": "invalid_token",
-                                "error_description": "OAuth access token expired",
-                            },
+                            {"error": "invalid_token",
+                             "error_description": "OAuth access token expired"},
                             status_code=401,
                             headers={"WWW-Authenticate": WWW_AUTH_HEADER},
                         )

--- a/cekura-mcp-server/openapi_mcp_server.py
+++ b/cekura-mcp-server/openapi_mcp_server.py
@@ -906,7 +906,7 @@ def main():
 
     import uvicorn
     from starlette.middleware.base import BaseHTTPMiddleware
-    from starlette.responses import JSONResponse
+    from starlette.responses import JSONResponse, Response
     from starlette.routing import Route
 
     parser = argparse.ArgumentParser(description="Cekura OpenAPI MCP Server")
@@ -1088,15 +1088,23 @@ def main():
         logger.info(f"observe: forwarded session {session_id} as call_id={call_id} (skill={skill}, turns={len(transcript)})")
         return JSONResponse({"status": "ok", "call_id": call_id, "upstream_status": resp.status_code})
 
+    def _has_api_key(request) -> bool:
+        return bool(
+            request.headers.get('X-CEKURA-API-KEY')
+            or request.headers.get('x-cekura-api-key')
+        )
+
     async def oauth_protected_resource(request):
-        # RFC 9728 — resource server advertises its authorization server
+        if _has_api_key(request):
+            return Response(status_code=404)
         return JSONResponse({
             "resource": MCP_SERVER_URL,
             "authorization_servers": [MCP_ISSUER_URL],
         })
 
     async def oauth_as_metadata(request):
-        # Convenience fallback for clients that check AS metadata directly on resource server
+        if _has_api_key(request):
+            return Response(status_code=404)
         return JSONResponse({
             "issuer": MCP_ISSUER_URL,
             "authorization_endpoint": f"{MCP_ISSUER_URL}/user/oauth/authorize",


### PR DESCRIPTION
Cleans up MCP auth UX so the three credential types — `X-CEKURA-API-KEY`, Supabase JWT, OAuth `oauth_access` JWT — stop bleeding into each other's flows.

## Changes
1. **OAuth discovery gate.** `/.well-known/oauth-*` returns 404 when `X-CEKURA-API-KEY` is present. API-key users no longer get pushed into a browser OAuth flow on endpoint 401s.
2. **Reactive OAuth refresh.** `CredentialMiddleware` unsigned-peeks `oauth_access` JWTs and returns HTTP 401 + `WWW-Authenticate` when `exp` is past. MCP client refreshes via `/oauth/token` and retries silently. No buffering, no body inspection — matches the MCP/OAuth 2.1 spec for resource servers.

## Before / after

### API key (`X-CEKURA-API-KEY`)
| Scenario | Before | After |
|---|---|---|
| Valid key, endpoint accepts API key | ✅ 200 | ✅ 200 |
| Valid key, endpoint rejects API key | 🔴 browser OAuth prompt | 🟡 clean tool error |
| Invalid / revoked key | 🔴 browser OAuth prompt | 🟡 clean tool error |
| `.well-known/oauth-*` probe | metadata advertised | **404** (OAuth invisible) |

### Supabase JWT (`Authorization: Bearer …`)
| Scenario | Before | After |
|---|---|---|
| Valid token | ✅ 200 | ✅ 200 |
| Expired / rejected | 🟡 misleading "check CEKURA_API_KEY" | 🟡 clean "Bearer token rejected" |
| `.well-known/oauth-*` probe | metadata advertised | metadata advertised (unchanged) |

### OAuth access token (`Authorization: Bearer <oauth_access>`)
| Scenario | Before | After |
|---|---|---|
| Valid token | ✅ 200 | ✅ 200 |
| Expired access token (proactive refresh missed) | 🔴 manual re-auth | 🟢 **silent refresh + retry** |
| Already-expired token sent | 🔴 manual re-auth | 🟢 **silent refresh + retry** |
| Token revoked server-side mid-exp-window | 🔴 manual re-auth | 🔴 manual re-auth (accepted trade-off) |
| Refresh token expired | 🔴 browser re-auth | 🔴 browser re-auth (unchanged) |

🟢 silent · 🟡 tool error · 🔴 user-facing prompt

## Trade-off
Server-side revocation between the JWT's `exp` and its natural expiry isn't caught locally. Same trade-off most OAuth resource servers make (GitHub, Stripe, etc.).

## Why not body-scanning / contextvar signaling
Both tried during review iteration:
- FastMCP's per-session task forks context at `initialize`; per-request middleware contextvars don't propagate.
- FastMCP catches every exception from tools and wraps as HTTP 200 JSON-RPC.

Moving the auth check *upstream* of FastMCP sidesteps both.

## Files changed
- `cekura-mcp-server/openapi_mcp_server.py` — `.well-known/*` header gate + JWT exp pre-check in `CredentialMiddleware`.
- `cekura-mcp-server/http_client.py` — restored pre-PR raise-on-401 behavior; removed JWT helpers no longer needed.

## Test plan
- [x] `pytest tests/test_http_client.py tests/test_overlays.py -q` — 38/38.
- [x] Local matrix above against dockerized backend.
- [ ] Manual smoke: OAuth user with expired access token → silent refresh + retry.
- [ ] Manual smoke: API-key user on endpoint rejecting API-key auth → tool error, no browser prompt.

Supersedes #637.