### PR TITLE
[Auto] Sync docs for backend PR #9311

### DIFF
--- a/api-reference/schedules/delete-metric-optimiser-cron-job.mdx
+++ b/api-reference/schedules/delete-metric-optimiser-cron-job.mdx
@@ -1,0 +1,6 @@
+---
+title: Delete Metric Optimiser Cron Job
+description: "Irreversible. Deletes the cron job and stops it from firing. Past optimiser runs are retained."
+openapi: delete /schedules/v1/metric-optimiser-cron-jobs/{id}/
+slug: delete-metric-optimiser-cron-job
+---

--- a/api-reference/schedules/get-metric-optimiser-cron-job.mdx
+++ b/api-reference/schedules/get-metric-optimiser-cron-job.mdx
@@ -1,0 +1,6 @@
+---
+title: Get Metric Optimiser Cron Job
+description: "Retrieve a scheduled metric-optimiser job by id."
+openapi: get /schedules/v1/metric-optimiser-cron-jobs/{id}/
+slug: get-metric-optimiser-cron-job
+---

--- a/api-reference/schedules/list-metric-optimiser-cron-jobs.mdx
+++ b/api-reference/schedules/list-metric-optimiser-cron-jobs.mdx
@@ -1,0 +1,6 @@
+---
+title: List Metric Optimiser Cron Jobs
+description: "List all scheduled metric-optimiser jobs."
+openapi: get /schedules/v1/metric-optimiser-cron-jobs/
+slug: list-metric-optimiser-cron-jobs
+---

--- a/api-reference/schedules/schedule-metric-optimiser-cron-job.mdx
+++ b/api-reference/schedules/schedule-metric-optimiser-cron-job.mdx
@@ -1,0 +1,6 @@
+---
+title: Schedule Metric Optimiser Cron Job
+description: "Create a cron job that runs the Metric Lab optimiser against one or more metrics on a recurring schedule. The optimiser uses every test set already in each metric's Lab (every MetricReview row). Set `auto_apply` to overwrite the live metric prompt when the optimised score is at least as good as the baseline on the labelled set — otherwise the run is read-only and emails a diff summary."
+openapi: post /schedules/v1/metric-optimiser-cron-jobs/
+slug: schedule-metric-optimiser-cron-job
+---

--- a/api-reference/schedules/update-metric-optimiser-cron-job-full.mdx
+++ b/api-reference/schedules/update-metric-optimiser-cron-job-full.mdx
@@ -1,0 +1,6 @@
+---
+title: Update Metric Optimiser Cron Job (Full)
+description: "Update an existing scheduled metric-optimiser job."
+openapi: put /schedules/v1/metric-optimiser-cron-jobs/{id}/
+slug: update-metric-optimiser-cron-job-full
+---

--- a/api-reference/schedules/update-metric-optimiser-cron-job-partial.mdx
+++ b/api-reference/schedules/update-metric-optimiser-cron-job-partial.mdx
@@ -1,0 +1,6 @@
+---
+title: Update Metric Optimiser Cron Job (Partial)
+description: "Partially update an existing scheduled metric-optimiser job."
+openapi: patch /schedules/v1/metric-optimiser-cron-jobs/{id}/
+slug: update-metric-optimiser-cron-job-partial
+---

--- a/api-reference/test_framework/apply-external-metric-optimisation-proposal.mdx
+++ b/api-reference/test_framework/apply-external-metric-optimisation-proposal.mdx
@@ -1,0 +1,6 @@
+---
+title: Apply External Metric Optimisation Proposal
+description: "Copies the fields from `pending_optimisation_proposal` (description, evaluation_trigger, type, custom_code) into the live metric columns and clears the proposal. 400 if no pending proposal exists."
+openapi: post /test_framework/v1/metrics-external/{id}/apply_optimisation_proposal/
+slug: apply-external-metric-optimisation-proposal
+---

--- a/api-reference/test_framework/apply-metric-optimisation-proposal.mdx
+++ b/api-reference/test_framework/apply-metric-optimisation-proposal.mdx
@@ -1,0 +1,6 @@
+---
+title: Apply Metric Optimisation Proposal
+description: "Copies the fields from `pending_optimisation_proposal` (description, evaluation_trigger, type, custom_code) into the live metric columns and clears the proposal. 400 if no pending proposal exists."
+openapi: post /test_framework/v1/metrics/{id}/apply_optimisation_proposal/
+slug: apply-metric-optimisation-proposal
+---

--- a/api-reference/test_framework/dismiss-external-metric-optimisation-proposal.mdx
+++ b/api-reference/test_framework/dismiss-external-metric-optimisation-proposal.mdx
@@ -1,0 +1,6 @@
+---
+title: Dismiss External Metric Optimisation Proposal
+description: "Discards the metric's `pending_optimisation_proposal` without applying. Idempotent — a metric with no pending proposal returns 200."
+openapi: post /test_framework/v1/metrics-external/{id}/dismiss_optimisation_proposal/
+slug: dismiss-external-metric-optimisation-proposal
+---

--- a/api-reference/test_framework/dismiss-metric-optimisation-proposal.mdx
+++ b/api-reference/test_framework/dismiss-metric-optimisation-proposal.mdx
@@ -1,0 +1,6 @@
+---
+title: Dismiss Metric Optimisation Proposal
+description: "Discards the metric's `pending_optimisation_proposal` without applying. Idempotent — a metric with no pending proposal returns 200."
+openapi: post /test_framework/v1/metrics/{id}/dismiss_optimisation_proposal/
+slug: dismiss-metric-optimisation-proposal
+---

--- a/api-reference/test_framework/poll-agent-import-progress.mdx
+++ b/api-reference/test_framework/poll-agent-import-progress.mdx
@@ -1,0 +1,6 @@
+---
+title: Poll Agent Import Progress
+description: "Returns the staged status of a background agent import started via `configure_from_provider`. Each stage reports pending / in_progress / completed / skipped / failed so a step-by-step loader can be rendered."
+openapi: get /test_framework/v2/aiagents/import-progress/
+slug: poll-agent-import-progress
+---

--- a/api-reference/test_framework/poll-cloud-provider-agent-import-progress.mdx
+++ b/api-reference/test_framework/poll-cloud-provider-agent-import-progress.mdx
@@ -1,0 +1,6 @@
+---
+title: Poll Cloud Provider Agent Import Progress
+description: "Returns the staged status of a background agent import started via `configure_from_provider`. Each stage reports pending / in_progress / completed / skipped / failed so a step-by-step loader can be rendered."
+openapi: get /test_framework/v2/aiagents/import-progress/
+slug: poll-cloud-provider-agent-import-progress
+---

--- a/api-reference/test_framework/resolve-share-token.mdx
+++ b/api-reference/test_framework/resolve-share-token.mdx
@@ -1,0 +1,6 @@
+---
+title: Resolve Share Token
+description: "Resolve a shareable-link token to the underlying source object(s)."
+openapi: get /test_framework/v1/share-tokens/{token}/resolve/
+slug: resolve-share-token
+---

--- a/cekura-mcp-server/mcp_tools.json
+++ b/cekura-mcp-server/mcp_tools.json
@@ -45,13 +45,6 @@
   "scenarios_improve_instructions_create": {
     "description_suffix": "Lower-level instruction refiner: takes `agent` + `extra_instructions` and rewrites a scenario's `instructions` text. For multi-scenario or higher-level natural-language refinement use `scenarios_agent_create` instead. Async \u2014 poll via `scenarios_instructions_progress_retrieve`."
   },
-  "aiagents_partial_update": {
-    "description_suffix": "When refining an existing agent based on test results or natural-language feedback, prefer `scenarios_agent_create` or `runs_improve_prompt_create` / `runs_improve_prompt_bg_create` (run-driven prompt improvement). Use this raw patch only when the user has explicitly given concrete field values to write.",
-    "_property_types_note": "pipecat_data is a JSON object the spec mistypes as string; coerced to object so the client sends a dict. Only needed for Pipecat agents \u2014 other providers omit pipecat_data, so it's a no-op for them.",
-    "property_types": {
-      "pipecat_data": "object"
-    }
-  },
   "metrics_list": {
     "description_suffix": "Always pass `agent_id` or `project_id` \u2014 omitting both returns all metrics in your account (potentially hundreds, exceeding response limits). `metrics_list(agent_id=1234)` returns metrics accessible to that agent including both agent-level and project-level metrics."
   },

--- a/cekura-mcp-server/mcp_tools.json
+++ b/cekura-mcp-server/mcp_tools.json
@@ -1,109 +1,81 @@
 {
   "_comment": "Per-tool MCP enrichments. Applied on top of the OpenAPI-derived schema at registration time. Covers MCP-transport-specific limitations and cross-tool references not meaningful to plain REST callers.",
-
   "aiagents_upload_knowledge_base": {
     "description_suffix": "Pass each file as `{\"name\": \"manual.pdf\", \"content_base64\": \"...\"}` where `content_base64` is the file content base64-encoded (a raw base64 string or a `data:<mime>;base64,...` data URI both work). Max 50 MB per file. Allowed extensions: pdf, txt, json, csv, xml, md."
   },
-
   "scenarios_run_voice": {
-    "description_suffix": "The run mode (voice / text / WebRTC) is determined by WHICH run endpoint you call — not by the agent config."
+    "description_suffix": "The run mode (voice / text / WebRTC) is determined by WHICH run endpoint you call \u2014 not by the agent config."
   },
-
   "scenarios_run_text": {
-    "description_suffix": "The run mode is determined by WHICH run endpoint you call — not by the agent config. DO NOT USE for voice-specific metrics (latency, pitch) — they will be zero."
+    "description_suffix": "The run mode is determined by WHICH run endpoint you call \u2014 not by the agent config. DO NOT USE for voice-specific metrics (latency, pitch) \u2014 they will be zero."
   },
-
   "scenarios_run_pipecat_v1": {
     "description_suffix": "The run mode is determined by WHICH run endpoint you call, not the agent config. Requires a Pipecat API key configured on the project."
   },
-
   "scenarios_run_websocket": {
     "description_suffix": "The run mode is determined by WHICH run endpoint you call, not the agent config."
   },
-
   "observe_create": {
-    "description_suffix": "File uploads not supported — use `voice_recording_url` instead of `voice_recording`. Do not pass `metric_ids` — causes a 500 error on current staging; use `call_logs_evaluate_metrics_create` after ingestion instead. Wrong roles silently produce an empty transcript with no error returned."
+    "description_suffix": "File uploads not supported \u2014 use `voice_recording_url` instead of `voice_recording`. Do not pass `metric_ids` \u2014 causes a 500 error on current staging; use `call_logs_evaluate_metrics_create` after ingestion instead. Wrong roles silently produce an empty transcript with no error returned."
   },
-
   "runs_bulk_retrieve": {
     "description_suffix": "`run_ids` must be a bare comma-separated string (e.g. `\"86368,86369\"`). Passing a JSON array `[86368, 86369]` or a JSON-quoted string both return `400: run_ids must be comma-separated integers`."
   },
-
   "call_logs_evaluate_metrics_create": {
-    "description_suffix": "Known issue: the `metrics` filter is not enforced — all metrics assigned to the call log are evaluated regardless of which IDs are passed."
+    "description_suffix": "Known issue: the `metrics` filter is not enforced \u2014 all metrics assigned to the call log are evaluated regardless of which IDs are passed."
   },
-
   "metrics_create": {
-    "description_suffix": "**Prefer `metrics_generate`** (AI-authored from agent prompt) over this tool unless the user has explicitly given concrete field values to write. Use `metrics_generate_clean_description_create` to clean up an existing description and `metrics_generate_evaluation_trigger_create` to derive a trigger. The `prompt` field is only active when explicitly setting `llm_provider` to a non-default value — for standard `llm_judge` metrics, the criterion goes in `description`. `assistant_id` is optional despite appearing required in some schema views — omit it entirely; passing an empty string returns a 400 error. `add_to_new_agents`: when omitted or `true`, this metric is automatically assigned to every new agent created in the project — set to `false` to scope to specific agents only. To attach a metric to evaluators after creation, use `scenarios_partial_update` with `metrics: [id1, id2, ...]`; use `metrics_list(agent_id=<id>)` to find available IDs."
+    "description_suffix": "**Prefer `metrics_generate`** (AI-authored from agent prompt) over this tool unless the user has explicitly given concrete field values to write. Use `metrics_generate_clean_description_create` to clean up an existing description and `metrics_generate_evaluation_trigger_create` to derive a trigger. The `prompt` field is only active when explicitly setting `llm_provider` to a non-default value \u2014 for standard `llm_judge` metrics, the criterion goes in `description`. `assistant_id` is optional despite appearing required in some schema views \u2014 omit it entirely; passing an empty string returns a 400 error. `add_to_new_agents`: when omitted or `true`, this metric is automatically assigned to every new agent created in the project \u2014 set to `false` to scope to specific agents only. To attach a metric to evaluators after creation, use `scenarios_partial_update` with `metrics: [id1, id2, ...]`; use `metrics_list(agent_id=<id>)` to find available IDs."
   },
-
   "metrics_partial_update": {
     "description_suffix": "**Prefer `metrics_generate_clean_description_create` / `metrics_generate_evaluation_trigger_create` / `metrics_simplify_prompt_create`** when refining metric fields with AI assistance. Use this raw patch only when the user has given concrete field values to write."
   },
-
   "scenarios_create": {
-    "description_suffix": "**Prefer `scenarios_generate_bg`** for authoring new scenarios — it accepts per-scenario `extra_instructions` so callers can shape each scenario individually. Use this raw create only when the user has given concrete field values to write. To refine an existing scenario, use `scenarios_agent_create` (natural-language improvement) or `scenarios_improve_instructions_create` (rewrites the `instructions` text).\n\n**Tools (`tool_ids`):** it is recommended to include `TOOL_END_CALL` by default so the testing agent can hang up once it has completed its objective — leave it out only if the user does not want the agent to end the call. Other commonly used tool IDs include `TOOL_END_CALL_ONLY_ON_TRANSFER` (use instead of `TOOL_END_CALL` when the expected outcome is a transfer to a human/IVR, so the agent does not sit through hold music) and `TOOL_DTMF` (send keypad tones for IVR navigation). Example: `\"tool_ids\": [\"TOOL_END_CALL\"]`."
+    "description_suffix": "**Prefer `scenarios_generate_bg`** for authoring new scenarios \u2014 it accepts per-scenario `extra_instructions` so callers can shape each scenario individually. Use this raw create only when the user has given concrete field values to write. To refine an existing scenario, use `scenarios_agent_create` (natural-language improvement) or `scenarios_improve_instructions_create` (rewrites the `instructions` text).\n\n**Tools (`tool_ids`):** it is recommended to include `TOOL_END_CALL` by default so the testing agent can hang up once it has completed its objective \u2014 leave it out only if the user does not want the agent to end the call. Other commonly used tool IDs include `TOOL_END_CALL_ONLY_ON_TRANSFER` (use instead of `TOOL_END_CALL` when the expected outcome is a transfer to a human/IVR, so the agent does not sit through hold music) and `TOOL_DTMF` (send keypad tones for IVR navigation). Example: `\"tool_ids\": [\"TOOL_END_CALL\"]`."
   },
-
   "scenarios_partial_update": {
     "description_suffix": "**Prefer `scenarios_agent_create`** (natural-language improvement of one or more scenarios) or `scenarios_improve_instructions_create` (rewrites just the `instructions` text). Use this raw patch only when the user has explicitly given concrete field values to write."
   },
-
   "scenarios_agent_create": {
-    "description_suffix": "Unified scenario-agent endpoint — clarifies (no `scenarios` field in payload) AND improves (with `scenarios` field). The `_create` suffix is a DRF/spectacular naming artifact, NOT a separate create endpoint. Use this whenever the user wants AI-driven scenario refinement; do not reach for `scenarios_create` for that case. Async — poll via `scenarios_agent_progress`."
+    "description_suffix": "Unified scenario-agent endpoint \u2014 clarifies (no `scenarios` field in payload) AND improves (with `scenarios` field). The `_create` suffix is a DRF/spectacular naming artifact, NOT a separate create endpoint. Use this whenever the user wants AI-driven scenario refinement; do not reach for `scenarios_create` for that case. Async \u2014 poll via `scenarios_agent_progress`."
   },
-
   "scenarios_generate_bg": {
-    "description_suffix": "Preferred path for authoring new scenarios. Accepts per-scenario `extra_instructions` so each generated scenario can be shaped individually — use this rather than `scenarios_create` unless the user has given concrete field values to write. Async — poll via `scenarios_generate_progress`.\n\n**Tools (`tool_ids`):** it is recommended to include `TOOL_END_CALL` by default so the generated testing agents can hang up once they have completed their objective — leave it out only if the user does not want the agent to end the call. Other commonly used tool IDs include `TOOL_END_CALL_ONLY_ON_TRANSFER` (use instead of `TOOL_END_CALL` when the expected outcome is a transfer to a human/IVR, so the agent does not sit through hold music) and `TOOL_DTMF` (send keypad tones for IVR navigation). Example: `\"tool_ids\": [\"TOOL_END_CALL\"]`."
+    "description_suffix": "Preferred path for authoring new scenarios. Accepts per-scenario `extra_instructions` so each generated scenario can be shaped individually \u2014 use this rather than `scenarios_create` unless the user has given concrete field values to write. Async \u2014 poll via `scenarios_generate_progress`.\n\n**Tools (`tool_ids`):** it is recommended to include `TOOL_END_CALL` by default so the generated testing agents can hang up once they have completed their objective \u2014 leave it out only if the user does not want the agent to end the call. Other commonly used tool IDs include `TOOL_END_CALL_ONLY_ON_TRANSFER` (use instead of `TOOL_END_CALL` when the expected outcome is a transfer to a human/IVR, so the agent does not sit through hold music) and `TOOL_DTMF` (send keypad tones for IVR navigation). Example: `\"tool_ids\": [\"TOOL_END_CALL\"]`."
   },
-
   "scenarios_improve_instructions_create": {
-    "description_suffix": "Lower-level instruction refiner: takes `agent` + `extra_instructions` and rewrites a scenario's `instructions` text. For multi-scenario or higher-level natural-language refinement use `scenarios_agent_create` instead. Async — poll via `scenarios_instructions_progress_retrieve`."
+    "description_suffix": "Lower-level instruction refiner: takes `agent` + `extra_instructions` and rewrites a scenario's `instructions` text. For multi-scenario or higher-level natural-language refinement use `scenarios_agent_create` instead. Async \u2014 poll via `scenarios_instructions_progress_retrieve`."
   },
-
-  "aiagents_create": {
-    "description_suffix": "When the goal is to *improve* an existing agent based on test results or natural-language feedback, prefer `scenarios_agent_create` (it can update agent fields as part of the improvement loop). Use this raw create only when the user has given concrete field values to write.",
-    "_property_types_note": "pipecat_data is a JSON object the spec mistypes as string; coerced to object so the client sends a dict. Only needed for Pipecat agents — other providers omit pipecat_data, so it's a no-op for them.",
-    "property_types": {"pipecat_data": "object"}
-  },
-
   "aiagents_partial_update": {
     "description_suffix": "When refining an existing agent based on test results or natural-language feedback, prefer `scenarios_agent_create` or `runs_improve_prompt_create` / `runs_improve_prompt_bg_create` (run-driven prompt improvement). Use this raw patch only when the user has explicitly given concrete field values to write.",
-    "_property_types_note": "pipecat_data is a JSON object the spec mistypes as string; coerced to object so the client sends a dict. Only needed for Pipecat agents — other providers omit pipecat_data, so it's a no-op for them.",
-    "property_types": {"pipecat_data": "object"}
+    "_property_types_note": "pipecat_data is a JSON object the spec mistypes as string; coerced to object so the client sends a dict. Only needed for Pipecat agents \u2014 other providers omit pipecat_data, so it's a no-op for them.",
+    "property_types": {
+      "pipecat_data": "object"
+    }
   },
-
   "metrics_list": {
-    "description_suffix": "Always pass `agent_id` or `project_id` — omitting both returns all metrics in your account (potentially hundreds, exceeding response limits). `metrics_list(agent_id=1234)` returns metrics accessible to that agent including both agent-level and project-level metrics."
+    "description_suffix": "Always pass `agent_id` or `project_id` \u2014 omitting both returns all metrics in your account (potentially hundreds, exceeding response limits). `metrics_list(agent_id=1234)` returns metrics accessible to that agent including both agent-level and project-level metrics."
   },
-
   "metrics_bulk_create": {
     "description_suffix": "Pass the array of metric objects as the `items` parameter. Each item accepts the same fields as `metrics_create`. Example: `items: [{\"name\": \"Empathy\", \"type\": \"llm_judge\", \"eval_type\": \"binary_qualitative\", \"description\": \"Did the agent show empathy?\", \"project\": 1234}]`. For `llm_judge` metrics, put the evaluation criterion in `description`, not `prompt`."
   },
-
   "test_profiles_partial_update": {
-    "description_suffix": "The `information` dict is replaced in full on every update — re-send the complete dict. Any key omitted will be deleted from the stored profile."
+    "description_suffix": "The `information` dict is replaced in full on every update \u2014 re-send the complete dict. Any key omitted will be deleted from the stored profile."
   },
-
   "scenarios_folder_move": {
     "description_suffix": "To assign a scenario to a folder, use `scenarios_partial_update` with the `folder_path` field instead."
   },
-
   "call_logs_create_scenarios_progress": {
     "description_suffix": "Done when `completed_scenarios + failed_scenarios >= total_scenarios`. The `scenarios_list` field is populated only after completion."
   },
-
   "scenarios_folder_delete": {
     "destructive": true,
     "description_suffix": "Recursively deletes the folder and all scenarios beneath it. Cannot be undone."
   },
-
   "scenarios_bulk_delete": {
     "destructive": true,
     "description_suffix": "Bulk delete affects every ID in the `scenarios` array. Always confirm the exact list with the user before calling."
   },
-
   "scenarios_bulk_update": {
-    "description_suffix": "Affects every ID in the `scenarios` array in one transaction. `append_instruction` is non-idempotent — re-running with the same value appends it again. For single-scenario edits prefer `scenarios_partial_update`."
+    "description_suffix": "Affects every ID in the `scenarios` array in one transaction. `append_instruction` is non-idempotent \u2014 re-running with the same value appends it again. For single-scenario edits prefer `scenarios_partial_update`."
   }
 }

--- a/documentation/key-concepts/agents/Agent_Setup_Guide.mdx
+++ b/documentation/key-concepts/agents/Agent_Setup_Guide.mdx
@@ -34,11 +34,11 @@ import { CopyPageButton } from "/snippets/copy-page-button.mdx";
 
 ### Agent Description
 
-Agent Description is a comprehensive overview of your voice conversational agent’s purpose, behaviour, and operational guidelines. It encapsulates all the instructions, prompts, and rules you provide to your AI agent.
+Agent Description is a comprehensive overview of your voice conversational agent's purpose, behaviour, and operational guidelines. It encapsulates all the instructions, prompts, and rules you provide to your AI agent.
 
-> By clearly articulating your agent’s description, you enable us to **generate automatic, accurate evaluators.**
+> By clearly articulating your agent's description, you enable us to **generate automatic, accurate evaluators.**
 
-<Info>Most customers include their `agent’s main prompt` here.</Info>
+<Info>Most customers include their `agent's main prompt` here.</Info>
 
 ![Description Pn](/images/Agent_Setup_Guide/agent_description.png)
 
@@ -104,7 +104,6 @@ Select the platform your agent is built on. Cekura supports a wide range of prov
   <Card title="Bland AI" icon="/images/providers/bland.svg" href="/documentation/integrations/chat-testing#bland"/>
   <Card title="Synthflow" icon="/images/providers/synthflow.svg" />
   <Card title="Kore.ai" icon="/images/providers/koreai.svg" />
-  <Card title="Trillet" icon="/images/providers/trillet.svg" />
   <Card title="Genesys" icon="/images/providers/genesys.svg" />
   <Card title="Agentforce" icon="/images/providers/agentforce.svg" />
 </CardGroup>

--- a/mint.json
+++ b/mint.json
@@ -237,7 +237,7 @@
             "api-reference/test_framework/duplicate-agent",
             "api-reference/test_framework/upload-knowledge-base",
             "api-reference/test_framework/create-ai-agent-mock-call-path",
-            "api-reference/test_framework/poll-cloud-provider-agent-import-progress"
+            "api-reference/test_framework/poll-agent-import-progress"
           ]
         },
         {
@@ -411,8 +411,8 @@
             "api-reference/schedules/schedule-metric-optimiser-cron-job",
             "api-reference/schedules/delete-metric-optimiser-cron-job",
             "api-reference/schedules/get-metric-optimiser-cron-job",
-            "api-reference/schedules/update-metric-optimiser-cron-job-partial",
-            "api-reference/schedules/update-metric-optimiser-cron-job-full"
+            "api-reference/schedules/update-metric-optimiser-cron-job-full",
+            "api-reference/schedules/update-metric-optimiser-cron-job-partial"
           ]
         },
         {

--- a/mint.json
+++ b/mint.json
@@ -147,6 +147,7 @@
         "documentation/guides/organizing-projects",
         "documentation/guides/github-actions-ci-cd",
         "documentation/guides/cronjob",
+        "documentation/guides/auto-optimise-metrics-schedule",
         "documentation/guides/prompting",
         {
           "group": "Agent Integration",
@@ -235,7 +236,17 @@
             "api-reference/test_framework/delete-agent",
             "api-reference/test_framework/duplicate-agent",
             "api-reference/test_framework/upload-knowledge-base",
-            "api-reference/test_framework/create-ai-agent-mock-call-path"
+            "api-reference/test_framework/create-ai-agent-mock-call-path",
+            "api-reference/test_framework/poll-cloud-provider-agent-import-progress"
+          ]
+        },
+        {
+          "group": "Dynamic Variables",
+          "pages": [
+            "api-reference/test_framework/list-dynamic-variables",
+            "api-reference/test_framework/create-dynamic-variables",
+            "api-reference/test_framework/update-dynamic-variable",
+            "api-reference/test_framework/delete-dynamic-variable"
           ]
         },
         {
@@ -267,7 +278,11 @@
             "api-reference/test_framework/list-critical-metric-scenarios",
             "api-reference/test_framework/update-critical-metric-scenario",
             "api-reference/test_framework/metric-preview",
-            "api-reference/test_framework/metric-preview-progress"
+            "api-reference/test_framework/metric-preview-progress",
+            "api-reference/test_framework/apply-external-metric-optimisation-proposal",
+            "api-reference/test_framework/dismiss-external-metric-optimisation-proposal",
+            "api-reference/test_framework/apply-metric-optimisation-proposal",
+            "api-reference/test_framework/dismiss-metric-optimisation-proposal"
           ]
         },
         {
@@ -391,7 +406,13 @@
             "api-reference/schedules/list-schedule-jobs",
             "api-reference/schedules/create-schedule-job",
             "api-reference/schedules/update-schedule-job",
-            "api-reference/schedules/delete-schedule-job"
+            "api-reference/schedules/delete-schedule-job",
+            "api-reference/schedules/list-metric-optimiser-cron-jobs",
+            "api-reference/schedules/schedule-metric-optimiser-cron-job",
+            "api-reference/schedules/delete-metric-optimiser-cron-job",
+            "api-reference/schedules/get-metric-optimiser-cron-job",
+            "api-reference/schedules/update-metric-optimiser-cron-job-partial",
+            "api-reference/schedules/update-metric-optimiser-cron-job-full"
           ]
         },
         {
@@ -462,7 +483,8 @@
             "api-reference/observability/call-logs-improve-prompt",
             "api-reference/observability/call-logs-improve-prompt-bg",
             "api-reference/observability/call-logs-improve-prompt-progress",
-            "api-reference/observability/call-logs-improve-prompt-issues"
+            "api-reference/observability/call-logs-improve-prompt-issues",
+            "api-reference/test_framework/resolve-share-token"
           ]
         }
       ]

--- a/openapi.json
+++ b/openapi.json
@@ -1713,7 +1713,8 @@
         "/observability/v1/alerts/": {
             "get": {
                 "operationId": "alerts-list",
-                "description": "List alerts",
+                "description": "Return all alerts configured in the project, including their sub_type (`normal` | `significant_change` | `threshold`), source metric, current Slack/notification config, and trigger counters. Use before creating a new alert to check if one already exists on the same metric.",
+                "summary": "List alerts in a project",
                 "parameters": [
                     {
                         "in": "query",
@@ -1783,11 +1784,20 @@
                         },
                         "description": ""
                     }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "alerts-list",
+                        "description": "Return all alerts configured in the project, including their sub_type (`normal` | `significant_change` | `threshold`), source metric, current Slack/notification config, and trigger counters. Use before creating a new alert to check if one already exists on the same metric."
+                    }
                 }
             },
             "post": {
                 "operationId": "alerts-create",
-                "description": "Create a new alert",
+                "description": "Create an alert that fires when a metric crosses a threshold. Three sub_types:\n\n- `normal` — Failure alert. Fires per failing call. Only for binary metrics (eval_type starts with `binary_`) plus the latency / infrastructure / critical-deviation built-ins.\n- `significant_change` — Trend alert. Fires when a numeric/continuous metric's rolling mean deviates from history. Pass `preset: \"balanced\"` (or `\"conservative\"` / `\"aggressive\"`) to skip manual std_multiplier / ewma_alpha / window_size math — the server expands the preset. Balanced is the safe default.\n- `threshold` — Hard ceiling/floor. Fires when ≥ `min_breaches` of the last `window_size` evaluations cross `value`. Use for numeric metrics where the user has a known good range. Operator is `gt` | `lt` | `outside` ({low, high}).\n\n**Slack delivery requires** `notifications.slack.workspace_id` (+ optional `channel_id`). Alerts with empty `notifications` are silent — fire counters still increment but no message is sent. Pick a workspace_id from `slack_workspaces_list`.",
+                "summary": "Create an alert on a metric",
                 "tags": [
                     "observability"
                 ],
@@ -1827,13 +1837,22 @@
                         },
                         "description": ""
                     }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "alerts-create",
