### PR TITLE
[Auto] Sync docs for backend PR #9390

### DIFF
--- a/cekura-mcp-server/mcp_tools.json
+++ b/cekura-mcp-server/mcp_tools.json
@@ -1,125 +1,118 @@
 {
   "_comment": "Per-tool MCP enrichments. Applied on top of the OpenAPI-derived schema at registration time. Covers MCP-transport-specific limitations and cross-tool references not meaningful to plain REST callers.",
-
   "aiagents_upload_knowledge_base": {
     "description_suffix": "Pass each file as `{\"name\": \"manual.pdf\", \"content_base64\": \"...\"}` where `content_base64` is the file content base64-encoded (a raw base64 string or a `data:<mime>;base64,...` data URI both work). Max 50 MB per file. Allowed extensions: pdf, txt, json, csv, xml, md."
   },
-
   "scenarios_run_voice": {
-    "description_suffix": "The run mode (voice / text / WebRTC) is determined by WHICH run endpoint you call — not by the agent config."
+    "description_suffix": "The run mode (voice / text / WebRTC) is determined by WHICH run endpoint you call \u2014 not by the agent config."
   },
-
   "scenarios_run_text": {
-    "description_suffix": "The run mode is determined by WHICH run endpoint you call — not by the agent config. DO NOT USE for voice-specific metrics (latency, pitch) — they will be zero."
+    "description_suffix": "The run mode is determined by WHICH run endpoint you call \u2014 not by the agent config. DO NOT USE for voice-specific metrics (latency, pitch) \u2014 they will be zero."
   },
-
   "scenarios_run_pipecat_v1": {
     "description_suffix": "The run mode is determined by WHICH run endpoint you call, not the agent config. Requires a Pipecat API key configured on the project."
   },
-
   "scenarios_run_websocket": {
     "description_suffix": "The run mode is determined by WHICH run endpoint you call, not the agent config."
   },
-
   "observe_create": {
-    "description_suffix": "File uploads not supported — use `voice_recording_url` instead of `voice_recording`. Do not pass `metric_ids` — causes a 500 error on current staging; use `call_logs_evaluate_metrics_create` after ingestion instead. Wrong roles silently produce an empty transcript with no error returned."
+    "description_suffix": "File uploads not supported \u2014 use `voice_recording_url` instead of `voice_recording`. Do not pass `metric_ids` \u2014 causes a 500 error on current staging; use `call_logs_evaluate_metrics_create` after ingestion instead. Wrong roles silently produce an empty transcript with no error returned."
   },
-
   "runs_bulk_retrieve": {
     "description_suffix": "`run_ids` must be a bare comma-separated string (e.g. `\"86368,86369\"`). Passing a JSON array `[86368, 86369]` or a JSON-quoted string both return `400: run_ids must be comma-separated integers`."
   },
-
   "call_logs_evaluate_metrics_create": {
-    "description_suffix": "Known issue: the `metrics` filter is not enforced — all metrics assigned to the call log are evaluated regardless of which IDs are passed."
+    "description_suffix": "Known issue: the `metrics` filter is not enforced \u2014 all metrics assigned to the call log are evaluated regardless of which IDs are passed."
   },
-
   "metrics_create": {
-    "description_suffix": "**Prefer `metrics_generate`** (AI-authored from agent prompt) over this tool unless the user has explicitly given concrete field values to write. Use `metrics_generate_clean_description_create` to clean up an existing description and `metrics_generate_evaluation_trigger_create` to derive a trigger. The `prompt` field is only active when explicitly setting `llm_provider` to a non-default value — for standard `llm_judge` metrics, the criterion goes in `description`. `assistant_id` is optional despite appearing required in some schema views — omit it entirely; passing an empty string returns a 400 error. `add_to_new_agents`: when omitted or `true`, this metric is automatically assigned to every new agent created in the project — set to `false` to scope to specific agents only. To attach a metric to evaluators after creation, use `scenarios_partial_update` with `metrics: [id1, id2, ...]`; use `metrics_list(agent_id=<id>)` to find available IDs."
+    "description_suffix": "**Prefer `metrics_generate`** (AI-authored from agent prompt) over this tool unless the user has explicitly given concrete field values to write. Use `metrics_generate_clean_description_create` to clean up an existing description and `metrics_generate_evaluation_trigger_create` to derive a trigger. The `prompt` field is only active when explicitly setting `llm_provider` to a non-default value \u2014 for standard `llm_judge` metrics, the criterion goes in `description`. `assistant_id` is optional despite appearing required in some schema views \u2014 omit it entirely; passing an empty string returns a 400 error. `add_to_new_agents`: when omitted or `true`, this metric is automatically assigned to every new agent created in the project \u2014 set to `false` to scope to specific agents only. To attach a metric to evaluators after creation, use `scenarios_partial_update` with `metrics: [id1, id2, ...]`; use `metrics_list(agent_id=<id>)` to find available IDs."
   },
-
   "metrics_partial_update": {
     "description_suffix": "**Prefer `metrics_generate_clean_description_create` / `metrics_generate_evaluation_trigger_create` / `metrics_simplify_prompt_create`** when refining metric fields with AI assistance. Use this raw patch only when the user has given concrete field values to write."
   },
-
   "scenarios_create": {
-    "description_suffix": "**Prefer `scenarios_generate_bg`** for authoring new scenarios — it accepts per-scenario `extra_instructions` so callers can shape each scenario individually. Use this raw create only when the user has given concrete field values to write. To refine an existing scenario, use `scenarios_agent_create` (natural-language improvement) or `scenarios_improve_instructions_create` (rewrites the `instructions` text).\n\n**Tools (`tool_ids`):** it is recommended to include `TOOL_END_CALL` by default so the testing agent can hang up once it has completed its objective — leave it out only if the user does not want the agent to end the call. Other commonly used tool IDs include `TOOL_END_CALL_ONLY_ON_TRANSFER` (use instead of `TOOL_END_CALL` when the expected outcome is a transfer to a human/IVR, so the agent does not sit through hold music) and `TOOL_DTMF` (send keypad tones for IVR navigation). Example: `\"tool_ids\": [\"TOOL_END_CALL\"]`."
+    "description_suffix": "**Prefer `scenarios_generate_bg`** for authoring new scenarios \u2014 it accepts per-scenario `extra_instructions` so callers can shape each scenario individually. Use this raw create only when the user has given concrete field values to write. To refine an existing scenario, use `scenarios_agent_create` (natural-language improvement) or `scenarios_improve_instructions_create` (rewrites the `instructions` text).\n\n**Tools (`tool_ids`):** it is recommended to include `TOOL_END_CALL` by default so the testing agent can hang up once it has completed its objective \u2014 leave it out only if the user does not want the agent to end the call. Other commonly used tool IDs include `TOOL_END_CALL_ONLY_ON_TRANSFER` (use instead of `TOOL_END_CALL` when the expected outcome is a transfer to a human/IVR, so the agent does not sit through hold music) and `TOOL_DTMF` (send keypad tones for IVR navigation). Example: `\"tool_ids\": [\"TOOL_END_CALL\"]`."
   },
-
   "scenarios_partial_update": {
     "description_suffix": "**Prefer `scenarios_agent_create`** (natural-language improvement of one or more scenarios) or `scenarios_improve_instructions_create` (rewrites just the `instructions` text). Use this raw patch only when the user has explicitly given concrete field values to write."
   },
-
   "scenarios_agent_create": {
-    "description_suffix": "Unified scenario-agent endpoint — clarifies (no `scenarios` field in payload) AND improves (with `scenarios` field). The `_create` suffix is a DRF/spectacular naming artifact, NOT a separate create endpoint. Use this whenever the user wants AI-driven scenario refinement; do not reach for `scenarios_create` for that case. Async — poll via `scenarios_agent_progress`."
+    "description_suffix": "Unified scenario-agent endpoint \u2014 clarifies (no `scenarios` field in payload) AND improves (with `scenarios` field). The `_create` suffix is a DRF/spectacular naming artifact, NOT a separate create endpoint. Use this whenever the user wants AI-driven scenario refinement; do not reach for `scenarios_create` for that case. Async \u2014 poll via `scenarios_agent_progress`."
   },
-
   "scenarios_generate_bg": {
-    "description_suffix": "Preferred path for authoring new scenarios. Accepts per-scenario `extra_instructions` so each generated scenario can be shaped individually — use this rather than `scenarios_create` unless the user has given concrete field values to write. Async — poll via `scenarios_generate_progress`.\n\n**Tools (`tool_ids`):** it is recommended to include `TOOL_END_CALL` by default so the generated testing agents can hang up once they have completed their objective — leave it out only if the user does not want the agent to end the call. Other commonly used tool IDs include `TOOL_END_CALL_ONLY_ON_TRANSFER` (use instead of `TOOL_END_CALL` when the expected outcome is a transfer to a human/IVR, so the agent does not sit through hold music) and `TOOL_DTMF` (send keypad tones for IVR navigation). Example: `\"tool_ids\": [\"TOOL_END_CALL\"]`."
+    "description_suffix": "Preferred path for authoring new scenarios. Accepts per-scenario `extra_instructions` so each generated scenario can be shaped individually \u2014 use this rather than `scenarios_create` unless the user has given concrete field values to write. Async \u2014 poll via `scenarios_generate_progress`.\n\n**Tools (`tool_ids`):** it is recommended to include `TOOL_END_CALL` by default so the generated testing agents can hang up once they have completed their objective \u2014 leave it out only if the user does not want the agent to end the call. Other commonly used tool IDs include `TOOL_END_CALL_ONLY_ON_TRANSFER` (use instead of `TOOL_END_CALL` when the expected outcome is a transfer to a human/IVR, so the agent does not sit through hold music) and `TOOL_DTMF` (send keypad tones for IVR navigation). Example: `\"tool_ids\": [\"TOOL_END_CALL\"]`."
   },
-
   "scenarios_improve_instructions_create": {
-    "description_suffix": "Lower-level instruction refiner: takes `agent` + `extra_instructions` and rewrites a scenario's `instructions` text. For multi-scenario or higher-level natural-language refinement use `scenarios_agent_create` instead. Async — poll via `scenarios_instructions_progress_retrieve`."
+    "description_suffix": "Lower-level instruction refiner: takes `agent` + `extra_instructions` and rewrites a scenario's `instructions` text. For multi-scenario or higher-level natural-language refinement use `scenarios_agent_create` instead. Async \u2014 poll via `scenarios_instructions_progress_retrieve`."
   },
-
   "aiagents_create": {
     "description_suffix": "When the goal is to *improve* an existing agent based on test results or natural-language feedback, prefer `scenarios_agent_create` (it can update agent fields as part of the improvement loop). Use this raw create only when the user has given concrete field values to write.",
-    "_property_types_note": "pipecat_data is a JSON object the spec mistypes as string; coerced to object so the client sends a dict. Only needed for Pipecat agents — other providers omit pipecat_data, so it's a no-op for them.",
-    "property_types": {"pipecat_data": "object"}
+    "_property_types_note": "pipecat_data is a JSON object the spec mistypes as string; coerced to object so the client sends a dict. Only needed for Pipecat agents \u2014 other providers omit pipecat_data, so it's a no-op for them.",
+    "property_types": {
+      "pipecat_data": "object"
+    }
   },
-
   "aiagents_partial_update": {
     "description_suffix": "When refining an existing agent based on test results or natural-language feedback, prefer `scenarios_agent_create` or `runs_improve_prompt_create` / `runs_improve_prompt_bg_create` (run-driven prompt improvement). Use this raw patch only when the user has explicitly given concrete field values to write.",
-    "_property_types_note": "pipecat_data is a JSON object the spec mistypes as string; coerced to object so the client sends a dict. Only needed for Pipecat agents — other providers omit pipecat_data, so it's a no-op for them.",
-    "property_types": {"pipecat_data": "object"}
+    "_property_types_note": "pipecat_data is a JSON object the spec mistypes as string; coerced to object so the client sends a dict. Only needed for Pipecat agents \u2014 other providers omit pipecat_data, so it's a no-op for them.",
+    "property_types": {
+      "pipecat_data": "object"
+    }
   },
-
   "metrics_list": {
-    "description_suffix": "Always pass `agent_id` or `project_id` — omitting both returns all metrics in your account (potentially hundreds, exceeding response limits). `metrics_list(agent_id=1234)` returns metrics accessible to that agent including both agent-level and project-level metrics."
+    "description_suffix": "Always pass `agent_id` or `project_id` \u2014 omitting both returns all metrics in your account (potentially hundreds, exceeding response limits). `metrics_list(agent_id=1234)` returns metrics accessible to that agent including both agent-level and project-level metrics."
   },
-
   "metrics_bulk_create": {
     "description_suffix": "Pass the array of metric objects as the `items` parameter. Each item accepts the same fields as `metrics_create`. Example: `items: [{\"name\": \"Empathy\", \"type\": \"llm_judge\", \"eval_type\": \"binary_qualitative\", \"description\": \"Did the agent show empathy?\", \"project\": 1234}]`. For `llm_judge` metrics, put the evaluation criterion in `description`, not `prompt`."
   },
-
   "test_profiles_partial_update": {
-    "description_suffix": "The `information` dict is replaced in full on every update — re-send the complete dict. Any key omitted will be deleted from the stored profile."
+    "description_suffix": "The `information` dict is replaced in full on every update \u2014 re-send the complete dict. Any key omitted will be deleted from the stored profile."
   },
-
   "scenarios_folder_move": {
     "description_suffix": "To assign a scenario to a folder, use `scenarios_partial_update` with the `folder_path` field instead."
   },
-
   "call_logs_create_scenarios_progress": {
     "description_suffix": "Done when `completed_scenarios + failed_scenarios >= total_scenarios`. The `scenarios_list` field is populated only after completion."
   },
-
   "scenarios_folder_delete": {
     "destructive": true,
     "description_suffix": "Recursively deletes the folder and all scenarios beneath it. Cannot be undone."
   },
-
   "scenarios_bulk_delete": {
     "destructive": true,
     "description_suffix": "Bulk delete affects every ID in the `scenarios` array. Always confirm the exact list with the user before calling."
   },
-
   "scenarios_bulk_update": {
-    "description_suffix": "Affects every ID in the `scenarios` array in one transaction. `append_instruction` is non-idempotent — re-running with the same value appends it again. For single-scenario edits prefer `scenarios_partial_update`."
+    "description_suffix": "Affects every ID in the `scenarios` array in one transaction. `append_instruction` is non-idempotent \u2014 re-running with the same value appends it again. For single-scenario edits prefer `scenarios_partial_update`."
   },
-
   "call_logs_mark_metric_vote_create": {
     "description_suffix": "Use `metrics_list(agent_id=<id>)` to find available metric IDs before voting. Pass the metric ID in the `metric_id` field."
   },
-
   "runs_mark_metric_vote_create": {
     "description_suffix": "Use `metrics_list(agent_id=<id>)` to find available metric IDs before voting. Pass the metric ID in the `metric_id` field."
   },
-
   "metrics_generate_clean_description_bg_create": {
     "description_suffix": "File uploads via multipart/form-data are not supported over MCP. Use the Python SDK or REST API directly to upload reference transcript files."
   },
-
   "metrics_generate_clean_description_progress_retrieve": {
     "description_suffix": "Poll this endpoint with the progress_id returned from metrics_generate_clean_description_bg_create. Status values: queued, processing, completed, failed. On completed, clean_description and thinking fields contain the result."
+  },
+  "aiagents_tools_auto_fetch_create": {
+    "description_suffix": "Async \u2014 returns a progress_id. Poll aiagents_tools_auto_fetch_progress_retrieve with the progress_id until completed or failed."
+  },
+  "aiagents_tools_auto_fetch_progress_retrieve": {
+    "description_suffix": "Poll with the progress_id from aiagents_tools_auto_fetch_create. Status values: in_progress, completed (with discovered tool counts), failed (with error)."
+  },
+  "aiagents_tools_disable_mock_create": {
+    "description_suffix": "Async \u2014 returns a progress_id. Poll aiagents_tools_disable_mock_progress_retrieve with the progress_id until completed or failed."
+  },
+  "aiagents_tools_disable_mock_progress_retrieve": {
+    "description_suffix": "Poll with the progress_id from aiagents_tools_disable_mock_create. Status values: in_progress, completed, failed (with error)."
+  },
+  "aiagents_tools_enable_mock_create": {
+    "description_suffix": "Async \u2014 returns a progress_id. Poll aiagents_tools_enable_mock_progress_retrieve with the progress_id until completed (yields mcp_endpoints array) or failed."
+  },
+  "aiagents_tools_enable_mock_progress_retrieve": {
+    "description_suffix": "Poll with the progress_id from aiagents_tools_enable_mock_create. Status values: in_progress, completed (with mcp_endpoints[]), failed (with error). The mcp_endpoints array is populated only after completion."
   }
 }

