### PR TITLE
[Auto] Sync docs for backend PR #9377

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -21580,7 +21580,8 @@
         "/test_framework/v1/predefined-metrics-external/copy/": {
             "post": {
                 "operationId": "predefined-metrics-external-copy-create",
-                "description": "Predefined metrics copy",
+                "description": "Copy one or more predefined metrics (e.g. Voice Tone + Clarity, Latency, CSAT) into a project so they evaluate its calls. Pass `project_id` and `predefined_metric_ids` (get the IDs from the predefined metrics list). Use this to add these built-in metrics — they cannot be created through the metrics create endpoint.",
+                "summary": "Attach predefined metrics to a project",
                 "tags": [
                     "test_framework"
                 ],
@@ -21800,7 +21801,8 @@
         "/test_framework/v1/predefined-metrics/copy/": {
             "post": {
                 "operationId": "predefined-metrics-copy-create",
-                "description": "Predefined metrics copy",
+                "description": "Copy one or more predefined metrics (e.g. Voice Tone + Clarity, Latency, CSAT) into a project so they evaluate its calls. Pass `project_id` and `predefined_metric_ids` (get the IDs from the predefined metrics list). Use this to add these built-in metrics — they cannot be created through the metrics create endpoint.",
+                "summary": "Attach predefined metrics to a project",
                 "tags": [
                     "test_framework"
                 ],
@@ -21839,6 +21841,15 @@
                             }
                         },
                         "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mcp-destructive": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "predefined-metrics-copy-create",
+                        "description": "Copy one or more predefined metrics (e.g. Voice Tone + Clarity, Latency, CSAT) into a project so they evaluate its calls. Pass `project_id` and `predefined_metric_ids` (get the IDs from the predefined metrics list). Use this to add these built-in metrics — they cannot be created through the metrics create endpoint."
                     }
                 }
             }


### PR DESCRIPTION
Auto-generated docs sync for backend PR [#9377](https://github.com/cekura-ai/vocera.backend/pull/9377).

Reviewers: @dileep-chagam

## Summary

**Spec/overlay:** 1 newly exposed operation (predefined_metrics_copy_create) for attaching built-in metrics (Voice Tone + Clarity, Latency, CSAT) to projects. No overlay needed — the operation's @extend_schema description is comprehensive and guides agents to use predefined_metrics_list for finding available metric IDs. 1 SDK/CLI follow-up filed for parity.

## Changes

- `openapi.json` — regenerate_from_backend

## SDK / CLI parity follow-ups

- `predefined_metrics_copy_create` (POST `/test_framework/v1/predefined-metrics/copy/`) — add

---
*Auto-generated from backend PR #9377.*

<!-- mcp-sync:file-hashes -->
```json
{}
```
<!-- /mcp-sync:file-hashes -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cekura-ai/docs/pull/657" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->