+                        "description": "Create an alert that fires when a metric crosses a threshold. Three sub_types:\n\n- `normal` — Failure alert. Fires per failing call. Only for binary metrics (eval_type starts with `binary_`) plus the latency / infrastructure / critical-deviation built-ins.\n- `significant_change` — Trend alert. Fires when a numeric/continuous metric's rolling mean deviates from history. Pass `preset: \"balanced\"` (or `\"conservative\"` / `\"aggressive\"`) to skip manual std_multiplier / ewma_alpha / window_size math — the server expands the preset. Balanced is the safe default.\n- `threshold` — Hard ceiling/floor. Fires when ≥ `min_breaches` of the last `window_size` evaluations cross `value`. Use for numeric metrics where the user has a known good range. Operator is `gt` | `lt` | `outside` ({low, high}).\n\n**Slack delivery requires** `notifications.slack.workspace_id` (+ optional `channel_id`). Alerts with empty `notifications` are silent — fire counters still increment but no message is sent. Pick a workspace_id from `slack_workspaces_list`."
+                    }
                 }
             }
         },
         "/observability/v1/alerts/{id}/": {
             "get": {
                 "operationId": "alerts-retrieve",
-                "description": "Retrieve an alert by ID",
+                "description": "Return one alert with its source / threshold / notifications JSON expanded. Use this before updating to confirm the current shape — `partial_update` merges into existing JSON, so you need to know what's already there.",
+                "summary": "Get an alert's full config",
                 "parameters": [
                     {
                         "in": "path",
@@ -1864,11 +1883,19 @@
                         },
                         "description": ""
                     }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "alerts-retrieve",
+                        "description": "Return one alert with its source / threshold / notifications JSON expanded. Use this before updating to confirm the current shape — `partial_update` merges into existing JSON, so you need to know what's already there."
+                    }
                 }
             },
             "put": {
                 "operationId": "alerts-update",
-                "description": "Update an alert",
+                "description": "Manage alerts that fire when metric thresholds are crossed.",
                 "parameters": [
                     {
                         "in": "path",
@@ -1923,7 +1950,8 @@
             },
             "patch": {
                 "operationId": "alerts-partial-update",
-                "description": "Update an alert",
+                "description": "Update fields on an existing alert. Common uses from chat:\n\n- Tune sensitivity: pass `preset: \"conservative\"` to make a noisy trend alert quieter (or `\"aggressive\"` to catch smaller shifts). Explicit `threshold.std_multiplier` / `ewma_alpha` / `source.window_size` override the preset.\n- Change Slack routing: pass a new `notifications.slack` block.\n- Disable temporarily: pass `enabled: false`.\n\nChanging `sub_type` requires the matching `source` + `threshold` shape — see `alerts_create` for the field matrix per sub_type. Partial updates merge JSON, so omitted nested keys keep their existing values.",
+                "summary": "Update an alert (partial)",
                 "parameters": [
                     {
                         "in": "path",
@@ -1973,11 +2001,20 @@
                         },
                         "description": ""
                     }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "alerts-partial-update",
+                        "description": "Update fields on an existing alert. Common uses from chat:\n\n- Tune sensitivity: pass `preset: \"conservative\"` to make a noisy trend alert quieter (or `\"aggressive\"` to catch smaller shifts). Explicit `threshold.std_multiplier` / `ewma_alpha` / `source.window_size` override the preset.\n- Change Slack routing: pass a new `notifications.slack` block.\n- Disable temporarily: pass `enabled: false`.\n\nChanging `sub_type` requires the matching `source` + `threshold` shape — see `alerts_create` for the field matrix per sub_type. Partial updates merge JSON, so omitted nested keys keep their existing values."
+                    }
                 }
             },
             "delete": {
                 "operationId": "alerts-destroy",
-                "description": "Delete an alert",
+                "description": "Permanently delete an alert. ⚠ Irreversible. The chat agent refuses this operation at the SDK layer; direct API/SDK callers can still use it.",
+                "summary": "Delete an alert",
                 "parameters": [
                     {
                         "in": "path",
@@ -2000,6 +2037,15 @@
                 "responses": {
                     "204": {
                         "description": "No response body"
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mcp-destructive": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "alerts-destroy",
+                        "description": "Permanently delete an alert. ⚠ Irreversible. The chat agent refuses this operation at the SDK layer; direct API/SDK callers can still use it."
                     }
                 }
             }
@@ -2101,7 +2147,8 @@
         "/observability/v1/alerts/review/": {
             "get": {
                 "operationId": "alerts-review-retrieve",
-                "description": "Aggregate fired-alert data for the review page.\n\nReturns deterministic SQL-only aggregates: KPI summary, time-bucketed\ntimeline, and a per-alert breakdown with sparkline. LLM summaries are\non-demand via the separate `summarize` action.\n\nQuery params:\n    project_id: required.\n    hours: optional, defaults to 24.",
+                "description": "Aggregate every alert's fire activity over a rolling window. Returns KPI totals (total fires, unique alerts that fired, top firing alert), a time-bucketed timeline (hourly for 24h, 3-hour for 3d, 6-hour for 7d), and a per-alert breakdown with a sparkline of fires-per-bucket. Use to answer 'what alerts fired this week?' or 'is anything noisy right now?'. Pass `hours` (default 24, capped at 168) to widen the window. The response shape lets you compose a written report in a single call.",
+                "summary": "Review alert activity in a project",
                 "tags": [
                     "observability"
                 ],
@@ -2121,13 +2168,21 @@
                         },
                         "description": ""
                     }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "alerts-review-retrieve",
+                        "description": "Aggregate every alert's fire activity over a rolling window. Returns KPI totals (total fires, unique alerts that fired, top firing alert), a time-bucketed timeline (hourly for 24h, 3-hour for 3d, 6-hour for 7d), and a per-alert breakdown with a sparkline of fires-per-bucket. Use to answer 'what alerts fired this week?' or 'is anything noisy right now?'. Pass `hours` (default 24, capped at 168) to widen the window. The response shape lets you compose a written report in a single call."
+                    }
                 }
             }
         },
         "/observability/v1/alerts/summarize_progress/": {
             "get": {
                 "operationId": "alerts-summarize-progress-retrieve",
-                "description": "Alerts summarize progress",
+                "description": "Manage alerts that fire when metric thresholds are crossed.",
                 "tags": [
                     "observability"
                 ],
@@ -7444,6 +7499,8 @@
         "/slack/slack-workspaces/": {
             "get": {
                 "operationId": "slack-slack-workspaces-list",
+                "description": "Return every Slack workspace connected to the project, with the bot's default `channel_id`, `team_name`, and verification status. Use to pick a `workspace_id` (and optionally a different `channel_id`) for the `notifications.slack` block on `alerts_create`. Access tokens and bot IDs are not returned.",
+                "summary": "List Slack workspaces configured for a project",
                 "tags": [
                     "slack"
                 ],
@@ -7467,7 +7524,14 @@
                         "description": ""
                     }
                 },
-                "description": "List slack slack workspaces"
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "slack-slack-workspaces-list",
+                        "description": "Return every Slack workspace connected to the project, with the bot's default `channel_id`, `team_name`, and verification status. Use to pick a `workspace_id` (and optionally a different `channel_id`) for the `notifications.slack` block on `alerts_create`. Access tokens and bot IDs are not returned."
+                    }
+                }
             },
             "post": {
                 "operationId": "slack-slack-workspaces-create",
@@ -51170,13 +51234,24 @@
                         "description": "ID of monitored object"
                     },
                     "source": {
-                        "description": "Source config. For metrics: {\"sub_type\": \"normal\"|\"significant_change\", \"filters\": {...}, \"window_size\": 50}"
+                        "description": "Source config keyed on `sub_type`. `normal`: {sub_type, filters?}. `significant_change`: {sub_type, window_size, filters?}. `threshold`: {sub_type, window_size, filters?}. `filters` is an optional CallLogQueryFilter expression."
                     },
                     "threshold": {
-                        "description": "Threshold config. Normal metric: {\"condition\": \"value_lt_5\"}. Significant change: {\"std_multiplier\": 2.0, \"ewma_alpha\": 0.1, \"direction\": \"both\"}. Duration/volume: {\"operator\": \"gt\", \"value\": 300}"
+                        "description": "Threshold config keyed on the source's `sub_type`. `normal`: {} (fires on every failing eval). `significant_change`: {std_multiplier, ewma_alpha, direction}. `threshold`: {operator (gt|lt|outside), value (number | {low, high}), min_breaches}."
                     },
                     "notifications": {
-                        "description": "Notification config. Slack: {\"slack\": {\"workspace_id\": 10, \"channel_id\": \"C123\"}}. Empty = all project workspaces"
+                        "description": "Notification routing. `{slack: {workspace_id, channel_id?}}` to send to a specific workspace/channel. Empty fans out to every project workspace; empty + no project workspaces means the alert is silent."
+                    },
+                    "preset": {
+                        "enum": [
+                            "conservative",
+                            "balanced",
+                            "aggressive"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "a6fd953985219e0b",
+                        "writeOnly": true,
+                        "description": "Optional shorthand for trend alerts: 'conservative' | 'balanced' | 'aggressive'. Expands to std_multiplier / ewma_alpha / window_size. Explicit values in `source` or `threshold` override the preset. Ignored unless sub_type == 'significant_change'.\n\n* `conservative` - conservative\n* `balanced` - balanced\n* `aggressive` - aggressive"
                     }
                 },
                 "required": [
@@ -51238,13 +51313,13 @@
                         "readOnly": true
                     },
                     "source": {
-                        "description": "Source config. For metrics: {\"sub_type\": \"normal\"|\"significant_change\", \"filters\": {...}, \"window_size\": 50}"
+                        "description": "Source config keyed on `sub_type`. `normal`: {sub_type, filters?}. `significant_change`: {sub_type, window_size, filters?}. `threshold`: {sub_type, window_size, filters?}. `filters` is an optional CallLogQueryFilter expression."
                     },
                     "threshold": {
-                        "description": "Threshold config. Normal metric: {\"condition\": \"value_lt_5\"}. Significant change: {\"std_multiplier\": 2.0, \"ewma_alpha\": 0.1, \"direction\": \"both\"}. Duration/volume: {\"operator\": \"gt\", \"value\": 300}"
+                        "description": "Threshold config keyed on the source's `sub_type`. `normal`: {} (fires on every failing eval). `significant_change`: {std_multiplier, ewma_alpha, direction}. `threshold`: {operator (gt|lt|outside), value (number | {low, high}), min_breaches}."
                     },
                     "notifications": {
-                        "description": "Notification config. Slack: {\"slack\": {\"workspace_id\": 10, \"channel_id\": \"C123\"}}. Empty = all project workspaces"
+                        "description": "Notification routing. `{slack: {workspace_id, channel_id?}}` to send to a specific workspace/channel. Empty fans out to every project workspace; empty + no project workspaces means the alert is silent."
                     },
                     "last_triggered_at": {
                         "type": [
@@ -51336,13 +51411,13 @@
                         "readOnly": true
                     },
                     "source": {
-                        "description": "Source config. For metrics: {\"sub_type\": \"normal\"|\"significant_change\", \"filters\": {...}, \"window_size\": 50}"
+                        "description": "Source config keyed on `sub_type`. `normal`: {sub_type, filters?}. `significant_change`: {sub_type, window_size, filters?}. `threshold`: {sub_type, window_size, filters?}. `filters` is an optional CallLogQueryFilter expression."
                     },
                     "threshold": {
-                        "description": "Threshold config. Normal metric: {\"condition\": \"value_lt_5\"}. Significant change: {\"std_multiplier\": 2.0, \"ewma_alpha\": 0.1, \"direction\": \"both\"}. Duration/volume: {\"operator\": \"gt\", \"value\": 300}"
+                        "description": "Threshold config keyed on the source's `sub_type`. `normal`: {} (fires on every failing eval). `significant_change`: {std_multiplier, ewma_alpha, direction}. `threshold`: {operator (gt|lt|outside), value (number | {low, high}), min_breaches}."
                     },
                     "notifications": {
-                        "description": "Notification config. Slack: {\"slack\": {\"workspace_id\": 10, \"channel_id\": \"C123\"}}. Empty = all project workspaces"
+                        "description": "Notification routing. `{slack: {workspace_id, channel_id?}}` to send to a specific workspace/channel. Empty fans out to every project workspace; empty + no project workspaces means the alert is silent."
                     },
                     "trigger_count": {
                         "type": "integer",
@@ -51394,13 +51469,24 @@
                         "description": "Enable/disable alert"
                     },
                     "source": {
-                        "description": "Source config. For metrics: {\"sub_type\": \"normal\"|\"significant_change\", \"filters\": {...}, \"window_size\": 50}"
+                        "description": "Source config keyed on `sub_type`. `normal`: {sub_type, filters?}. `significant_change`: {sub_type, window_size, filters?}. `threshold`: {sub_type, window_size, filters?}. `filters` is an optional CallLogQueryFilter expression."
                     },
                     "threshold": {
-                        "description": "Threshold config. Normal metric: {\"condition\": \"value_lt_5\"}. Significant change: {\"std_multiplier\": 2.0, \"ewma_alpha\": 0.1, \"direction\": \"both\"}. Duration/volume: {\"operator\": \"gt\", \"value\": 300}"
+                        "description": "Threshold config keyed on the source's `sub_type`. `normal`: {} (fires on every failing eval). `significant_change`: {std_multiplier, ewma_alpha, direction}. `threshold`: {operator (gt|lt|outside), value (number | {low, high}), min_breaches}."
                     },
                     "notifications": {
-                        "description": "Notification config. Slack: {\"slack\": {\"workspace_id\": 10, \"channel_id\": \"C123\"}}. Empty = all project workspaces"
+                        "description": "Notification routing. `{slack: {workspace_id, channel_id?}}` to send to a specific workspace/channel. Empty fans out to every project workspace; empty + no project workspaces means the alert is silent."
+                    },
+                    "preset": {
+                        "enum": [
+                            "conservative",
+                            "balanced",
+                            "aggressive"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "a6fd953985219e0b",
+                        "writeOnly": true,
+                        "description": "Optional shorthand for trend alerts: 'conservative' | 'balanced' | 'aggressive'. Expands to std_multiplier / ewma_alpha / window_size. Explicit values in `source` or `threshold` override the preset. Ignored unless the alert's sub_type == 'significant_change'.\n\n* `conservative` - conservative\n* `balanced` - balanced\n* `aggressive` - aggressive"
                     }
                 },
                 "required": [
@@ -58418,13 +58504,24 @@
                         "description": "Enable/disable alert"
                     },
                     "source": {
-                        "description": "Source config. For metrics: {\"sub_type\": \"normal\"|\"significant_change\", \"filters\": {...}, \"window_size\": 50}"
+                        "description": "Source config keyed on `sub_type`. `normal`: {sub_type, filters?}. `significant_change`: {sub_type, window_size, filters?}. `threshold`: {sub_type, window_size, filters?}. `filters` is an optional CallLogQueryFilter expression."
                     },
                     "threshold": {
-                        "description": "Threshold config. Normal metric: {\"condition\": \"value_lt_5\"}. Significant change: {\"std_multiplier\": 2.0, \"ewma_alpha\": 0.1, \"direction\": \"both\"}. Duration/volume: {\"operator\": \"gt\", \"value\": 300}"
+                        "description": "Threshold config keyed on the source's `sub_type`. `normal`: {} (fires on every failing eval). `significant_change`: {std_multiplier, ewma_alpha, direction}. `threshold`: {operator (gt|lt|outside), value (number | {low, high}), min_breaches}."
                     },
                     "notifications": {
-                        "description": "Notification config. Slack: {\"slack\": {\"workspace_id\": 10, \"channel_id\": \"C123\"}}. Empty = all project workspaces"
+                        "description": "Notification routing. `{slack: {workspace_id, channel_id?}}` to send to a specific workspace/channel. Empty fans out to every project workspace; empty + no project workspaces means the alert is silent."
+                    },
+                    "preset": {
+                        "enum": [
+                            "conservative",
+                            "balanced",
+                            "aggressive"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "a6fd953985219e0b",
+                        "writeOnly": true,
+                        "description": "Optional shorthand for trend alerts: 'conservative' | 'balanced' | 'aggressive'. Expands to std_multiplier / ewma_alpha / window_size. Explicit values in `source` or `threshold` override the preset. Ignored unless the alert's sub_type == 'significant_change'.\n\n* `conservative` - conservative\n* `balanced` - balanced\n* `aggressive` - aggressive"
                     }
                 }
             },

--- a/openapi.json
+++ b/openapi.json
@@ -8387,6 +8387,61 @@
                 "description": "Subscriptions subscriptions reactivate"
             }
         },
+        "/subscriptions/subscriptions/{id}/renew/": {
+            "post": {
+                "operationId": "subscriptions-subscriptions-renew-create",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "subscriptions"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Subscription"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Subscription"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Subscription"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Subscription"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "description": "Subscriptions subscriptions renew"
+            }
+        },
         "/subscriptions/subscriptions/{id}/update_payment_method/": {
             "post": {
                 "operationId": "subscriptions-subscriptions-update-payment-method-create",
@@ -12910,7 +12965,8 @@
         "/test_framework/v1/aiagents/{agent_id}/tools/auto-fetch/": {
             "post": {
                 "operationId": "aiagents-tools-auto-fetch-create",
-                "description": "Auto-fetch tools from provider and generate mock data asynchronously.\n\nValidates inputs, fires a background Celery task for the slow provider API calls\nand LLM mock-data generation, and returns a progress_id immediately.\nPoll auto-fetch-progress/ with the progress_id to check completion.\nThis does NOT enable mock mode in the provider. Use the enable-mock endpoint for that.",
+                "description": "Discover the agent's tools (from a managed provider or a customer-hosted MCP server) and LLM-generate mock input/output data for each. Persists Tool rows and records the provider configuration on the agent. ⚠ Overwrites empty Tool rows; existing rows with mock data are kept. For provider=\"custom\", supply `mcp_server_url`; the URL is SSRF-validated (no private/loopback targets).",
+                "summary": "Auto-fetch mock tools for an agent",
                 "parameters": [
                     {
                         "in": "path",
@@ -12932,12 +12988,22 @@
                                 "$ref": "#/components/schemas/AutoFetchToolsRequest"
                             },
                             "examples": {
-                                "Auto-FetchToolsRequest": {
+                                "Auto-FetchToolsRequest(managedProvider)": {
                                     "value": {
                                         "provider": "retell",
                                         "assistant_id": "agent_abc123"
                                     },
-                                    "summary": "Auto-Fetch Tools Request"
+                                    "summary": "Auto-Fetch Tools Request (managed provider)"
+                                },
+                                "Auto-FetchToolsRequest(customMCPServer)": {
+                                    "value": {
+                                        "provider": "custom",
+                                        "mcp_server_url": "https://customer.example.com/mcp",
+                                        "mcp_server_headers": {
+                                            "Authorization": "Bearer ..."
+                                        }
+                                    },
+                                    "summary": "Auto-Fetch Tools Request (custom MCP server)"
                                 }
                             }
                         },
@@ -13049,7 +13115,8 @@
         "/test_framework/v1/aiagents/{agent_id}/tools/disable-mock/": {
             "post": {
                 "operationId": "aiagents-tools-disable-mock-create",
-                "description": "Kick off a background task to disable mock tools for this agent.\nReturns a progress_id to poll disable-mock-progress/ for status.",
+                "description": "Restore the agent's tools to their original (non-mock) state. For managed providers this PATCHes the provider assistant back to its `original_tool_ids` and deletes the cloned tools. For provider=\"custom\" this only flips `mock_enabled` off; the `mcp_server_url` is preserved so re-enable works.",
+                "summary": "Disable mock tools for an agent",
                 "parameters": [
                     {
                         "in": "path",
@@ -13116,6 +13183,7 @@
             "get": {
                 "operationId": "aiagents-tools-disable-mock-progress-retrieve",
                 "description": "Poll the status of a background disable-mock task.",
+                "summary": "Poll status of a disable-mock task",
                 "parameters": [
                     {
                         "in": "path",
@@ -13123,6 +13191,14 @@
                         "schema": {
                             "type": "string",
                             "pattern": "^\\d+$"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "progress_id",
+                        "schema": {
+                            "type": "string"
                         },
                         "required": true
                     }
@@ -13140,7 +13216,17 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Tool"
+                                    "$ref": "#/components/schemas/DisableMockProgressResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/DisableMockProgressErrorResponse"
                                 }
                             }
                         },
@@ -13152,7 +13238,8 @@
         "/test_framework/v1/aiagents/{agent_id}/tools/enable-mock/": {
             "post": {
                 "operationId": "aiagents-tools-enable-mock-create",
-                "description": "Kick off a background task to enable mock tools for this agent.\nReturns a progress_id to poll enable-mock-progress/ for status.\nAuto-fetch must be run first to populate tool mock data.",
+                "description": "Activate mock-tool mode using the data created by `auto-fetch`. For managed providers (vapi/retell/elevenlabs) this clones the provider's tools at the provider and swaps URLs to Cekura-hosted endpoints. For provider=\"custom\" it just registers `mcp_sub_tool_map` so MockMCPView can serve `/mcp/N/` calls. Returns a `progress_id`; poll `enable-mock-progress/` for the resulting `mcp_endpoints`. Run `auto-fetch` first.",
+                "summary": "Enable mock tools for an agent",
                 "parameters": [
                     {
                         "in": "path",
@@ -13219,6 +13306,7 @@
             "get": {
                 "operationId": "aiagents-tools-enable-mock-progress-retrieve",
                 "description": "Poll the status of a background enable-mock task.",
+                "summary": "Poll status of an enable-mock task",
                 "parameters": [
                     {
                         "in": "path",
@@ -13226,6 +13314,14 @@
                         "schema": {
                             "type": "string",
                             "pattern": "^\\d+$"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "progress_id",
+                        "schema": {
+                            "type": "string"
                         },
                         "required": true
                     }
@@ -13243,7 +13339,17 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Tool"
+                                    "$ref": "#/components/schemas/EnableMockProgressResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/EnableMockProgressErrorResponse"
                                 }
                             }
                         },
@@ -13255,7 +13361,8 @@
         "/test_framework/v1/aiagents/{agent_id}/tools/mock-status/": {
             "get": {
                 "operationId": "aiagents-tools-mock-status-retrieve",
-                "description": "Get the current mock tools status for this agent.",
+                "description": "Single source of truth for \"what mock-tool runtime URLs do I have, and what are they configured for?\". `mcp_endpoints[]` lists each Cekura-hosted MCP JSON-RPC endpoint with the sub-tools it serves; `tool_endpoints[]` lists standalone (non-MCP) per-tool webhook URLs. URLs are computed from `settings.CEKURA_BASE_URL`, so each environment renders the correct host.",
+                "summary": "Current mock-tools state for an agent",
                 "parameters": [
                     {
                         "in": "path",
@@ -13280,7 +13387,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Tool"
+                                    "$ref": "#/components/schemas/MockStatusResponse"
                                 }
                             }
                         },
@@ -38193,10 +38300,10 @@
             },
             "post": {
                 "operationId": "test-framework-v2-aiagents-create",
-                "description": "Register a new AI voice agent. Required fields: name, description, project, inbound. Provider credentials are nested under provider.{type, agent_id, credentials} instead of flat fields. transcript_provider defaults to provider.type when omitted.\n\n**provider.credentials keys by type (voice providers only):**\n- vapi: api_key + config.{public_key, trigger_url}\n- retell: api_key + agent_id + optional chat_agent_details.config.agent_id\n- elevenlabs: api_key + config.{trigger_url}\n- bland: api_key + agent_id (pathway_id) + config.{encrypted_key} for Twilio\n- livekit: api_key + config.{api_secret (required), url (required)}\n- pipecat: api_key + config.{webhook_url}\n- cisco: no credentials needed\n- self_hosted: credentials.config.{url (wss://), headers}\nNote: agentforce goes in chat_agent_details; koreai/genesys/synthflow use the v1 API.\n\nSee examples below for full per-provider payloads.",
+                "description": "Register a new AI voice agent. Required fields: name, description, project, inbound. Provider credentials are nested under provider.{type, agent_id, credentials} instead of flat fields. transcript_provider defaults to provider.type when omitted.\n\n**provider.credentials keys by type (voice providers only):**\n- vapi: api_key + config.{public_key, trigger_url}\n- retell: api_key + agent_id + optional chat_agent_details.config.agent_id\n- elevenlabs: api_key + config.{trigger_url}\n- bland: api_key + agent_id (pathway_id) + config.{encrypted_key} for Twilio\n- livekit: api_key + config.{api_secret (required), url (required)}\n- pipecat: api_key + config.{webhook_url}\n- cisco: no credentials needed\n- self_hosted: credentials.config.{url (wss://), headers}\nNote: agentforce goes in chat_agent_details; koreai/genesys/synthflow use the v1 API.\n\n**Auto-import from a cloud provider** — set `provider.configure_from_provider: true` (vapi/retell/elevenlabs/synthflow) with `provider.agent_id` + `provider.credentials.api_key`. Cekura fetches the prompt, name, language, who-speaks-first, phone number, tool calls, dynamic variables and knowledge base and configures the agent automatically — `name` and `description` become optional (auto-fetched). The response is **202** with the created agent plus a `progress_id`; poll `import-progress/` to follow the staged import.\n\nSee examples below for full per-provider payloads.",
                 "summary": "Create an AI voice agent",
                 "tags": [
-                    "AI Agents"
+                    "test_framework"
                 ],
                 "requestBody": {
                     "content": {
@@ -38205,103 +38312,20 @@
                                 "$ref": "#/components/schemas/AIAgentV2"
                             },
                             "examples": {
-                                "Self-hosted(contactNumberOnly—MostCommon)": {
+                                "CloudAuto-import(configureFromProvider)": {
                                     "value": {
-                                        "agent_name": "Support Bot",
-                                        "description": "Handles inbound support calls for ACME Inc.",
-                                        "inbound": true,
-                                        "project": 1376,
-                                        "contact_number": "+14155551234",
-                                        "language": "en",
-                                        "assistant_provider": "self_hosted"
-                                    },
-                                    "summary": "Self-hosted (contact number only — most common)",
-                                    "description": "Typical onboarding: your agent is already deployed on your own stack with a phone number. Cekura just observes and evaluates; no provider credentials needed."
-                                },
-                                "VAPIAgent": {
-                                    "value": {
-                                        "agent_name": "VAPI Sales Agent",
-                                        "description": "Outbound sales qualification calls",
-                                        "inbound": false,
-                                        "project": 1376,
-                                        "contact_number": "+14155551234",
-                                        "language": "en",
-                                        "assistant_provider": "vapi",
-                                        "vapi_api_key": "vapi_sk_xxx",
-                                        "vapi_data": {
-                                            "public_key": "vapi_pk_xxx"
-                                        },
-                                        "assistant_id": "asst_abc123"
-                                    },
-                                    "summary": "VAPI agent"
-                                },
-                                "RetellAgent": {
-                                    "value": {
-                                        "agent_name": "Retell Booking Agent",
-                                        "description": "Schedules dental appointments",
-                                        "inbound": true,
-                                        "project": 1376,
-                                        "contact_number": "+14155551234",
-                                        "language": "en",
-                                        "assistant_provider": "retell",
-                                        "retell_api_key": "key_xxx",
-                                        "chat_assistant_id": "retell_agent_abc123",
-                                        "retell_data": {
-                                            "trigger_url": "https://api.retellai.com/create-phone-call"
+                                        "project": 42,
+                                        "provider": {
+                                            "type": "retell",
+                                            "agent_id": "agent_abc123",
+                                            "credentials": {
+                                                "api_key": "key_xxx"
+                                            },
+                                            "configure_from_provider": true
                                         }
                                     },
-                                    "summary": "Retell agent",
-                                    "description": "Retell requires BOTH retell_api_key AND chat_assistant_id (used for voice too, despite the field's name)."
-                                },
-                                "BlandAgent": {
-                                    "value": {
-                                        "agent_name": "Bland Support Agent",
-                                        "description": "Handles tier-1 billing questions",
-                                        "inbound": true,
-                                        "project": 1376,
-                                        "contact_number": "+14155551234",
-                                        "language": "en",
-                                        "assistant_provider": "bland",
-                                        "bland_api_key": "bland_xxx",
-                                        "chat_assistant_id": "bland_pathway_xyz",
-                                        "bland_data": {
-                                            "encrypted_key": "twilio_encrypted_key_xxx"
-                                        }
-                                    },
-                                    "summary": "Bland agent",
-                                    "description": "Bland requires bland_api_key AND chat_assistant_id (Bland calls this field pathway_id internally). bland_data.encrypted_key is the Twilio credential bundle."
-                                },
-                                "LiveKitAgent": {
-                                    "value": {
-                                        "agent_name": "LiveKit Concierge",
-                                        "description": "Multi-modal front-desk agent",
-                                        "inbound": true,
-                                        "project": 1376,
-                                        "language": "en",
-                                        "assistant_provider": "livekit",
-                                        "livekit_api_key": "APIxxx",
-                                        "livekit_data": {
-                                            "api_secret": "secret_xxx",
-                                            "url": "wss://acme.livekit.cloud"
-                                        }
-                                    },
-                                    "summary": "LiveKit agent"
-                                },
-                                "Self-hostedViaWebsocketURL": {
-                                    "value": {
-                                        "agent_name": "Internal Test Agent",
-                                        "description": "Staging build of the support flow",
-                                        "inbound": false,
-                                        "project": 1376,
-                                        "assistant_provider": "self_hosted",
-                                        "websocket_url": "wss://staging.example.com/agent",
-                                        "websocket_headers": {
-                                            "Authorization": "Bearer token_xxx"
-                                        },
-                                        "language": "en"
-                                    },
-                                    "summary": "Self-hosted via websocket URL",
-                                    "description": "Your agent exposes a websocket endpoint for text-mode testing."
+                                    "summary": "Cloud auto-import (configure_from_provider)",
+                                    "description": "Fetch & configure everything from the provider; returns 202 + progress_id."
                                 },
                                 "Self-hosted(observation-only,MostCommon)": {
                                     "value": {
@@ -38470,6 +38494,16 @@
                         },
                         "description": ""
                     },
+                    "202": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AIAgentConfigureFromProviderResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
                     "400": {
                         "content": {
                             "application/json": {
@@ -38494,7 +38528,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "test-framework-v2-aiagents-create",
-                        "description": "Register a new AI voice agent. Required fields: name, description, project, inbound. Provider credentials are nested under provider.{type, agent_id, credentials} instead of flat fields. transcript_provider defaults to provider.type when omitted.\n\n**provider.credentials keys by type (voice providers only):**\n- vapi: api_key + config.{public_key, trigger_url}\n- retell: api_key + agent_id + optional chat_agent_details.config.agent_id\n- elevenlabs: api_key + config.{trigger_url}\n- bland: api_key + agent_id (pathway_id) + config.{encrypted_key} for Twilio\n- livekit: api_key + config.{api_secret (required), url (required)}\n- pipecat: api_key + config.{webhook_url}\n- cisco: no credentials needed\n- self_hosted: credentials.config.{url (wss://), headers}\nNote: agentforce goes in chat_agent_details; koreai/genesys/synthflow use the v1 API.\n\nSee examples below for full per-provider payloads."
+                        "description": "Register a new AI voice agent. Required fields: name, description, project, inbound. Provider credentials are nested under provider.{type, agent_id, credentials} instead of flat fields. transcript_provider defaults to provider.type when omitted.\n\n**provider.credentials keys by type (voice providers only):**\n- vapi: api_key + config.{public_key, trigger_url}\n- retell: api_key + agent_id + optional chat_agent_details.config.agent_id\n- elevenlabs: api_key + config.{trigger_url}\n- bland: api_key + agent_id (pathway_id) + config.{encrypted_key} for Twilio\n- livekit: api_key + config.{api_secret (required), url (required)}\n- pipecat: api_key + config.{webhook_url}\n- cisco: no credentials needed\n- self_hosted: credentials.config.{url (wss://), headers}\nNote: agentforce goes in chat_agent_details; koreai/genesys/synthflow use the v1 API.\n\n**Auto-import from a cloud provider** — set `provider.configure_from_provider: true` (vapi/retell/elevenlabs/synthflow) with `provider.agent_id` + `provider.credentials.api_key`. Cekura fetches the prompt, name, language, who-speaks-first, phone number, tool calls, dynamic variables and knowledge base and configures the agent automatically — `name` and `description` become optional (auto-fetched). The response is **202** with the created agent plus a `progress_id`; poll `import-progress/` to follow the staged import.\n\nSee examples below for full per-provider payloads."
                     }
                 }
             }
@@ -39345,75 +39379,10 @@
                 }
             }
         },
-        "/test_framework/v2/aiagents/import-from-provider/": {
-            "post": {
-                "operationId": "test-framework-v2-aiagents-import-from-provider-create",
-                "description": "Create an agent from an existing cloud-provider assistant. Supply the provider type and assistant ID (under `provider.type` / `provider.agent_id`) plus credentials, and Cekura fetches the system prompt, language/first-message settings, tool calls and dynamic variables from the provider and configures the agent automatically.\n\nSupported providers: vapi, retell, elevenlabs, synthflow. Request body is the same shape as `aiagents_create`. Returns the created agent immediately plus a `progress_id`; poll `import-progress/` with it to follow the per-step import status.",
-                "summary": "Import an AI agent from a cloud provider",
-                "tags": [
-                    "test_framework"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/AIAgentV2"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/AIAgentV2"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/AIAgentV2"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "202": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ImportFromProviderResponse"
-                                }
-                            }
-                        },
-                        "description": ""
-                    },
-                    "400": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "field_name": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
-        },
         "/test_framework/v2/aiagents/import-progress/": {
             "get": {
                 "operationId": "test-framework-v2-aiagents-import-progress-retrieve",
-                "description": "Returns the staged status of a background agent import started by `import-from-provider`. Each stage reports pending / in_progress / completed / skipped / failed so a step-by-step loader can be rendered.",
+                "description": "Returns the staged status of a background agent import started via `configure_from_provider`. Each stage reports pending / in_progress / completed / skipped / failed so a step-by-step loader can be rendered.",
                 "summary": "Poll cloud-provider import progress",
                 "parameters": [
                     {
@@ -50623,6 +50592,22 @@
                     "inbound"
                 ]
             },
+            "AIAgentConfigureFromProviderResponse": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer"
+                    },
+                    "progress_id": {
+                        "type": "string",
+                        "description": "Poll import-progress/ with this to follow the staged import."
+                    }
+                },
+                "required": [
+                    "id",
+                    "progress_id"
+                ]
+            },
             "AIAgentDynamicVariable": {
                 "type": "object",
                 "properties": {
@@ -50905,7 +50890,7 @@
                     },
                     "name": {
                         "type": "string",
-                        "description": "Agent name.",
+                        "description": "Agent name. Optional when configure_from_provider is set — it's fetched from the provider.",
                         "maxLength": 255
                     },
                     "description": {
@@ -51021,8 +51006,7 @@
                     }
                 },
                 "required": [
-                    "description",
-                    "name"
+                    "description"
                 ]
             },
             "AgentCredentials": {
@@ -51117,7 +51101,12 @@
                             "boolean",
                             "null"
                         ],
-                        "description": "Auto-sync agent prompt from the provider every 30s. Supported for: vapi, retell, elevenlabs, synthflow."
+                        "description": "Auto-sync the agent from the provider on a schedule. Supported for: vapi, retell, elevenlabs, synthflow."
+                    },
+                    "configure_from_provider": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "When true on create for a cloud provider (vapi/retell/elevenlabs/synthflow), Cekura fetches the assistant's prompt, settings, phone, tools, dynamic variables and knowledge base and configures the agent automatically. Requires agent_id + credentials.api_key. The create response includes a progress_id to poll import-progress/."
                     },
                     "send_post_conversation_metadata": {
                         "type": [
@@ -51743,23 +51732,32 @@
                         "enum": [
                             "vapi",
                             "retell",
-                            "elevenlabs"
+                            "elevenlabs",
+                            "custom"
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "ff667bd2cd27b9d3",
-                        "description": "Provider to fetch tools from\n\n* `vapi` - vapi\n* `retell` - retell\n* `elevenlabs` - elevenlabs"
+                        "x-spec-enum-id": "e3f60d118bb06f46",
+                        "description": "Provider to fetch tools from. Use \"custom\" for self-hosted agents that expose an MCP server directly.\n\n* `vapi` - vapi\n* `retell` - retell\n* `elevenlabs` - elevenlabs\n* `custom` - custom"
                     },
                     "assistant_id": {
                         "type": "string",
-                        "description": "Assistant/Agent ID from the provider (e.g., VAPI Assistant ID)"
+                        "description": "Provider assistant/agent ID. Required for vapi/retell/elevenlabs; ignored for custom."
                     },
                     "api_key": {
                         "type": "string",
-                        "description": "Optional API key for the provider. If not provided, will use stored credentials."
+                        "description": "Optional API key for the managed provider. Ignored for custom. If not provided, stored credentials are used."
+                    },
+                    "mcp_server_url": {
+                        "type": "string",
+                        "description": "Required when provider=\"custom\". URL of the customer-hosted MCP server (JSON-RPC 2.0)."
+                    },
+                    "mcp_server_headers": {
+                        "type": "object",
+                        "additionalProperties": {},
+                        "description": "Optional auth/custom headers forwarded to the MCP server during tool discovery (provider=\"custom\" only)."
                     }
                 },
                 "required": [
-                    "assistant_id",
                     "provider"
                 ]
             },
@@ -54071,6 +54069,56 @@
                     "detail"
                 ]
             },
+            "DisableMockProgressErrorResponse": {
+                "type": "object",
+                "properties": {
+                    "detail": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "detail"
+                ]
+            },
+            "DisableMockProgressResponse": {
+                "type": "object",
+                "properties": {
+                    "status": {
+                        "enum": [
+                            "in_progress",
+                            "completed",
+                            "failed"
+                        ],
+                        "type": "string",
+                        "description": "* `in_progress` - in_progress\n* `completed` - completed\n* `failed` - failed",
+                        "x-spec-enum-id": "6e9575e5767aaee0"
+                    },
+                    "mock_enabled": {
+                        "type": [
+                            "boolean",
+                            "null"
+                        ]
+                    },
+                    "message": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "error": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    }
+                },
+                "required": [
+                    "error",
+                    "message",
+                    "mock_enabled",
+                    "status"
+                ]
+            },
             "DisableMockToolsRequest": {
                 "type": "object",
                 "properties": {
@@ -54206,6 +54254,63 @@
                 },
                 "required": [
                     "detail"
+                ]
+            },
+            "EnableMockProgressErrorResponse": {
+                "type": "object",
+                "properties": {
+                    "detail": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "detail"
+                ]
+            },
+            "EnableMockProgressResponse": {
+                "type": "object",
+                "properties": {
+                    "status": {
+                        "enum": [
+                            "in_progress",
+                            "completed",
+                            "failed"
+                        ],
+                        "type": "string",
+                        "description": "* `in_progress` - in_progress\n* `completed` - completed\n* `failed` - failed",
+                        "x-spec-enum-id": "6e9575e5767aaee0"
+                    },
+                    "mock_enabled": {
+                        "type": [
+                            "boolean",
+                            "null"
+                        ]
+                    },
+                    "mcp_endpoints": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/MockMCPEndpoint"
+                        },
+                        "description": "MCP mock endpoints registered for this agent (one per MCP-typed tool). Empty for agents without MCP tools."
+                    },
+                    "message": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "error": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    }
+                },
+                "required": [
+                    "error",
+                    "message",
+                    "mock_enabled",
+                    "status"
                 ]
             },
             "EnableMockToolsRequest": {
@@ -54430,21 +54535,6 @@
                     "region"
                 ],
                 "title": "Genesys"
-            },
-            "ImportFromProviderResponse": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "integer"
-                    },
-                    "progress_id": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "id",
-                    "progress_id"
-                ]
             },
             "ImportPlivoNumber": {
                 "type": "object",
@@ -56698,6 +56788,106 @@
                     "metric"
                 ]
             },