--- a/openapi.json
+++ b/openapi.json
@@ -12563,6 +12563,14 @@
                         },
                         "description": ""
                     }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "aiagents-tool-retrieve",
+                        "description": "Get a specific tool by name"
+                    }
                 }
             },
             "post": {
@@ -12598,6 +12606,14 @@
                 "responses": {
                     "201": {
                         "description": "No response body"
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "aiagents-tool-create",
+                        "description": "Execute tool by matching input and returning corresponding output.\n\nSupports two payload formats:\n1. Flat input (default): {\"param1\": \"value1\", \"param2\": \"value2\"}\n2. VAPI function format: {\"message\": {\"type\": \"tool-calls\", \"toolCallList\": [{\"id\": \"...\", \"arguments\": {...}}]}}"
                     }
                 }
             },
@@ -12725,6 +12741,14 @@
                         },
                         "description": ""
                     }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "aiagents-tool-partial-update",
+                        "description": "Update a specific tool by name"
+                    }
                 }
             },
             "delete": {
@@ -12776,6 +12800,14 @@
                             }
                         },
                         "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "aiagents-tool-destroy",
+                        "description": "⚠ Irreversible. Detaches the named tool from this agent by marking it deleted. The tool definition is not deleted — other agents referencing the same tool_name are unaffected."
                     }
                 }
             }
