### PR TITLE
[Auto] Sync docs for backend PR #9419

### DIFF
--- a/documentation/key-concepts/evaluators/mock-tools.mdx
+++ b/documentation/key-concepts/evaluators/mock-tools.mdx
@@ -67,6 +67,22 @@ Auto-fetch reads your tool configurations from your provider (VAPI, Retell, or E
   **LiveKit**: Auto-fetch is not supported for LiveKit. To use mock tools with LiveKit, you can manually create mock tools and integrate the Cekura SDK in your LiveKit agent. See the [LiveKit Tracing guide](/documentation/integrations/livekit/tracing) for setup instructions.
 </Note>
 
+#### Viewing Generated Mock Tool Data
+
+When Auto-Fetch generates mock data for scenarios whose agent has mock tools attached, the expected mock tool calls are stored on each scenario as `generated_mock_tool_entries`. This data includes:
+
+- **Tool ID**: The identifier for the mock tool
+- **Tool Name**: The name of the tool being mocked
+- **Expected Input**: The input parameters the tool expects
+- **Expected Output**: The response the tool will return
+
+You can view this data in two ways:
+
+1. **Via the Evaluator UI**: When viewing a scenario in the Cekura dashboard, the generated mock tool entries are displayed so you can see what tool calls the evaluator will make during testing
+2. **Via the API**: Retrieve a scenario using the scenarios retrieve endpoint to access the `generated_mock_tool_entries` field programmatically
+
+This visibility helps you understand exactly what mock tool interactions will occur during each test run, making it easier to debug and validate your agent's tool-calling behavior.
+
 #### Enabling and Disabling Mock Mode
 
 After running Auto-Fetch, use the **Mock** toggle to control whether your provider's tools are redirected to Cekura's mock endpoints.


### PR DESCRIPTION
Auto-generated docs sync for backend PR [#9419](https://github.com/cekura-ai/vocera.backend/pull/9419).

Reviewers: @dileep-chagam, @cekurarsan

## Summary

**Spec/overlay:** Backend PR #9419: Return generated_mock_tool_entries on scenarios retrieve (API + MCP). Bucket A: scenarios-retrieve enhanced with new field + description update. No overlay needed (no transport quirks).

**Conceptual docs:** Updated documentation/key-concepts/evaluators/mock-tools.mdx to document the `generated_mock_tool_entries` field. Added a new subsection explaining that auto-generated mock tool data is stored on scenarios and can be retrieved via the scenarios retrieve endpoint or viewed in the evaluator UI.

## Changes

- `openapi.json` — regenerate_from_backend
- `documentation/key-concepts/evaluators/mock-tools.mdx` — update

---
*Auto-generated from backend PR #9419.*

<!-- mcp-sync:file-hashes -->
```json
{
  "documentation/key-concepts/evaluators/mock-tools.mdx": "95ce5d5ba274fb506ee4aa2cd4234a623fa532a15bdb3ab8bca00bab3527b919"
}
```
<!-- /mcp-sync:file-hashes -->