+            "MockMCPEndpoint": {
+                "type": "object",
+                "properties": {
+                    "mock_index": {
+                        "type": "integer"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "tool_names": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "required": [
+                    "mock_index",
+                    "tool_names",
+                    "url"
+                ]
+            },
+            "MockStatusMCPEndpoint": {
+                "type": "object",
+                "properties": {
+                    "mock_index": {
+                        "type": "integer"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "tool_names": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "required": [
+                    "mock_index",
+                    "tool_names",
+                    "url"
+                ]
+            },
+            "MockStatusResponse": {
+                "type": "object",
+                "properties": {
+                    "mock_enabled": {
+                        "type": "boolean"
+                    },
+                    "provider": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "assistant_id": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "mcp_endpoints": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/MockStatusMCPEndpoint"
+                        },
+                        "description": "MCP JSON-RPC endpoints registered on the agent. Empty if no MCP-typed tools are mocked."
+                    },
+                    "tool_endpoints": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/MockStatusToolEndpoint"
+                        },
+                        "description": "Per-tool webhook endpoints for standalone (non-MCP) tools. Excludes MCP sub-tools, which are listed under mcp_endpoints[].tool_names."
+                    }
+                },
+                "required": [
+                    "assistant_id",
+                    "mcp_endpoints",
+                    "mock_enabled",
+                    "provider",
+                    "tool_endpoints"
+                ]
+            },
+            "MockStatusToolEndpoint": {
+                "type": "object",
+                "properties": {
+                    "tool_name": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "tool_name",
+                    "url"
+                ]
+            },
             "MoveFolderRequest": {
                 "type": "object",
                 "properties": {
@@ -58372,7 +58562,7 @@
                     },
                     "name": {
                         "type": "string",
-                        "description": "Agent name.",
+                        "description": "Agent name. Optional when configure_from_provider is set — it's fetched from the provider.",
                         "maxLength": 255
                     },
                     "description": {
@@ -61959,6 +62149,16 @@
                     },
                     "freetext_params": {
                         "description": "Parameter names skipped during mock matching because they are free-text (e.g. [\"notes\", \"reason\"])"
+                    },
+                    "mock_url": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "Per-tool webhook URL. None if this Tool is served through an MCP endpoint."
+                    },
+                    "served_via": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "How this tool is accessed at runtime. `{'type': 'direct'}` for standalone tools; `{'type': 'mcp', 'mock_index': N, 'url': '.../mcp/N/'}` for MCP sub-tools."
                     }
                 }
             },
@@ -68607,6 +68807,16 @@
                     },
                     "freetext_params": {
                         "description": "Parameter names skipped during mock matching because they are free-text (e.g. [\"notes\", \"reason\"])"
+                    },
+                    "mock_url": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "Per-tool webhook URL. None if this Tool is served through an MCP endpoint."
+                    },
+                    "served_via": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "How this tool is accessed at runtime. `{'type': 'direct'}` for standalone tools; `{'type': 'mcp', 'mock_index': N, 'url': '.../mcp/N/'}` for MCP sub-tools."
                     }
                 },
                 "required": [

--- a/openapi.json
+++ b/openapi.json
@@ -61,6 +61,25 @@
                 "description": "A8c8aef15013e2e52ccf6000350258a1eab6cd2a11e62f592c5e19092d7204d7"
             }
         },
+        "/app/otel/validate/": {
+            "get": {
+                "operationId": "app-otel-validate-retrieve",
+                "description": "Validate an API key owns the given agent or project.\n\nUsed by the OTel auth service. Returns 200 on success,\n401 on bad/missing key, 403 on ownership mismatch.\n\nQuery params: agent_id or project_id.",
+                "tags": [
+                    "app"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No response body"
+                    }
+                }
+            }
+        },
         "/app/v1/product-chat/": {
             "post": {
                 "operationId": "app-v1-product-chat-create",
@@ -1694,8 +1713,7 @@
         "/observability/v1/alerts/": {
             "get": {
                 "operationId": "alerts-list",
-                "description": "Return all alerts configured in the project, including their sub_type (`normal` | `significant_change` | `threshold`), source metric, current Slack/notification config, and trigger counters. Use before creating a new alert to check if one already exists on the same metric.",
-                "summary": "List alerts in a project",
+                "description": "List alerts",
                 "parameters": [
                     {
                         "in": "query",
@@ -1765,20 +1783,11 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "alerts-list",
-                        "description": "Return all alerts configured in the project, including their sub_type (`normal` | `significant_change` | `threshold`), source metric, current Slack/notification config, and trigger counters. Use before creating a new alert to check if one already exists on the same metric."
-                    }
                 }
             },
             "post": {
                 "operationId": "alerts-create",
-                "description": "Create an alert that fires when a metric crosses a threshold. Three sub_types:\n\n- `normal` — Failure alert. Fires per failing call. Only for binary metrics (eval_type starts with `binary_`) plus the latency / infrastructure / critical-deviation built-ins.\n- `significant_change` — Trend alert. Fires when a numeric/continuous metric's rolling mean deviates from history. Pass `preset: \"balanced\"` (or `\"conservative\"` / `\"aggressive\"`) to skip manual std_multiplier / ewma_alpha / window_size math — the server expands the preset. Balanced is the safe default.\n- `threshold` — Hard ceiling/floor. Fires when ≥ `min_breaches` of the last `window_size` evaluations cross `value`. Use for numeric metrics where the user has a known good range. Operator is `gt` | `lt` | `outside` ({low, high}).\n\n**Slack delivery requires** `notifications.slack.workspace_id` (+ optional `channel_id`). Alerts with empty `notifications` are silent — fire counters still increment but no message is sent. Pick a workspace_id from `slack_workspaces_list`.",
-                "summary": "Create an alert on a metric",
+                "description": "Create a new alert",
                 "tags": [
                     "observability"
                 ],
@@ -1818,22 +1827,13 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "alerts-create",
-                        "description": "Create an alert that fires when a metric crosses a threshold. Three sub_types:\n\n- `normal` — Failure alert. Fires per failing call. Only for binary metrics (eval_type starts with `binary_`) plus the latency / infrastructure / critical-deviation built-ins.\n- `significant_change` — Trend alert. Fires when a numeric/continuous metric's rolling mean deviates from history. Pass `preset: \"balanced\"` (or `\"conservative\"` / `\"aggressive\"`) to skip manual std_multiplier / ewma_alpha / window_size math — the server expands the preset. Balanced is the safe default.\n- `threshold` — Hard ceiling/floor. Fires when ≥ `min_breaches` of the last `window_size` evaluations cross `value`. Use for numeric metrics where the user has a known good range. Operator is `gt` | `lt` | `outside` ({low, high}).\n\n**Slack delivery requires** `notifications.slack.workspace_id` (+ optional `channel_id`). Alerts with empty `notifications` are silent — fire counters still increment but no message is sent. Pick a workspace_id from `slack_workspaces_list`."
-                    }
                 }
             }
         },
         "/observability/v1/alerts/{id}/": {
             "get": {
                 "operationId": "alerts-retrieve",
-                "description": "Return one alert with its source / threshold / notifications JSON expanded. Use this before updating to confirm the current shape — `partial_update` merges into existing JSON, so you need to know what's already there.",
-                "summary": "Get an alert's full config",
+                "description": "Retrieve an alert by ID",
                 "parameters": [
                     {
                         "in": "path",
@@ -1864,19 +1864,11 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "alerts-retrieve",
-                        "description": "Return one alert with its source / threshold / notifications JSON expanded. Use this before updating to confirm the current shape — `partial_update` merges into existing JSON, so you need to know what's already there."
-                    }
                 }
             },
             "put": {
                 "operationId": "alerts-update",
-                "description": "Manage alerts that fire when metric thresholds are crossed.",
+                "description": "Update an alert",
                 "parameters": [
                     {
                         "in": "path",
@@ -1931,8 +1923,7 @@
             },
             "patch": {
                 "operationId": "alerts-partial-update",
-                "description": "Update fields on an existing alert. Common uses from chat:\n\n- Tune sensitivity: pass `preset: \"conservative\"` to make a noisy trend alert quieter (or `\"aggressive\"` to catch smaller shifts). Explicit `threshold.std_multiplier` / `ewma_alpha` / `source.window_size` override the preset.\n- Change Slack routing: pass a new `notifications.slack` block.\n- Disable temporarily: pass `enabled: false`.\n\nChanging `sub_type` requires the matching `source` + `threshold` shape — see `alerts_create` for the field matrix per sub_type. Partial updates merge JSON, so omitted nested keys keep their existing values.",
-                "summary": "Update an alert (partial)",
+                "description": "Update an alert",
                 "parameters": [
                     {
                         "in": "path",
@@ -1982,20 +1973,11 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "alerts-partial-update",
-                        "description": "Update fields on an existing alert. Common uses from chat:\n\n- Tune sensitivity: pass `preset: \"conservative\"` to make a noisy trend alert quieter (or `\"aggressive\"` to catch smaller shifts). Explicit `threshold.std_multiplier` / `ewma_alpha` / `source.window_size` override the preset.\n- Change Slack routing: pass a new `notifications.slack` block.\n- Disable temporarily: pass `enabled: false`.\n\nChanging `sub_type` requires the matching `source` + `threshold` shape — see `alerts_create` for the field matrix per sub_type. Partial updates merge JSON, so omitted nested keys keep their existing values."
-                    }
                 }
             },
             "delete": {
                 "operationId": "alerts-destroy",
-                "description": "Permanently delete an alert. ⚠ Irreversible. The chat agent refuses this operation at the SDK layer; direct API/SDK callers can still use it.",
-                "summary": "Delete an alert",
+                "description": "Delete an alert",
                 "parameters": [
                     {
                         "in": "path",
@@ -2019,14 +2001,177 @@
                     "204": {
                         "description": "No response body"
                     }
+                }
+            }
+        },
+        "/observability/v1/alerts/{id}/review_detail/": {
+            "get": {
+                "operationId": "alerts-review-detail-retrieve",
+                "description": "Per-alert review data — config snapshot, timeline, paginated fires.\n\nPowers the per-alert review page. Single-alert version of the bulk\n`review` action. Timeline is computed with a DB-side GROUP BY so the\nendpoint stays fast for noisy alerts (thousands of fires in 7d).\n\nQuery params:\n    hours: optional, defaults to 24. Capped at 7 days.\n    page: optional, defaults to 1.\n    page_size: optional, defaults to 50, capped at 200.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this alert.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "observability"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AlertDetail"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/observability/v1/alerts/{id}/summarize/": {
+            "post": {
+                "operationId": "alerts-summarize-create",
+                "description": "Kick off an LLM summary of the last N hours of fires for this alert.\n\nReturns a progress_id. Frontend polls `summarize_progress` until status\nis 'completed' or 'error'. Cached for 1 hour keyed on (alert, hours,\nlatest fire id) — re-invocations within that window return the same\nprogress_id.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this alert.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "observability"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AlertDetail"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AlertDetail"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AlertDetail"
+                            }
+                        }
+                    },
+                    "required": true
                 },
-                "x-mcp-expose": true,
-                "x-mcp-destructive": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "alerts-destroy",
-                        "description": "Permanently delete an alert. ⚠ Irreversible. The chat agent refuses this operation at the SDK layer; direct API/SDK callers can still use it."
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AlertDetail"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/observability/v1/alerts/review/": {
+            "get": {
+                "operationId": "alerts-review-retrieve",
+                "description": "Aggregate fired-alert data for the review page.\n\nReturns deterministic SQL-only aggregates: KPI summary, time-bucketed\ntimeline, and a per-alert breakdown with sparkline. LLM summaries are\non-demand via the separate `summarize` action.\n\nQuery params:\n    project_id: required.\n    hours: optional, defaults to 24.",
+                "tags": [
+                    "observability"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AlertDetail"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/observability/v1/alerts/summarize_progress/": {
+            "get": {
+                "operationId": "alerts-summarize-progress-retrieve",
+                "description": "Alerts summarize progress",
+                "tags": [
+                    "observability"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AlertDetail"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/observability/v1/alerts/trigger_summary/": {
+            "get": {
+                "operationId": "alerts-trigger-summary-retrieve",
+                "description": "Return fire counts per alert over a time window.\n\nPowers the \"Last 24h\" status pill on the alerts list. Counts CallLogAlert\nrows linked to each alert in the project, scoped to the window.\n\nQuery params:\n    project_id: required, scopes the result to alerts in this project.\n    hours: optional, defaults to 24. Window size in hours.\n\nReturns: { \"<alert_id>\": <fire_count>, ... }",
+                "tags": [
+                    "observability"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AlertDetail"
+                                }
+                            }
+                        },
+                        "description": ""
                     }
                 }
             }
@@ -4105,6 +4250,35 @@
                 }
             }
         },
+        "/observability/v1/call-logs/{id}/trace/": {
+            "get": {
+                "operationId": "call-logs-trace-retrieve",
+                "description": "Proxy trace data from Grafana Tempo for a CallLog.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "observability"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No response body"
+                    }
+                }
+            }
+        },
         "/observability/v1/call-logs/{id}/unmark_critical_scenario_wrong/": {
             "post": {
                 "operationId": "call-logs-unmark-critical-scenario-wrong-create",
@@ -5593,10 +5767,150 @@
                 }
             }
         },
+        "/observability/v1/metric-failure-mode-insights/": {
+            "get": {
+                "operationId": "metric-failure-mode-insights-list",
+                "description": "List metric failure mode insights",
+                "tags": [
+                    "observability"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/MetricFailureModeInsight"
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/observability/v1/metric-failure-mode-insights/{id}/": {
+            "get": {
+                "operationId": "metric-failure-mode-insights-retrieve",
+                "description": "Retrieve a metric failure mode insight by ID",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric failure mode insight.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "observability"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricFailureModeInsight"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "metric-failure-mode-insights-destroy",
+                "description": "Delete a metric failure mode insight",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric failure mode insight.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "observability"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No response body"
+                    }
+                }
+            }
+        },
+        "/observability/v1/metric-failure-mode-insights/generate/": {
+            "post": {
+                "operationId": "metric-failure-mode-insights-generate-create",
+                "description": "Queue a failure-mode audit; returns the new row in ``pending``.\n\nProject scoping comes from the JSON body (``project`` field),\nnot query params — that's why this action sits in\n``permission_query_params_skip_actions``. The project-level\npermission classes still gate the request via the serializer\nvalidation + ``get_object_or_404`` below.",
+                "tags": [
+                    "observability"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricFailureModeInsightGenerate"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricFailureModeInsightGenerate"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricFailureModeInsightGenerate"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricFailureModeInsightGenerate"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/observability/v1/observe/": {
             "post": {
                 "operationId": "observe-create",
-                "description": "Primary ingestion endpoint for production call logs. Your agent (or its provider's post-call webhook) POSTs here with the transcript, recording URL, and metadata; Cekura stores it as a `CallLog`, schedules metric evaluation, and surfaces it in Observability.\n\n**Identifying the agent (pick one):**\n- `agent` — Cekura agent ID (preferred when you've already registered via `POST /aiagents/`)\n- `assistant_id` — external assistant identifier (VAPI/Retell/OpenAI-style `asst_...`). Cekura resolves it to your agent.\n\n**Transcript formats** (via `transcript_type`):\n- `vapi`, `retell`, `elevenlabs`, `bland`, `livekit`, `pipecat`, `koreai`, `trillet` — provider-native shapes; pass `transcript_json` exactly as the provider emits it.\n- `cekura` (default) — `[{role, content, start_time, end_time}, ...]`. Valid roles: `\"Testing Agent\"` (the caller) and `\"Main Agent\"` (the agent under test). Note: `\"agent\"` and `\"user\"` are **not** valid for this format.\n\n**Provider-specific alternatives:**\n- LiveKit webhooks: `POST /observability/v1/livekit/observe/` (raw LiveKit webhook shape)\n- Pipecat webhooks: `POST /observability/v1/pipecat/observe/` (raw Pipecat webhook shape)\n\n**Fields to know:**\n- `voice_recording_url` — link to the call audio; enables audio-based metrics.\n- `metadata` — freeform tags for filtering in Observability (`customer_id`, `campaign_id`, etc.).\n- `dynamic_variables` — values injected into the agent at runtime; shown alongside the transcript.\n- `customer_number` — caller's number in E.164 format, e.g. `+14155551234`.\n- `call_ended_reason` — reason for call termination (`completed`, `user-hangup`, `agent-hangup`, etc.).\n- `metric_ids` — comma-separated metric IDs to evaluate immediately (e.g. `\"1,2,3\"`).\n\n**Async processing:** metrics are evaluated in the background. The initial response shows `status: \"evaluating\"` with an empty `metrics` list. Retrieve the call log again after 30–60 seconds to see completed metric results.\n\n**Billing:** each ingested call consumes observability credits. Calls with audio cost more than text-only calls. Check your balance via `GET /test_framework/v1/billing_info`.",
+                "description": "Primary ingestion endpoint for production call logs. Your agent (or its provider's post-call webhook) POSTs here with the transcript, recording URL, and metadata; Cekura stores it as a `CallLog`, schedules metric evaluation, and surfaces it in Observability.\n\n**Identifying the agent (pick one):**\n- `agent` — Cekura agent ID (preferred when you've already registered via `POST /aiagents/`)\n- `assistant_id` — external assistant identifier (VAPI/Retell/OpenAI-style `asst_...`). Cekura resolves it to your agent.\n\n**Transcript formats** (via `transcript_type`):\n- `vapi`, `retell`, `elevenlabs`, `bland`, `livekit`, `pipecat`, `koreai` — provider-native shapes; pass `transcript_json` exactly as the provider emits it.\n- `cekura` (default) — `[{role, content, start_time, end_time}, ...]`. Valid roles: `\"Testing Agent\"` (the caller) and `\"Main Agent\"` (the agent under test). Note: `\"agent\"` and `\"user\"` are **not** valid for this format.\n\n**Provider-specific alternatives:**\n- LiveKit webhooks: `POST /observability/v1/livekit/observe/` (raw LiveKit webhook shape)\n- Pipecat webhooks: `POST /observability/v1/pipecat/observe/` (raw Pipecat webhook shape)\n\n**Fields to know:**\n- `voice_recording_url` — link to the call audio; enables audio-based metrics.\n- `metadata` — freeform tags for filtering in Observability (`customer_id`, `campaign_id`, etc.).\n- `dynamic_variables` — values injected into the agent at runtime; shown alongside the transcript.\n- `customer_number` — caller's number in E.164 format, e.g. `+14155551234`.\n- `call_ended_reason` — reason for call termination (`completed`, `user-hangup`, `agent-hangup`, etc.).\n- `metric_ids` — comma-separated metric IDs to evaluate immediately (e.g. `\"1,2,3\"`).\n\n**Async processing:** metrics are evaluated in the background. The initial response shows `status: \"evaluating\"` with an empty `metrics` list. Retrieve the call log again after 30–60 seconds to see completed metric results.\n\n**Billing:** each ingested call consumes observability credits. Calls with audio cost more than text-only calls. Check your balance via `GET /test_framework/v1/billing_info`.",
                 "summary": "Ingest a production call (webhook)",
                 "tags": [
                     "Observability"
@@ -5713,7 +6027,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "observe-create",
-                        "description": "Primary ingestion endpoint for production call logs. Your agent (or its provider's post-call webhook) POSTs here with the transcript, recording URL, and metadata; Cekura stores it as a `CallLog`, schedules metric evaluation, and surfaces it in Observability.\n\n**Identifying the agent (pick one):**\n- `agent` — Cekura agent ID (preferred when you've already registered via `POST /aiagents/`)\n- `assistant_id` — external assistant identifier (VAPI/Retell/OpenAI-style `asst_...`). Cekura resolves it to your agent.\n\n**Transcript formats** (via `transcript_type`):\n- `vapi`, `retell`, `elevenlabs`, `bland`, `livekit`, `pipecat`, `koreai`, `trillet` — provider-native shapes; pass `transcript_json` exactly as the provider emits it.\n- `cekura` (default) — `[{role, content, start_time, end_time}, ...]`. Valid roles: `\"Testing Agent\"` (the caller) and `\"Main Agent\"` (the agent under test). Note: `\"agent\"` and `\"user\"` are **not** valid for this format.\n\n**Provider-specific alternatives:**\n- LiveKit webhooks: `POST /observability/v1/livekit/observe/` (raw LiveKit webhook shape)\n- Pipecat webhooks: `POST /observability/v1/pipecat/observe/` (raw Pipecat webhook shape)\n\n**Fields to know:**\n- `voice_recording_url` — link to the call audio; enables audio-based metrics.\n- `metadata` — freeform tags for filtering in Observability (`customer_id`, `campaign_id`, etc.).\n- `dynamic_variables` — values injected into the agent at runtime; shown alongside the transcript.\n- `customer_number` — caller's number in E.164 format, e.g. `+14155551234`.\n- `call_ended_reason` — reason for call termination (`completed`, `user-hangup`, `agent-hangup`, etc.).\n- `metric_ids` — comma-separated metric IDs to evaluate immediately (e.g. `\"1,2,3\"`).\n\n**Async processing:** metrics are evaluated in the background. The initial response shows `status: \"evaluating\"` with an empty `metrics` list. Retrieve the call log again after 30–60 seconds to see completed metric results.\n\n**Billing:** each ingested call consumes observability credits. Calls with audio cost more than text-only calls. Check your balance via `GET /test_framework/v1/billing_info`."
+                        "description": "Primary ingestion endpoint for production call logs. Your agent (or its provider's post-call webhook) POSTs here with the transcript, recording URL, and metadata; Cekura stores it as a `CallLog`, schedules metric evaluation, and surfaces it in Observability.\n\n**Identifying the agent (pick one):**\n- `agent` — Cekura agent ID (preferred when you've already registered via `POST /aiagents/`)\n- `assistant_id` — external assistant identifier (VAPI/Retell/OpenAI-style `asst_...`). Cekura resolves it to your agent.\n\n**Transcript formats** (via `transcript_type`):\n- `vapi`, `retell`, `elevenlabs`, `bland`, `livekit`, `pipecat`, `koreai` — provider-native shapes; pass `transcript_json` exactly as the provider emits it.\n- `cekura` (default) — `[{role, content, start_time, end_time}, ...]`. Valid roles: `\"Testing Agent\"` (the caller) and `\"Main Agent\"` (the agent under test). Note: `\"agent\"` and `\"user\"` are **not** valid for this format.\n\n**Provider-specific alternatives:**\n- LiveKit webhooks: `POST /observability/v1/livekit/observe/` (raw LiveKit webhook shape)\n- Pipecat webhooks: `POST /observability/v1/pipecat/observe/` (raw Pipecat webhook shape)\n\n**Fields to know:**\n- `voice_recording_url` — link to the call audio; enables audio-based metrics.\n- `metadata` — freeform tags for filtering in Observability (`customer_id`, `campaign_id`, etc.).\n- `dynamic_variables` — values injected into the agent at runtime; shown alongside the transcript.\n- `customer_number` — caller's number in E.164 format, e.g. `+14155551234`.\n- `call_ended_reason` — reason for call termination (`completed`, `user-hangup`, `agent-hangup`, etc.).\n- `metric_ids` — comma-separated metric IDs to evaluate immediately (e.g. `\"1,2,3\"`).\n\n**Async processing:** metrics are evaluated in the background. The initial response shows `status: \"evaluating\"` with an empty `metrics` list. Retrieve the call log again after 30–60 seconds to see completed metric results.\n\n**Billing:** each ingested call consumes observability credits. Calls with audio cost more than text-only calls. Check your balance via `GET /test_framework/v1/billing_info`."
                     }
                 }
             }
@@ -6802,6 +7116,274 @@
                 }
             }
         },