@@ -12850,6 +12882,14 @@
                             }
                         },
                         "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "aiagents-tools-list",
+                        "description": "List all tools for this agent"
                     }
                 }
             },
@@ -12936,6 +12976,14 @@
                             }
                         },
                         "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "aiagents-tools-create",
+                        "description": "Create a new tool for agent"
                     }
                 }
             }
@@ -13032,6 +13080,15 @@
                         },
                         "description": ""
                     }
+                },
+                "x-mcp-expose": true,
+                "x-mcp-destructive": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "aiagents-tools-auto-fetch-create",
+                        "description": "Discover the agent's tools (from a managed provider or a customer-hosted MCP server) and LLM-generate mock input/output data for each. Persists Tool rows and records the provider configuration on the agent. ⚠ Overwrites empty Tool rows; existing rows with mock data are kept. For provider=\"custom\", supply `mcp_server_url`; the URL is SSRF-validated (no private/loopback targets)."
+                    }
                 }
             }
         },
@@ -13086,6 +13143,14 @@
                             }
                         },
                         "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "aiagents-tools-auto-fetch-progress-retrieve",
+                        "description": "Poll the status of a background auto-fetch tools task.\n\nReturns the current state: in_progress, completed (with counts), or failed (with error)."
                     }
                 }
             }
