### PR TITLE
docs: scrub internal service name + remove internal-only endpoints from the spec

### DIFF
--- a/api-reference/test_framework/run-evaluator-sip.mdx
+++ b/api-reference/test_framework/run-evaluator-sip.mdx
@@ -1,6 +1,6 @@
 ---
 title: Run Evaluator SIP
-description: "Execute evaluators against an agent over a direct SIP connection (orchestrated by the Patronus service). Requires `sip_endpoint` configured on the agent."
+description: "Execute evaluators against an agent over a direct SIP connection (orchestrated by Cekura's SIP voice service). Requires `sip_endpoint` configured on the agent."
 openapi: post /test_framework/v1/scenarios/run_scenarios_sip/
 slug: run-evaluator-sip
 ---

--- a/api-reference/user/post-userwebhooksupabase.mdx
+++ b/api-reference/user/post-userwebhooksupabase.mdx
@@ -1,4 +1,0 @@
----
-openapi: post /user/webhook/supabase/
-description: "User webhook supabase"
----

--- a/openapi.json
+++ b/openapi.json
@@ -5754,55 +5754,6 @@
                 }
             }
         },
-        "/observability/v1/livekit/egress-credentials/": {
-            "get": {
-                "operationId": "livekit-egress-credentials-retrieve",
-                "description": "Generate scoped S3 credentials for LiveKit egress with a random UUID prefix.",
-                "parameters": [
-                    {
-                        "in": "query",
-                        "name": "agent_id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "ID of the agent to validate LiveKit configuration",
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "observability"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/LiveKitEgressCredentialsResponse"
-                                }
-                            }
-                        },
-                        "description": ""
-                    },
-                    "400": {
-                        "description": "Missing agent_id or invalid agent configuration"
-                    },
-                    "403": {
-                        "description": "Permission denied"
-                    },
-                    "404": {
-                        "description": "Agent not found"
-                    },
-                    "500": {
-                        "description": "Failed to generate credentials"
-                    }
-                }
-            }
-        },
         "/observability/v1/livekit/observe/": {
             "post": {
                 "operationId": "livekit-observe-create",
@@ -6383,25 +6334,6 @@
                             }
                         },
                         "description": ""
-                    }
-                }
-            }
-        },
-        "/observability/v1/pipecat/egress-credentials/": {
-            "get": {
-                "operationId": "pipecat-egress-credentials-retrieve",
-                "description": "Generate scoped S3 credentials for Pipecat audio uploads with a random UUID prefix.",
-                "tags": [
-                    "observability"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "No response body"
                     }
                 }
             }
@@ -26542,35 +26474,6 @@
                             }
                         },
                         "description": ""
-                    }
-                }
-            }
-        },
-        "/test_framework/v1/runs/{run_id}/datadog-logs/": {
-            "get": {
-                "operationId": "runs-datadog-logs-retrieve",
-                "description": "Fetch Datadog logs for a given simulation run ID.\n\nRestricted to OAuth tokens minted by the `cekura-support-bot` client via\nthe client_credentials grant. Even though the support-bot client can\nimpersonate any user, the token's subject user must have access to the\nrun's project — either as an org-admin or via a direct project membership.\nOrg-level membership alone is not enough: a user added to project A\nshould not see logs for runs in project B in the same org.",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "run_id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "test_framework"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "No response body"
                     }
                 }
             }
@@ -49295,25 +49198,6 @@
                     }
                 },
                 "description": "Projects members"