+        "/schedules/v1/metric-optimiser-cron-jobs/": {
+            "get": {
+                "operationId": "metric-optimiser-cron-jobs-list",
+                "description": "List all scheduled metric-optimiser jobs.",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "project_id",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "organization_id",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "tags": [
+                    "schedules"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/MetricOptimiserCronJob"
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "post": {
+                "operationId": "metric-optimiser-cron-jobs-create",
+                "description": "Create a cron job that runs the Metric Lab optimiser against one or more metrics on a recurring schedule. The optimiser uses every test set already in each metric's Lab (every MetricReview row). Set `auto_apply` to overwrite the live metric prompt when the optimised score is at least as good as the baseline on the labelled set — otherwise the run is read-only and emails a diff summary.",
+                "summary": "Schedule a recurring metric optimiser run",
+                "tags": [
+                    "schedules"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricOptimiserCronJob"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricOptimiserCronJob"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricOptimiserCronJob"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricOptimiserCronJob"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/schedules/v1/metric-optimiser-cron-jobs/{id}/": {
+            "get": {
+                "operationId": "metric-optimiser-cron-jobs-retrieve",
+                "description": "Retrieve a scheduled metric-optimiser job by id.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric optimiser cron job.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "schedules"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricOptimiserCronJob"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "put": {
+                "operationId": "metric-optimiser-cron-jobs-update",
+                "description": "Update an existing scheduled metric-optimiser job.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric optimiser cron job.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "schedules"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricOptimiserCronJob"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricOptimiserCronJob"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricOptimiserCronJob"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricOptimiserCronJob"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "patch": {
+                "operationId": "metric-optimiser-cron-jobs-partial-update",
+                "description": "Partially update an existing scheduled metric-optimiser job.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric optimiser cron job.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "schedules"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedMetricOptimiserCronJob"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedMetricOptimiserCronJob"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedMetricOptimiserCronJob"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricOptimiserCronJob"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "metric-optimiser-cron-jobs-destroy",
+                "description": "Irreversible. Deletes the cron job and stops it from firing. Past optimiser runs are retained.",
+                "summary": "Delete a scheduled metric-optimiser job",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric optimiser cron job.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "schedules"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No response body"
+                    },
+                    "404": {
+                        "description": "No response body"
+                    }
+                }
+            }
+        },
         "/slack/events/": {
             "post": {
                 "operationId": "slack-events-create",
@@ -6862,8 +7444,6 @@
         "/slack/slack-workspaces/": {
             "get": {
                 "operationId": "slack-slack-workspaces-list",
-                "description": "Return every Slack workspace connected to the project, with the bot's default `channel_id`, `team_name`, and verification status. Use to pick a `workspace_id` (and optionally a different `channel_id`) for the `notifications.slack` block on `alerts_create`. Access tokens and bot IDs are not returned.",
-                "summary": "List Slack workspaces configured for a project",
                 "tags": [
                     "slack"
                 ],
@@ -6887,14 +7467,7 @@
                         "description": ""
                     }
                 },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "slack-slack-workspaces-list",
-                        "description": "Return every Slack workspace connected to the project, with the bot's default `channel_id`, `team_name`, and verification status. Use to pick a `workspace_id` (and optionally a different `channel_id`) for the `notifications.slack` block on `alerts_create`. Access tokens and bot IDs are not returned."
-                    }
-                }
+                "description": "List slack slack workspaces"
             },
             "post": {
                 "operationId": "slack-slack-workspaces-create",
@@ -8049,7 +8622,7 @@
         "/test_framework/billing/info/": {
             "get": {
                 "operationId": "billing-info-retrieve",
-                "description": "Returns credits remaining, credits used, and subscription status for the organization. The organization is automatically determined from the API key. Only organization-scoped API keys are supported.",
+                "description": "Returns credits remaining, credits used, balance expiry, and subscription status for an organization. When called with an organization-scoped API key, the org is taken from the key. When called with a user session or OAuth bearer, pass `organization_id` as a query parameter — the caller must be an admin of that organization.",
                 "summary": "Get billing information",
                 "tags": [
                     "test_framework"
@@ -8082,7 +8655,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "billing-info-retrieve",
-                        "description": "Returns credits remaining, credits used, and subscription status for the organization. The organization is automatically determined from the API key. Only organization-scoped API keys are supported."
+                        "description": "Returns credits remaining, credits used, balance expiry, and subscription status for an organization. When called with an organization-scoped API key, the org is taken from the key. When called with a user session or OAuth bearer, pass `organization_id` as a query parameter — the caller must be an admin of that organization."
                     }
                 }
             }
@@ -10259,19 +10832,11 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-list",
-                        "description": "aiagents_list: List AI voice agents in your account. Filter by `project_id` to scope to one project, or omit to list every agent the caller can access. Returns a paginated list of agent summaries (id, name, provider, contact number, created/updated timestamps).\n\nPerformance tip: passing `project_id` from your workspace context narrows the result. Try `page_size=20` first — you can paginate or raise the page size if you actually need more."
-                    }
                 }
             },
             "post": {
                 "operationId": "aiagents-create",
-                "description": "aiagents_create: Register a new AI voice agent with Cekura for testing / observability. Required: `agent_name`, `project` (project ID), `assistant_provider`. Other fields depend on the provider (see below).\n\n**Most common case:** you already have an agent running on your own provider stack with a dedicated phone number. Pass `agent_name`, `description`, `inbound`, `project`, `contact_number` (E.164 format, e.g. `+14155551234`), and `language` — Cekura observes that number without needing provider credentials. Set `assistant_provider=\"self_hosted\"` (optionally `websocket_url` for text-mode runs).\n\n**Provider integrations:** set `assistant_provider` to one of the valid values below and pass the matching credentials. `assistant_id` alone does NOT substitute for provider credentials — providers like VAPI, Retell, and Bland validate their api_key on create.\n\n**Valid `assistant_provider` values** (live enum — superset of prose docs you may see elsewhere):\n- `self_hosted` — websocket or observation-only; no api_key needed. Use `websocket_url` + `websocket_headers` for text-mode runs.\n- `vapi` — requires `vapi_api_key`; optional `assistant_id`, `vapi_data.public_key`.\n- `retell` — requires `retell_api_key` AND `chat_assistant_id` (yes — Retell uses this field even for voice).\n- `bland` — requires `bland_api_key` AND `chat_assistant_id` (Bland internally calls this `pathway_id`); `bland_data.encrypted_key` for Twilio.\n- `livekit` — requires `livekit_api_key` + `livekit_data.api_secret` + `livekit_data.url`.\n- `elevenlabs` — requires `elevenlabs_api_key`.\n- `agentforce` — Salesforce Agentforce; needs `agentforce_client_secret` + `agentforce_data` (client_id, domain, agent_id).\n- `trillet` — requires `trillet_api_key` + `trillet_data.workspace_id`.\n- `cisco` — Cisco Webex.\n- `vocera` — Cekura-hosted agent.\n- `sms` — text-only SMS channel; use `chat_assistant_id`.\n- `whatsapp` — text-only WhatsApp channel; use `chat_assistant_id`.\n- `\"\"` (empty string) — unset; agent is not runnable until a provider is configured.\n\n**Note:** the serializer exposes fields for some providers (`pipecat_*`, `synthflow_*`, `koreai_*`, `genesys_*`, `custom_provider_*`) that are NOT currently in the `assistant_provider` enum. Those fields exist for response/config purposes but the matching provider value cannot be selected today.\n\n**Outbound agents:** set `inbound=false`. Actual call placement uses the scenario's configured phone number or a number from the org's provisioned pool — `outbound_numbers` is not required for calls to be placed (it is used for webhook validation only).\n\n**Other fields to know:**\n- `language` — BCP-47 locale (`en`, `es`, `fr`, …). Must match the personalities used for evaluators.\n- `transcript_provider` — STT vendor (`vapi | retell | synthflow | elevenlabs | bland | livekit | pipecat | koreai | custom | trillet | cisco | genesys`). Does NOT auto-pair with `assistant_provider`; set both independently when needed.\n- `llm_model`, `llm_temperature`, `llm_max_tokens`, `llm_system_prompt` — simulation LLM settings (used by Cekura when simulating callers in test runs; NOT your agent's own LLM).\n- `auto_fetch_calls_enabled` — auto-import calls from the provider every 30s (VAPI/Retell only).\n- `auto_sync_prompt_enabled` — auto-sync prompts from the provider every 30s.\n\n**Read-only status fields** like `vapi_api_key_configured`, `retell_api_key_configured` appear in the response to indicate which provider credentials are stored (credentials themselves are masked).",
+                "description": "aiagents_create: Register a new AI voice agent with Cekura for testing / observability. Required: `agent_name`, `project` (project ID), `assistant_provider`. Other fields depend on the provider (see below).\n\n**Most common case:** you already have an agent running on your own provider stack with a dedicated phone number. Pass `agent_name`, `description`, `inbound`, `project`, `contact_number` (E.164 format, e.g. `+14155551234`), and `language` — Cekura observes that number without needing provider credentials. Set `assistant_provider=\"self_hosted\"` (optionally `websocket_url` for text-mode runs).\n\n**Provider integrations:** set `assistant_provider` to one of the valid values below and pass the matching credentials. `assistant_id` alone does NOT substitute for provider credentials — providers like VAPI, Retell, and Bland validate their api_key on create.\n\n**Valid `assistant_provider` values** (live enum — superset of prose docs you may see elsewhere):\n- `self_hosted` — websocket or observation-only; no api_key needed. Use `websocket_url` + `websocket_headers` for text-mode runs.\n- `vapi` — requires `vapi_api_key`; optional `assistant_id`, `vapi_data.public_key`.\n- `retell` — requires `retell_api_key` AND `chat_assistant_id` (yes — Retell uses this field even for voice).\n- `bland` — requires `bland_api_key` AND `chat_assistant_id` (Bland internally calls this `pathway_id`); `bland_data.encrypted_key` for Twilio.\n- `livekit` — requires `livekit_api_key` + `livekit_data.api_secret` + `livekit_data.url`.\n- `elevenlabs` — requires `elevenlabs_api_key`.\n- `agentforce` — Salesforce Agentforce; needs `agentforce_client_secret` + `agentforce_data` (client_id, domain, agent_id).\n- `cisco` — Cisco Webex.\n- `vocera` — Cekura-hosted agent.\n- `sms` — text-only SMS channel; use `chat_assistant_id`.\n- `whatsapp` — text-only WhatsApp channel; use `chat_assistant_id`.\n- `\"\"` (empty string) — unset; agent is not runnable until a provider is configured.\n\n**Note:** the serializer exposes fields for some providers (`pipecat_*`, `synthflow_*`, `koreai_*`, `genesys_*`, `custom_provider_*`) that are NOT currently in the `assistant_provider` enum. Those fields exist for response/config purposes but the matching provider value cannot be selected today.\n\n**Outbound agents:** set `inbound=false`. Actual call placement uses the scenario's configured phone number or a number from the org's provisioned pool — `outbound_numbers` is not required for calls to be placed (it is used for webhook validation only).\n\n**Other fields to know:**\n- `language` — BCP-47 locale (`en`, `es`, `fr`, …). Must match the personalities used for evaluators.\n- `transcript_provider` — STT vendor (`vapi | retell | synthflow | elevenlabs | bland | livekit | pipecat | koreai | custom | cisco | genesys`). Does NOT auto-pair with `assistant_provider`; set both independently when needed.\n- `llm_model`, `llm_temperature`, `llm_max_tokens`, `llm_system_prompt` — simulation LLM settings (used by Cekura when simulating callers in test runs; NOT your agent's own LLM).\n- `auto_fetch_calls_enabled` — auto-import calls from the provider every 30s (VAPI/Retell only).\n- `auto_sync_prompt_enabled` — auto-sync prompts from the provider every 30s.\n\n**Read-only status fields** like `vapi_api_key_configured`, `retell_api_key_configured` appear in the response to indicate which provider credentials are stored (credentials themselves are masked).",
                 "summary": "Create an AI voice agent",
                 "tags": [
                     "AI Agents"
@@ -10430,14 +10995,6 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-create",
-                        "description": "aiagents_create: Register a new AI voice agent with Cekura for testing / observability. Required: `agent_name`, `project` (project ID), `assistant_provider`. Other fields depend on the provider (see below).\n\n**Most common case:** you already have an agent running on your own provider stack with a dedicated phone number. Pass `agent_name`, `description`, `inbound`, `project`, `contact_number` (E.164 format, e.g. `+14155551234`), and `language` — Cekura observes that number without needing provider credentials. Set `assistant_provider=\"self_hosted\"` (optionally `websocket_url` for text-mode runs).\n\n**Provider integrations:** set `assistant_provider` to one of the valid values below and pass the matching credentials. `assistant_id` alone does NOT substitute for provider credentials — providers like VAPI, Retell, and Bland validate their api_key on create.\n\n**Valid `assistant_provider` values** (live enum — superset of prose docs you may see elsewhere):\n- `self_hosted` — websocket or observation-only; no api_key needed. Use `websocket_url` + `websocket_headers` for text-mode runs.\n- `vapi` — requires `vapi_api_key`; optional `assistant_id`, `vapi_data.public_key`.\n- `retell` — requires `retell_api_key` AND `chat_assistant_id` (yes — Retell uses this field even for voice).\n- `bland` — requires `bland_api_key` AND `chat_assistant_id` (Bland internally calls this `pathway_id`); `bland_data.encrypted_key` for Twilio.\n- `livekit` — requires `livekit_api_key` + `livekit_data.api_secret` + `livekit_data.url`.\n- `elevenlabs` — requires `elevenlabs_api_key`.\n- `agentforce` — Salesforce Agentforce; needs `agentforce_client_secret` + `agentforce_data` (client_id, domain, agent_id).\n- `trillet` — requires `trillet_api_key` + `trillet_data.workspace_id`.\n- `cisco` — Cisco Webex.\n- `vocera` — Cekura-hosted agent.\n- `sms` — text-only SMS channel; use `chat_assistant_id`.\n- `whatsapp` — text-only WhatsApp channel; use `chat_assistant_id`.\n- `\"\"` (empty string) — unset; agent is not runnable until a provider is configured.\n\n**Note:** the serializer exposes fields for some providers (`pipecat_*`, `synthflow_*`, `koreai_*`, `genesys_*`, `custom_provider_*`) that are NOT currently in the `assistant_provider` enum. Those fields exist for response/config purposes but the matching provider value cannot be selected today.\n\n**Outbound agents:** set `inbound=false`. Actual call placement uses the scenario's configured phone number or a number from the org's provisioned pool — `outbound_numbers` is not required for calls to be placed (it is used for webhook validation only).\n\n**Other fields to know:**\n- `language` — BCP-47 locale (`en`, `es`, `fr`, …). Must match the personalities used for evaluators.\n- `transcript_provider` — STT vendor (`vapi | retell | synthflow | elevenlabs | bland | livekit | pipecat | koreai | custom | trillet | cisco | genesys`). Does NOT auto-pair with `assistant_provider`; set both independently when needed.\n- `llm_model`, `llm_temperature`, `llm_max_tokens`, `llm_system_prompt` — simulation LLM settings (used by Cekura when simulating callers in test runs; NOT your agent's own LLM).\n- `auto_fetch_calls_enabled` — auto-import calls from the provider every 30s (VAPI/Retell only).\n- `auto_sync_prompt_enabled` — auto-sync prompts from the provider every 30s.\n\n**Read-only status fields** like `vapi_api_key_configured`, `retell_api_key_configured` appear in the response to indicate which provider credentials are stored (credentials themselves are masked)."
-                    }
                 }
             }
         },
@@ -10512,7 +11069,7 @@
             },
             "post": {
                 "operationId": "aiagents-external-create",
-                "description": "aiagents_create: Register a new AI voice agent with Cekura for testing / observability. Required: `agent_name`, `project` (project ID), `assistant_provider`. Other fields depend on the provider (see below).\n\n**Most common case:** you already have an agent running on your own provider stack with a dedicated phone number. Pass `agent_name`, `description`, `inbound`, `project`, `contact_number` (E.164 format, e.g. `+14155551234`), and `language` — Cekura observes that number without needing provider credentials. Set `assistant_provider=\"self_hosted\"` (optionally `websocket_url` for text-mode runs).\n\n**Provider integrations:** set `assistant_provider` to one of the valid values below and pass the matching credentials. `assistant_id` alone does NOT substitute for provider credentials — providers like VAPI, Retell, and Bland validate their api_key on create.\n\n**Valid `assistant_provider` values** (live enum — superset of prose docs you may see elsewhere):\n- `self_hosted` — websocket or observation-only; no api_key needed. Use `websocket_url` + `websocket_headers` for text-mode runs.\n- `vapi` — requires `vapi_api_key`; optional `assistant_id`, `vapi_data.public_key`.\n- `retell` — requires `retell_api_key` AND `chat_assistant_id` (yes — Retell uses this field even for voice).\n- `bland` — requires `bland_api_key` AND `chat_assistant_id` (Bland internally calls this `pathway_id`); `bland_data.encrypted_key` for Twilio.\n- `livekit` — requires `livekit_api_key` + `livekit_data.api_secret` + `livekit_data.url`.\n- `elevenlabs` — requires `elevenlabs_api_key`.\n- `agentforce` — Salesforce Agentforce; needs `agentforce_client_secret` + `agentforce_data` (client_id, domain, agent_id).\n- `trillet` — requires `trillet_api_key` + `trillet_data.workspace_id`.\n- `cisco` — Cisco Webex.\n- `vocera` — Cekura-hosted agent.\n- `sms` — text-only SMS channel; use `chat_assistant_id`.\n- `whatsapp` — text-only WhatsApp channel; use `chat_assistant_id`.\n- `\"\"` (empty string) — unset; agent is not runnable until a provider is configured.\n\n**Note:** the serializer exposes fields for some providers (`pipecat_*`, `synthflow_*`, `koreai_*`, `genesys_*`, `custom_provider_*`) that are NOT currently in the `assistant_provider` enum. Those fields exist for response/config purposes but the matching provider value cannot be selected today.\n\n**Outbound agents:** set `inbound=false`. Actual call placement uses the scenario's configured phone number or a number from the org's provisioned pool — `outbound_numbers` is not required for calls to be placed (it is used for webhook validation only).\n\n**Other fields to know:**\n- `language` — BCP-47 locale (`en`, `es`, `fr`, …). Must match the personalities used for evaluators.\n- `transcript_provider` — STT vendor (`vapi | retell | synthflow | elevenlabs | bland | livekit | pipecat | koreai | custom | trillet | cisco | genesys`). Does NOT auto-pair with `assistant_provider`; set both independently when needed.\n- `llm_model`, `llm_temperature`, `llm_max_tokens`, `llm_system_prompt` — simulation LLM settings (used by Cekura when simulating callers in test runs; NOT your agent's own LLM).\n- `auto_fetch_calls_enabled` — auto-import calls from the provider every 30s (VAPI/Retell only).\n- `auto_sync_prompt_enabled` — auto-sync prompts from the provider every 30s.\n\n**Read-only status fields** like `vapi_api_key_configured`, `retell_api_key_configured` appear in the response to indicate which provider credentials are stored (credentials themselves are masked).",
+                "description": "aiagents_create: Register a new AI voice agent with Cekura for testing / observability. Required: `agent_name`, `project` (project ID), `assistant_provider`. Other fields depend on the provider (see below).\n\n**Most common case:** you already have an agent running on your own provider stack with a dedicated phone number. Pass `agent_name`, `description`, `inbound`, `project`, `contact_number` (E.164 format, e.g. `+14155551234`), and `language` — Cekura observes that number without needing provider credentials. Set `assistant_provider=\"self_hosted\"` (optionally `websocket_url` for text-mode runs).\n\n**Provider integrations:** set `assistant_provider` to one of the valid values below and pass the matching credentials. `assistant_id` alone does NOT substitute for provider credentials — providers like VAPI, Retell, and Bland validate their api_key on create.\n\n**Valid `assistant_provider` values** (live enum — superset of prose docs you may see elsewhere):\n- `self_hosted` — websocket or observation-only; no api_key needed. Use `websocket_url` + `websocket_headers` for text-mode runs.\n- `vapi` — requires `vapi_api_key`; optional `assistant_id`, `vapi_data.public_key`.\n- `retell` — requires `retell_api_key` AND `chat_assistant_id` (yes — Retell uses this field even for voice).\n- `bland` — requires `bland_api_key` AND `chat_assistant_id` (Bland internally calls this `pathway_id`); `bland_data.encrypted_key` for Twilio.\n- `livekit` — requires `livekit_api_key` + `livekit_data.api_secret` + `livekit_data.url`.\n- `elevenlabs` — requires `elevenlabs_api_key`.\n- `agentforce` — Salesforce Agentforce; needs `agentforce_client_secret` + `agentforce_data` (client_id, domain, agent_id).\n- `cisco` — Cisco Webex.\n- `vocera` — Cekura-hosted agent.\n- `sms` — text-only SMS channel; use `chat_assistant_id`.\n- `whatsapp` — text-only WhatsApp channel; use `chat_assistant_id`.\n- `\"\"` (empty string) — unset; agent is not runnable until a provider is configured.\n\n**Note:** the serializer exposes fields for some providers (`pipecat_*`, `synthflow_*`, `koreai_*`, `genesys_*`, `custom_provider_*`) that are NOT currently in the `assistant_provider` enum. Those fields exist for response/config purposes but the matching provider value cannot be selected today.\n\n**Outbound agents:** set `inbound=false`. Actual call placement uses the scenario's configured phone number or a number from the org's provisioned pool — `outbound_numbers` is not required for calls to be placed (it is used for webhook validation only).\n\n**Other fields to know:**\n- `language` — BCP-47 locale (`en`, `es`, `fr`, …). Must match the personalities used for evaluators.\n- `transcript_provider` — STT vendor (`vapi | retell | synthflow | elevenlabs | bland | livekit | pipecat | koreai | custom | cisco | genesys`). Does NOT auto-pair with `assistant_provider`; set both independently when needed.\n- `llm_model`, `llm_temperature`, `llm_max_tokens`, `llm_system_prompt` — simulation LLM settings (used by Cekura when simulating callers in test runs; NOT your agent's own LLM).\n- `auto_fetch_calls_enabled` — auto-import calls from the provider every 30s (VAPI/Retell only).\n- `auto_sync_prompt_enabled` — auto-sync prompts from the provider every 30s.\n\n**Read-only status fields** like `vapi_api_key_configured`, `retell_api_key_configured` appear in the response to indicate which provider credentials are stored (credentials themselves are masked).",
                 "summary": "Create an AI voice agent",
                 "tags": [
                     "AI Agents"
@@ -11568,8 +12125,9 @@
         },
         "/test_framework/v1/aiagents/{agent_id}/dynamic-variable/{id}/": {
             "patch": {
-                "operationId": "aiagents-dynamic-variable-partial-update",
-                "description": "Update a single dynamic variable definition.",
+                "operationId": "dynamic-variables-partial-update",
+                "description": "Partially updates a single dynamic variable definition by ID.",
+                "summary": "Update a dynamic variable definition",
                 "parameters": [
                     {
                         "in": "path",
@@ -11591,8 +12149,27 @@
                     }
                 ],
                 "tags": [
-                    "test_framework"
+                    "Dynamic Variables"
                 ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedAIAgentDynamicVariable"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedAIAgentDynamicVariable"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedAIAgentDynamicVariable"
+                            }
+                        }
+                    }
+                },
                 "security": [
                     {
                         "api_key": []
@@ -11600,13 +12177,21 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "No response body"
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AIAgentDynamicVariable"
+                                }
+                            }
+                        },
+                        "description": ""
                     }
                 }
             },
             "delete": {
-                "operationId": "aiagents-dynamic-variable-destroy",
-                "description": "Delete a single dynamic variable definition.",
+                "operationId": "dynamic-variables-destroy",
+                "description": "Permanently deletes a single dynamic variable definition. ⚠ Irreversible.",
+                "summary": "Delete a dynamic variable definition",
                 "parameters": [
                     {
                         "in": "path",
@@ -11628,7 +12213,7 @@
                     }
                 ],
                 "tags": [
-                    "test_framework"
+                    "Dynamic Variables"
                 ],
                 "security": [
                     {
@@ -11644,8 +12229,9 @@
         },
         "/test_framework/v1/aiagents/{agent_id}/dynamic-variables/": {
             "get": {
-                "operationId": "aiagents-dynamic-variables-retrieve",
-                "description": "List all user-defined dynamic variable definitions for this agent.",
+                "operationId": "dynamic-variables-list",
+                "description": "Returns all user-defined dynamic variable definitions for the agent, ordered by name.",
+                "summary": "List dynamic variable definitions for an agent",
                 "parameters": [
                     {
                         "in": "path",
@@ -11658,7 +12244,7 @@
                     }
                 ],
                 "tags": [
-                    "test_framework"
+                    "Dynamic Variables"
                 ],
                 "security": [
                     {
@@ -11667,13 +12253,24 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "No response body"
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/AIAgentDynamicVariable"
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
                     }
                 }
             },
             "post": {
-                "operationId": "aiagents-dynamic-variables-create",
-                "description": "Bulk-create dynamic variable definitions.\nAccepts a list of {name, description} objects.",
+                "operationId": "dynamic-variables-create",
+                "description": "Upserts a list of dynamic variable definitions for the agent. Each entry is matched by `name` — existing variables are updated, new ones are created. Pass a JSON array of `{name, description}` objects. Returns the complete list of definitions after the operation.",
+                "summary": "Upsert dynamic variable definitions (bulk, by name)",
                 "parameters": [
                     {
                         "in": "path",
@@ -11686,8 +12283,54 @@
                     }
                 ],
                 "tags": [
-                    "test_framework"
+                    "Dynamic Variables"
                 ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/AIAgentDynamicVariable"
+                                }
+                            },
+                            "examples": {
+                                "UpsertTwoVariables": {
+                                    "value": [
+                                        [
+                                            {
+                                                "name": "prompt",
+                                                "description": "Full system prompt for this call"
+                                            },
+                                            {
+                                                "name": "agent_type",
+                                                "description": "Role of the agent (sales, support, ...)"
+                                            }
+                                        ]
+                                    ],
+                                    "summary": "Upsert two variables"
+                                }
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/AIAgentDynamicVariable"
+                                }
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/AIAgentDynamicVariable"
+                                }
+                            }
+                        }
+                    },
+                    "required": true
+                },
                 "security": [
                     {
                         "api_key": []
@@ -11695,7 +12338,17 @@
                 ],
                 "responses": {
                     "201": {
-                        "description": "No response body"
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/AIAgentDynamicVariable"
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
                     }
                 }
             }
@@ -11735,14 +12388,6 @@
                 "responses": {
                     "200": {
                         "description": "No response body"
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-mcp-create",
-                        "description": "Mock MCP server endpoint.\n\nImplements the MCP JSON-RPC 2.0 protocol so VAPI can use a Cekura-hosted\nmock in place of a real MCP server.  Handles three methods:\n\n  initialize   — standard MCP handshake\n  tools/list   — returns Tool records for this specific MCP endpoint only\n  tools/call   — looks up the named Tool and returns its mock output\n\nURL: /v1/aiagents/{agent_id}/mcp/{mock_index}/\nEach original VAPI MCP tool gets its own sequential index (1, 2, 3 ...) so\nthat different MCP tools on the same assistant each serve only their own\nsub-tools and never mix with each other.\n\nNo authentication is required — this endpoint must be reachable by VAPI."
                     }
                 }
             }
@@ -11821,14 +12466,6 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-tool-retrieve",
-                        "description": "Get a specific tool by name"
-                    }
                 }
             },
             "post": {
@@ -11864,14 +12501,6 @@
                 "responses": {
                     "201": {
                         "description": "No response body"
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-tool-create",
-                        "description": "Execute tool by matching input and returning corresponding output.\n\nSupports two payload formats:\n1. Flat input (default): {\"param1\": \"value1\", \"param2\": \"value2\"}\n2. VAPI function format: {\"message\": {\"type\": \"tool-calls\", \"toolCallList\": [{\"id\": \"...\", \"arguments\": {...}}]}}"
                     }
                 }
             },
@@ -11999,14 +12628,6 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-tool-partial-update",
-                        "description": "Update a specific tool by name"
-                    }
                 }
             },
             "delete": {
@@ -12058,14 +12679,6 @@
                             }
                         },
                         "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-tool-destroy",
-                        "description": "⚠ Irreversible. Detaches the named tool from this agent by marking it deleted. The tool definition is not deleted — other agents referencing the same tool_name are unaffected."
                     }
                 }
             }
@@ -12140,14 +12753,6 @@
                             }
                         },
                         "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-tools-list",
-                        "description": "List all tools for this agent"
                     }
                 }
             },
@@ -12235,14 +12840,6 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-tools-create",
-                        "description": "Create a new tool for agent"
-                    }
                 }
             }
         },