@@ -13154,6 +13219,15 @@
                         },
                         "description": ""
                     }
+                },
+                "x-mcp-expose": true,
+                "x-mcp-destructive": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "aiagents-tools-disable-mock-create",
+                        "description": "Restore the agent's tools to their original (non-mock) state. For managed providers this PATCHes the provider assistant back to its `original_tool_ids` and deletes the cloned tools. For provider=\"custom\" this only flips `mock_enabled` off; the `mcp_server_url` is preserved so re-enable works."
+                    }
                 }
             }
         },
@@ -13209,6 +13283,14 @@
                             }
                         },
                         "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "aiagents-tools-disable-mock-progress-retrieve",
+                        "description": "Poll the status of a background disable-mock task."
                     }
                 }
             }
@@ -13277,6 +13359,15 @@
                         },
                         "description": ""
                     }
+                },
+                "x-mcp-expose": true,
+                "x-mcp-destructive": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "aiagents-tools-enable-mock-create",
+                        "description": "Activate mock-tool mode using the data created by `auto-fetch`. For managed providers (vapi/retell/elevenlabs) this clones the provider's tools at the provider and swaps URLs to Cekura-hosted endpoints. For provider=\"custom\" it just registers `mcp_sub_tool_map` so MockMCPView can serve `/mcp/N/` calls. Returns a `progress_id`; poll `enable-mock-progress/` for the resulting `mcp_endpoints`. Run `auto-fetch` first."
+                    }
                 }
             }
         },