-            }
-        },
-        "/user/webhook/supabase/": {
-            "post": {
-                "operationId": "user-webhook-supabase-create",
-                "tags": [
-                    "user"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "No response body"
-                    }
-                },
-                "description": "User webhook supabase"
             }
         },
         "/webpage/domain/": {

--- a/openapi.json
+++ b/openapi.json
@@ -3562,7 +3562,7 @@
         "/observability/v1/call-logs-external/filters_call_id/": {
             "get": {
                 "operationId": "call-logs-external-filters-call-id-retrieve",
-                "description": "Autocomplete-search the production CallLog `call_id` field (the provider's call identifier string, e.g. `\"patronus_xyz\"`). This is distinct from simulation `run_id` (integer; see `runs_list`) and from CallLog ID (integer DB ID).",
+                "description": "Autocomplete-search the production CallLog `call_id` field (the provider's call identifier string). This is distinct from simulation `run_id` (integer; see `runs_list`) and from CallLog ID (integer DB ID).",
                 "tags": [
                     "observability"
                 ],
@@ -5015,7 +5015,7 @@
         "/observability/v1/call-logs/filters_call_id/": {
             "get": {
                 "operationId": "call-logs-filters-call-id-retrieve",
-                "description": "Autocomplete-search the production CallLog `call_id` field (the provider's call identifier string, e.g. `\"patronus_xyz\"`). This is distinct from simulation `run_id` (integer; see `runs_list`) and from CallLog ID (integer DB ID).",
+                "description": "Autocomplete-search the production CallLog `call_id` field (the provider's call identifier string). This is distinct from simulation `run_id` (integer; see `runs_list`) and from CallLog ID (integer DB ID).",
                 "tags": [
                     "observability"
                 ],
@@ -9924,7 +9924,7 @@
         "/test_framework/process-patronus-message-response/": {
             "post": {
                 "operationId": "test-framework-process-patronus-message-response-create",
-                "description": "API view to process incoming message responses from Patronus.\nThis view handles the storage of incoming webhook data and updates\nthe status of runs based on the call status received in the payload.",
+                "description": "API view to process incoming message responses from the voice service.\nThis view handles the storage of incoming webhook data and updates\nthe status of runs based on the call status received in the payload.",
                 "tags": [
                     "test_framework"
                 ],
@@ -19918,7 +19918,7 @@
         "/test_framework/v1/personalities-external/{id}/call/": {
             "post": {
                 "operationId": "personalities-external-call-create",
-                "description": "Initiate a WebRTC call to talk to a personality directly from the browser.\nOnly callable via Bearer token (Supabase) authentication - not API keys.\nProxies to Patronus /calls/initiate/webrtc and returns Daily.co credentials.",
+                "description": "Initiate a WebRTC call to talk to a personality directly from the browser.\nOnly callable via Bearer token (Supabase) authentication - not API keys.\nInitiates a WebRTC call via Cekura's voice service and returns Daily.co credentials.",
                 "parameters": [
                     {
                         "in": "path",
@@ -20341,7 +20341,7 @@
         "/test_framework/v1/personalities/{id}/call/": {
             "post": {
                 "operationId": "personalities-call-create",
-                "description": "Initiate a WebRTC call to talk to a personality directly from the browser.\nOnly callable via Bearer token (Supabase) authentication - not API keys.\nProxies to Patronus /calls/initiate/webrtc and returns Daily.co credentials.",
+                "description": "Initiate a WebRTC call to talk to a personality directly from the browser.\nOnly callable via Bearer token (Supabase) authentication - not API keys.\nInitiates a WebRTC call via Cekura's voice service and returns Daily.co credentials.",
                 "parameters": [
                     {
                         "in": "path",
@@ -20953,7 +20953,7 @@
         "/test_framework/v1/phone-numbers/providers/metadata/": {
             "get": {
                 "operationId": "phone-numbers-providers-metadata-retrieve",
-                "description": "Fetches decrypted metadata for a phone number by phone_number or id. Called by Patronus and Pipecat services.",
+                "description": "Fetches decrypted metadata for a phone number by phone_number or id. Called by Cekura's internal voice services.",
                 "tags": [
                     "test_framework"
                 ],
@@ -31540,7 +31540,7 @@
         "/test_framework/v1/scenarios-external/run_scenarios_sip/": {
             "post": {
                 "operationId": "scenarios-run-sip",
-                "description": "SIP VOICE RUN (direct SIP via Patronus): Execute evaluators against an agent over a direct SIP connection (orchestrated by the Patronus service). The agent must have `sip_endpoint` configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone calls via Cekura's standard voice path\n- `scenarios_run_vapi_webrtc` / `_retell_webrtc` — provider-managed WebRTC\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
+                "description": "SIP VOICE RUN (direct SIP): Execute evaluators against an agent over a direct SIP connection (orchestrated by Cekura's SIP voice service). The agent must have `sip_endpoint` configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone calls via Cekura's standard voice path\n- `scenarios_run_vapi_webrtc` / `_retell_webrtc` — provider-managed WebRTC\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
                 "summary": "Run evaluators over a direct SIP connection",
                 "tags": [
                     "Evaluators"
@@ -36550,7 +36550,7 @@
         "/test_framework/v1/scenarios/run_scenarios_sip/": {
             "post": {
                 "operationId": "scenarios-run-sip_2",
-                "description": "SIP VOICE RUN (direct SIP via Patronus): Execute evaluators against an agent over a direct SIP connection (orchestrated by the Patronus service). The agent must have `sip_endpoint` configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone calls via Cekura's standard voice path\n- `scenarios_run_vapi_webrtc` / `_retell_webrtc` — provider-managed WebRTC\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
+                "description": "SIP VOICE RUN (direct SIP): Execute evaluators against an agent over a direct SIP connection (orchestrated by Cekura's SIP voice service). The agent must have `sip_endpoint` configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone calls via Cekura's standard voice path\n- `scenarios_run_vapi_webrtc` / `_retell_webrtc` — provider-managed WebRTC\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
                 "summary": "Run evaluators over a direct SIP connection",
                 "tags": [
                     "Evaluators"
@@ -36726,7 +36726,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-run-sip",
-                        "description": "SIP VOICE RUN (direct SIP via Patronus): Execute evaluators against an agent over a direct SIP connection (orchestrated by the Patronus service). The agent must have `sip_endpoint` configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone calls via Cekura's standard voice path\n- `scenarios_run_vapi_webrtc` / `_retell_webrtc` — provider-managed WebRTC\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)"
+                        "description": "SIP VOICE RUN (direct SIP): Execute evaluators against an agent over a direct SIP connection (orchestrated by Cekura's SIP voice service). The agent must have `sip_endpoint` configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone calls via Cekura's standard voice path\n- `scenarios_run_vapi_webrtc` / `_retell_webrtc` — provider-managed WebRTC\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)"
                     }
                 }
             }
@@ -44066,7 +44066,7 @@
         "/test_framework/v2/scenarios/run_scenarios_sip/": {
             "post": {
                 "operationId": "scenarios-run-sip_3",
-                "description": "SIP VOICE RUN (direct SIP via Patronus): Execute evaluators against an agent over a direct SIP connection (orchestrated by the Patronus service). The agent must have `sip_endpoint` configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone calls via Cekura's standard voice path\n- `scenarios_run_vapi_webrtc` / `_retell_webrtc` — provider-managed WebRTC\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
+                "description": "SIP VOICE RUN (direct SIP): Execute evaluators against an agent over a direct SIP connection (orchestrated by Cekura's SIP voice service). The agent must have `sip_endpoint` configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone calls via Cekura's standard voice path\n- `scenarios_run_vapi_webrtc` / `_retell_webrtc` — provider-managed WebRTC\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
                 "summary": "Run evaluators over a direct SIP connection",
                 "tags": [
                     "Evaluators"


### PR DESCRIPTION
## Problem

Internal details were leaking through this repo's published `openapi.json` (served on the docs site + surfaced to the Cekura MCP server) and the API-reference pages. Two classes:

1. **Internal voice-service codename** in operation descriptions — incl. the **MCP-exposed** `scenarios_run_sip` tool (*"direct SIP via \<codename\> … orchestrated by the \<codename\> service"*), the most likely way a customer learned the name.
2. **Internal-only endpoints** published in the spec (none `x-mcp-expose`, but fully visible to anyone reading the spec; one rendered a live doc page) that leaked Datadog, the `cekura-support-bot` OAuth client + impersonation, S3 credential minting, and Supabase.

## Fix

**(a) Codename scrub** — neutral wording, identical to the upstream backend change so the next regen is a no-op:
- `openapi.json` — `scenarios_run_sip` (MCP-exposed), WebRTC-call proxy, phone-number-metadata, process-message-response, and the `call_id` autocomplete example.
- `api-reference/test_framework/run-evaluator-sip.mdx`.

**(b) Remove internal-only endpoints** (−117 spec lines + the orphaned doc page) — these regenerate-out at the source via `@extend_schema(exclude=True)`:
- `GET /test_framework/v1/runs/{run_id}/datadog-logs/` (leaked Datadog, `cekura-support-bot`, impersonation, `client_credentials`)
- `GET /observability/v1/{livekit,pipecat}/egress-credentials/` (internal S3 creds)
- `POST /user/webhook/supabase/` (internal Supabase webhook) + deleted `api-reference/user/post-userwebhooksupabase.mdx`

**No operationIds, paths (other than the four removed), enum values, or schema field names changed.**

## Verification

- `openapi.json` valid JSON; all four paths confirmed gone; codename strings gone.
- `cekura-mcp-server` `pytest` → **8 failures, all pre-existing on `origin/main`** (verified via stash); these changes add **zero** new failures and break no MCP tool/overlay.
- Residual codename strings in `openapi.json` are exactly the intentionally-excluded set (the `process-patronus-message-response` route/operationId, `patronus_settings` field, `call_service_provider` enum value+label) — those need code/data changes; see the backend PR.

Companion PRs: vocera.backend (root cause) and cekura-skills (`call_id` examples).

🤖 Generated with [Claude Code](https://claude.com/claude-code)