@@ -12268,17 +12865,26 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/Tool"
+                                "$ref": "#/components/schemas/AutoFetchToolsRequest"
+                            },
+                            "examples": {
+                                "Auto-FetchToolsRequest": {
+                                    "value": {
+                                        "provider": "retell",
+                                        "assistant_id": "agent_abc123"
+                                    },
+                                    "summary": "Auto-Fetch Tools Request"
+                                }
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/Tool"
+                                "$ref": "#/components/schemas/AutoFetchToolsRequest"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/Tool"
+                                "$ref": "#/components/schemas/AutoFetchToolsRequest"
                             }
                         }
                     },
@@ -12294,7 +12900,25 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Tool"
+                                    "$ref": "#/components/schemas/AutoFetchToolsResponse"
+                                },
+                                "examples": {
+                                    "Auto-FetchToolsSuccessResponse": {
+                                        "value": {
+                                            "progress_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                                        },
+                                        "summary": "Auto-Fetch Tools Success Response"
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AutoFetchErrorResponse"
                                 }
                             }
                         },
@@ -12316,6 +12940,14 @@
                             "pattern": "^\\d+$"
                         },
                         "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "progress_id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
                     }
                 ],
                 "tags": [
@@ -12331,7 +12963,17 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Tool"
+                                    "$ref": "#/components/schemas/AutoFetchProgressResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AutoFetchProgressErrorResponse"
                                 }
                             }
                         },
@@ -12632,14 +13274,6 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-retrieve",
-                        "description": "Retrieve an AI voice agent by ID"
-                    }
                 }
             },
             "put": {
@@ -12728,14 +13362,6 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-update",
-                        "description": "Fully replace an AI agent's fields. Prefer `PATCH` (partial_update) unless you need full-replacement semantics. See `aiagents_create` for the field shape and per-provider examples."
-                    }
                 }
             },
             "patch": {
@@ -12818,14 +13444,6 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-partial-update",
-                        "description": "Partially update an AI agent. Same field shape as create — see `aiagents_create` for details and per-provider examples."
-                    }
                 }
             },
             "delete": {
@@ -12880,14 +13498,6 @@
                             }
                         },
                         "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-destroy",
-                        "description": "⚠ Irreversible. Deletes the agent.\n\n**Cascade behaviour (controlled by `delete_related` query param):**\n- `delete_related=true` (default) — also deletes the agent's evaluators, results, and runs.\n- `delete_related=false` — detaches evaluators (sets agent=null) and leaves results untouched."
                     }
                 }
             }
@@ -13079,14 +13689,6 @@
                             }
                         },
                         "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-duplicate-create",
-                        "description": "Duplicate an AI voice agent with all its configuration"
                     }
                 }
             }
@@ -13415,14 +14017,6 @@
                             }
                         },
                         "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-upload-knowledge-base",
-                        "description": "Upload one or more files to the agent's knowledge base. Accepts either a `multipart/form-data` body (used by the web dashboard) or an `application/json` body where each entry carries base64-encoded file content."
                     }
                 }
             }
@@ -15721,6 +16315,68 @@
                 }
             }
         },
+        "/test_framework/v1/metrics-external/{id}/apply_optimisation_proposal/": {
+            "post": {
+                "operationId": "metrics-external-apply-optimisation-proposal-create",
+                "description": "Copies the fields from `pending_optimisation_proposal` (description, evaluation_trigger, type, custom_code) into the live metric columns and clears the proposal. 400 if no pending proposal exists.",
+                "summary": "Apply a pending optimisation proposal",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Metric updated; pending proposal cleared."
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/metrics-external/{id}/dismiss_optimisation_proposal/": {
+            "post": {
+                "operationId": "metrics-external-dismiss-optimisation-proposal-create",
+                "description": "Discards the metric's `pending_optimisation_proposal` without applying. Idempotent — a metric with no pending proposal returns 200.",
+                "summary": "Dismiss a pending optimisation proposal",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Proposal cleared."
+                    }
+                }
+            }
+        },
         "/test_framework/v1/metrics-external/{id}/evaluate_advance_metric/": {
             "post": {
                 "operationId": "metrics-external-evaluate-advance-metric-create",
@@ -16501,6 +17157,91 @@
                 }
             }
         },
+        "/test_framework/v1/metrics-external/generate_clean_description_bg/": {
+            "post": {
+                "operationId": "metrics-external-generate-clean-description-bg-create",
+                "description": "Enqueue a background job to generate a clean metric description. Returns a `progress_id`; poll `generate_clean_description_progress` until `status` is `completed` or `failed`.",
+                "summary": "Start async clean description generation",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CleanMetricDescriptionRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CleanMetricDescriptionRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CleanMetricDescriptionRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GenerateCleanDescriptionBgResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/metrics-external/generate_clean_description_progress/": {
+            "get": {
+                "operationId": "metrics-external-generate-clean-description-progress-retrieve",
+                "description": "Poll the result of a `generate_clean_description_bg` job. `status` is one of: `queued`, `processing`, `completed`, `failed`. On `completed`, `clean_description` and `thinking` are present.",
+                "summary": "Poll async clean description generation",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "progress_id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "progress_id returned from generate_clean_description_bg",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GenerateCleanDescriptionProgressResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/test_framework/v1/metrics-external/generate_evaluation_trigger/": {
             "post": {
                 "operationId": "metrics-external-generate-evaluation-trigger-create",
@@ -17213,6 +17954,68 @@
                             }
                         },
                         "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/metrics/{id}/apply_optimisation_proposal/": {
+            "post": {
+                "operationId": "metrics-apply-optimisation-proposal-create",
+                "description": "Copies the fields from `pending_optimisation_proposal` (description, evaluation_trigger, type, custom_code) into the live metric columns and clears the proposal. 400 if no pending proposal exists.",
+                "summary": "Apply a pending optimisation proposal",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Metric updated; pending proposal cleared."
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/metrics/{id}/dismiss_optimisation_proposal/": {
+            "post": {
+                "operationId": "metrics-dismiss-optimisation-proposal-create",
+                "description": "Discards the metric's `pending_optimisation_proposal` without applying. Idempotent — a metric with no pending proposal returns 200.",
+                "summary": "Dismiss a pending optimisation proposal",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Proposal cleared."
                     }
                 }
             }
@@ -18017,6 +18820,107 @@
                         "enabled": true,
                         "name": "metrics-generate-clean-description-create",
                         "description": "Generate a clean metric description based on agent description and metric description."
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/metrics/generate_clean_description_bg/": {
+            "post": {
+                "operationId": "metrics-generate-clean-description-bg-create",
+                "description": "Enqueue a background job to generate a clean metric description. Returns a `progress_id`; poll `generate_clean_description_progress` until `status` is `completed` or `failed`.",
+                "summary": "Start async clean description generation",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CleanMetricDescriptionRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CleanMetricDescriptionRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CleanMetricDescriptionRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GenerateCleanDescriptionBgResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "metrics-generate-clean-description-bg-create",
+                        "description": "Enqueue a background job to generate a clean metric description. Returns a `progress_id`; poll `generate_clean_description_progress` until `status` is `completed` or `failed`."
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/metrics/generate_clean_description_progress/": {
+            "get": {
+                "operationId": "metrics-generate-clean-description-progress-retrieve",
+                "description": "Poll the result of a `generate_clean_description_bg` job. `status` is one of: `queued`, `processing`, `completed`, `failed`. On `completed`, `clean_description` and `thinking` are present.",
+                "summary": "Poll async clean description generation",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "progress_id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "progress_id returned from generate_clean_description_bg",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GenerateCleanDescriptionProgressResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "metrics-generate-clean-description-progress-retrieve",
+                        "description": "Poll the result of a `generate_clean_description_bg` job. `status` is one of: `queued`, `processing`, `completed`, `failed`. On `completed`, `clean_description` and `thinking` are present."
                     }
                 }
             }
@@ -19539,50 +20443,6 @@
                         "description": ""
                     }
                 }
-            },
-            "post": {
-                "operationId": "phone-numbers-create",
-                "description": "Create a new phone number",
-                "tags": [
-                    "test_framework"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PhoneNumber"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PhoneNumber"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PhoneNumber"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/PhoneNumber"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
             }
         },
         "/test_framework/v1/phone-numbers-external/": {
@@ -19606,50 +20466,6 @@
                                     "items": {
                                         "$ref": "#/components/schemas/PhoneNumber"
                                     }
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            },
-            "post": {
-                "operationId": "phone-numbers-external-create",
-                "description": "Create a new phone number",
-                "tags": [
-                    "test_framework"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PhoneNumber"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PhoneNumber"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PhoneNumber"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/PhoneNumber"
                                 }
                             }
                         },
@@ -19691,143 +20507,6 @@
                             }
                         },
                         "description": ""
-                    }
-                }
-            },
-            "put": {
-                "operationId": "phone-numbers-external-update",
-                "description": "Update a phone number",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "A unique integer value identifying this phone number.",
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "test_framework"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PhoneNumber"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PhoneNumber"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PhoneNumber"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/PhoneNumber"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            },
-            "patch": {
-                "operationId": "phone-numbers-external-partial-update",
-                "description": "Update a phone number",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "A unique integer value identifying this phone number.",
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "test_framework"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchedPhoneNumber"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchedPhoneNumber"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchedPhoneNumber"
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/PhoneNumber"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            },
-            "delete": {
-                "operationId": "phone-numbers-external-destroy",
-                "description": "Delete a phone number",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "A unique integer value identifying this phone number.",
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "test_framework"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No response body"
                     }
                 }
             }
@@ -19962,143 +20641,6 @@
                             }
                         },
                         "description": ""
-                    }
-                }
-            },
-            "put": {
-                "operationId": "phone-numbers-update",
-                "description": "Update a phone number",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "A unique integer value identifying this phone number.",
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "test_framework"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PhoneNumber"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PhoneNumber"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PhoneNumber"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/PhoneNumber"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            },
-            "patch": {
-                "operationId": "phone-numbers-partial-update",
-                "description": "Update a phone number",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "A unique integer value identifying this phone number.",
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "test_framework"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchedPhoneNumber"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchedPhoneNumber"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchedPhoneNumber"
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/PhoneNumber"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            },
-            "delete": {
-                "operationId": "phone-numbers-destroy",
-                "description": "Delete a phone number",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "A unique integer value identifying this phone number.",
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "test_framework"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No response body"
                     }
                 }
             }