@@ -13333,6 +13424,14 @@
                         },
                         "description": ""
                     }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "aiagents-tools-enable-mock-progress-retrieve",
+                        "description": "Poll the status of a background enable-mock task."
+                    }
                 }
             }
         },
@@ -13370,6 +13469,14 @@
                             }
                         },
                         "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "aiagents-tools-mock-status-retrieve",
+                        "description": "Single source of truth for \"what mock-tool runtime URLs do I have, and what are they configured for?\". `mcp_endpoints[]` lists each Cekura-hosted MCP JSON-RPC endpoint with the sub-tools it serves; `tool_endpoints[]` lists standalone (non-MCP) per-tool webhook URLs. URLs are computed from `settings.CEKURA_BASE_URL`, so each environment renders the correct host."
                     }
                 }
             }
@@ -21589,17 +21696,17 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/PredefinedMetric"
+                                "$ref": "#/components/schemas/PredefinedMetricCopyRequest"
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/PredefinedMetric"
+                                "$ref": "#/components/schemas/PredefinedMetricCopyRequest"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/PredefinedMetric"
+                                "$ref": "#/components/schemas/PredefinedMetricCopyRequest"
                             }
                         }
                     },
@@ -21615,7 +21722,10 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/PredefinedMetric"
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/MetricList"
+                                    }
                                 }
                             }
                         },
