### PR TITLE
[Auto] Sync docs for backend PR #9390

### DIFF
--- a/cekura-mcp-server/mcp_tools.json
+++ b/cekura-mcp-server/mcp_tools.json
@@ -4,10 +4,10 @@
     "description_suffix": "Pass each file as `{\"name\": \"manual.pdf\", \"content_base64\": \"...\"}` where `content_base64` is the file content base64-encoded (a raw base64 string or a `data:<mime>;base64,...` data URI both work). Max 50 MB per file. Allowed extensions: pdf, txt, json, csv, xml, md."
   },
   "scenarios_run_voice": {
-    "description_suffix": "The run mode (voice / text / WebRTC) is determined by WHICH run endpoint you call \u2014 not by the agent config."
+    "description_suffix": "The run mode (voice / text / WebRTC) is determined by WHICH run endpoint you call — not by the agent config."
   },
   "scenarios_run_text": {
-    "description_suffix": "The run mode is determined by WHICH run endpoint you call \u2014 not by the agent config. DO NOT USE for voice-specific metrics (latency, pitch) \u2014 they will be zero."
+    "description_suffix": "The run mode is determined by WHICH run endpoint you call — not by the agent config. DO NOT USE for voice-specific metrics (latency, pitch) — they will be zero."
   },
   "scenarios_run_pipecat_v1": {
     "description_suffix": "The run mode is determined by WHICH run endpoint you call, not the agent config. Requires a Pipecat API key configured on the project."
@@ -16,57 +16,57 @@
     "description_suffix": "The run mode is determined by WHICH run endpoint you call, not the agent config."
   },
   "observe_create": {
-    "description_suffix": "File uploads not supported \u2014 use `voice_recording_url` instead of `voice_recording`. Do not pass `metric_ids` \u2014 causes a 500 error on current staging; use `call_logs_evaluate_metrics_create` after ingestion instead. Wrong roles silently produce an empty transcript with no error returned."
+    "description_suffix": "File uploads not supported — use `voice_recording_url` instead of `voice_recording`. Do not pass `metric_ids` — causes a 500 error on current staging; use `call_logs_evaluate_metrics_create` after ingestion instead. Wrong roles silently produce an empty transcript with no error returned."
   },
   "runs_bulk_retrieve": {
     "description_suffix": "`run_ids` must be a bare comma-separated string (e.g. `\"86368,86369\"`). Passing a JSON array `[86368, 86369]` or a JSON-quoted string both return `400: run_ids must be comma-separated integers`."
   },
   "call_logs_evaluate_metrics_create": {
-    "description_suffix": "Known issue: the `metrics` filter is not enforced \u2014 all metrics assigned to the call log are evaluated regardless of which IDs are passed."
+    "description_suffix": "Known issue: the `metrics` filter is not enforced — all metrics assigned to the call log are evaluated regardless of which IDs are passed."
   },
   "metrics_create": {
-    "description_suffix": "**Prefer `metrics_generate`** (AI-authored from agent prompt) over this tool unless the user has explicitly given concrete field values to write. Use `metrics_generate_clean_description_create` to clean up an existing description and `metrics_generate_evaluation_trigger_create` to derive a trigger. The `prompt` field is only active when explicitly setting `llm_provider` to a non-default value \u2014 for standard `llm_judge` metrics, the criterion goes in `description`. `assistant_id` is optional despite appearing required in some schema views \u2014 omit it entirely; passing an empty string returns a 400 error. `add_to_new_agents`: when omitted or `true`, this metric is automatically assigned to every new agent created in the project \u2014 set to `false` to scope to specific agents only. To attach a metric to evaluators after creation, use `scenarios_partial_update` with `metrics: [id1, id2, ...]`; use `metrics_list(agent_id=<id>)` to find available IDs."
+    "description_suffix": "**Prefer `metrics_generate`** (AI-authored from agent prompt) over this tool unless the user has explicitly given concrete field values to write. Use `metrics_generate_clean_description_create` to clean up an existing description and `metrics_generate_evaluation_trigger_create` to derive a trigger. The `prompt` field is only active when explicitly setting `llm_provider` to a non-default value — for standard `llm_judge` metrics, the criterion goes in `description`. `assistant_id` is optional despite appearing required in some schema views — omit it entirely; passing an empty string returns a 400 error. `add_to_new_agents`: when omitted or `true`, this metric is automatically assigned to every new agent created in the project — set to `false` to scope to specific agents only. To attach a metric to evaluators after creation, use `scenarios_partial_update` with `metrics: [id1, id2, ...]`; use `metrics_list(agent_id=<id>)` to find available IDs."
   },
   "metrics_partial_update": {
     "description_suffix": "**Prefer `metrics_generate_clean_description_create` / `metrics_generate_evaluation_trigger_create` / `metrics_simplify_prompt_create`** when refining metric fields with AI assistance. Use this raw patch only when the user has given concrete field values to write."
   },
   "scenarios_create": {
-    "description_suffix": "**Prefer `scenarios_generate_bg`** for authoring new scenarios \u2014 it accepts per-scenario `extra_instructions` so callers can shape each scenario individually. Use this raw create only when the user has given concrete field values to write. To refine an existing scenario, use `scenarios_agent_create` (natural-language improvement) or `scenarios_improve_instructions_create` (rewrites the `instructions` text).\n\n**Tools (`tool_ids`):** it is recommended to include `TOOL_END_CALL` by default so the testing agent can hang up once it has completed its objective \u2014 leave it out only if the user does not want the agent to end the call. Other commonly used tool IDs include `TOOL_END_CALL_ONLY_ON_TRANSFER` (use instead of `TOOL_END_CALL` when the expected outcome is a transfer to a human/IVR, so the agent does not sit through hold music) and `TOOL_DTMF` (send keypad tones for IVR navigation). Example: `\"tool_ids\": [\"TOOL_END_CALL\"]`."
+    "description_suffix": "**Prefer `scenarios_generate_bg`** for authoring new scenarios — it accepts per-scenario `extra_instructions` so callers can shape each scenario individually. Use this raw create only when the user has given concrete field values to write. To refine an existing scenario, use `scenarios_agent_create` (natural-language improvement) or `scenarios_improve_instructions_create` (rewrites the `instructions` text).\n\n**Tools (`tool_ids`):** it is recommended to include `TOOL_END_CALL` by default so the testing agent can hang up once it has completed its objective — leave it out only if the user does not want the agent to end the call. Other commonly used tool IDs include `TOOL_END_CALL_ONLY_ON_TRANSFER` (use instead of `TOOL_END_CALL` when the expected outcome is a transfer to a human/IVR, so the agent does not sit through hold music) and `TOOL_DTMF` (send keypad tones for IVR navigation). Example: `\"tool_ids\": [\"TOOL_END_CALL\"]`."
   },
   "scenarios_partial_update": {
     "description_suffix": "**Prefer `scenarios_agent_create`** (natural-language improvement of one or more scenarios) or `scenarios_improve_instructions_create` (rewrites just the `instructions` text). Use this raw patch only when the user has explicitly given concrete field values to write."
   },
   "scenarios_agent_create": {
-    "description_suffix": "Unified scenario-agent endpoint \u2014 clarifies (no `scenarios` field in payload) AND improves (with `scenarios` field). The `_create` suffix is a DRF/spectacular naming artifact, NOT a separate create endpoint. Use this whenever the user wants AI-driven scenario refinement; do not reach for `scenarios_create` for that case. Async \u2014 poll via `scenarios_agent_progress`."
+    "description_suffix": "Unified scenario-agent endpoint — clarifies (no `scenarios` field in payload) AND improves (with `scenarios` field). The `_create` suffix is a DRF/spectacular naming artifact, NOT a separate create endpoint. Use this whenever the user wants AI-driven scenario refinement; do not reach for `scenarios_create` for that case. Async — poll via `scenarios_agent_progress`."
   },
   "scenarios_generate_bg": {
-    "description_suffix": "Preferred path for authoring new scenarios. Accepts per-scenario `extra_instructions` so each generated scenario can be shaped individually \u2014 use this rather than `scenarios_create` unless the user has given concrete field values to write. Async \u2014 poll via `scenarios_generate_progress`.\n\n**Tools (`tool_ids`):** it is recommended to include `TOOL_END_CALL` by default so the generated testing agents can hang up once they have completed their objective \u2014 leave it out only if the user does not want the agent to end the call. Other commonly used tool IDs include `TOOL_END_CALL_ONLY_ON_TRANSFER` (use instead of `TOOL_END_CALL` when the expected outcome is a transfer to a human/IVR, so the agent does not sit through hold music) and `TOOL_DTMF` (send keypad tones for IVR navigation). Example: `\"tool_ids\": [\"TOOL_END_CALL\"]`."
+    "description_suffix": "Preferred path for authoring new scenarios. Accepts per-scenario `extra_instructions` so each generated scenario can be shaped individually — use this rather than `scenarios_create` unless the user has given concrete field values to write. Async — poll via `scenarios_generate_progress`.\n\n**Tools (`tool_ids`):** it is recommended to include `TOOL_END_CALL` by default so the generated testing agents can hang up once they have completed their objective — leave it out only if the user does not want the agent to end the call. Other commonly used tool IDs include `TOOL_END_CALL_ONLY_ON_TRANSFER` (use instead of `TOOL_END_CALL` when the expected outcome is a transfer to a human/IVR, so the agent does not sit through hold music) and `TOOL_DTMF` (send keypad tones for IVR navigation). Example: `\"tool_ids\": [\"TOOL_END_CALL\"]`."
   },
   "scenarios_improve_instructions_create": {
-    "description_suffix": "Lower-level instruction refiner: takes `agent` + `extra_instructions` and rewrites a scenario's `instructions` text. For multi-scenario or higher-level natural-language refinement use `scenarios_agent_create` instead. Async \u2014 poll via `scenarios_instructions_progress_retrieve`."
+    "description_suffix": "Lower-level instruction refiner: takes `agent` + `extra_instructions` and rewrites a scenario's `instructions` text. For multi-scenario or higher-level natural-language refinement use `scenarios_agent_create` instead. Async — poll via `scenarios_instructions_progress_retrieve`."
   },
   "aiagents_create": {
     "description_suffix": "When the goal is to *improve* an existing agent based on test results or natural-language feedback, prefer `scenarios_agent_create` (it can update agent fields as part of the improvement loop). Use this raw create only when the user has given concrete field values to write.",
-    "_property_types_note": "pipecat_data is a JSON object the spec mistypes as string; coerced to object so the client sends a dict. Only needed for Pipecat agents \u2014 other providers omit pipecat_data, so it's a no-op for them.",
+    "_property_types_note": "pipecat_data is a JSON object the spec mistypes as string; coerced to object so the client sends a dict. Only needed for Pipecat agents — other providers omit pipecat_data, so it's a no-op for them.",
     "property_types": {
       "pipecat_data": "object"
     }
   },
   "aiagents_partial_update": {
     "description_suffix": "When refining an existing agent based on test results or natural-language feedback, prefer `scenarios_agent_create` or `runs_improve_prompt_create` / `runs_improve_prompt_bg_create` (run-driven prompt improvement). Use this raw patch only when the user has explicitly given concrete field values to write.",
-    "_property_types_note": "pipecat_data is a JSON object the spec mistypes as string; coerced to object so the client sends a dict. Only needed for Pipecat agents \u2014 other providers omit pipecat_data, so it's a no-op for them.",
+    "_property_types_note": "pipecat_data is a JSON object the spec mistypes as string; coerced to object so the client sends a dict. Only needed for Pipecat agents — other providers omit pipecat_data, so it's a no-op for them.",
     "property_types": {
       "pipecat_data": "object"
     }
   },
   "metrics_list": {
-    "description_suffix": "Always pass `agent_id` or `project_id` \u2014 omitting both returns all metrics in your account (potentially hundreds, exceeding response limits). `metrics_list(agent_id=1234)` returns metrics accessible to that agent including both agent-level and project-level metrics."
+    "description_suffix": "Always pass `agent_id` or `project_id` — omitting both returns all metrics in your account (potentially hundreds, exceeding response limits). `metrics_list(agent_id=1234)` returns metrics accessible to that agent including both agent-level and project-level metrics."
   },
   "metrics_bulk_create": {
     "description_suffix": "Pass the array of metric objects as the `items` parameter. Each item accepts the same fields as `metrics_create`. Example: `items: [{\"name\": \"Empathy\", \"type\": \"llm_judge\", \"eval_type\": \"binary_qualitative\", \"description\": \"Did the agent show empathy?\", \"project\": 1234}]`. For `llm_judge` metrics, put the evaluation criterion in `description`, not `prompt`."
   },
   "test_profiles_partial_update": {
-    "description_suffix": "The `information` dict is replaced in full on every update \u2014 re-send the complete dict. Any key omitted will be deleted from the stored profile."
+    "description_suffix": "The `information` dict is replaced in full on every update — re-send the complete dict. Any key omitted will be deleted from the stored profile."
   },
   "scenarios_folder_move": {
     "description_suffix": "To assign a scenario to a folder, use `scenarios_partial_update` with the `folder_path` field instead."
@@ -83,7 +83,7 @@
     "description_suffix": "Bulk delete affects every ID in the `scenarios` array. Always confirm the exact list with the user before calling."
   },
   "scenarios_bulk_update": {
-    "description_suffix": "Affects every ID in the `scenarios` array in one transaction. `append_instruction` is non-idempotent \u2014 re-running with the same value appends it again. For single-scenario edits prefer `scenarios_partial_update`."
+    "description_suffix": "Affects every ID in the `scenarios` array in one transaction. `append_instruction` is non-idempotent — re-running with the same value appends it again. For single-scenario edits prefer `scenarios_partial_update`."
   },
   "call_logs_mark_metric_vote_create": {
     "description_suffix": "Use `metrics_list(agent_id=<id>)` to find available metric IDs before voting. Pass the metric ID in the `metric_id` field."
@@ -98,19 +98,19 @@
     "description_suffix": "Poll this endpoint with the progress_id returned from metrics_generate_clean_description_bg_create. Status values: queued, processing, completed, failed. On completed, clean_description and thinking fields contain the result."
   },
   "aiagents_tools_auto_fetch_create": {
-    "description_suffix": "Async \u2014 returns a progress_id. Poll aiagents_tools_auto_fetch_progress_retrieve with the progress_id until completed or failed."
+    "description_suffix": "Async — returns a progress_id. Poll aiagents_tools_auto_fetch_progress_retrieve with the progress_id until completed or failed."
   },
   "aiagents_tools_auto_fetch_progress_retrieve": {
     "description_suffix": "Poll with the progress_id from aiagents_tools_auto_fetch_create. Status values: in_progress, completed (with discovered tool counts), failed (with error)."
   },
   "aiagents_tools_disable_mock_create": {
-    "description_suffix": "Async \u2014 returns a progress_id. Poll aiagents_tools_disable_mock_progress_retrieve with the progress_id until completed or failed."
+    "description_suffix": "Async — returns a progress_id. Poll aiagents_tools_disable_mock_progress_retrieve with the progress_id until completed or failed."
   },
   "aiagents_tools_disable_mock_progress_retrieve": {
     "description_suffix": "Poll with the progress_id from aiagents_tools_disable_mock_create. Status values: in_progress, completed, failed (with error)."
   },
   "aiagents_tools_enable_mock_create": {
-    "description_suffix": "Async \u2014 returns a progress_id. Poll aiagents_tools_enable_mock_progress_retrieve with the progress_id until completed (yields mcp_endpoints array) or failed."
+    "description_suffix": "Async — returns a progress_id. Poll aiagents_tools_enable_mock_progress_retrieve with the progress_id until completed (yields mcp_endpoints array) or failed."
   },
   "aiagents_tools_enable_mock_progress_retrieve": {
     "description_suffix": "Poll with the progress_id from aiagents_tools_enable_mock_create. Status values: in_progress, completed (with mcp_endpoints[]), failed (with error). The mcp_endpoints array is populated only after completion."


### PR DESCRIPTION
Auto-generated docs sync for backend PR [#9390](https://github.com/cekura-ai/vocera.backend/pull/9390).

Reviewers: @dileep-chagam

## Summary

**Spec/overlay:** 12 newly-exposed MCP tools (tool management API endpoints under /v1/aiagents/{id}/tool(s)/ now exposed via mcp_hooks.py _is_duplicate_route change). 3 overlay patches added for async_progress_pairing signals. 12 SDK/CLI follow-ups filed.

**Conceptual docs:** No edits — PR #9390 fixed OpenAPI schema generation (predefined-copy request schema, added summaries to mock-tool endpoints, removed MCP exposure from provider callback) and restored MCP exposure to /v1/aiagents/{id}/tool(s)/ management routes. Changes are spec-level: mcp/overview.mdx correctly says "84+ tools" (still accurate); mock-tools.mdx and pre-defined-metrics.mdx are concept pages that describe features, not API access methods. No conceptual content is inaccurate after this PR.

## Changes

- `openapi.json` — regenerate_from_backend
- `cekura-mcp-server/mcp_tools.json` — patch_json
- `cekura-mcp-server/mcp_tools.json` — patch_json
- `cekura-mcp-server/mcp_tools.json` — patch_json

## SDK / CLI parity follow-ups

- `aiagents_tool_retrieve` (GET `/test_framework/v1/aiagents/{agent_id}/tool/{tool_name}/`) — add
- `aiagents_tool_partial_update` (PATCH `/test_framework/v1/aiagents/{agent_id}/tool/{tool_name}/`) — add
- `aiagents_tool_destroy` (DELETE `/test_framework/v1/aiagents/{agent_id}/tool/{tool_name}/`) — add
- `aiagents_tools_list` (GET `/test_framework/v1/aiagents/{agent_id}/tools/`) — add
- `aiagents_tools_create` (POST `/test_framework/v1/aiagents/{agent_id}/tools/`) — add
- `aiagents_tools_auto_fetch_create` (POST `/test_framework/v1/aiagents/{agent_id}/tools/auto-fetch/`) — add
- `aiagents_tools_auto_fetch_progress_retrieve` (GET `/test_framework/v1/aiagents/{agent_id}/tools/auto-fetch-progress/`) — add
- `aiagents_tools_disable_mock_create` (POST `/test_framework/v1/aiagents/{agent_id}/tools/disable-mock/`) — add
- `aiagents_tools_disable_mock_progress_retrieve` (GET `/test_framework/v1/aiagents/{agent_id}/tools/disable-mock-progress/`) — add
- `aiagents_tools_enable_mock_create` (POST `/test_framework/v1/aiagents/{agent_id}/tools/enable-mock/`) — add
- `aiagents_tools_enable_mock_progress_retrieve` (GET `/test_framework/v1/aiagents/{agent_id}/tools/enable-mock-progress/`) — add
- `aiagents_tools_mock_status_retrieve` (GET `/test_framework/v1/aiagents/{agent_id}/tools/mock-status/`) — add

## Applied with notes

- mcp_tools.json: existing overlay at /aiagents_tools_auto_fetch_create differs from proposed; left existing in place (D2 precedence)
- mcp_tools.json: existing overlay at /aiagents_tools_enable_mock_create differs from proposed; left existing in place (D2 precedence)
- mcp_tools.json: existing overlay at /aiagents_tools_disable_mock_create differs from proposed; left existing in place (D2 precedence)

---
*Auto-generated from backend PR #9390.*

<!-- mcp-sync:file-hashes -->
```json
{}
```
<!-- /mcp-sync:file-hashes -->