@@ -23575,7 +24117,7 @@
         "/test_framework/v1/runs/": {
             "get": {
                 "operationId": "runs-list",
-                "description": "List test runs. Each item's `id` is the integer `run_id` used at `/runs/{run_id}/`; the `call_id` field is a provider string identifier, NOT an endpoint ID.",
+                "description": "List test runs",
                 "parameters": [
                     {
                         "in": "query",
@@ -23933,7 +24475,7 @@
         "/test_framework/v1/runs-external/": {
             "get": {
                 "operationId": "runs-external-list",
-                "description": "List test runs. Each item's `id` is the integer `run_id` used at `/runs/{run_id}/`; the `call_id` field is a provider string identifier, NOT an endpoint ID.",
+                "description": "List test runs",
                 "parameters": [
                     {
                         "in": "query",
@@ -24291,7 +24833,7 @@
         "/test_framework/v1/runs-external/{id}/": {
             "get": {
                 "operationId": "runs-external-retrieve",
-                "description": "Retrieve a test run by `run_id` (the integer path parameter). The `call_id` field on the response is the provider's call identifier (string) — do NOT pass it where `run_id` is expected.",
+                "description": "Retrieve a test run by ID",
                 "parameters": [
                     {
                         "in": "path",
@@ -25164,7 +25706,7 @@
         "/test_framework/v1/runs/{id}/": {
             "get": {
                 "operationId": "runs-retrieve",
-                "description": "Retrieve a test run by `run_id` (the integer path parameter). The `call_id` field on the response is the provider's call identifier (string) — do NOT pass it where `run_id` is expected.",
+                "description": "Retrieve a test run by ID",
                 "parameters": [
                     {
                         "in": "path",
@@ -25748,6 +26290,35 @@
                 }
             }
         },
+        "/test_framework/v1/runs/{id}/trace/": {
+            "get": {
+                "operationId": "runs-trace-retrieve",
+                "description": "Proxy trace data from Grafana Tempo for a Run.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No response body"
+                    }
+                }
+            }
+        },
         "/test_framework/v1/runs/{id}/unmark_critical_scenario_wrong/": {
             "post": {
                 "operationId": "runs-unmark-critical-scenario-wrong-create",
@@ -25800,6 +26371,35 @@
                             }
                         },
                         "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/runs/{run_id}/datadog-logs/": {
+            "get": {
+                "operationId": "runs-datadog-logs-retrieve",
+                "description": "Fetch Datadog logs for a given simulation run ID.\n\nRestricted to OAuth tokens minted by the `cekura-support-bot` client via\nthe client_credentials grant. Even though the support-bot client can\nimpersonate any user, the token's subject user must have access to the\nrun's project — either as an org-admin or via a direct project membership.\nOrg-level membership alone is not enough: a user added to project A\nshould not see logs for runs in project B in the same org.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "run_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No response body"
                     }
                 }
             }
@@ -36346,6 +36946,35 @@
                 }
             }
         },
+        "/test_framework/v1/share-tokens/{token}/resolve/": {
+            "get": {
+                "operationId": "share-tokens-resolve-retrieve",
+                "description": "Resolve a shareable-link token to the underlying source object(s).\n\nGiven the opaque token from a `https://<host>/share/results/<token>` URL,\nreturns the result_id (or other source object IDs) the token grants access\nto, plus org/agent context and expiry state.\n\nRestricted to OAuth tokens minted by the `cekura-support-bot` client via\nthe client_credentials grant. The support-bot's subject user must be a\nmember of the source object's organization — so support agents can only\nresolve tokens for results belonging to the customer they're helping.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "token",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No response body"
+                    }
+                }
+            }
+        },
         "/test_framework/v1/test-profiles/": {
             "get": {
                 "operationId": "test-profiles-list",
@@ -37432,6 +38061,1438 @@
                 "responses": {
                     "204": {
                         "description": "No response body"
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/aiagents/": {
+            "get": {
+                "operationId": "test-framework-v2-aiagents-list",
+                "description": "List AI voice agents. Filter by project_id to scope to one project. Returns agents in the v2 format with a nested provider block.",
+                "summary": "List AI voice agents",
+                "parameters": [
+                    {
+                        "name": "page",
+                        "required": false,
+                        "in": "query",
+                        "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "project_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Filter by project ID"
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedAIAgentV2List"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "test-framework-v2-aiagents-list",
+                        "description": "List AI voice agents. Filter by project_id to scope to one project. Returns agents in the v2 format with a nested provider block."
+                    }
+                }
+            },
+            "post": {
+                "operationId": "test-framework-v2-aiagents-create",
+                "description": "Register a new AI voice agent. Required fields: name, description, project, inbound. Provider credentials are nested under provider.{type, agent_id, credentials} instead of flat fields. transcript_provider defaults to provider.type when omitted.\n\n**provider.credentials keys by type (voice providers only):**\n- vapi: api_key + config.{public_key, trigger_url}\n- retell: api_key + agent_id + optional chat_agent_details.config.agent_id\n- elevenlabs: api_key + config.{trigger_url}\n- bland: api_key + agent_id (pathway_id) + config.{encrypted_key} for Twilio\n- livekit: api_key + config.{api_secret (required), url (required)}\n- pipecat: api_key + config.{webhook_url}\n- cisco: no credentials needed\n- self_hosted: credentials.config.{url (wss://), headers}\nNote: agentforce goes in chat_agent_details; koreai/genesys/synthflow use the v1 API.\n\nSee examples below for full per-provider payloads.",
+                "summary": "Create an AI voice agent",
+                "tags": [
+                    "AI Agents"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AIAgentV2"
+                            },
+                            "examples": {
+                                "Self-hosted(contactNumberOnly—MostCommon)": {
+                                    "value": {
+                                        "agent_name": "Support Bot",
+                                        "description": "Handles inbound support calls for ACME Inc.",
+                                        "inbound": true,
+                                        "project": 1376,
+                                        "contact_number": "+14155551234",
+                                        "language": "en",
+                                        "assistant_provider": "self_hosted"
+                                    },
+                                    "summary": "Self-hosted (contact number only — most common)",
+                                    "description": "Typical onboarding: your agent is already deployed on your own stack with a phone number. Cekura just observes and evaluates; no provider credentials needed."
+                                },
+                                "VAPIAgent": {
+                                    "value": {
+                                        "agent_name": "VAPI Sales Agent",
+                                        "description": "Outbound sales qualification calls",
+                                        "inbound": false,
+                                        "project": 1376,
+                                        "contact_number": "+14155551234",
+                                        "language": "en",
+                                        "assistant_provider": "vapi",
+                                        "vapi_api_key": "vapi_sk_xxx",
+                                        "vapi_data": {
+                                            "public_key": "vapi_pk_xxx"
+                                        },
+                                        "assistant_id": "asst_abc123"
+                                    },
+                                    "summary": "VAPI agent"
+                                },
+                                "RetellAgent": {
+                                    "value": {
+                                        "agent_name": "Retell Booking Agent",
+                                        "description": "Schedules dental appointments",
+                                        "inbound": true,
+                                        "project": 1376,
+                                        "contact_number": "+14155551234",
+                                        "language": "en",
+                                        "assistant_provider": "retell",
+                                        "retell_api_key": "key_xxx",
+                                        "chat_assistant_id": "retell_agent_abc123",
+                                        "retell_data": {
+                                            "trigger_url": "https://api.retellai.com/create-phone-call"
+                                        }
+                                    },
+                                    "summary": "Retell agent",
+                                    "description": "Retell requires BOTH retell_api_key AND chat_assistant_id (used for voice too, despite the field's name)."
+                                },
+                                "BlandAgent": {
+                                    "value": {
+                                        "agent_name": "Bland Support Agent",
+                                        "description": "Handles tier-1 billing questions",
+                                        "inbound": true,
+                                        "project": 1376,
+                                        "contact_number": "+14155551234",
+                                        "language": "en",
+                                        "assistant_provider": "bland",
+                                        "bland_api_key": "bland_xxx",
+                                        "chat_assistant_id": "bland_pathway_xyz",
+                                        "bland_data": {
+                                            "encrypted_key": "twilio_encrypted_key_xxx"
+                                        }
+                                    },
+                                    "summary": "Bland agent",
+                                    "description": "Bland requires bland_api_key AND chat_assistant_id (Bland calls this field pathway_id internally). bland_data.encrypted_key is the Twilio credential bundle."
+                                },
+                                "LiveKitAgent": {
+                                    "value": {
+                                        "agent_name": "LiveKit Concierge",
+                                        "description": "Multi-modal front-desk agent",
+                                        "inbound": true,
+                                        "project": 1376,
+                                        "language": "en",
+                                        "assistant_provider": "livekit",
+                                        "livekit_api_key": "APIxxx",
+                                        "livekit_data": {
+                                            "api_secret": "secret_xxx",
+                                            "url": "wss://acme.livekit.cloud"
+                                        }
+                                    },
+                                    "summary": "LiveKit agent"
+                                },
+                                "Self-hostedViaWebsocketURL": {
+                                    "value": {
+                                        "agent_name": "Internal Test Agent",
+                                        "description": "Staging build of the support flow",
+                                        "inbound": false,
+                                        "project": 1376,
+                                        "assistant_provider": "self_hosted",
+                                        "websocket_url": "wss://staging.example.com/agent",
+                                        "websocket_headers": {
+                                            "Authorization": "Bearer token_xxx"
+                                        },
+                                        "language": "en"
+                                    },
+                                    "summary": "Self-hosted via websocket URL",
+                                    "description": "Your agent exposes a websocket endpoint for text-mode testing."
+                                },
+                                "Self-hosted(observation-only,MostCommon)": {
+                                    "value": {
+                                        "name": "Support Bot",
+                                        "description": "Handles inbound support calls",
+                                        "project": 42,
+                                        "inbound": true,
+                                        "phone_number": "+14155551234",
+                                        "provider": {
+                                            "type": "self_hosted"
+                                        }
+                                    },
+                                    "summary": "Self-hosted (observation-only, most common)"
+                                },
+                                "Self-hostedViaWebSocket(text-modeTesting)": {
+                                    "value": {
+                                        "name": "WS Agent",
+                                        "description": "Agent with websocket endpoint for text-mode test runs",
+                                        "project": 42,
+                                        "inbound": false,
+                                        "provider": {
+                                            "type": "self_hosted",
+                                            "chat_agent_details": {
+                                                "type": "self_hosted",
+                                                "config": {
+                                                    "url": "wss://staging.example.com/agent",
+                                                    "headers": {
+                                                        "Authorization": "Bearer token"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "summary": "Self-hosted via WebSocket (text-mode testing)",
+                                    "description": "Websocket is a CHAT/TEXT connection — put url and headers in chat_agent_details, not provider.credentials."
+                                },
+                                "VAPI": {
+                                    "value": {
+                                        "name": "VAPI Sales Agent",
+                                        "description": "Outbound sales qualification",
+                                        "project": 42,
+                                        "inbound": false,
+                                        "phone_number": "+14155551234",
+                                        "provider": {
+                                            "type": "vapi",
+                                            "agent_id": "asst_abc123xyz",
+                                            "credentials": {
+                                                "api_key": "vapi_sk_xxx",
+                                                "config": {
+                                                    "public_key": "vapi_pk_xxx"
+                                                }
+                                            },
+                                            "auto_import_calls": true,
+                                            "auto_sync_prompt": true
+                                        }
+                                    }
+                                },
+                                "Retell": {
+                                    "value": {
+                                        "name": "Retell Booking Agent",
+                                        "description": "Schedules appointments",
+                                        "project": 42,
+                                        "inbound": true,
+                                        "phone_number": "+14155551234",
+                                        "provider": {
+                                            "type": "retell",
+                                            "agent_id": "retell_voice_agent_abc123",
+                                            "credentials": {
+                                                "api_key": "key_xxx",
+                                                "config": {
+                                                    "trigger_url": "https://api.retellai.com/create-phone-call"
+                                                }
+                                            },
+                                            "chat_agent_details": {
+                                                "type": "retell",
+                                                "config": {
+                                                    "agent_id": "retell_chat_agent_xyz456"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "description": "agent_id = Retell agent for voice/inbound calls. chat_agent_details = optional separate agent for text-mode test runs."
+                                },
+                                "Bland": {
+                                    "value": {
+                                        "name": "Bland Support Agent",
+                                        "description": "Handles billing questions",
+                                        "project": 42,
+                                        "inbound": true,
+                                        "phone_number": "+14155551234",
+                                        "provider": {
+                                            "type": "bland",
+                                            "agent_id": "bland_pathway_xyz",
+                                            "credentials": {
+                                                "api_key": "bland_xxx",
+                                                "config": {
+                                                    "encrypted_key": "twilio_encrypted_key_xxx"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "description": "agent_id is the Bland pathway_id. bland_data.encrypted_key is the Twilio credential bundle."
+                                },
+                                "LiveKit": {
+                                    "value": {
+                                        "name": "LiveKit Concierge",
+                                        "description": "Multi-modal front-desk agent",
+                                        "project": 42,
+                                        "inbound": true,
+                                        "provider": {
+                                            "type": "livekit",
+                                            "credentials": {
+                                                "api_key": "APIxxx",
+                                                "config": {
+                                                    "api_secret": "secret_xxx",
+                                                    "url": "wss://acme.livekit.cloud"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "description": "api_secret and url are required inside credentials.config."
+                                },
+                                "ElevenLabs": {
+                                    "value": {
+                                        "name": "ElevenLabs Voice Agent",
+                                        "description": "Voice agent on ElevenLabs",
+                                        "project": 42,
+                                        "inbound": true,
+                                        "provider": {
+                                            "type": "elevenlabs",
+                                            "agent_id": "elevenlabs_agent_abc123",
+                                            "credentials": {
+                                                "api_key": "elevenlabs_key_xxx"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AIAgentV2"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AIAgentV2"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AIAgentV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "test-framework-v2-aiagents-create",
+                        "description": "Register a new AI voice agent. Required fields: name, description, project, inbound. Provider credentials are nested under provider.{type, agent_id, credentials} instead of flat fields. transcript_provider defaults to provider.type when omitted.\n\n**provider.credentials keys by type (voice providers only):**\n- vapi: api_key + config.{public_key, trigger_url}\n- retell: api_key + agent_id + optional chat_agent_details.config.agent_id\n- elevenlabs: api_key + config.{trigger_url}\n- bland: api_key + agent_id (pathway_id) + config.{encrypted_key} for Twilio\n- livekit: api_key + config.{api_secret (required), url (required)}\n- pipecat: api_key + config.{webhook_url}\n- cisco: no credentials needed\n- self_hosted: credentials.config.{url (wss://), headers}\nNote: agentforce goes in chat_agent_details; koreai/genesys/synthflow use the v1 API.\n\nSee examples below for full per-provider payloads."
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/aiagents/{id}/": {
+            "get": {
+                "operationId": "test-framework-v2-aiagents-retrieve",
+                "description": "Retrieve an AI voice agent",
+                "summary": "Retrieve an AI voice agent",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this ai agent.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AIAgentV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "detail": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "test-framework-v2-aiagents-retrieve",
+                        "description": "Retrieve an AI voice agent"
+                    }
+                }
+            },
+            "put": {
+                "operationId": "test-framework-v2-aiagents-update",
+                "description": "Fully replace an agent's fields. Prefer PATCH unless you need full-replacement semantics.",
+                "summary": "Replace an AI voice agent (full update)",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this ai agent.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "AI Agents"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AIAgentV2"
+                            },
+                            "examples": {
+                                "ReplaceAgent(fullPayload)": {
+                                    "value": {
+                                        "agent_name": "Support Bot v2",
+                                        "description": "Handles inbound support calls for ACME Inc.",
+                                        "inbound": true,
+                                        "project": 1376,
+                                        "contact_number": "+14155551234",
+                                        "language": "en",
+                                        "assistant_provider": "self_hosted"
+                                    },
+                                    "summary": "Replace agent (full payload)"
+                                }
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AIAgentV2"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AIAgentV2"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AIAgentV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "test-framework-v2-aiagents-update",
+                        "description": "Fully replace an agent's fields. Prefer PATCH unless you need full-replacement semantics."
+                    }
+                }
+            },
+            "patch": {
+                "operationId": "test-framework-v2-aiagents-partial-update",
+                "description": "Partially update an agent. Only fields included in the request body are modified.",
+                "summary": "Update an AI voice agent (partial)",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this ai agent.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "AI Agents"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedAIAgentV2"
+                            },
+                            "examples": {
+                                "Rename+UpdateDescription": {
+                                    "value": {
+                                        "agent_name": "Support Bot v2",
+                                        "description": "Updated description"
+                                    },
+                                    "summary": "Rename + update description"
+                                }
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedAIAgentV2"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedAIAgentV2"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AIAgentV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "test-framework-v2-aiagents-partial-update",
+                        "description": "Partially update an agent. Only fields included in the request body are modified."
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "test-framework-v2-aiagents-destroy",
+                "description": "⚠ Irreversible. Deletes the agent. Pass delete_related=false to detach evaluators instead of deleting them.",
+                "summary": "Delete an AI voice agent",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this ai agent.",
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "delete_related",
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "description": "If true (default), delete associated evaluators, results and runs. If false, detach evaluators and leave results as-is."
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No response body"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "test-framework-v2-aiagents-destroy",
+                        "description": "⚠ Irreversible. Deletes the agent. Pass delete_related=false to detach evaluators instead of deleting them."
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/aiagents/{id}/delete_knowledge_base/": {
+            "delete": {
+                "operationId": "test-framework-v2-aiagents-delete-knowledge-base-destroy",
+                "description": "Aiagents delete knowledge base",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this ai agent.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "deleted_count": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/aiagents/{id}/disable_personalities/": {
+            "post": {
+                "operationId": "test-framework-v2-aiagents-disable-personalities-create",
+                "description": "Aiagents disable personalities",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this ai agent.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AIAgentV2"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AIAgentV2"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AIAgentV2"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AIAgentV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/aiagents/{id}/duplicate/": {
+            "post": {
+                "operationId": "test-framework-v2-aiagents-duplicate-create",
+                "description": "Create a copy of the agent with all its configuration. Returns the new agent in v2 format.",
+                "summary": "Duplicate an AI voice agent",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this ai agent.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostCopyAgent"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostCopyAgent"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostCopyAgent"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AIAgentV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "test-framework-v2-aiagents-duplicate-create",
+                        "description": "Create a copy of the agent with all its configuration. Returns the new agent in v2 format."
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/aiagents/{id}/enable_personalities/": {
+            "post": {
+                "operationId": "test-framework-v2-aiagents-enable-personalities-create",
+                "description": "Aiagents enable personalities",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this ai agent.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AIAgentV2"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AIAgentV2"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AIAgentV2"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AIAgentV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/aiagents/{id}/knowledge_base/": {
+            "get": {
+                "operationId": "test-framework-v2-aiagents-knowledge-base-list",
+                "description": "Aiagents knowledge base",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this ai agent.",
+                        "required": true
+                    },
+                    {
+                        "name": "page",
+                        "required": false,
+                        "in": "query",
+                        "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedKnowledgeBaseFileList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "detail": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/aiagents/{id}/personalities/": {
+            "get": {
+                "operationId": "test-framework-v2-aiagents-personalities-retrieve",
+                "description": "Aiagents personalities",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this ai agent.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AIAgentV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/aiagents/{id}/runs_overview/": {
+            "get": {
+                "operationId": "test-framework-v2-aiagents-runs-overview-retrieve",
+                "description": "Aiagents runs overview",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this ai agent.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AIAgentV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/aiagents/{id}/upload_knowledge_base/": {
+            "post": {
+                "operationId": "aiagents-upload-knowledge-base_3",
+                "description": "Upload one or more files to the agent's knowledge base. Accepts either a `multipart/form-data` body (used by the web dashboard) or an `application/json` body where each entry carries base64-encoded file content.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this ai agent.",
+                        "required": true
+                    },
+                    {
+                        "name": "page",
+                        "required": false,
+                        "in": "query",
+                        "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "multipart/form-data": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "files": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string",
+                                            "format": "binary"
+                                        },
+                                        "description": "List of files to upload to the knowledge base"
+                                    }
+                                },
+                                "required": [
+                                    "files"
+                                ]
+                            }
+                        },
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "files": {
+                                        "type": "array",
+                                        "description": "List of files to upload, each provided as base64-encoded content.",
+                                        "items": {
+                                            "type": "object",
+                                            "required": [
+                                                "name",
+                                                "content_base64"
+                                            ],
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string",
+                                                    "description": "Filename including extension (e.g. `manual.pdf`)."
+                                                },
+                                                "content_base64": {
+                                                    "type": "string",
+                                                    "contentEncoding": "base64",
+                                                    "description": "Base64-encoded file content. Accepts a raw base64 string or a `data:<mime>;base64,...` data URI."
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "required": [
+                                    "files"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedKnowledgeBaseFileList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "aiagents-upload-knowledge-base",
+                        "description": "Upload one or more files to the agent's knowledge base. Accepts either a `multipart/form-data` body (used by the web dashboard) or an `application/json` body where each entry carries base64-encoded file content."
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/aiagents/import-from-provider/": {
+            "post": {
+                "operationId": "test-framework-v2-aiagents-import-from-provider-create",
+                "description": "Create an agent from an existing cloud-provider assistant. Supply the provider type and assistant ID (under `provider.type` / `provider.agent_id`) plus credentials, and Cekura fetches the system prompt, language/first-message settings, tool calls and dynamic variables from the provider and configures the agent automatically.\n\nSupported providers: vapi, retell, elevenlabs, synthflow. Request body is the same shape as `aiagents_create`. Returns the created agent immediately plus a `progress_id`; poll `import-progress/` with it to follow the per-step import status.",
+                "summary": "Import an AI agent from a cloud provider",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AIAgentV2"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AIAgentV2"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AIAgentV2"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ImportFromProviderResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/aiagents/import-progress/": {
+            "get": {
+                "operationId": "test-framework-v2-aiagents-import-progress-retrieve",
+                "description": "Returns the staged status of a background agent import started by `import-from-provider`. Each stage reports pending / in_progress / completed / skipped / failed so a step-by-step loader can be rendered.",
+                "summary": "Poll cloud-provider import progress",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "progress_id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ImportProgressResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/aiagents/runs_overview_project/": {
+            "get": {
+                "operationId": "test-framework-v2-aiagents-runs-overview-project-retrieve",
+                "description": "Aiagents runs overview project",
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AIAgentV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/aiagents/short_list/": {
+            "get": {
+                "operationId": "test-framework-v2-aiagents-short-list-list",
+                "description": "Aiagents short list",
+                "parameters": [
+                    {
+                        "name": "page",
+                        "required": false,
+                        "in": "query",
+                        "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "project_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Filter agents by project ID"
+                    },
+                    {
+                        "in": "query",
+                        "name": "organization_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Filter agents by organization ID"
+                    },
+                    {
+                        "in": "query",
+                        "name": "q",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Search agents by name"
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedAIAgentListList"
+                                }
+                            }
+                        },
+                        "description": ""
                     }
                 }
             }
@@ -48025,187 +50086,6 @@
                 },
                 "description": "Delete a workflows workflow"
             }
-        },
-        "/observability/v1/alerts/{id}/review_detail/": {
-            "get": {
-                "operationId": "alerts-review-detail-retrieve",
-                "description": "Per-alert review data — config snapshot, timeline, paginated fires.\n\nPowers the per-alert review page. Single-alert version of the bulk\n`review` action. Timeline is computed with a DB-side GROUP BY so the\nendpoint stays fast for noisy alerts (thousands of fires in 7d).\n\nQuery params:\n    hours: optional, defaults to 24. Capped at 7 days.\n    page: optional, defaults to 1.\n    page_size: optional, defaults to 50, capped at 200.",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "A unique integer value identifying this alert.",
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "observability"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/AlertDetail"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
-        },
-        "/observability/v1/alerts/{id}/summarize/": {
-            "post": {
-                "operationId": "alerts-summarize-create",
-                "description": "Kick off an LLM summary of the last N hours of fires for this alert.\n\nReturns a progress_id. Frontend polls `summarize_progress` until status\nis 'completed' or 'error'. Cached for 1 hour keyed on (alert, hours,\nlatest fire id) — re-invocations within that window return the same\nprogress_id.",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "A unique integer value identifying this alert.",
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "observability"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/AlertDetail"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/AlertDetail"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/AlertDetail"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/AlertDetail"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
-        },
-        "/observability/v1/alerts/review/": {
-            "get": {
-                "operationId": "alerts-review-retrieve",
-                "description": "Aggregate every alert's fire activity over a rolling window. Returns KPI totals (total fires, unique alerts that fired, top firing alert), a time-bucketed timeline (hourly for 24h, 3-hour for 3d, 6-hour for 7d), and a per-alert breakdown with a sparkline of fires-per-bucket. Use to answer 'what alerts fired this week?' or 'is anything noisy right now?'. Pass `hours` (default 24, capped at 168) to widen the window. The response shape lets you compose a written report in a single call.",
-                "summary": "Review alert activity in a project",
-                "tags": [
-                    "observability"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/AlertDetail"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "alerts-review-retrieve",
-                        "description": "Aggregate every alert's fire activity over a rolling window. Returns KPI totals (total fires, unique alerts that fired, top firing alert), a time-bucketed timeline (hourly for 24h, 3-hour for 3d, 6-hour for 7d), and a per-alert breakdown with a sparkline of fires-per-bucket. Use to answer 'what alerts fired this week?' or 'is anything noisy right now?'. Pass `hours` (default 24, capped at 168) to widen the window. The response shape lets you compose a written report in a single call."
-                    }
-                }
-            }
-        },
-        "/observability/v1/alerts/summarize_progress/": {
-            "get": {
-                "operationId": "alerts-summarize-progress-retrieve",
-                "description": "Manage alerts that fire when metric thresholds are crossed.",
-                "tags": [
-                    "observability"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/AlertDetail"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
-        },
-        "/observability/v1/alerts/trigger_summary/": {
-            "get": {
-                "operationId": "alerts-trigger-summary-retrieve",
-                "description": "Return fire counts per alert over a time window.\n\nPowers the \"Last 24h\" status pill on the alerts list. Counts CallLogAlert\nrows linked to each alert in the project, scoped to the window.\n\nQuery params:\n    project_id: required, scopes the result to alerts in this project.\n    hours: optional, defaults to 24. Window size in hours.\n\nReturns: { \"<alert_id>\": <fire_count>, ... }",
-                "tags": [
-                    "observability"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/AlertDetail"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
         }
     },
     "components": {
@@ -48391,16 +50271,15 @@
                             "pipecat",
                             "koreai",
                             "custom",
-                            "trillet",
                             "cisco",
                             "genesys",
                             "chirp",
                             ""
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "43adf9cc06494c10",
+                        "x-spec-enum-id": "64a9d3237300a426",
                         "default": "",
-                        "description": "\nService provider for speech-to-text transcription\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `synthflow` - Synthflow\n* `elevenlabs` - Elevenlabs\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `koreai` - Kore\n* `custom` - Custom\n* `trillet` - Trillet\n* `cisco` - Cisco\n* `genesys` - Genesys\n* `chirp` - Chirp"
+                        "description": "\nService provider for speech-to-text transcription\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `synthflow` - Synthflow\n* `elevenlabs` - Elevenlabs\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `koreai` - Kore\n* `custom` - Custom\n* `cisco` - Cisco\n* `genesys` - Genesys\n* `chirp` - Chirp"
                     },
                     "assistant_provider": {
                         "enum": [
@@ -48412,16 +50291,21 @@
                             "whatsapp",
                             "self_hosted",
                             "agentforce",
-                            "trillet",
                             "cisco",
                             "bland",
                             "livekit",
+                            "pipecat",
+                            "synthflow",
+                            "chirp",
+                            "koreai",
+                            "genesys",
+                            "amazon_connect",
                             ""
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "a7ddfee511394575",
+                        "x-spec-enum-id": "e4a9e996f7d53c98",
                         "default": "",
-                        "description": "\nService provider for the AI assistant functionality. Valid values (live enum):\n\n- `self_hosted` — websocket or observation-only; no api_key needed. Use `websocket_url` + `websocket_headers` for text-mode runs.\n- `vapi` — requires `vapi_api_key`; optional `assistant_id`, `vapi_data.public_key`.\n- `retell` — requires `retell_api_key` AND `chat_assistant_id` (used for voice too).\n- `bland` — requires `bland_api_key` AND `chat_assistant_id` (Bland calls this `pathway_id`); `bland_data.encrypted_key` for Twilio.\n- `livekit` — requires `livekit_api_key` + `livekit_data.api_secret` + `livekit_data.url`.\n- `elevenlabs` — requires `elevenlabs_api_key`.\n- `agentforce` — requires `agentforce_client_secret` + `agentforce_data`.\n- `trillet` — requires `trillet_api_key` + `trillet_data.workspace_id`.\n- `cisco` — Cisco Webex.\n- `vocera` — Cekura-hosted.\n- `sms` / `whatsapp` — text-only channels; use `chat_assistant_id`.\n- `\"\"` (empty) — unset; agent is not runnable until a provider is configured.\n\nNote: the serializer also exposes `pipecat_*`, `synthflow_*`, `koreai_*`, `genesys_*`, `custom_provider_*` fields, but those provider values are not currently selectable in this enum.\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `elevenlabs` - Elevenlabs\n* `vocera` - Vocera\n* `sms` - Sms\n* `whatsapp` - Whatsapp\n* `self_hosted` - Self Hosted\n* `agentforce` - Agentforce\n* `trillet` - Trillet\n* `cisco` - Cisco\n* `bland` - Bland\n* `livekit` - Livekit"
+                        "description": "\nService provider for the AI assistant functionality. Valid values (live enum):\n\n- `self_hosted` — websocket or observation-only; no api_key needed. Use `websocket_url` + `websocket_headers` for text-mode runs.\n- `vapi` — requires `vapi_api_key`; optional `assistant_id`, `vapi_data.public_key`.\n- `retell` — requires `retell_api_key` AND `chat_assistant_id` (used for voice too).\n- `bland` — requires `bland_api_key` AND `chat_assistant_id` (Bland calls this `pathway_id`); `bland_data.encrypted_key` for Twilio.\n- `livekit` — requires `livekit_api_key` + `livekit_data.api_secret` + `livekit_data.url`.\n- `elevenlabs` — requires `elevenlabs_api_key`.\n- `agentforce` — requires `agentforce_client_secret` + `agentforce_data`.\n- `amazon_connect` — requires `amazon_connect_data` with `snippet_id` and `connect_host`; optional `amazon_connect_security_token` and `region`.\n- `cisco` — Cisco Webex.\n- `vocera` — Cekura-hosted.\n- `sms` / `whatsapp` — text-only channels; use `chat_assistant_id`.\n- `\"\"` (empty) — unset; agent is not runnable until a provider is configured.\n\nNote: the serializer also exposes `pipecat_*`, `synthflow_*`, `koreai_*`, `genesys_*`, `custom_provider_*` fields, but those provider values are not currently selectable in this enum.\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `elevenlabs` - Elevenlabs\n* `vocera` - Vocera\n* `sms` - Sms\n* `whatsapp` - Whatsapp\n* `self_hosted` - Self Hosted\n* `agentforce` - Agentforce\n* `cisco` - Cisco\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `synthflow` - Synthflow\n* `chirp` - Chirp\n* `koreai` - Koreai\n* `genesys` - Genesys\n* `amazon_connect` - Amazon Connect"
                     },
                     "vapi_api_key": {
                         "type": "string",
@@ -48532,6 +50416,19 @@
                         "type": "string",
                         "description": "\nAgentforce additional data - client_id, domain, and agent_id\nExample: `{\"client_id\": \"sd7a8...\", \"domain\": \"https://example.sandbox.my.salesforce.com\", \"agent_id\": \"0Xx...\"}`\n"
                     },
+                    "amazon_connect_security_token": {
+                        "type": "string",
+                        "writeOnly": true,
+                        "description": "x-amz-security-token for Amazon Connect authenticated chat widgets."
+                    },
+                    "amazon_connect_security_token_configured": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "amazon_connect_data": {
+                        "type": "string",
+                        "description": "Amazon Connect config: snippet_id (required), connect_host (required), region (default us-east-1)."
+                    },
                     "custom_provider_api_key": {
                         "type": "string",
                         "writeOnly": true,
@@ -48556,19 +50453,6 @@
                     "elevenlabs_data": {
                         "type": "string",
                         "description": "\nElevenLabs additional configuration data\nExample: `{\"trigger_url\": \"https://example.com/trigger\"}`\n"
-                    },
-                    "trillet_api_key": {
-                        "type": "string",
-                        "writeOnly": true,
-                        "description": "\nAPI key for Trillet AI service provider\nExample: `\"trillet_api_key_123\"`\n"
-                    },
-                    "trillet_api_key_configured": {
-                        "type": "string",
-                        "readOnly": true
-                    },
-                    "trillet_data": {
-                        "type": "string",
-                        "description": "\nTrillet AI additional data including Workspace ID\nExample: `{\"workspace_id\": \"1234567890\"}`\n"
                     },
                     "chirp_data": {
                         "type": "string",
@@ -48673,6 +50557,38 @@
                     "agent_name",
                     "description",
                     "inbound"
+                ]
+            },
+            "AIAgentDynamicVariable": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Variable name exactly as it appears in the agent context (e.g. 'firstName', 'leadId')",
+                        "maxLength": 255
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "What this variable represents and its expected format / type. Example: \"The user's date of birth on file, in YYYY-MM-DD format\""
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    }
+                },
+                "required": [
+                    "description",
+                    "name"
                 ]
             },
             "AIAgentList": {
@@ -48915,6 +50831,306 @@
                     "name"
                 ]
             },
+            "AIAgentV2": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "readOnly": true,
+                        "description": "Agent ID.\nExample: `2142`"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Agent name.",
+                        "maxLength": 255
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "\nA detailed description of what this agent does and how it should interact\nExample: \n```text\nAI agent for handling customer support inquiries and resolving technical issues\n```\n"
+                    },
+                    "project": {
+                        "type": "integer",
+                        "description": "The project this agent belongs to"
+                    },
+                    "language": {
+                        "enum": [
+                            "af",
+                            "ar",
+                            "bn",
+                            "bg",
+                            "zh",
+                            "cs",
+                            "da",
+                            "nl",
+                            "en",
+                            "et",
+                            "fi",
+                            "fr",
+                            "de",
+                            "el",
+                            "gu",
+                            "hi",
+                            "he",
+                            "hu",
+                            "id",
+                            "it",
+                            "ja",
+                            "kn",
+                            "ko",
+                            "ms",
+                            "ml",
+                            "mr",
+                            "multi",
+                            "no",
+                            "pl",
+                            "pa",
+                            "pt",
+                            "ro",
+                            "ru",
+                            "sk",
+                            "es",
+                            "sv",
+                            "th",
+                            "tr",
+                            "tl",
+                            "ta",
+                            "te",
+                            "uk",
+                            "vi"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "b822ad429c7b7fec",
+                        "default": "en",
+                        "description": "\nThe primary language this agent uses for communication (e.g. 'en' for English)\n\n\n* `af` - Afrikaans\n* `ar` - Arabic\n* `bn` - Bengali\n* `bg` - Bulgarian\n* `zh` - Chinese Simplified\n* `cs` - Czech\n* `da` - Danish\n* `nl` - Dutch\n* `en` - English\n* `et` - Estonian\n* `fi` - Finnish\n* `fr` - French\n* `de` - German\n* `el` - Greek\n* `gu` - Gujarati\n* `hi` - Hindi\n* `he` - Hebrew\n* `hu` - Hungarian\n* `id` - Indonesian\n* `it` - Italian\n* `ja` - Japanese\n* `kn` - Kannada\n* `ko` - Korean\n* `ms` - Malay\n* `ml` - Malayalam\n* `mr` - Marathi\n* `multi` - Multilingual\n* `no` - Norwegian\n* `pl` - Polish\n* `pa` - Punjabi\n* `pt` - Portuguese\n* `ro` - Romanian\n* `ru` - Russian\n* `sk` - Slovak\n* `es` - Spanish\n* `sv` - Swedish\n* `th` - Thai\n* `tr` - Turkish\n* `tl` - Tagalog\n* `ta` - Tamil\n* `te` - Telugu\n* `uk` - Ukrainian\n* `vi` - Vietnamese"
+                    },
+                    "telephony": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/AgentTelephony"
+                            }
+                        ],
+                        "description": "Phone and SIP channel configuration."
+                    },
+                    "provider": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/AgentProvider"
+                            }
+                        ],
+                        "description": "AI platform integration. Nested credentials replace the flat {provider}_api_key fields."
+                    },
+                    "agent_speaks_first": {
+                        "type": [
+                            "boolean",
+                            "null"
+                        ],
+                        "description": "True = agent speaks first; False = test user speaks first; null = auto-detect."
+                    },
+                    "predefined_metrics": {
+                        "writeOnly": true,
+                        "description": "predefined metrics to use for the agent"
+                    },
+                    "knowledge_base_files": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "\nList of knowledge base files attached to the agent\nExample: `[1, 2, 3]`\n"
+                    },
+                    "enabled_personalities": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        },
+                        "readOnly": true,
+                        "description": "\nPersonality profiles enabled for this agent\nExample: `[1, 2, 3]`\n"
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "description": "\nTimestamp when the agent was created\nExample: `\"2021-01-01T00:00:00Z\"`\n"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "description": "\nTimestamp when the agent was last updated\nExample: `\"2021-01-01T00:00:00Z\"`\n"
+                    }
+                },
+                "required": [
+                    "description",
+                    "name"
+                ]
+            },
+            "AgentCredentials": {
+                "type": "object",
+                "description": "Nested credentials block inside the provider object.",
+                "properties": {
+                    "api_key": {
+                        "type": "string",
+                        "writeOnly": true,
+                        "description": "API key or client secret for the provider (write-only — never returned). Required for: vapi, retell, elevenlabs, bland, livekit, pipecat, synthflow. koreai uses client_secret (passed as api_key). Not needed for: cisco, chirp, self_hosted."
+                    },
+                    "config": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/ProviderCredentialsConfig"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    }
+                }
+            },
+            "AgentProvider": {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "enum": [
+                            "vapi",
+                            "retell",
+                            "elevenlabs",
+                            "self_hosted",
+                            "cisco",
+                            "bland",
+                            "livekit",
+                            "pipecat",
+                            "synthflow",
+                            "chirp",
+                            "koreai",
+                            "genesys",
+                            "custom",
+                            ""
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "115e139d63e24b68",
+                        "description": "Voice/inbound platform provider type. Valid values: vapi, retell, elevenlabs, bland, livekit, cisco, synthflow, chirp, koreai, genesys, self_hosted, pipecat, custom. Use 'custom' (or omit) for chat-only agents with no voice provider — the chat channel goes in chat_agent_details.type. Text-only channels (sms, whatsapp, agentforce, amazon_connect) belong in chat_agent_details.type, not here.\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `elevenlabs` - Elevenlabs\n* `self_hosted` - Self Hosted\n* `cisco` - Cisco\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `synthflow` - Synthflow\n* `chirp` - Chirp\n* `koreai` - Koreai\n* `genesys` - Genesys\n* `custom` - Custom (chat-only, no voice provider)"
+                    },
+                    "agent_id": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "Agent ID for voice/inbound runs on the provider's platform. For vapi, elevenlabs, retell, self_hosted, synthflow, and bland this is the voice agent ID (for bland it's the persona_id). Bland's pathway_id and retell's chat agent ID go in chat_agent_details.config.agent_id."
+                    },
+                    "credentials": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/AgentCredentials"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "chat_agent_details": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/ChatAgentDetails"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Optional chat/text-mode configuration. Defines which provider handles text-mode test runs. The allowed chat type depends on the voice provider.type."
+                    },
+                    "auto_dial_outbound": {
+                        "type": [
+                            "boolean",
+                            "null"
+                        ],
+                        "description": "Auto-dial the outbound number when running outbound scenarios. Supported for: vapi, retell, elevenlabs, bland, livekit."
+                    },
+                    "auto_import_calls": {
+                        "type": [
+                            "boolean",
+                            "null"
+                        ],
+                        "description": "Auto-import calls from the provider every 30s. Supported for: vapi, retell, elevenlabs."
+                    },
+                    "auto_sync_prompt": {
+                        "type": [
+                            "boolean",
+                            "null"
+                        ],
+                        "description": "Auto-sync agent prompt from the provider every 30s. Supported for: vapi, retell, elevenlabs, synthflow."
+                    },
+                    "send_post_conversation_metadata": {
+                        "type": [
+                            "boolean",
+                            "null"
+                        ],
+                        "description": "Enable Cekura to accept call transcripts pushed by your agent via POST /custom-provider-webhook/. Only for self-hosted (custom) providers."
+                    }
+                }
+            },
+            "AgentTelephony": {
+                "type": "object",
+                "description": "Phone/SIP channel configuration for the agent.",
+                "properties": {
+                    "phone_number": {
+                        "type": "string",
+                        "description": "E.164 phone number for inbound calls, e.g. +14155551234."
+                    },
+                    "inbound": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "True = agent receives inbound calls; False = outbound only."
+                    },
+                    "sip_uri": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "SIP URI, e.g. sip:user@domain.com."
+                    },
+                    "sip_auth": {
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "SIP credentials: {username, password}."
+                    },
+                    "outbound_numbers": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Phone numbers authorized for outbound calls (E.164 format). Example: `[\"+14155551234\", \"+14155550000\"]`"
+                    }
+                }
+            },
+            "AgentforceChatConfig": {
+                "type": "object",
+                "description": "Agentforce (Salesforce) chat configuration.",
+                "properties": {
+                    "client_secret": {
+                        "type": "string",
+                        "description": "OAuth2 client secret for Salesforce authentication."
+                    },
+                    "client_id": {
+                        "type": "string",
+                        "description": "OAuth2 client ID for Salesforce authentication."
+                    },
+                    "domain": {
+                        "type": "string",
+                        "description": "Salesforce domain, e.g. https://example.sandbox.my.salesforce.com."
+                    },
+                    "agent_id": {
+                        "type": "string",
+                        "description": "Agentforce agent ID (0Xx...)."
+                    }
+                },
+                "required": [
+                    "agent_id",
+                    "client_id",
+                    "client_secret",
+                    "domain"
+                ],
+                "title": "Agentforce"
+            },
             "AlertCreate": {
                 "type": "object",
                 "description": "",
@@ -48954,24 +51170,13 @@
                         "description": "ID of monitored object"
                     },
                     "source": {
-                        "description": "Source config keyed on `sub_type`. `normal`: {sub_type, filters?}. `significant_change`: {sub_type, window_size, filters?}. `threshold`: {sub_type, window_size, filters?}. `filters` is an optional CallLogQueryFilter expression."
+                        "description": "Source config. For metrics: {\"sub_type\": \"normal\"|\"significant_change\", \"filters\": {...}, \"window_size\": 50}"
                     },
                     "threshold": {
-                        "description": "Threshold config keyed on the source's `sub_type`. `normal`: {} (fires on every failing eval). `significant_change`: {std_multiplier, ewma_alpha, direction}. `threshold`: {operator (gt|lt|outside), value (number | {low, high}), min_breaches}."
+                        "description": "Threshold config. Normal metric: {\"condition\": \"value_lt_5\"}. Significant change: {\"std_multiplier\": 2.0, \"ewma_alpha\": 0.1, \"direction\": \"both\"}. Duration/volume: {\"operator\": \"gt\", \"value\": 300}"
                     },
                     "notifications": {
-                        "description": "Notification routing. `{slack: {workspace_id, channel_id?}}` to send to a specific workspace/channel. Empty fans out to every project workspace; empty + no project workspaces means the alert is silent."
-                    },
-                    "preset": {
-                        "enum": [
-                            "conservative",
-                            "balanced",
-                            "aggressive"
-                        ],
-                        "type": "string",
-                        "x-spec-enum-id": "a6fd953985219e0b",
-                        "writeOnly": true,
-                        "description": "Optional shorthand for trend alerts: 'conservative' | 'balanced' | 'aggressive'. Expands to std_multiplier / ewma_alpha / window_size. Explicit values in `source` or `threshold` override the preset. Ignored unless sub_type == 'significant_change'.\n\n* `conservative` - conservative\n* `balanced` - balanced\n* `aggressive` - aggressive"
+                        "description": "Notification config. Slack: {\"slack\": {\"workspace_id\": 10, \"channel_id\": \"C123\"}}. Empty = all project workspaces"
                     }
                 },
                 "required": [
@@ -49033,13 +51238,13 @@
                         "readOnly": true
                     },
                     "source": {
-                        "description": "Source config keyed on `sub_type`. `normal`: {sub_type, filters?}. `significant_change`: {sub_type, window_size, filters?}. `threshold`: {sub_type, window_size, filters?}. `filters` is an optional CallLogQueryFilter expression."
+                        "description": "Source config. For metrics: {\"sub_type\": \"normal\"|\"significant_change\", \"filters\": {...}, \"window_size\": 50}"
                     },
                     "threshold": {
-                        "description": "Threshold config keyed on the source's `sub_type`. `normal`: {} (fires on every failing eval). `significant_change`: {std_multiplier, ewma_alpha, direction}. `threshold`: {operator (gt|lt|outside), value (number | {low, high}), min_breaches}."
+                        "description": "Threshold config. Normal metric: {\"condition\": \"value_lt_5\"}. Significant change: {\"std_multiplier\": 2.0, \"ewma_alpha\": 0.1, \"direction\": \"both\"}. Duration/volume: {\"operator\": \"gt\", \"value\": 300}"
                     },
                     "notifications": {
-                        "description": "Notification routing. `{slack: {workspace_id, channel_id?}}` to send to a specific workspace/channel. Empty fans out to every project workspace; empty + no project workspaces means the alert is silent."
+                        "description": "Notification config. Slack: {\"slack\": {\"workspace_id\": 10, \"channel_id\": \"C123\"}}. Empty = all project workspaces"
                     },
                     "last_triggered_at": {
                         "type": [
@@ -49131,13 +51336,13 @@
                         "readOnly": true
                     },
                     "source": {
-                        "description": "Source config keyed on `sub_type`. `normal`: {sub_type, filters?}. `significant_change`: {sub_type, window_size, filters?}. `threshold`: {sub_type, window_size, filters?}. `filters` is an optional CallLogQueryFilter expression."
+                        "description": "Source config. For metrics: {\"sub_type\": \"normal\"|\"significant_change\", \"filters\": {...}, \"window_size\": 50}"
                     },
                     "threshold": {
-                        "description": "Threshold config keyed on the source's `sub_type`. `normal`: {} (fires on every failing eval). `significant_change`: {std_multiplier, ewma_alpha, direction}. `threshold`: {operator (gt|lt|outside), value (number | {low, high}), min_breaches}."
+                        "description": "Threshold config. Normal metric: {\"condition\": \"value_lt_5\"}. Significant change: {\"std_multiplier\": 2.0, \"ewma_alpha\": 0.1, \"direction\": \"both\"}. Duration/volume: {\"operator\": \"gt\", \"value\": 300}"
                     },
                     "notifications": {
-                        "description": "Notification routing. `{slack: {workspace_id, channel_id?}}` to send to a specific workspace/channel. Empty fans out to every project workspace; empty + no project workspaces means the alert is silent."
+                        "description": "Notification config. Slack: {\"slack\": {\"workspace_id\": 10, \"channel_id\": \"C123\"}}. Empty = all project workspaces"
                     },
                     "trigger_count": {
                         "type": "integer",
@@ -49189,28 +51394,49 @@
                         "description": "Enable/disable alert"
                     },
                     "source": {
-                        "description": "Source config keyed on `sub_type`. `normal`: {sub_type, filters?}. `significant_change`: {sub_type, window_size, filters?}. `threshold`: {sub_type, window_size, filters?}. `filters` is an optional CallLogQueryFilter expression."
+                        "description": "Source config. For metrics: {\"sub_type\": \"normal\"|\"significant_change\", \"filters\": {...}, \"window_size\": 50}"
                     },
                     "threshold": {
-                        "description": "Threshold config keyed on the source's `sub_type`. `normal`: {} (fires on every failing eval). `significant_change`: {std_multiplier, ewma_alpha, direction}. `threshold`: {operator (gt|lt|outside), value (number | {low, high}), min_breaches}."
+                        "description": "Threshold config. Normal metric: {\"condition\": \"value_lt_5\"}. Significant change: {\"std_multiplier\": 2.0, \"ewma_alpha\": 0.1, \"direction\": \"both\"}. Duration/volume: {\"operator\": \"gt\", \"value\": 300}"
                     },
                     "notifications": {
-                        "description": "Notification routing. `{slack: {workspace_id, channel_id?}}` to send to a specific workspace/channel. Empty fans out to every project workspace; empty + no project workspaces means the alert is silent."
-                    },
-                    "preset": {
-                        "enum": [
-                            "conservative",
-                            "balanced",
-                            "aggressive"
-                        ],
-                        "type": "string",
-                        "x-spec-enum-id": "a6fd953985219e0b",
-                        "writeOnly": true,
-                        "description": "Optional shorthand for trend alerts: 'conservative' | 'balanced' | 'aggressive'. Expands to std_multiplier / ewma_alpha / window_size. Explicit values in `source` or `threshold` override the preset. Ignored unless the alert's sub_type == 'significant_change'.\n\n* `conservative` - conservative\n* `balanced` - balanced\n* `aggressive` - aggressive"
+                        "description": "Notification config. Slack: {\"slack\": {\"workspace_id\": 10, \"channel_id\": \"C123\"}}. Empty = all project workspaces"
                     }
                 },
                 "required": [
                     "name"
+                ]
+            },
+            "AmazonConnectChatConfig": {
+                "type": "object",
+                "description": "Amazon Connect chat-widget configuration.",
+                "properties": {
+                    "widget_id": {
+                        "type": "string",
+                        "description": "Chat-widget UUID from the Amazon Connect console."
+                    },
+                    "security_token": {
+                        "type": "string",
+                        "writeOnly": true,
+                        "description": "x-amz-security-token for authenticated widgets (write-only — never returned)."
+                    },
+                    "snippet_id": {
+                        "type": "string",
+                        "description": "Base64-encoded KMS snippet from your Amazon Connect chat widget."
+                    },
+                    "connect_host": {
+                        "type": "string",
+                        "description": "Amazon Connect instance host, e.g. acme.my.connect.aws."
+                    },
+                    "region": {
+                        "type": "string",
+                        "description": "AWS region for the Connect instance. Defaults to us-east-1."
+                    }
+                },
+                "required": [
+                    "connect_host",
+                    "snippet_id",
+                    "widget_id"
                 ]
             },
             "AskAboutFailuresReportsRequest": {
@@ -49355,6 +51581,113 @@
                         "description": "When the action was performed"
                     }
                 }
+            },
+            "AutoFetchErrorResponse": {
+                "type": "object",
+                "properties": {
+                    "detail": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "detail"
+                ]
+            },
+            "AutoFetchProgressErrorResponse": {
+                "type": "object",
+                "properties": {
+                    "detail": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "detail"
+                ]
+            },
+            "AutoFetchProgressResponse": {
+                "type": "object",
+                "properties": {
+                    "status": {
+                        "enum": [
+                            "in_progress",
+                            "completed",
+                            "failed"
+                        ],
+                        "type": "string",
+                        "description": "* `in_progress` - in_progress\n* `completed` - completed\n* `failed` - failed",
+                        "x-spec-enum-id": "6e9575e5767aaee0"
+                    },
+                    "tools_created": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
+                    },
+                    "tools_updated": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
+                    },
+                    "message": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "error": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    }
+                },
+                "required": [
+                    "error",
+                    "message",
+                    "status",
+                    "tools_created",
+                    "tools_updated"
+                ]
+            },
+            "AutoFetchToolsRequest": {
+                "type": "object",
+                "properties": {
+                    "provider": {
+                        "enum": [
+                            "vapi",
+                            "retell",
+                            "elevenlabs"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "ff667bd2cd27b9d3",
+                        "description": "Provider to fetch tools from\n\n* `vapi` - vapi\n* `retell` - retell\n* `elevenlabs` - elevenlabs"
+                    },
+                    "assistant_id": {
+                        "type": "string",
+                        "description": "Assistant/Agent ID from the provider (e.g., VAPI Assistant ID)"
+                    },
+                    "api_key": {
+                        "type": "string",
+                        "description": "Optional API key for the provider. If not provided, will use stored credentials."
+                    }
+                },
+                "required": [
+                    "assistant_id",
+                    "provider"
+                ]
+            },
+            "AutoFetchToolsResponse": {
+                "type": "object",
+                "properties": {
+                    "progress_id": {
+                        "type": "string",
+                        "description": "Poll auto-fetch-progress/?progress_id=<value> to track completion"
+                    }
+                },
+                "required": [
+                    "progress_id"
+                ]
             },
             "Billing": {
                 "type": "object",
@@ -49511,6 +51844,31 @@
                 "required": [
                     "balance_expiry"
                 ]
+            },
+            "BlandChatConfig": {
+                "type": "object",
+                "description": "Bland chat configuration.",
+                "properties": {
+                    "agent_id": {
+                        "type": "string",
+                        "description": "The Bland pathway_id to use for text-mode test runs."
+                    }
+                },
+                "required": [
+                    "agent_id"
+                ],
+                "title": "Bland"
+            },
+            "BlandConfig": {
+                "type": "object",
+                "description": "Bland AI provider configuration.",
+                "properties": {
+                    "encrypted_key": {
+                        "type": "string",
+                        "description": "Twilio credential bundle for Bland outbound calls. Required when using Bland with Twilio telephony."
+                    }
+                },
+                "title": "Bland"
             },
             "BulkAgentAssignment": {
                 "type": "object",
@@ -50080,6 +52438,11 @@
                         "description": "Unique identifier for the call.\nExample: \n- `\"call_abc123xyz\"`\n- `\"stereo_audio_session_456\"`",
                         "maxLength": 100
                     },
+                    "trace_id": {
+                        "type": "string",
+                        "description": "OpenTelemetry trace ID (32-char hex). Set when OTel tracing is enabled.",
+                        "maxLength": 32
+                    },
                     "agent": {
                         "type": [
                             "integer",
@@ -50172,6 +52535,11 @@
                         "type": "string",
                         "description": "Unique identifier for the call.\nExample: \n- `\"call_abc123xyz\"`\n- `\"stereo_audio_session_456\"`",
                         "maxLength": 100
+                    },
+                    "trace_id": {
+                        "type": "string",
+                        "description": "OpenTelemetry trace ID (32-char hex). Set when OTel tracing is enabled.",
+                        "maxLength": 32
                     },
                     "timestamp": {
                         "type": "string",
@@ -50342,6 +52710,59 @@
                     "timestamp"
                 ]
             },
+            "ChatAgentConfig": {
+                "oneOf": [
+                    {
+                        "$ref": "#/components/schemas/RetellChatConfig"
+                    },
+                    {
+                        "$ref": "#/components/schemas/BlandChatConfig"
+                    },
+                    {
+                        "$ref": "#/components/schemas/AgentforceChatConfig"
+                    },
+                    {
+                        "$ref": "#/components/schemas/SelfHostedChatConfig"
+                    },
+                    {
+                        "$ref": "#/components/schemas/AmazonConnectChatConfig"
+                    }
+                ]
+            },
+            "ChatAgentDetails": {
+                "type": "object",
+                "description": "Chat-mode provider configuration nested inside the provider block.",
+                "properties": {
+                    "type": {
+                        "enum": [
+                            "retell",
+                            "bland",
+                            "vapi",
+                            "elevenlabs",
+                            "livekit",
+                            "sms",
+                            "whatsapp",
+                            "self_hosted",
+                            "agentforce",
+                            "amazon_connect",
+                            ""
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "390eccd47ab6c086",
+                        "description": "Chat provider type. Must be compatible with the voice provider.type. Valid values: retell, bland, vapi, elevenlabs, livekit, sms, whatsapp, self_hosted, agentforce, amazon_connect. Pass an empty string \"\" (or send chat_agent_details: null) to clear the chat overlay.\n\n* `retell` - retell\n* `bland` - bland\n* `vapi` - vapi\n* `elevenlabs` - elevenlabs\n* `livekit` - livekit\n* `sms` - sms\n* `whatsapp` - whatsapp\n* `self_hosted` - self_hosted\n* `agentforce` - agentforce\n* `amazon_connect` - amazon_connect"
+                    },
+                    "config": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/ChatAgentConfig"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    }
+                }
+            },
             "ChatMessage": {
                 "type": "object",
                 "description": "",
@@ -50488,6 +52909,55 @@
                     }
                 }
             },
+            "ChirpConfig": {
+                "type": "object",
+                "description": "CHIRP WebSocket voice configuration.",
+                "properties": {
+                    "chirp_websocket_url": {
+                        "type": "string",
+                        "description": "WebSocket endpoint your CHIRP agent listens on (Raw PCM 16kHz 16-bit mono), e.g. wss://your-host/voice."
+                    },
+                    "chirp_basic_auth_username": {
+                        "type": "string",
+                        "description": "Optional username for HTTP Basic Auth on the WebSocket upgrade."
+                    },
+                    "chirp_basic_auth_password": {
+                        "type": "string",
+                        "description": "Optional password for HTTP Basic Auth on the WebSocket upgrade (write-only — masked in responses)."
+                    }
+                },
+                "required": [
+                    "chirp_websocket_url"
+                ],
+                "title": "CHIRP"
+            },
+            "CleanMetricDescriptionRequest": {
+                "type": "object",
+                "properties": {
+                    "agent": {
+                        "type": "integer"
+                    },
+                    "metric_description": {
+                        "type": "string"
+                    },
+                    "eval_type": {
+                        "enum": [
+                            "boolean",
+                            "numeric",
+                            "rating",
+                            "enum"
+                        ],
+                        "type": "string",
+                        "description": "* `boolean` - boolean\n* `numeric` - numeric\n* `rating` - rating\n* `enum` - enum",
+                        "x-spec-enum-id": "ae756482f906eddf"
+                    }
+                },
+                "required": [
+                    "agent",
+                    "eval_type",
+                    "metric_description"
+                ]
+            },
             "Condition": {
                 "type": "object",
                 "description": "One entry in a ConditionalActions flow.",
@@ -50580,6 +53050,12 @@
                         "type": "string",
                         "description": "Unique identifier for the call.\nExample: \n- `\"call_abc123xyz\"`\n- `\"stereo_audio_session_456\"`",
                         "maxLength": 100
+                    },
+                    "trace_id": {
+                        "type": "string",
+                        "default": "",
+                        "description": "OpenTelemetry trace ID (32-char hex string). Example: \"4bf92f3577b34da6a3ce929d0e0e4736\"",
+                        "maxLength": 32
                     },
                     "agent": {
                         "type": "integer",
@@ -51620,6 +54096,21 @@
                     "target_node"
                 ]
             },
+            "ElevenLabsConfig": {
+                "type": "object",
+                "description": "ElevenLabs provider configuration.",
+                "properties": {
+                    "trigger_url": {
+                        "type": "string",
+                        "description": "URL Cekura calls to create outbound ElevenLabs phone calls."
+                    },
+                    "elevenlabs_base_url_override": {
+                        "type": "string",
+                        "description": "Optional custom base URL for ElevenLabs API, e.g. for EU residency. Leave empty to use the default endpoint."
+                    }
+                },
+                "title": "ElevenLabs"
+            },
             "EnableMockErrorResponse": {
                 "type": "object",
                 "properties": {
@@ -51804,6 +54295,71 @@
                     "score"
                 ]
             },
+            "GenerateCleanDescriptionBgResponse": {
+                "type": "object",
+                "properties": {
+                    "progress_id": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "progress_id"
+                ]
+            },
+            "GenerateCleanDescriptionProgressResponse": {
+                "type": "object",
+                "properties": {
+                    "status": {
+                        "type": "string"
+                    },
+                    "clean_description": {
+                        "type": "string"
+                    },
+                    "thinking": {
+                        "type": "string"
+                    },
+                    "error": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "status"
+                ]
+            },
+            "GenesysConfig": {
+                "type": "object",
+                "description": "Genesys Cloud provider configuration.",
+                "properties": {
+                    "client_id": {
+                        "type": "string",
+                        "description": "Genesys Cloud OAuth2 Client ID."
+                    },
+                    "region": {
+                        "type": "string",
+                        "description": "Genesys Cloud region, e.g. us-east-1."
+                    }
+                },
+                "required": [
+                    "client_id",
+                    "region"
+                ],
+                "title": "Genesys"
+            },
+            "ImportFromProviderResponse": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer"
+                    },
+                    "progress_id": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "id",
+                    "progress_id"
+                ]
+            },
             "ImportPlivoNumber": {
                 "type": "object",
                 "properties": {
@@ -51838,6 +54394,47 @@
                     "plivo_auth_id",
                     "plivo_auth_token",
                     "plivo_phone_number"
+                ]
+            },
+            "ImportProgressResponse": {
+                "type": "object",
+                "properties": {
+                    "agent_id": {
+                        "type": "integer"
+                    },
+                    "status": {
+                        "enum": [
+                            "in_progress",
+                            "completed",
+                            "failed"
+                        ],
+                        "type": "string",
+                        "description": "* `in_progress` - in_progress\n* `completed` - completed\n* `failed` - failed",
+                        "x-spec-enum-id": "6e9575e5767aaee0"
+                    },
+                    "current_stage": {
+                        "type": "string"
+                    },
+                    "stages": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                        }
+                    },
+                    "error": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    }
+                },
+                "required": [
+                    "agent_id",
+                    "current_stage",
+                    "error",
+                    "stages",
+                    "status"
                 ]
             },
             "ImportTelnyxNumber": {
@@ -52215,6 +54812,63 @@
                     "agent",
                     "file"
                 ]
+            },
+            "KoreAiConfig": {
+                "type": "object",
+                "description": "Kore.ai provider configuration.",
+                "properties": {
+                    "client_id": {
+                        "type": "string",
+                        "description": "KoreAI OAuth2 Client ID."
+                    },
+                    "bot_id": {
+                        "type": "string",
+                        "description": "KoreAI Bot ID to connect to."
+                    },
+                    "host": {
+                        "type": "string",
+                        "description": "KoreAI host URL. Defaults to https://bots.kore.ai."
+                    }
+                },
+                "required": [
+                    "bot_id",
+                    "client_id"
+                ],
+                "title": "Kore.ai"
+            },
+            "LiveKitConfig": {
+                "type": "object",
+                "description": "LiveKit provider configuration.",
+                "properties": {
+                    "api_secret": {
+                        "type": "string",
+                        "description": "LiveKit API secret. Required alongside api_key."
+                    },
+                    "url": {
+                        "type": "string",
+                        "description": "LiveKit server WebSocket URL, e.g. wss://acme.livekit.cloud."
+                    },
+                    "agent_name": {
+                        "type": "string",
+                        "description": "LiveKit agent name to connect to."
+                    },
+                    "config": {
+                        "description": "Additional LiveKit configuration as a JSON object."
+                    },
+                    "tracing_enabled": {
+                        "type": "boolean",
+                        "description": "Enable LiveKit tracing (requires Cekura SDK integrated in your LiveKit agent)."
+                    },
+                    "trigger_url": {
+                        "type": "string",
+                        "description": "URL Cekura calls to create outbound phone calls."
+                    }
+                },
+                "required": [
+                    "api_secret",
+                    "url"
+                ],
+                "title": "LiveKit"
             },
             "LiveKitEgressCredentialsResponse": {
                 "type": "object",
@@ -52754,10 +55408,157 @@
                             "null"
                         ],
                         "description": "When enabled, this metric is automatically assigned to new agents created in the project."
+                    },
+                    "pending_optimisation_proposal": {
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "readOnly": true,
+                        "description": "Unsaved proposal from a metric-optimiser cron run. Shape: {description, evaluation_trigger, type, custom_code, score, baseline_score, cron_job_id, cron_job_name, proposed_at}."
                     }
                 },
                 "required": [
                     "name"
+                ]
+            },
+            "MetricFailureModeInsight": {
+                "type": "object",
+                "description": "Insight row exposed to the Observability → Insights UI.",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "project": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "metric": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
+                        "readOnly": true
+                    },
+                    "predefined_metric": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
+                        "readOnly": true
+                    },
+                    "metric_name": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "window_start": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "window_end": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "num_calls_analyzed": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "status": {
+                        "enum": [
+                            "pending",
+                            "running",
+                            "succeeded",
+                            "failed",
+                            "skipped_no_failures"
+                        ],
+                        "type": "string",
+                        "description": "* `pending` - Pending\n* `running` - Running\n* `succeeded` - Succeeded\n* `failed` - Failed\n* `skipped_no_failures` - Skipped No Failures",
+                        "x-spec-enum-id": "7052652d8ca01a2a",
+                        "readOnly": true
+                    },
+                    "headline": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "overall_status_emoji": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "failure_modes": {
+                        "readOnly": true
+                    },
+                    "error_message": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "duration_seconds": {
+                        "type": [
+                            "number",
+                            "null"
+                        ],
+                        "format": "double",
+                        "readOnly": true
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    }
+                }
+            },
+            "MetricFailureModeInsightGenerate": {
+                "type": "object",
+                "description": "Request body for ``POST /metric-failure-mode-insights/generate/``.",
+                "properties": {
+                    "project": {
+                        "type": "integer",
+                        "description": "Project ID to generate insights for."
+                    },
+                    "metric": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
+                        "description": "Custom Metric ID (omit for predefined metric)."
+                    },
+                    "predefined_metric": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
+                        "description": "PredefinedMetric ID (omit for custom metric)."
+                    },
+                    "metric_name": {
+                        "type": "string",
+                        "description": "Metric display name — must match call_log.evaluation.metrics[].name.",
+                        "maxLength": 255
+                    },
+                    "window_days": {
+                        "type": "integer",
+                        "maximum": 90,
+                        "minimum": 1,
+                        "default": 7
+                    },
+                    "max_calls": {
+                        "type": "integer",
+                        "maximum": 2000,
+                        "minimum": 10,
+                        "default": 500
+                    }
+                },
+                "required": [
+                    "metric_name",
+                    "project"
                 ]
             },
             "MetricHistory": {
@@ -53333,6 +56134,98 @@
                 },
                 "required": [
                     "name"
+                ]
+            },
+            "MetricOptimiserCronJob": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "project": {
+                        "type": "integer",
+                        "description": "Project ID this cron job belongs to."
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Display name for the cronjob.",
+                        "maxLength": 255
+                    },
+                    "metrics": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        },
+                        "description": "Metric IDs the cron job will optimise on each firing."
+                    },
+                    "crontab_expression": {
+                        "type": "string",
+                        "description": "Standard 5-field cron expression (minute hour dom mon dow).",
+                        "maxLength": 255
+                    },
+                    "timezone": {
+                        "type": "string",
+                        "description": "IANA timezone name (e.g. America/Los_Angeles). Defaults to UTC."
+                    },
+                    "auto_apply": {
+                        "type": "boolean",
+                        "description": "If true, overwrite the live metric prompt with the optimised one whenever the optimised score is >= baseline on the labelled set. Defaults to false (read-only)."
+                    },
+                    "skip_evaluation": {
+                        "type": "boolean",
+                        "description": "Skip the post-optimisation evaluation pass to speed up the cron."
+                    },
+                    "is_active": {
+                        "type": "boolean"
+                    },
+                    "notify_on": {
+                        "enum": [
+                            "never",
+                            "success",
+                            "failure",
+                            "both"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "d06ae6855e4121c0",
+                        "description": "When to email project members about the run outcome.\n\n* `never` - Never\n* `success` - Success\n* `failure` - Failure\n* `both` - Both"
+                    },
+                    "created_by": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "created_via": {
+                        "enum": [
+                            "user",
+                            "api",
+                            "mcp",
+                            "cli",
+                            "sdk",
+                            null
+                        ],
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "* `user` - User\n* `api` - API\n* `mcp` - MCP\n* `cli` - CLI\n* `sdk` - SDK",
+                        "x-spec-enum-id": "360ac7f2b69a95cc",
+                        "readOnly": true
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    }
+                },
+                "required": [
+                    "crontab_expression",
+                    "metrics",
+                    "project"
                 ]
             },
             "MetricPreview": {
@@ -54503,6 +57396,15 @@
                         "type": "boolean",
                         "description": "Allow VIEW_ONLY role for memberships/invites on this pack. When False, view-only seats are blocked."
                     },