@@ -21810,17 +21920,17 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/PredefinedMetric"
+                                "$ref": "#/components/schemas/PredefinedMetricCopyRequest"
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/PredefinedMetric"
+                                "$ref": "#/components/schemas/PredefinedMetricCopyRequest"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/PredefinedMetric"
+                                "$ref": "#/components/schemas/PredefinedMetricCopyRequest"
                             }
                         }
                     },
@@ -21836,7 +21946,10 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/PredefinedMetric"
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/MetricList"
+                                    }
                                 }
                             }
                         },
@@ -63605,6 +63718,36 @@
                 "required": [
                     "description",
                     "name"
+                ]
+            },
+            "PredefinedMetricCopyRequest": {
+                "type": "object",
+                "properties": {
+                    "predefined_metric_ids": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        },
+                        "description": "IDs of the predefined metrics to attach. Get these from the predefined metrics list."
+                    },
+                    "project_id": {
+                        "type": "integer",
+                        "description": "Project to attach the metrics to. Provide either project_id or agent_id, not both."
+                    },
+                    "agent_id": {
+                        "type": "integer",
+                        "description": "Agent to attach the metrics to. Provide either project_id or agent_id, not both."
+                    },
+                    "scenarios": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        },
+                        "description": "Optional scenario IDs to scope the metrics to (max 1000). Omit to apply across the target."
+                    }
+                },
+                "required": [
+                    "predefined_metric_ids"
                 ]
             },
             "ProcessFeedbacksRequest": {

--- a/openapi.json
+++ b/openapi.json
@@ -12492,7 +12492,8 @@
         "/test_framework/v1/aiagents/{agent_id}/tool/{tool_name}/": {
             "get": {
                 "operationId": "aiagents-tool-retrieve",
-                "description": "Get a specific tool by name",
+                "description": "Return a single tool's full definition, including the input/output pairs that define its mock responses. Use it to inspect what a tool returns before updating it or enabling mock mode.",
+                "summary": "Get an agent's tool by name",
                 "parameters": [
                     {
                         "in": "path",
@@ -12569,7 +12570,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "aiagents-tool-retrieve",
-                        "description": "Get a specific tool by name"
+                        "description": "Return a single tool's full definition, including the input/output pairs that define its mock responses. Use it to inspect what a tool returns before updating it or enabling mock mode."
                     }
                 }
             },
@@ -12607,19 +12608,12 @@
                     "201": {
                         "description": "No response body"
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-tool-create",
-                        "description": "Execute tool by matching input and returning corresponding output.\n\nSupports two payload formats:\n1. Flat input (default): {\"param1\": \"value1\", \"param2\": \"value2\"}\n2. VAPI function format: {\"message\": {\"type\": \"tool-calls\", \"toolCallList\": [{\"id\": \"...\", \"arguments\": {...}}]}}"
-                    }
                 }
             },
             "patch": {
                 "operationId": "aiagents-tool-partial-update",
-                "description": "Update a specific tool by name",
+                "description": "Patch a tool's fields — its `name`, `description`, or `information` (the list of input/output pairs that define its mock responses). Only the fields you send are changed.",
+                "summary": "Update an agent's tool by name",
                 "parameters": [
                     {
                         "in": "path",
@@ -12747,7 +12741,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "aiagents-tool-partial-update",
-                        "description": "Update a specific tool by name"
+                        "description": "Patch a tool's fields — its `name`, `description`, or `information` (the list of input/output pairs that define its mock responses). Only the fields you send are changed."
                     }
                 }
             },
