### PR TITLE
[Auto] Sync docs for backend PR #9366

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -62656,8 +62656,7 @@
                             {
                                 "type": "null"
                             }
-                        ],
-                        "description": "Structured transcript data with timestamps.\nExample: \n```json\n[\n    {\n        \"role\": \"Testing Agent\",\n        \"content\": \"Hello\",\n        \"start_time\": 1.2,\n        \"end_time\": 1.8\n    },\n    {\n        \"role\": \"Main Agent\",\n        \"content\": \"Hello, how can I help you today?\",\n        \"start_time\": 1.8,\n        \"end_time\": 2.5\n    }\n]`"
+                        ]
                     },
                     "voice_recording": {
                         "type": "string",
@@ -69208,8 +69207,7 @@
                             {
                                 "type": "null"
                             }
-                        ],
-                        "description": "Structured transcript data with timestamps.\nExample: \n```json\n[\n    {\n        \"role\": \"Testing Agent\",\n        \"content\": \"Hello\",\n        \"start_time\": 1.2,\n        \"end_time\": 1.8\n    },\n    {\n        \"role\": \"Main Agent\",\n        \"content\": \"Hello, how can I help you today?\",\n        \"start_time\": 1.8,\n        \"end_time\": 2.5\n    }\n]`"
+                        ]
                     },
                     "voice_recording": {
                         "type": "string",


### PR DESCRIPTION
Auto-generated docs sync for backend PR [#9366](https://github.com/cekura-ai/vocera.backend/pull/9366).

Reviewers: @dileep-chagam, @cekurarsan

## Summary

**Spec/overlay:** Buckets: A=0, B-new=0, B-retract=0, C=0. Confirmed renames: 0. SDK/CLI follow-ups: 0.

**Conceptual docs:** Backend PR #9366 adds a CALL_HOLD tool choice to ScenarioToolChoices and plumbs callHoldFunctionEnabled to pipecat configuration. After reviewing candidate docs pages (evaluators/overview.mdx, pipecat/automated.mdx, tool-call-testing.mdx, mock-tools.mdx, and conditional-actions.mdx with sibling cross-check), no edits are warranted. The existing docs remain accurate: they describe tool call testing, pipecat configuration, and the <hold> tag syntax without enumerating all available tool choices or claiming completeness. The PR adds a new configuration option (CALL_HOLD in tool_ids) that complements existing functionality without invalidating any documented behavior. The pages are incomplete-but-not-wrong, which per Phase 2 rules means they should be left alone. The CALL_HOLD enum value will be available via the /enums/ API endpoint (auto-propagates per PR description), but docs pages don't enumerate tool choices exhaustively, so no update is needed.

## Changes

- `openapi.json` — regenerate_from_backend

## Duplicate URL variants surviving strip (mcp-hygiene)

- `call-logs-create-scenarios_2` — canonical `/observability/v1/call-logs/create_scenarios/`, duplicates: `/observability/v1/call-logs-external/create_scenarios/`
- `call-logs-create-scenarios-progress_2` — canonical `/observability/v1/call-logs/create_scenarios_progress/`, duplicates: `/observability/v1/call-logs-external/create_scenarios_progress/`
- `metrics-bulk-create_2` — canonical `/test_framework/v1/metrics/bulk_create/`, duplicates: `/test_framework/v1/metrics-external/bulk_create/`
- `metrics-generate_2` — canonical `/test_framework/v1/metrics/generate_metrics/`, duplicates: `/test_framework/v1/metrics-external/generate_metrics/`
- `metrics-preview-progress_2` — canonical `/test_framework/v1/metrics/preview-progress/`, duplicates: `/test_framework/v1/metrics-external/preview-progress/`
- `metrics-run-reviews-progress_2` — canonical `/test_framework/v1/metrics/run_reviews_progress/`, duplicates: `/test_framework/v1/metrics-external/run_reviews_progress/`
- `create-shareable-link-token_2` — canonical `/test_framework/v1/results/{id}/create_shareable_link_token/`, duplicates: `/test_framework/v1/results-external/{id}/create_shareable_link_token/`
- `delete-runs_2` — canonical `/test_framework/v1/results/{id}/delete_runs/`, duplicates: `/test_framework/v1/results-external/{id}/delete_runs/`
- `end-calls_2` — canonical `/test_framework/v1/results/{id}/end_calls/`, duplicates: `/test_framework/v1/results-external/{id}/end_calls/`
- `end-call_2` — canonical `/test_framework/v1/runs/{id}/end_call/`, duplicates: `/test_framework/v1/runs-external/{id}/end_call/`
- `scenarios-bulk-update_2` — canonical `/test_framework/v1/scenarios/adv_update/`, duplicates: `/test_framework/v1/scenarios-external/adv_update/`
- `scenarios-folder-create_2` — canonical `/test_framework/v1/scenarios/create_folder/`, duplicates: `/test_framework/v1/scenarios-external/create_folder/`
- `scenarios-create-from-transcript_2` — canonical `/test_framework/v1/scenarios/create_scenario_from_transcript/`, duplicates: `/test_framework/v1/scenarios-external/create_scenario_from_transcript/`
- `scenarios-folder-delete_2` — canonical `/test_framework/v1/scenarios/delete_folder/`, duplicates: `/test_framework/v1/scenarios-external/delete_folder/`
- `scenarios-bulk-delete_2` — canonical `/test_framework/v1/scenarios/delete_scenarios/`, duplicates: `/test_framework/v1/scenarios-external/delete_scenarios/`
- `scenarios-generate-bg_2` — canonical `/test_framework/v1/scenarios/generate-bg/`, duplicates: `/test_framework/v1/scenarios-external/generate-bg/`
- `scenarios-generate-progress_2` — canonical `/test_framework/v1/scenarios/generate-progress/`, duplicates: `/test_framework/v1/scenarios-external/generate-progress/`
- `scenarios-folder-move_2` — canonical `/test_framework/v1/scenarios/move_folder/`, duplicates: `/test_framework/v1/scenarios-external/move_folder/`
- `scenarios-folder-rename_2` — canonical `/test_framework/v1/scenarios/rename_folder/`, duplicates: `/test_framework/v1/scenarios-external/rename_folder/`
- `scenarios-run-voice_2` — canonical `/test_framework/v1/scenarios/run_scenarios/`, duplicates: `/test_framework/v1/scenarios-external/run_scenarios/`
- `scenarios-run-agora_2` — canonical `/test_framework/v1/scenarios/run_scenarios_agora/`, duplicates: `/test_framework/v1/scenarios-external/run_scenarios_agora/`
- `scenarios-run-chirp_2` — canonical `/test_framework/v1/scenarios/run_scenarios_chirp/`, duplicates: `/test_framework/v1/scenarios-external/run_scenarios_chirp/`
- `scenarios-run-elevenlabs_2` — canonical `/test_framework/v1/scenarios/run_scenarios_elevenlabs/`, duplicates: `/test_framework/v1/scenarios-external/run_scenarios_elevenlabs/`
- `scenarios-run-livekit-v2_2` — canonical `/test_framework/v1/scenarios/run_scenarios_livekit_v2/`, duplicates: `/test_framework/v1/scenarios-external/run_scenarios_livekit_v2/`
- `scenarios-run-pipecat-v1_2` — canonical `/test_framework/v1/scenarios/run_scenarios_pipecat/`, duplicates: `/test_framework/v1/scenarios-external/run_scenarios_pipecat/`
- `scenarios-run-pipecat-v2_2` — canonical `/test_framework/v1/scenarios/run_scenarios_pipecat_v2/`, duplicates: `/test_framework/v1/scenarios-external/run_scenarios_pipecat_v2/`
- `scenarios-run-retell-webrtc_2` — canonical `/test_framework/v1/scenarios/run_scenarios_retell_webrtc/`, duplicates: `/test_framework/v1/scenarios-external/run_scenarios_retell_webrtc/`
- `scenarios-run-sip_2` — canonical `/test_framework/v1/scenarios/run_scenarios_sip/`, duplicates: `/test_framework/v1/scenarios-external/run_scenarios_sip/`
- `scenarios-run-text_2` — canonical `/test_framework/v1/scenarios/run_scenarios_text/`, duplicates: `/test_framework/v1/scenarios-external/run_scenarios_text/`
- `scenarios-run-vapi-webrtc_2` — canonical `/test_framework/v1/scenarios/run_scenarios_vapi_webrtc/`, duplicates: `/test_framework/v1/scenarios-external/run_scenarios_vapi_webrtc/`
- `scenarios-run-websocket_2` — canonical `/test_framework/v1/scenarios/run_scenarios_with_websockets/`, duplicates: `/test_framework/v1/scenarios-external/run_scenarios_with_websockets/`
- `scenarios-agent-create_2` — canonical `/test_framework/v1/scenarios/scenario-agent/`, duplicates: `/test_framework/v1/scenarios-external/scenario-agent/`
- `scenarios-agent-progress_2` — canonical `/test_framework/v1/scenarios/scenario-agent-progress/`, duplicates: `/test_framework/v1/scenarios-external/scenario-agent-progress/`

---
*Auto-generated from backend PR #9366.*

<!-- mcp-sync:file-hashes -->
```json
{}
```
<!-- /mcp-sync:file-hashes -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cekura-ai/docs/pull/651" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->