+                    "data_retention_days": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
+                        "maximum": 2147483647,
+                        "minimum": -2147483648,
+                        "description": "Data retention period in days. Leave blank to skip archival for this plan."
+                    },
                     "created_at": {
                         "type": "string",
                         "format": "date-time",
@@ -54677,6 +57579,15 @@
                         "type": "boolean",
                         "description": "Allow VIEW_ONLY role for memberships/invites on this pack. When False, view-only seats are blocked."
                     },
+                    "data_retention_days": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
+                        "maximum": 2147483647,
+                        "minimum": -2147483648,
+                        "description": "Data retention period in days. Leave blank to skip archival for this plan."
+                    },
                     "extra_member_price": {
                         "type": "string",
                         "readOnly": true
@@ -54744,6 +57655,37 @@
                         "type": "array",
                         "items": {
                             "$ref": "#/components/schemas/AIAgentList"
+                        }
+                    }
+                }
+            },
+            "PaginatedAIAgentV2List": {
+                "type": "object",
+                "required": [
+                    "count",
+                    "results"
+                ],
+                "properties": {
+                    "count": {
+                        "type": "integer",
+                        "example": 123
+                    },
+                    "next": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "https://api.cekura.ai/example/v1/example-external/?page=4"
+                    },
+                    "previous": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "https://api.cekura.ai/example/v1/example-external/?page=3"
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/AIAgentV2"
                         }
                     }
                 }
@@ -55306,6 +58248,162 @@
                     }
                 }
             },
+            "PatchedAIAgentDynamicVariable": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Variable name exactly as it appears in the agent context (e.g. 'firstName', 'leadId')",
+                        "maxLength": 255
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "What this variable represents and its expected format / type. Example: \"The user's date of birth on file, in YYYY-MM-DD format\""
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    }
+                }
+            },
+            "PatchedAIAgentV2": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "readOnly": true,
+                        "description": "Agent ID.\nExample: `2142`"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Agent name.",
+                        "maxLength": 255
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "\nA detailed description of what this agent does and how it should interact\nExample: \n```text\nAI agent for handling customer support inquiries and resolving technical issues\n```\n"
+                    },
+                    "project": {
+                        "type": "integer",
+                        "description": "The project this agent belongs to"
+                    },
+                    "language": {
+                        "enum": [
+                            "af",
+                            "ar",
+                            "bn",
+                            "bg",
+                            "zh",
+                            "cs",
+                            "da",
+                            "nl",
+                            "en",
+                            "et",
+                            "fi",
+                            "fr",
+                            "de",
+                            "el",
+                            "gu",
+                            "hi",
+                            "he",
+                            "hu",
+                            "id",
+                            "it",
+                            "ja",
+                            "kn",
+                            "ko",
+                            "ms",
+                            "ml",
+                            "mr",
+                            "multi",
+                            "no",
+                            "pl",
+                            "pa",
+                            "pt",
+                            "ro",
+                            "ru",
+                            "sk",
+                            "es",
+                            "sv",
+                            "th",
+                            "tr",
+                            "tl",
+                            "ta",
+                            "te",
+                            "uk",
+                            "vi"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "b822ad429c7b7fec",
+                        "default": "en",
+                        "description": "\nThe primary language this agent uses for communication (e.g. 'en' for English)\n\n\n* `af` - Afrikaans\n* `ar` - Arabic\n* `bn` - Bengali\n* `bg` - Bulgarian\n* `zh` - Chinese Simplified\n* `cs` - Czech\n* `da` - Danish\n* `nl` - Dutch\n* `en` - English\n* `et` - Estonian\n* `fi` - Finnish\n* `fr` - French\n* `de` - German\n* `el` - Greek\n* `gu` - Gujarati\n* `hi` - Hindi\n* `he` - Hebrew\n* `hu` - Hungarian\n* `id` - Indonesian\n* `it` - Italian\n* `ja` - Japanese\n* `kn` - Kannada\n* `ko` - Korean\n* `ms` - Malay\n* `ml` - Malayalam\n* `mr` - Marathi\n* `multi` - Multilingual\n* `no` - Norwegian\n* `pl` - Polish\n* `pa` - Punjabi\n* `pt` - Portuguese\n* `ro` - Romanian\n* `ru` - Russian\n* `sk` - Slovak\n* `es` - Spanish\n* `sv` - Swedish\n* `th` - Thai\n* `tr` - Turkish\n* `tl` - Tagalog\n* `ta` - Tamil\n* `te` - Telugu\n* `uk` - Ukrainian\n* `vi` - Vietnamese"
+                    },
+                    "telephony": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/AgentTelephony"
+                            }
+                        ],
+                        "writeOnly": true,
+                        "description": "Phone and SIP channel configuration."
+                    },
+                    "provider": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/AgentProvider"
+                            }
+                        ],
+                        "writeOnly": true,
+                        "description": "AI platform integration. Nested credentials replace the flat {provider}_api_key fields."
+                    },
+                    "agent_speaks_first": {
+                        "type": [
+                            "boolean",
+                            "null"
+                        ],
+                        "description": "True = agent speaks first; False = test user speaks first; null = auto-detect."
+                    },
+                    "predefined_metrics": {
+                        "writeOnly": true,
+                        "description": "predefined metrics to use for the agent"
+                    },
+                    "knowledge_base_files": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "\nList of knowledge base files attached to the agent\nExample: `[1, 2, 3]`\n"
+                    },
+                    "enabled_personalities": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        },
+                        "readOnly": true,
+                        "description": "\nPersonality profiles enabled for this agent\nExample: `[1, 2, 3]`\n"
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "description": "\nTimestamp when the agent was created\nExample: `\"2021-01-01T00:00:00Z\"`\n"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "description": "\nTimestamp when the agent was last updated\nExample: `\"2021-01-01T00:00:00Z\"`\n"
+                    }
+                }
+            },
             "PatchedAlertUpdate": {
                 "type": "object",
                 "description": "",
@@ -55320,24 +58418,13 @@
                         "description": "Enable/disable alert"
                     },
                     "source": {
-                        "description": "Source config keyed on `sub_type`. `normal`: {sub_type, filters?}. `significant_change`: {sub_type, window_size, filters?}. `threshold`: {sub_type, window_size, filters?}. `filters` is an optional CallLogQueryFilter expression."
+                        "description": "Source config. For metrics: {\"sub_type\": \"normal\"|\"significant_change\", \"filters\": {...}, \"window_size\": 50}"
                     },
                     "threshold": {
-                        "description": "Threshold config keyed on the source's `sub_type`. `normal`: {} (fires on every failing eval). `significant_change`: {std_multiplier, ewma_alpha, direction}. `threshold`: {operator (gt|lt|outside), value (number | {low, high}), min_breaches}."
+                        "description": "Threshold config. Normal metric: {\"condition\": \"value_lt_5\"}. Significant change: {\"std_multiplier\": 2.0, \"ewma_alpha\": 0.1, \"direction\": \"both\"}. Duration/volume: {\"operator\": \"gt\", \"value\": 300}"
                     },
                     "notifications": {
-                        "description": "Notification routing. `{slack: {workspace_id, channel_id?}}` to send to a specific workspace/channel. Empty fans out to every project workspace; empty + no project workspaces means the alert is silent."
-                    },
-                    "preset": {
-                        "enum": [
-                            "conservative",
-                            "balanced",
-                            "aggressive"
-                        ],
-                        "type": "string",
-                        "x-spec-enum-id": "a6fd953985219e0b",
-                        "writeOnly": true,
-                        "description": "Optional shorthand for trend alerts: 'conservative' | 'balanced' | 'aggressive'. Expands to std_multiplier / ewma_alpha / window_size. Explicit values in `source` or `threshold` override the preset. Ignored unless the alert's sub_type == 'significant_change'.\n\n* `conservative` - conservative\n* `balanced` - balanced\n* `aggressive` - aggressive"
+                        "description": "Notification config. Slack: {\"slack\": {\"workspace_id\": 10, \"channel_id\": \"C123\"}}. Empty = all project workspaces"
                     }
                 }
             },
@@ -55508,6 +58595,11 @@
                         "type": "string",
                         "description": "Unique identifier for the call.\nExample: \n- `\"call_abc123xyz\"`\n- `\"stereo_audio_session_456\"`",
                         "maxLength": 100
+                    },
+                    "trace_id": {
+                        "type": "string",
+                        "description": "OpenTelemetry trace ID (32-char hex). Set when OTel tracing is enabled.",
+                        "maxLength": 32
                     },
                     "agent": {
                         "type": [
@@ -56147,6 +59239,93 @@
                     }
                 }
             },
+            "PatchedMetricOptimiserCronJob": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "project": {
+                        "type": "integer",
+                        "description": "Project ID this cron job belongs to."
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Display name for the cronjob.",
+                        "maxLength": 255
+                    },
+                    "metrics": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        },
+                        "description": "Metric IDs the cron job will optimise on each firing."
+                    },
+                    "crontab_expression": {
+                        "type": "string",
+                        "description": "Standard 5-field cron expression (minute hour dom mon dow).",
+                        "maxLength": 255
+                    },
+                    "timezone": {
+                        "type": "string",
+                        "description": "IANA timezone name (e.g. America/Los_Angeles). Defaults to UTC."
+                    },
+                    "auto_apply": {
+                        "type": "boolean",
+                        "description": "If true, overwrite the live metric prompt with the optimised one whenever the optimised score is >= baseline on the labelled set. Defaults to false (read-only)."
+                    },
+                    "skip_evaluation": {
+                        "type": "boolean",
+                        "description": "Skip the post-optimisation evaluation pass to speed up the cron."
+                    },
+                    "is_active": {
+                        "type": "boolean"
+                    },
+                    "notify_on": {
+                        "enum": [
+                            "never",
+                            "success",
+                            "failure",
+                            "both"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "d06ae6855e4121c0",
+                        "description": "When to email project members about the run outcome.\n\n* `never` - Never\n* `success` - Success\n* `failure` - Failure\n* `both` - Both"
+                    },
+                    "created_by": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "created_via": {
+                        "enum": [
+                            "user",
+                            "api",
+                            "mcp",
+                            "cli",
+                            "sdk",
+                            null
+                        ],
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "* `user` - User\n* `api` - API\n* `mcp` - MCP\n* `cli` - CLI\n* `sdk` - SDK",
+                        "x-spec-enum-id": "360ac7f2b69a95cc",
+                        "readOnly": true
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    }
+                }
+            },
             "PatchedMetricReviewInline": {
                 "type": "object",
                 "properties": {
@@ -56672,105 +59851,6 @@
                     }
                 }
             },