@@ -12815,7 +12809,8 @@
         "/test_framework/v1/aiagents/{agent_id}/tools/": {
             "get": {
                 "operationId": "aiagents-tools-list",
-                "description": "List all tools for this agent",
+                "description": "Return every tool configured on the agent, including mock tools and the input/output pairs that define their mock responses. Use this to see what's set up before enabling or disabling mock mode or updating a specific tool.",
+                "summary": "List an agent's tools",
                 "parameters": [
                     {
                         "in": "path",
@@ -12889,13 +12884,14 @@
                     "mcp": {
                         "enabled": true,
                         "name": "aiagents-tools-list",
-                        "description": "List all tools for this agent"
+                        "description": "Return every tool configured on the agent, including mock tools and the input/output pairs that define their mock responses. Use this to see what's set up before enabling or disabling mock mode or updating a specific tool."
                     }
                 }
             },
             "post": {
                 "operationId": "aiagents-tools-create",
-                "description": "Create a new tool for agent",
+                "description": "Register a tool on the agent, including its mock input/output pairs in `information`. For agents on a managed provider, prefer auto-fetch to import tools automatically; use this to add a custom or hand-authored tool.",
+                "summary": "Add a tool to an agent",
                 "parameters": [
                     {
                         "in": "path",
@@ -12983,7 +12979,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "aiagents-tools-create",
-                        "description": "Create a new tool for agent"
+                        "description": "Register a tool on the agent, including its mock input/output pairs in `information`. For agents on a managed provider, prefer auto-fetch to import tools automatically; use this to add a custom or hand-authored tool."
                     }
                 }
             }
@@ -13096,6 +13092,7 @@
             "get": {
                 "operationId": "aiagents-tools-auto-fetch-progress-retrieve",
                 "description": "Poll the status of a background auto-fetch tools task.\n\nReturns the current state: in_progress, completed (with counts), or failed (with error).",
+                "summary": "Poll auto-fetch tool import progress",
                 "parameters": [
                     {
                         "in": "path",


### PR DESCRIPTION
Auto-generated docs sync for backend PR [#9390](https://github.com/cekura-ai/vocera.backend/pull/9390).

Reviewers: @dileep-chagam

## Summary

**Spec/overlay:** 4 tool-management endpoints newly exposed (aiagents_tool_retrieve, aiagents_tool_partial_update, aiagents_tools_list, aiagents_tools_create). All carry summaries and descriptions. No overlay patches needed — no transport-quirk signals fired. 4 SDK/CLI follow-ups filed.

## Changes

- `openapi.json` — regenerate_from_backend

## SDK / CLI parity follow-ups

- `aiagents_tool_retrieve` (GET `/test_framework/v1/aiagents/{agent_id}/tool/{tool_name}/`) — add
- `aiagents_tool_partial_update` (PATCH `/test_framework/v1/aiagents/{agent_id}/tool/{tool_name}/`) — add
- `aiagents_tools_list` (GET `/test_framework/v1/aiagents/{agent_id}/tools/`) — add
- `aiagents_tools_create` (POST `/test_framework/v1/aiagents/{agent_id}/tools/`) — add

---
*Auto-generated from backend PR #9390.*

<!-- mcp-sync:file-hashes -->
```json
{}
```
<!-- /mcp-sync:file-hashes -->