-            "PatchedPhoneNumber": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
-                    "scenario_id": {
-                        "type": "string",
-                        "readOnly": true
-                    },
-                    "scenario_name": {
-                        "type": "string",
-                        "readOnly": true
-                    },
-                    "number": {
-                        "type": "string",
-                        "maxLength": 15
-                    },
-                    "phone_number_id": {
-                        "type": "string",
-                        "maxLength": 255
-                    },
-                    "call_service_provider": {
-                        "enum": [
-                            "vapi",
-                            "patronus"
-                        ],
-                        "type": "string",
-                        "x-spec-enum-id": "f442d6949d5b96ff",
-                        "description": "Call service provider this phone number is associated with.\nExample: `\"vapi\"` or `\"retell\"`\n\n* `vapi` - VAPI\n* `patronus` - Patronus"
-                    },
-                    "name": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "Name or identifier for this phone number",
-                        "maxLength": 255
-                    },
-                    "provider": {
-                        "enum": [
-                            "cekura",
-                            "twilio",
-                            "telnyx",
-                            "plivo",
-                            null
-                        ],
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "x-spec-enum-id": "0a9c3a00dd5354a9",
-                        "description": "Provider of this phone number (Cekura or Twilio)\n\n* `cekura` - Cekura\n* `twilio` - Twilio\n* `telnyx` - Telnyx\n* `plivo` - Plivo"
-                    },
-                    "sms_enabled": {
-                        "type": [
-                            "boolean",
-                            "null"
-                        ],
-                        "description": "Whether SMS is enabled for this phone number"
-                    },
-                    "metadata": {
-                        "oneOf": [
-                            {},
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "description": "Encrypted provider credentials and other metadata"
-                    },
-                    "created_at": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "format": "date-time",
-                        "description": "When this record was created.\nExample: `2024-03-15T10:30:45Z`"
-                    },
-                    "updated_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "description": "When this record was last updated.\nExample: `2024-03-15T10:35:11Z`"
-                    },
-                    "organization": {
-                        "type": [
-                            "integer",
-                            "null"
-                        ]
-                    },
-                    "user": {
-                        "type": [
-                            "integer",
-                            "null"
-                        ]
-                    }
-                }
-            },
             "PatchedPredefinedMetric": {
                 "type": "object",
                 "properties": {
@@ -57233,13 +60313,13 @@
                             "koreai",
                             "custom",
                             "agentforce",
-                            "trillet",
                             "genesys",
-                            "chirp"
+                            "chirp",
+                            "amazon_connect"
                         ],
                         "type": "string",
-                        "description": "* `vapi` - Vapi\n* `retell` - Retell\n* `synthflow` - Synthflow\n* `elevenlabs` - Elevenlabs\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `koreai` - Kore\n* `custom` - Custom\n* `agentforce` - Agentforce\n* `trillet` - Trillet\n* `genesys` - Genesys\n* `chirp` - Chirp",
-                        "x-spec-enum-id": "399049906f2153fc"
+                        "description": "* `vapi` - Vapi\n* `retell` - Retell\n* `synthflow` - Synthflow\n* `elevenlabs` - Elevenlabs\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `koreai` - Kore\n* `custom` - Custom\n* `agentforce` - Agentforce\n* `genesys` - Genesys\n* `chirp` - Chirp\n* `amazon_connect` - Amazon Connect",
+                        "x-spec-enum-id": "762c611fc8db42f9"
                     },
                     "key": {
                         "type": "string",
@@ -57466,6 +60546,11 @@
                         "type": "string",
                         "readOnly": true,
                         "description": "\nCall ID from the Assistant provider\nExample: `call_abc123`\n"
+                    },
+                    "trace_id": {
+                        "type": "string",
+                        "description": "OpenTelemetry trace ID (32-char hex). Set when OTel tracing is enabled.",
+                        "maxLength": 32
                     },
                     "scenario": {
                         "type": [
@@ -58018,7 +61103,7 @@
                     "configuration": {
                         "type": "object",
                         "additionalProperties": {},
-                        "description": "\nCustom configuration parameters for specific metrics.\nFor pronounciation metric, you can set `words` as 2-tuple (word, phonemes) list\nexample:\n```json\n{\n    \"words\": [[\"hello\", \"hɛl.loʊ\"], [\"world\", \"wɝɚɚɚld\"]]\n}\n```\n"
+                        "description": "Per-metric configuration.\n\nSome predefined metrics carry **per-agent** configuration, keyed by agent id: `configuration[<key>] = {\"<agent_id>\": <value>}`. On read, every agent attached to the metric is returned; on write, only the agent ids you include are updated.\n\nCall-level keys (not per-agent):\n* **Detect Silence** — `silence_duration` (int, seconds, default 10): minimum mutual silence before flagging a failure.\n* **Infrastructure Issues** — `infra_issues_timeout` (int, seconds, default 10): max seconds before the Main Agent must respond after the Testing Agent finishes speaking.\n\nPer-agent keys (each value is `{\"<agent_id>\": <value>}`):\n* **Dropoff Node** — `nodes`: `{\"<agent_id>\": [{name, description}]}` — conversation stages used to classify where a call dropped off.\n* **Topic of Call** — `nodes`: `{\"<agent_id>\": [{name, description}]}` — topic categories used to classify each call.\n* **Pronunciation Check** — `pronunciation_words`: `{\"<agent_id>\": [[word, phonemes], ...]}` — how specific words should be pronounced (e.g. {\"42\": [[\"Cekura\", \"suh-KYUR-uh\"]]}).\n* **Letterwise Pronunciation** — `spelling_word_types`: `{\"<agent_id>\": [\"name\", \"email\", ...]}` — word categories the Main Agent must spell out letter-by-letter.\n* **Hallucination** — `hallucination_kb_files`: `{\"<agent_id>\": [file_id, ...]}` — KnowledgeBaseFile IDs used as the source of truth for fact-checking."
                     },
                     "add_to_new_agents": {
                         "type": [
@@ -58351,16 +61436,15 @@
                             "pipecat",
                             "koreai",
                             "custom",
-                            "trillet",
                             "cisco",
                             "genesys",
                             "chirp",
                             ""
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "43adf9cc06494c10",
+                        "x-spec-enum-id": "64a9d3237300a426",
                         "default": "",
-                        "description": "\nService provider for speech-to-text transcription\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `synthflow` - Synthflow\n* `elevenlabs` - Elevenlabs\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `koreai` - Kore\n* `custom` - Custom\n* `trillet` - Trillet\n* `cisco` - Cisco\n* `genesys` - Genesys\n* `chirp` - Chirp"
+                        "description": "\nService provider for speech-to-text transcription\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `synthflow` - Synthflow\n* `elevenlabs` - Elevenlabs\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `koreai` - Kore\n* `custom` - Custom\n* `cisco` - Cisco\n* `genesys` - Genesys\n* `chirp` - Chirp"
                     },
                     "assistant_provider": {
                         "enum": [
@@ -58372,16 +61456,21 @@
                             "whatsapp",
                             "self_hosted",
                             "agentforce",
-                            "trillet",
                             "cisco",
                             "bland",
                             "livekit",
+                            "pipecat",
+                            "synthflow",
+                            "chirp",
+                            "koreai",
+                            "genesys",
+                            "amazon_connect",
                             ""
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "a7ddfee511394575",
+                        "x-spec-enum-id": "e4a9e996f7d53c98",
                         "default": "",
-                        "description": "\nService provider for the AI assistant functionality. Valid values (live enum):\n\n- `self_hosted` — websocket or observation-only; no api_key needed. Use `websocket_url` + `websocket_headers` for text-mode runs.\n- `vapi` — requires `vapi_api_key`; optional `assistant_id`, `vapi_data.public_key`.\n- `retell` — requires `retell_api_key` AND `chat_assistant_id` (used for voice too).\n- `bland` — requires `bland_api_key` AND `chat_assistant_id` (Bland calls this `pathway_id`); `bland_data.encrypted_key` for Twilio.\n- `livekit` — requires `livekit_api_key` + `livekit_data.api_secret` + `livekit_data.url`.\n- `elevenlabs` — requires `elevenlabs_api_key`.\n- `agentforce` — requires `agentforce_client_secret` + `agentforce_data`.\n- `trillet` — requires `trillet_api_key` + `trillet_data.workspace_id`.\n- `cisco` — Cisco Webex.\n- `vocera` — Cekura-hosted.\n- `sms` / `whatsapp` — text-only channels; use `chat_assistant_id`.\n- `\"\"` (empty) — unset; agent is not runnable until a provider is configured.\n\nNote: the serializer also exposes `pipecat_*`, `synthflow_*`, `koreai_*`, `genesys_*`, `custom_provider_*` fields, but those provider values are not currently selectable in this enum.\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `elevenlabs` - Elevenlabs\n* `vocera` - Vocera\n* `sms` - Sms\n* `whatsapp` - Whatsapp\n* `self_hosted` - Self Hosted\n* `agentforce` - Agentforce\n* `trillet` - Trillet\n* `cisco` - Cisco\n* `bland` - Bland\n* `livekit` - Livekit"
+                        "description": "\nService provider for the AI assistant functionality. Valid values (live enum):\n\n- `self_hosted` — websocket or observation-only; no api_key needed. Use `websocket_url` + `websocket_headers` for text-mode runs.\n- `vapi` — requires `vapi_api_key`; optional `assistant_id`, `vapi_data.public_key`.\n- `retell` — requires `retell_api_key` AND `chat_assistant_id` (used for voice too).\n- `bland` — requires `bland_api_key` AND `chat_assistant_id` (Bland calls this `pathway_id`); `bland_data.encrypted_key` for Twilio.\n- `livekit` — requires `livekit_api_key` + `livekit_data.api_secret` + `livekit_data.url`.\n- `elevenlabs` — requires `elevenlabs_api_key`.\n- `agentforce` — requires `agentforce_client_secret` + `agentforce_data`.\n- `amazon_connect` — requires `amazon_connect_data` with `snippet_id` and `connect_host`; optional `amazon_connect_security_token` and `region`.\n- `cisco` — Cisco Webex.\n- `vocera` — Cekura-hosted.\n- `sms` / `whatsapp` — text-only channels; use `chat_assistant_id`.\n- `\"\"` (empty) — unset; agent is not runnable until a provider is configured.\n\nNote: the serializer also exposes `pipecat_*`, `synthflow_*`, `koreai_*`, `genesys_*`, `custom_provider_*` fields, but those provider values are not currently selectable in this enum.\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `elevenlabs` - Elevenlabs\n* `vocera` - Vocera\n* `sms` - Sms\n* `whatsapp` - Whatsapp\n* `self_hosted` - Self Hosted\n* `agentforce` - Agentforce\n* `cisco` - Cisco\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `synthflow` - Synthflow\n* `chirp` - Chirp\n* `koreai` - Koreai\n* `genesys` - Genesys\n* `amazon_connect` - Amazon Connect"
                     },
                     "vapi_api_key": {
                         "type": "string",
@@ -58492,6 +61581,19 @@
                         "type": "string",
                         "description": "\nAgentforce additional data - client_id, domain, and agent_id\nExample: `{\"client_id\": \"sd7a8...\", \"domain\": \"https://example.sandbox.my.salesforce.com\", \"agent_id\": \"0Xx...\"}`\n"
                     },
+                    "amazon_connect_security_token": {
+                        "type": "string",
+                        "writeOnly": true,
+                        "description": "x-amz-security-token for Amazon Connect authenticated chat widgets."
+                    },
+                    "amazon_connect_security_token_configured": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "amazon_connect_data": {
+                        "type": "string",
+                        "description": "Amazon Connect config: snippet_id (required), connect_host (required), region (default us-east-1)."
+                    },
                     "custom_provider_api_key": {
                         "type": "string",
                         "writeOnly": true,
@@ -58516,19 +61618,6 @@
                     "elevenlabs_data": {
                         "type": "string",
                         "description": "\nElevenLabs additional configuration data\nExample: `{\"trigger_url\": \"https://example.com/trigger\"}`\n"
-                    },
-                    "trillet_api_key": {
-                        "type": "string",
-                        "writeOnly": true,
-                        "description": "\nAPI key for Trillet AI service provider\nExample: `\"trillet_api_key_123\"`\n"
-                    },
-                    "trillet_api_key_configured": {
-                        "type": "string",
-                        "readOnly": true
-                    },
-                    "trillet_data": {
-                        "type": "string",
-                        "description": "\nTrillet AI additional data including Workspace ID\nExample: `{\"workspace_id\": \"1234567890\"}`\n"
                     },
                     "chirp_data": {
                         "type": "string",
@@ -59551,6 +62640,31 @@
                     "phone_number_id"
                 ]
             },
+            "PipecatConfig": {
+                "type": "object",
+                "description": "Pipecat provider configuration.",
+                "properties": {
+                    "pipecat_agent_name": {
+                        "type": "string",
+                        "description": "Name of the Pipecat agent. Required when tracing_enabled is false."
+                    },
+                    "config": {
+                        "description": "Additional agent configuration as a JSON object."
+                    },
+                    "room_properties": {
+                        "description": "Room properties configuration as a JSON object."
+                    },
+                    "webhook_url": {
+                        "type": "string",
+                        "description": "Webhook URL for Pipecat call events."
+                    },
+                    "tracing_enabled": {
+                        "type": "boolean",
+                        "description": "Enable Pipecat tracing (requires Cekura SDK integrated in your Pipecat agent). When true, pipecat_agent_name is not required."
+                    }
+                },
+                "title": "Pipecat"
+            },
             "PredefinedMetric": {
                 "type": "object",
                 "properties": {
@@ -59719,8 +62833,7 @@
                         "items": {
                             "type": "integer"
                         },
-                        "description": "List of test set IDs to process feedbacks from",
-                        "minItems": 1
+                        "description": "Test set IDs whose feedback drives the optimization. If omitted, defaults to every test set already added to this metric's Lab."
                     },
                     "simplified_prompt": {
                         "type": "string",
@@ -59733,8 +62846,7 @@
                     }
                 },
                 "required": [
-                    "metric_id",
-                    "test_set_ids"
+                    "metric_id"
                 ]
             },
             "ProcessFeedbacksResponse": {
@@ -60173,13 +63285,13 @@
                             "koreai",
                             "custom",
                             "agentforce",
-                            "trillet",
                             "genesys",
-                            "chirp"
+                            "chirp",
+                            "amazon_connect"
                         ],
                         "type": "string",
-                        "description": "* `vapi` - Vapi\n* `retell` - Retell\n* `synthflow` - Synthflow\n* `elevenlabs` - Elevenlabs\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `koreai` - Kore\n* `custom` - Custom\n* `agentforce` - Agentforce\n* `trillet` - Trillet\n* `genesys` - Genesys\n* `chirp` - Chirp",
-                        "x-spec-enum-id": "399049906f2153fc"
+                        "description": "* `vapi` - Vapi\n* `retell` - Retell\n* `synthflow` - Synthflow\n* `elevenlabs` - Elevenlabs\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `koreai` - Kore\n* `custom` - Custom\n* `agentforce` - Agentforce\n* `genesys` - Genesys\n* `chirp` - Chirp\n* `amazon_connect` - Amazon Connect",
+                        "x-spec-enum-id": "762c611fc8db42f9"
                     },
                     "key": {
                         "type": "string",
@@ -60227,13 +63339,13 @@
                             "koreai",
                             "custom",
                             "agentforce",
-                            "trillet",
                             "genesys",
-                            "chirp"
+                            "chirp",
+                            "amazon_connect"
                         ],
                         "type": "string",
-                        "description": "* `vapi` - Vapi\n* `retell` - Retell\n* `synthflow` - Synthflow\n* `elevenlabs` - Elevenlabs\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `koreai` - Kore\n* `custom` - Custom\n* `agentforce` - Agentforce\n* `trillet` - Trillet\n* `genesys` - Genesys\n* `chirp` - Chirp",
-                        "x-spec-enum-id": "399049906f2153fc"
+                        "description": "* `vapi` - Vapi\n* `retell` - Retell\n* `synthflow` - Synthflow\n* `elevenlabs` - Elevenlabs\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `koreai` - Kore\n* `custom` - Custom\n* `agentforce` - Agentforce\n* `genesys` - Genesys\n* `chirp` - Chirp\n* `amazon_connect` - Amazon Connect",
+                        "x-spec-enum-id": "762c611fc8db42f9"
                     },
                     "created_at": {
                         "type": "string",
@@ -60241,6 +63353,43 @@
                         "readOnly": true
                     }
                 }
+            },
+            "ProviderCredentialsConfig": {
+                "oneOf": [
+                    {
+                        "$ref": "#/components/schemas/VapiConfig"
+                    },
+                    {
+                        "$ref": "#/components/schemas/RetellConfig"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ElevenLabsConfig"
+                    },
+                    {
+                        "$ref": "#/components/schemas/BlandConfig"
+                    },
+                    {
+                        "$ref": "#/components/schemas/LiveKitConfig"
+                    },
+                    {
+                        "$ref": "#/components/schemas/SynthflowConfig"
+                    },
+                    {
+                        "$ref": "#/components/schemas/KoreAiConfig"
+                    },
+                    {
+                        "$ref": "#/components/schemas/GenesysConfig"
+                    },
+                    {
+                        "$ref": "#/components/schemas/PipecatConfig"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ChirpConfig"
+                    },
+                    {
+                        "$ref": "#/components/schemas/SelfHostedConfig"
+                    }
+                ]
             },
             "RenameFolderRequest": {
                 "type": "object",
@@ -60608,6 +63757,35 @@
                     "agent"
                 ]
             },
+            "RetellChatConfig": {
+                "type": "object",
+                "description": "Retell chat configuration.",
+                "properties": {
+                    "agent_id": {
+                        "type": "string",
+                        "description": "The Retell agent ID to use for text-mode test runs."
+                    }
+                },
+                "required": [
+                    "agent_id"
+                ],
+                "title": "Retell"
+            },
+            "RetellConfig": {
+                "type": "object",
+                "description": "Retell provider configuration.",
+                "properties": {
+                    "trigger_url": {
+                        "type": "string",
+                        "description": "URL Cekura calls to create outbound Retell phone calls."
+                    },
+                    "livekit_server_url": {
+                        "type": "string",
+                        "description": "Override the default Retell LiveKit server URL, e.g. wss://retell-ai-4ihahnq7.livekit.cloud. Only change if you need a specific Retell region."
+                    }
+                },
+                "title": "Retell"
+            },
             "ReviewResult": {
                 "type": "object",
                 "properties": {
@@ -60660,6 +63838,11 @@
                         "type": "string",
                         "readOnly": true,
                         "description": "\nCall ID from the Assistant provider\nExample: `call_abc123`\n"
+                    },
+                    "trace_id": {
+                        "type": "string",
+                        "description": "OpenTelemetry trace ID (32-char hex). Set when OTel tracing is enabled.",
+                        "maxLength": 32
                     },
                     "scenario": {
                         "type": [
@@ -60897,6 +64080,11 @@
                         "type": "string",
                         "description": "\nCall ID from the Assistant provider\nExample: `call_abc123`\n",
                         "maxLength": 255
+                    },
+                    "trace_id": {
+                        "type": "string",
+                        "description": "OpenTelemetry trace ID (32-char hex). Set when OTel tracing is enabled.",
+                        "maxLength": 32
                     },
                     "scenario": {
                         "type": [
@@ -63465,7 +66653,7 @@
                     "configuration": {
                         "type": "object",
                         "additionalProperties": {},
-                        "description": "\nCustom configuration parameters for specific metrics.\nFor pronounciation metric, you can set `words` as 2-tuple (word, phonemes) list\nexample:\n```json\n{\n    \"words\": [[\"hello\", \"hɛl.loʊ\"], [\"world\", \"wɝɚɚɚld\"]]\n}\n```\n"
+                        "description": "Per-metric configuration.\n\nSome predefined metrics carry **per-agent** configuration, keyed by agent id: `configuration[<key>] = {\"<agent_id>\": <value>}`. On read, every agent attached to the metric is returned; on write, only the agent ids you include are updated.\n\nCall-level keys (not per-agent):\n* **Detect Silence** — `silence_duration` (int, seconds, default 10): minimum mutual silence before flagging a failure.\n* **Infrastructure Issues** — `infra_issues_timeout` (int, seconds, default 10): max seconds before the Main Agent must respond after the Testing Agent finishes speaking.\n\nPer-agent keys (each value is `{\"<agent_id>\": <value>}`):\n* **Dropoff Node** — `nodes`: `{\"<agent_id>\": [{name, description}]}` — conversation stages used to classify where a call dropped off.\n* **Topic of Call** — `nodes`: `{\"<agent_id>\": [{name, description}]}` — topic categories used to classify each call.\n* **Pronunciation Check** — `pronunciation_words`: `{\"<agent_id>\": [[word, phonemes], ...]}` — how specific words should be pronounced (e.g. {\"42\": [[\"Cekura\", \"suh-KYUR-uh\"]]}).\n* **Letterwise Pronunciation** — `spelling_word_types`: `{\"<agent_id>\": [\"name\", \"email\", ...]}` — word categories the Main Agent must spell out letter-by-letter.\n* **Hallucination** — `hallucination_kb_files`: `{\"<agent_id>\": [file_id, ...]}` — KnowledgeBaseFile IDs used as the source of truth for fact-checking."
                     },
                     "add_to_new_agents": {
                         "type": [
@@ -64375,16 +67563,15 @@
                             "pipecat",
                             "koreai",
                             "custom",
-                            "trillet",
                             "cisco",
                             "genesys",
                             "chirp",
                             ""
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "43adf9cc06494c10",
+                        "x-spec-enum-id": "64a9d3237300a426",
                         "default": "",
-                        "description": "\nService provider for speech-to-text transcription\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `synthflow` - Synthflow\n* `elevenlabs` - Elevenlabs\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `koreai` - Kore\n* `custom` - Custom\n* `trillet` - Trillet\n* `cisco` - Cisco\n* `genesys` - Genesys\n* `chirp` - Chirp"
+                        "description": "\nService provider for speech-to-text transcription\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `synthflow` - Synthflow\n* `elevenlabs` - Elevenlabs\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `koreai` - Kore\n* `custom` - Custom\n* `cisco` - Cisco\n* `genesys` - Genesys\n* `chirp` - Chirp"
                     },
                     "assistant_provider": {
                         "enum": [
@@ -64396,16 +67583,21 @@
                             "whatsapp",
                             "self_hosted",
                             "agentforce",
-                            "trillet",
                             "cisco",
                             "bland",
                             "livekit",
+                            "pipecat",
+                            "synthflow",
+                            "chirp",
+                            "koreai",
+                            "genesys",
+                            "amazon_connect",
                             ""
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "a7ddfee511394575",
+                        "x-spec-enum-id": "e4a9e996f7d53c98",
                         "default": "",
-                        "description": "\nService provider for the AI assistant functionality. Valid values (live enum):\n\n- `self_hosted` — websocket or observation-only; no api_key needed. Use `websocket_url` + `websocket_headers` for text-mode runs.\n- `vapi` — requires `vapi_api_key`; optional `assistant_id`, `vapi_data.public_key`.\n- `retell` — requires `retell_api_key` AND `chat_assistant_id` (used for voice too).\n- `bland` — requires `bland_api_key` AND `chat_assistant_id` (Bland calls this `pathway_id`); `bland_data.encrypted_key` for Twilio.\n- `livekit` — requires `livekit_api_key` + `livekit_data.api_secret` + `livekit_data.url`.\n- `elevenlabs` — requires `elevenlabs_api_key`.\n- `agentforce` — requires `agentforce_client_secret` + `agentforce_data`.\n- `trillet` — requires `trillet_api_key` + `trillet_data.workspace_id`.\n- `cisco` — Cisco Webex.\n- `vocera` — Cekura-hosted.\n- `sms` / `whatsapp` — text-only channels; use `chat_assistant_id`.\n- `\"\"` (empty) — unset; agent is not runnable until a provider is configured.\n\nNote: the serializer also exposes `pipecat_*`, `synthflow_*`, `koreai_*`, `genesys_*`, `custom_provider_*` fields, but those provider values are not currently selectable in this enum.\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `elevenlabs` - Elevenlabs\n* `vocera` - Vocera\n* `sms` - Sms\n* `whatsapp` - Whatsapp\n* `self_hosted` - Self Hosted\n* `agentforce` - Agentforce\n* `trillet` - Trillet\n* `cisco` - Cisco\n* `bland` - Bland\n* `livekit` - Livekit"
+                        "description": "\nService provider for the AI assistant functionality. Valid values (live enum):\n\n- `self_hosted` — websocket or observation-only; no api_key needed. Use `websocket_url` + `websocket_headers` for text-mode runs.\n- `vapi` — requires `vapi_api_key`; optional `assistant_id`, `vapi_data.public_key`.\n- `retell` — requires `retell_api_key` AND `chat_assistant_id` (used for voice too).\n- `bland` — requires `bland_api_key` AND `chat_assistant_id` (Bland calls this `pathway_id`); `bland_data.encrypted_key` for Twilio.\n- `livekit` — requires `livekit_api_key` + `livekit_data.api_secret` + `livekit_data.url`.\n- `elevenlabs` — requires `elevenlabs_api_key`.\n- `agentforce` — requires `agentforce_client_secret` + `agentforce_data`.\n- `amazon_connect` — requires `amazon_connect_data` with `snippet_id` and `connect_host`; optional `amazon_connect_security_token` and `region`.\n- `cisco` — Cisco Webex.\n- `vocera` — Cekura-hosted.\n- `sms` / `whatsapp` — text-only channels; use `chat_assistant_id`.\n- `\"\"` (empty) — unset; agent is not runnable until a provider is configured.\n\nNote: the serializer also exposes `pipecat_*`, `synthflow_*`, `koreai_*`, `genesys_*`, `custom_provider_*` fields, but those provider values are not currently selectable in this enum.\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `elevenlabs` - Elevenlabs\n* `vocera` - Vocera\n* `sms` - Sms\n* `whatsapp` - Whatsapp\n* `self_hosted` - Self Hosted\n* `agentforce` - Agentforce\n* `cisco` - Cisco\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `synthflow` - Synthflow\n* `chirp` - Chirp\n* `koreai` - Koreai\n* `genesys` - Genesys\n* `amazon_connect` - Amazon Connect"
                     },
                     "vapi_api_key": {
                         "type": "string",
@@ -64516,6 +67708,19 @@
                         "type": "string",
                         "description": "\nAgentforce additional data - client_id, domain, and agent_id\nExample: `{\"client_id\": \"sd7a8...\", \"domain\": \"https://example.sandbox.my.salesforce.com\", \"agent_id\": \"0Xx...\"}`\n"
                     },
+                    "amazon_connect_security_token": {
+                        "type": "string",
+                        "writeOnly": true,
+                        "description": "x-amz-security-token for Amazon Connect authenticated chat widgets."
+                    },
+                    "amazon_connect_security_token_configured": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "amazon_connect_data": {
+                        "type": "string",
+                        "description": "Amazon Connect config: snippet_id (required), connect_host (required), region (default us-east-1)."
+                    },
                     "custom_provider_api_key": {
                         "type": "string",
                         "writeOnly": true,
@@ -64540,19 +67745,6 @@
                     "elevenlabs_data": {
                         "type": "string",
                         "description": "\nElevenLabs additional configuration data\nExample: `{\"trigger_url\": \"https://example.com/trigger\"}`\n"
-                    },
-                    "trillet_api_key": {
-                        "type": "string",
-                        "writeOnly": true,
-                        "description": "\nAPI key for Trillet AI service provider\nExample: `\"trillet_api_key_123\"`\n"
-                    },
-                    "trillet_api_key_configured": {
-                        "type": "string",
-                        "readOnly": true
-                    },
-                    "trillet_data": {
-                        "type": "string",
-                        "description": "\nTrillet AI additional data including Workspace ID\nExample: `{\"workspace_id\": \"1234567890\"}`\n"
                     },
                     "chirp_data": {
                         "type": "string",
@@ -64658,6 +67850,41 @@
                     "description",
                     "inbound"
                 ]
+            },
+            "SelfHostedChatConfig": {
+                "type": "object",
+                "description": "Self-hosted websocket chat configuration.",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "description": "WebSocket endpoint URL (wss://) to connect for text-mode test runs."
+                    },
+                    "headers": {
+                        "type": "object",
+                        "additionalProperties": {},
+                        "description": "Optional headers to send on the WebSocket upgrade request, e.g. {\"Authorization\": \"Bearer token\"}."
+                    },
+                    "websocket_secret": {
+                        "type": "string",
+                        "writeOnly": true,
+                        "description": "Secret sent as the X-VOCERA-SECRET header on the WebSocket upgrade (write-only — masked in responses)."
+                    }
+                },
+                "required": [
+                    "url"
+                ],
+                "title": "Self-hosted (WebSocket)"
+            },
+            "SelfHostedConfig": {
+                "type": "object",
+                "description": "Self-hosted provider configuration.",
+                "properties": {
+                    "send_post_conversation_metadata": {
+                        "type": "boolean",
+                        "description": "Enable Cekura to accept call transcripts pushed by your agent via POST /custom-provider-webhook/. Set to true when your agent sends its own transcripts to Cekura after each call."
+                    }
+                },
+                "title": "Self-hosted"
             },
             "SimplifyPromptProgressResponse": {
                 "type": "object",
@@ -64996,6 +68223,17 @@
                     "name",
                     "subscription_overage"
                 ]
+            },
+            "SynthflowConfig": {
+                "type": "object",
+                "description": "Synthflow provider configuration.",
+                "properties": {
+                    "synthflow_base_url_override": {
+                        "type": "string",
+                        "description": "Optional custom base URL for Synthflow API, e.g. for EU residency. Leave empty to use the default endpoint."
+                    }
+                },
+                "title": "Synthflow"
             },
             "TestProfileData": {
                 "type": "object",
@@ -65518,6 +68756,21 @@
                 "required": [
                     "project"
                 ]
+            },
+            "VapiConfig": {
+                "type": "object",
+                "description": "VAPI provider configuration.",
+                "properties": {
+                    "public_key": {
+                        "type": "string",
+                        "description": "VAPI public key for WebRTC sessions."
+                    },
+                    "trigger_url": {
+                        "type": "string",
+                        "description": "URL Cekura calls to create outbound VAPI phone calls."
+                    }
+                },
+                "title": "VAPI"
             },
             "View": {
                 "type": "object",


### PR DESCRIPTION
Auto-generated docs sync for backend PR [#9311](https://github.com/cekura-ai/vocera.backend/pull/9311).

Reviewers: @dileep-chagam, @rahul-cekura

## Summary

**Spec/overlay:** Spec refreshed with 9 new paths added (0 MCP-exposed). Bucket C: 4 exposure suggestions. No overlay changes needed — all new ops are not-exposed.

**Conceptual docs:** Removed Trillet provider from Agent Setup Guide. Flagged cloud import feature as follow-up for provider-specific testing docs.

## Changes

- `openapi.json` — regenerate_from_backend
- `documentation/key-concepts/agents/Agent_Setup_Guide.mdx` — update

## Exposure suggestions (@mcp_expose candidates)

- **`metrics_apply_optimisation_proposal_create`** (POST `/test_framework/v1/metrics/{id}/apply_optimisation_proposal/`)
  - User-facing metric optimization action — accepts an AI-generated proposal and applies it to the metric. Co-located with already-exposed metrics CRUD. Consider adding @mcp_expose().
- **`metrics_dismiss_optimisation_proposal_create`** (POST `/test_framework/v1/metrics/{id}/dismiss_optimisation_proposal/`)
  - User-facing metric optimization action — dismisses an AI-generated proposal. Co-located with already-exposed metrics CRUD. Consider adding @mcp_expose().
- **`metric_optimiser_cron_jobs_list`** (GET `/schedules/v1/metric-optimiser-cron-jobs/`)
  - Lists scheduled metric optimization jobs. Part of user-facing CRUD for managing recurring metric optimization. Consider exposing the full CRUD set (list, create, retrieve, update, delete) if users should manage these schedules via MCP.
- **`test_framework_v2_aiagents_import_progress_retrieve`** (GET `/test_framework/v2/aiagents/import-progress/`)
  - Progress endpoint for agent import operations. If there's a corresponding agent import endpoint already exposed, this should be exposed for polling. Check if an async agent-import tool exists.

## Human follow-ups (conceptual docs)

- Backend PR adds cloud auto-import (configure_from_provider) for VAPI, Retell, ElevenLabs, and Synthflow agents, allowing users to automatically fetch prompt, settings, tools, dynamic variables, and knowledge base from the provider. Consider adding a section to the provider-specific testing docs (vapi/testing.mdx, retell/testing.mdx, elevenlabs/testing.mdx) describing this feature as an alternative to manual configuration. The API documentation (v2/aiagents create) already documents it, but the integration guides don't mention it yet.
  (hint: `documentation/integrations/vapi/testing.mdx, documentation/integrations/retell/testing.mdx, documentation/integrations/elevenlabs/testing.mdx`; reason: new feature not yet documented in integration guides)
- Backend PR adds Synthflow as a supported provider for cloud auto-import (configure_from_provider), but no Synthflow testing documentation exists yet. The provider is listed in Agent_Setup_Guide.mdx but has no dedicated integration guide. Consider creating documentation/integrations/synthflow/testing.mdx following the pattern of vapi/testing.mdx and retell/testing.mdx.
  (hint: `documentation/integrations/synthflow/testing.mdx`; reason: new provider support, no integration guide exists)

## Applied with notes

- documentation/key-concepts/agents/Agent_Setup_Guide.mdx: branch diverged from both main and prior skill output; left existing in place — human intervention needed

---
*Auto-generated from backend PR #9311.*

<!-- mcp-sync:file-hashes -->
```json
{}
```
<!-- /mcp-sync:file-hashes -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cekura-ai/docs/pull/645" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->