### PR TITLE
[Auto] Sync docs for backend PR #9437

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -27894,7 +27894,8 @@
         "/test_framework/v1/scenarios-external/{id}/": {
             "get": {
                 "operationId": "scenarios-external-retrieve",
-                "description": "Retrieve a test scenario by ID",
+                "description": "Fetch a single evaluator by id. Returns full configuration including instructions, expected outcome, metrics, test profile, and — when the agent has mock tools attached and the scenario was auto-generated — the expected mock tool calls (`generated_mock_tool_entries`) with their inputs and outputs.",
+                "summary": "Retrieve an evaluator (scenario)",
                 "parameters": [
                     {
                         "in": "path",
@@ -29456,7 +29457,7 @@
         "/test_framework/v1/scenarios-external/generate-bg/": {
             "post": {
                 "operationId": "scenarios-generate-bg",
-                "description": "Generate scenarios for a given agent in the background. Returns a `progress_id` immediately; poll GET /scenarios/generate-progress/?progress_id={id} until `total_scenarios == completed_scenarios`.\n\n**What happens automatically on generation:**\n- A default test profile is created for the agent if none exists. Each generated scenario will have `test_profile_data` populated with synthetic caller information (name, address, phone, email).\n- 10 project-level evaluation metrics are attached to every generated scenario automatically (e.g. Latency, Pitch, Interruption Score). Scenarios created manually via `scenarios_create` start with no metrics attached.\n\n**Response fields:** `progress_id` (UUID string) for polling; `session_id` is always null.",
+                "description": "Generate scenarios for a given agent in the background. Returns a `progress_id` immediately; poll GET /scenarios/generate-progress/?progress_id={id} until `total_scenarios == completed_scenarios`.\n\n**What happens automatically on generation:**\n- A scenario-specific test profile is created and its `information` is populated using the sectioned shape: `main_agent_variables` (dynamic-variable values that reach the agent under test at call time — e.g. `user_id`, `account_id`) and `testing_agent_variables` (persona/context used by the simulated caller — e.g. `customer_name`, `date_of_birth`). Section values are kept consistent with any generated mock-tool data.\n- 10 project-level evaluation metrics are attached to every generated scenario automatically (e.g. Latency, Pitch, Interruption Score). Scenarios created manually via `scenarios_create` start with no metrics attached.\n\n**Response fields:** `progress_id` (UUID string) for polling; `session_id` is always null.",
                 "tags": [
                     "test_framework"
                 ],
@@ -32704,7 +32705,8 @@
         "/test_framework/v1/scenarios/{id}/": {
             "get": {
                 "operationId": "scenarios-retrieve",
-                "description": "Retrieve a test scenario by ID",
+                "description": "Fetch a single evaluator by id. Returns full configuration including instructions, expected outcome, metrics, test profile, and — when the agent has mock tools attached and the scenario was auto-generated — the expected mock tool calls (`generated_mock_tool_entries`) with their inputs and outputs.",
+                "summary": "Retrieve an evaluator (scenario)",
                 "parameters": [
                     {
                         "in": "path",
@@ -32756,7 +32758,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-retrieve",
-                        "description": "Retrieve a test scenario by ID"
+                        "description": "Fetch a single evaluator by id. Returns full configuration including instructions, expected outcome, metrics, test profile, and — when the agent has mock tools attached and the scenario was auto-generated — the expected mock tool calls (`generated_mock_tool_entries`) with their inputs and outputs."
                     }
                 }
             },
@@ -34346,7 +34348,7 @@
         "/test_framework/v1/scenarios/generate-bg/": {
             "post": {
                 "operationId": "scenarios-generate-bg_2",
-                "description": "Generate scenarios for a given agent in the background. Returns a `progress_id` immediately; poll GET /scenarios/generate-progress/?progress_id={id} until `total_scenarios == completed_scenarios`.\n\n**What happens automatically on generation:**\n- A default test profile is created for the agent if none exists. Each generated scenario will have `test_profile_data` populated with synthetic caller information (name, address, phone, email).\n- 10 project-level evaluation metrics are attached to every generated scenario automatically (e.g. Latency, Pitch, Interruption Score). Scenarios created manually via `scenarios_create` start with no metrics attached.\n\n**Response fields:** `progress_id` (UUID string) for polling; `session_id` is always null.",
+                "description": "Generate scenarios for a given agent in the background. Returns a `progress_id` immediately; poll GET /scenarios/generate-progress/?progress_id={id} until `total_scenarios == completed_scenarios`.\n\n**What happens automatically on generation:**\n- A scenario-specific test profile is created and its `information` is populated using the sectioned shape: `main_agent_variables` (dynamic-variable values that reach the agent under test at call time — e.g. `user_id`, `account_id`) and `testing_agent_variables` (persona/context used by the simulated caller — e.g. `customer_name`, `date_of_birth`). Section values are kept consistent with any generated mock-tool data.\n- 10 project-level evaluation metrics are attached to every generated scenario automatically (e.g. Latency, Pitch, Interruption Score). Scenarios created manually via `scenarios_create` start with no metrics attached.\n\n**Response fields:** `progress_id` (UUID string) for polling; `session_id` is always null.",
                 "tags": [
                     "test_framework"
                 ],
@@ -34415,7 +34417,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-generate-bg",
-                        "description": "Generate scenarios for a given agent in the background. Returns a `progress_id` immediately; poll GET /scenarios/generate-progress/?progress_id={id} until `total_scenarios == completed_scenarios`.\n\n**What happens automatically on generation:**\n- A default test profile is created for the agent if none exists. Each generated scenario will have `test_profile_data` populated with synthetic caller information (name, address, phone, email).\n- 10 project-level evaluation metrics are attached to every generated scenario automatically (e.g. Latency, Pitch, Interruption Score). Scenarios created manually via `scenarios_create` start with no metrics attached.\n\n**Response fields:** `progress_id` (UUID string) for polling; `session_id` is always null."
+                        "description": "Generate scenarios for a given agent in the background. Returns a `progress_id` immediately; poll GET /scenarios/generate-progress/?progress_id={id} until `total_scenarios == completed_scenarios`.\n\n**What happens automatically on generation:**\n- A scenario-specific test profile is created and its `information` is populated using the sectioned shape: `main_agent_variables` (dynamic-variable values that reach the agent under test at call time — e.g. `user_id`, `account_id`) and `testing_agent_variables` (persona/context used by the simulated caller — e.g. `customer_name`, `date_of_birth`). Section values are kept consistent with any generated mock-tool data.\n- 10 project-level evaluation metrics are attached to every generated scenario automatically (e.g. Latency, Pitch, Interruption Score). Scenarios created manually via `scenarios_create` start with no metrics attached.\n\n**Response fields:** `progress_id` (UUID string) for polling; `session_id` is always null."
                     }
                 }
             }
@@ -37835,8 +37837,14 @@
                                                 "agent": 123,
                                                 "name": "<string>",
                                                 "information": {
-                                                    "user_name": "<string>",
-                                                    "user_email": "<string>"
+                                                    "main_agent_variables": {
+                                                        "user_id": "<string>",
+                                                        "account_id": "<string>"
+                                                    },
+                                                    "testing_agent_variables": {
+                                                        "user_name": "<string>",
+                                                        "user_email": "<string>"
+                                                    }
                                                 }
                                             }
                                         ],
@@ -37875,8 +37883,14 @@
                                         "agent": 123,
                                         "name": "<string>",
                                         "information": {
-                                            "user_name": "<string>",
-                                            "user_email": "<string>"
+                                            "main_agent_variables": {
+                                                "user_id": "<string>",
+                                                "account_id": "<string>"
+                                            },
+                                            "testing_agent_variables": {
+                                                "user_name": "<string>",
+                                                "user_email": "<string>"
+                                            }
                                         }
                                     },
                                     "summary": "Create Test Profile with Agent"
@@ -37886,8 +37900,14 @@
                                         "project": 456,
                                         "name": "<string>",
                                         "information": {
-                                            "user_name": "<string>",
-                                            "user_email": "<string>"
+                                            "main_agent_variables": {
+                                                "user_id": "<string>",
+                                                "account_id": "<string>"
+                                            },
+                                            "testing_agent_variables": {
+                                                "user_name": "<string>",
+                                                "user_email": "<string>"
+                                            }
                                         }
                                     },
                                     "summary": "Create Test Profile with Project"
@@ -37927,8 +37947,14 @@
                                             "agent": null,
                                             "name": "<string>",
                                             "information": {
-                                                "user_name": "John Doe",
-                                                "user_email": "john.doe@example.com"
+                                                "main_agent_variables": {
+                                                    "user_id": "U-42",
+                                                    "account_id": "ACC-4521"
+                                                },
+                                                "testing_agent_variables": {
+                                                    "user_name": "John Doe",
+                                                    "user_email": "john.doe@example.com"
+                                                }
                                             }
                                         },
                                         "summary": "Create Test Profile Response"
@@ -38014,8 +38040,14 @@
                                                 "agent": 123,
                                                 "name": "<string>",
                                                 "information": {
-                                                    "user_name": "<string>",
-                                                    "user_email": "<string>"
+                                                    "main_agent_variables": {
+                                                        "user_id": "<string>",
+                                                        "account_id": "<string>"
+                                                    },
+                                                    "testing_agent_variables": {
+                                                        "user_name": "<string>",
+                                                        "user_email": "<string>"
+                                                    }
                                                 }
                                             }
                                         ],
@@ -38046,8 +38078,14 @@
                                         "agent": 123,
                                         "name": "<string>",
                                         "information": {
-                                            "user_name": "<string>",
-                                            "user_email": "<string>"
+                                            "main_agent_variables": {
+                                                "user_id": "<string>",
+                                                "account_id": "<string>"
+                                            },
+                                            "testing_agent_variables": {
+                                                "user_name": "<string>",
+                                                "user_email": "<string>"
+                                            }
                                         }
                                     },
                                     "summary": "Create Test Profile with Agent"
@@ -38057,8 +38095,14 @@
                                         "project": 456,
                                         "name": "<string>",
                                         "information": {
-                                            "user_name": "<string>",
-                                            "user_email": "<string>"
+                                            "main_agent_variables": {
+                                                "user_id": "<string>",
+                                                "account_id": "<string>"
+                                            },
+                                            "testing_agent_variables": {
+                                                "user_name": "<string>",
+                                                "user_email": "<string>"
+                                            }
                                         }
                                     },
                                     "summary": "Create Test Profile with Project"
@@ -38098,8 +38142,14 @@
                                             "agent": null,
                                             "name": "<string>",
                                             "information": {
-                                                "user_name": "John Doe",
-                                                "user_email": "john.doe@example.com"
+                                                "main_agent_variables": {
+                                                    "user_id": "U-42",
+                                                    "account_id": "ACC-4521"
+                                                },
+                                                "testing_agent_variables": {
+                                                    "user_name": "John Doe",
+                                                    "user_email": "john.doe@example.com"
+                                                }
                                             }
                                         },
                                         "summary": "Create Test Profile Response"
@@ -38167,8 +38217,14 @@
                                             "agent": 123,
                                             "name": "<string>",
                                             "information": {
-                                                "user_name": "<string>",
-                                                "user_email": "<string>"
+                                                "main_agent_variables": {
+                                                    "user_id": "<string>",
+                                                    "account_id": "<string>"
+                                                },
+                                                "testing_agent_variables": {
+                                                    "user_name": "<string>",
+                                                    "user_email": "<string>"
+                                                }
                                             }
                                         },
                                         "summary": "Get Test Profile"
@@ -38263,8 +38319,14 @@
                                     "value": {
                                         "name": "<string>",
                                         "information": {
-                                            "user_name": "<string>",
-                                            "user_email": "<string>"
+                                            "main_agent_variables": {
+                                                "user_id": "<string>",
+                                                "account_id": "<string>"
+                                            },
+                                            "testing_agent_variables": {
+                                                "user_name": "<string>",
+                                                "user_email": "<string>"
+                                            }
                                         }
                                     },
                                     "summary": "Partial Update Test Profile"
@@ -38302,8 +38364,14 @@
                                             "agent": 123,
                                             "name": "<string>",
                                             "information": {
-                                                "user_name": "<string>",
-                                                "user_email": "<string>"
+                                                "main_agent_variables": {
+                                                    "user_id": "<string>",
+                                                    "account_id": "<string>"
+                                                },
+                                                "testing_agent_variables": {
+                                                    "user_name": "<string>",
+                                                    "user_email": "<string>"
+                                                }
                                             }
                                         },
                                         "summary": "Partial Update Test Profile Response"
@@ -38397,8 +38465,14 @@
                                             "agent": 123,
                                             "name": "<string>",
                                             "information": {
-                                                "user_name": "<string>",
-                                                "user_email": "<string>"
+                                                "main_agent_variables": {
+                                                    "user_id": "<string>",
+                                                    "account_id": "<string>"
+                                                },
+                                                "testing_agent_variables": {
+                                                    "user_name": "<string>",
+                                                    "user_email": "<string>"
+                                                }
                                             }
                                         },
                                         "summary": "Get Test Profile"
@@ -38501,8 +38575,14 @@
                                     "value": {
                                         "name": "<string>",
                                         "information": {
-                                            "user_name": "<string>",
-                                            "user_email": "<string>"
+                                            "main_agent_variables": {
+                                                "user_id": "<string>",
+                                                "account_id": "<string>"
+                                            },
+                                            "testing_agent_variables": {
+                                                "user_name": "<string>",
+                                                "user_email": "<string>"
+                                            }
                                         }
                                     },
                                     "summary": "Partial Update Test Profile"
@@ -38540,8 +38620,14 @@
                                             "agent": 123,
                                             "name": "<string>",
                                             "information": {
-                                                "user_name": "<string>",
-                                                "user_email": "<string>"
+                                                "main_agent_variables": {
+                                                    "user_id": "<string>",
+                                                    "account_id": "<string>"
+                                                },
+                                                "testing_agent_variables": {
+                                                    "user_name": "<string>",
+                                                    "user_email": "<string>"
+                                                }
                                             }
                                         },
                                         "summary": "Partial Update Test Profile Response"
@@ -40402,7 +40488,8 @@
         "/test_framework/v2/scenarios/{id}/": {
             "get": {
                 "operationId": "test-framework-v2-scenarios-retrieve",
-                "description": "Retrieve a test scenario by ID",
+                "description": "Fetch a single evaluator by id. Returns full configuration including instructions, expected outcome, metrics, test profile, and — when the agent has mock tools attached and the scenario was auto-generated — the expected mock tool calls (`generated_mock_tool_entries`) with their inputs and outputs.",
+                "summary": "Retrieve an evaluator (scenario)",
                 "parameters": [
                     {
                         "in": "path",
@@ -41964,7 +42051,7 @@
         "/test_framework/v2/scenarios/generate-bg/": {
             "post": {
                 "operationId": "scenarios-generate-bg_3",
-                "description": "Generate scenarios for a given agent in the background. Returns a `progress_id` immediately; poll GET /scenarios/generate-progress/?progress_id={id} until `total_scenarios == completed_scenarios`.\n\n**What happens automatically on generation:**\n- A default test profile is created for the agent if none exists. Each generated scenario will have `test_profile_data` populated with synthetic caller information (name, address, phone, email).\n- 10 project-level evaluation metrics are attached to every generated scenario automatically (e.g. Latency, Pitch, Interruption Score). Scenarios created manually via `scenarios_create` start with no metrics attached.\n\n**Response fields:** `progress_id` (UUID string) for polling; `session_id` is always null.",
+                "description": "Generate scenarios for a given agent in the background. Returns a `progress_id` immediately; poll GET /scenarios/generate-progress/?progress_id={id} until `total_scenarios == completed_scenarios`.\n\n**What happens automatically on generation:**\n- A scenario-specific test profile is created and its `information` is populated using the sectioned shape: `main_agent_variables` (dynamic-variable values that reach the agent under test at call time — e.g. `user_id`, `account_id`) and `testing_agent_variables` (persona/context used by the simulated caller — e.g. `customer_name`, `date_of_birth`). Section values are kept consistent with any generated mock-tool data.\n- 10 project-level evaluation metrics are attached to every generated scenario automatically (e.g. Latency, Pitch, Interruption Score). Scenarios created manually via `scenarios_create` start with no metrics attached.\n\n**Response fields:** `progress_id` (UUID string) for polling; `session_id` is always null.",
                 "tags": [
                     "test_framework"
                 ],
@@ -53214,7 +53301,6 @@
             },
             "CallLogDetail": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -53406,7 +53492,6 @@
             },
             "CallLogList": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -54600,7 +54685,6 @@
             },
             "Dashboard": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -54732,7 +54816,6 @@
             },
             "DashboardList": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -57005,7 +57088,6 @@
             },
             "MetricList": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -59676,7 +59758,6 @@
             },
             "PatchedCallLogDetail": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -60134,7 +60215,6 @@
             },
             "PatchedDashboard": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -62120,7 +62200,7 @@
                     "information": {
                         "type": "object",
                         "additionalProperties": {},
-                        "description": "Information fields of the test profile"
+                        "description": "Test profile information. Use the sectioned shape — `main_agent_variables` (sent to the agent under test as dynamic variables at call time) and `testing_agent_variables` (persona/context used by the simulated caller, not sent to the agent). Legacy flat dicts (no section keys) are still accepted and delivered to both sides for backward compatibility. Example: {\"main_agent_variables\": {\"user_id\": \"U-42\"}, \"testing_agent_variables\": {\"customer_name\": \"John Doe\"}}."
                     }
                 }
             },
@@ -62412,7 +62492,6 @@
             },
             "PatchedSchemaPostScenario": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "agent": {
                         "type": [
@@ -65409,7 +65488,6 @@
             },
             "RunList": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -65834,7 +65912,6 @@
             },
             "Scenario": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -66029,16 +66106,15 @@
                             }
                         ],
                         "readOnly": true,
-                        "description": "\nDetails of the test profile associated with this scenario\nExample:\n```json\n{\n    \"id\": \"<integer>\",\n    \"agent_id\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"information\": {\n        \"user_name\": \"<string>\",\n        \"user_email\": \"<string>\",\n        \"order_id\": \"<string>\",\n    },\n}\n```\n"
+                        "description": "\nDetails of the test profile associated with this scenario. `information` uses the\nsectioned shape: `main_agent_variables` are sent to the agent under test as\ndynamic variables at call time; `testing_agent_variables` are persona/context\nused by Cekura's simulated caller. Legacy flat dicts (no section keys) still\nwork — at call time they are delivered to both sides for backward compatibility.\nExample:\n```json\n{\n    \"id\": \"<integer>\",\n    \"agent_id\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"information\": {\n        \"main_agent_variables\": {\n            \"user_id\": \"<string>\",\n            \"account_id\": \"<string>\"\n        },\n        \"testing_agent_variables\": {\n            \"user_name\": \"<string>\",\n            \"user_email\": \"<string>\",\n            \"order_id\": \"<string>\"\n        }\n    }\n}\n```\n"
                     },
                     "dynamic_variable_values": {
-                        "oneOf": [
-                            {},
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "description": "Generated values for the agent's dynamic variables for this scenario. Keys are variable names; values are the generated values."
+                        "readOnly": true,
+                        "description": "REMOVED FROM API. Reads return the historical value for legacy rows (`null` for new rows). Writes are no longer accepted — supplying a non-null value yields a 400 error. Put dynamic-variable values in `test_profile_data.information.main_agent_variables` instead: create the test profile via POST /test-profiles/ and attach it via the `test_profile` field on the scenario."
+                    },
+                    "generated_mock_tool_entries": {
+                        "readOnly": true,
+                        "description": "Expected mock tool calls generated for this evaluator during scenario auto-generation when the agent has mock tools attached. Each entry has shape {tool_id, tool_name, new_entry: {input, output}}."
                     },
                     "folder_path": {
                         "type": [
@@ -66488,7 +66564,7 @@
                                 "type": "null"
                             }
                         ],
-                        "description": "Generated values for the agent's dynamic variables for this scenario. Keys are variable names; values are the generated values."
+                        "description": "REMOVED FROM API. Historically stored a flat copy of the agent's dynamic-variable values for the scenario. The column is retained read-only for legacy rows; reads still return its historical value, but writes via the API are rejected with a 400. At call time the Run-level helper consults this column ONLY when the attached test_profile is legacy-flat (or absent) — sectioned test profiles are the canonical source and ignore this column. Put dynamic-variable values in `test_profile.information.main_agent_variables` for new scenarios."
                     },
                     "phone_number": {
                         "type": [
@@ -66704,7 +66780,6 @@
             },
             "ScenarioList": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -66872,7 +66947,7 @@
                                 "type": "null"
                             }
                         ],
-                        "description": "Generated values for the agent's dynamic variables for this scenario. Keys are variable names; values are the generated values."
+                        "description": "REMOVED FROM API. Historically stored a flat copy of the agent's dynamic-variable values for the scenario. The column is retained read-only for legacy rows; reads still return its historical value, but writes via the API are rejected with a 400. At call time the Run-level helper consults this column ONLY when the attached test_profile is legacy-flat (or absent) — sectioned test profiles are the canonical source and ignore this column. Put dynamic-variable values in `test_profile.information.main_agent_variables` for new scenarios."
                     },
                     "created_at": {
                         "type": "string",
@@ -66924,7 +66999,6 @@
             },
             "ScenarioSerializerV2": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -67122,16 +67196,15 @@
                             }
                         ],
                         "readOnly": true,
-                        "description": "\nDetails of the test profile associated with this scenario\nExample:\n```json\n{\n    \"id\": \"<integer>\",\n    \"agent_id\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"information\": {\n        \"user_name\": \"<string>\",\n        \"user_email\": \"<string>\",\n        \"order_id\": \"<string>\",\n    },\n}\n```\n"
+                        "description": "\nDetails of the test profile associated with this scenario. `information` uses the\nsectioned shape: `main_agent_variables` are sent to the agent under test as\ndynamic variables at call time; `testing_agent_variables` are persona/context\nused by Cekura's simulated caller. Legacy flat dicts (no section keys) still\nwork — at call time they are delivered to both sides for backward compatibility.\nExample:\n```json\n{\n    \"id\": \"<integer>\",\n    \"agent_id\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"information\": {\n        \"main_agent_variables\": {\n            \"user_id\": \"<string>\",\n            \"account_id\": \"<string>\"\n        },\n        \"testing_agent_variables\": {\n            \"user_name\": \"<string>\",\n            \"user_email\": \"<string>\",\n            \"order_id\": \"<string>\"\n        }\n    }\n}\n```\n"
                     },
                     "dynamic_variable_values": {
-                        "oneOf": [
-                            {},
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "description": "Generated values for the agent's dynamic variables for this scenario. Keys are variable names; values are the generated values."
+                        "readOnly": true,
+                        "description": "REMOVED FROM API. Reads return the historical value for legacy rows (`null` for new rows). Writes are no longer accepted — supplying a non-null value yields a 400 error. Put dynamic-variable values in `test_profile_data.information.main_agent_variables` instead: create the test profile via POST /test-profiles/ and attach it via the `test_profile` field on the scenario."
+                    },
+                    "generated_mock_tool_entries": {
+                        "readOnly": true,
+                        "description": "Expected mock tool calls generated for this evaluator during scenario auto-generation when the agent has mock tools attached. Each entry has shape {tool_id, tool_name, new_entry: {input, output}}."
                     },
                     "folder_path": {
                         "type": [
@@ -67661,7 +67734,7 @@
                     "information": {
                         "type": "object",
                         "additionalProperties": {},
-                        "description": "Information fields of the test profile"
+                        "description": "Test profile information. Use the sectioned shape — `main_agent_variables` (sent to the agent under test as dynamic variables at call time) and `testing_agent_variables` (persona/context used by the simulated caller, not sent to the agent). Legacy flat dicts (no section keys) are still accepted and delivered to both sides for backward compatibility. Example: {\"main_agent_variables\": {\"user_id\": \"U-42\"}, \"testing_agent_variables\": {\"customer_name\": \"John Doe\"}}."
                     }
                 },
                 "required": [
@@ -68370,7 +68443,6 @@
             },
             "SchemaPostRunScenarios": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "agent_id": {
                         "type": "integer",
@@ -68619,7 +68691,6 @@
             },
             "SchemaPostScenario": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "agent": {
                         "type": [
@@ -68779,7 +68850,6 @@
             },
             "SchemaScenario": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -68974,16 +69044,15 @@
                             }
                         ],
                         "readOnly": true,
-                        "description": "\nDetails of the test profile associated with this scenario\nExample:\n```json\n{\n    \"id\": \"<integer>\",\n    \"agent_id\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"information\": {\n        \"user_name\": \"<string>\",\n        \"user_email\": \"<string>\",\n        \"order_id\": \"<string>\",\n    },\n}\n```\n"
+                        "description": "\nDetails of the test profile associated with this scenario. `information` uses the\nsectioned shape: `main_agent_variables` are sent to the agent under test as\ndynamic variables at call time; `testing_agent_variables` are persona/context\nused by Cekura's simulated caller. Legacy flat dicts (no section keys) still\nwork — at call time they are delivered to both sides for backward compatibility.\nExample:\n```json\n{\n    \"id\": \"<integer>\",\n    \"agent_id\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"information\": {\n        \"main_agent_variables\": {\n            \"user_id\": \"<string>\",\n            \"account_id\": \"<string>\"\n        },\n        \"testing_agent_variables\": {\n            \"user_name\": \"<string>\",\n            \"user_email\": \"<string>\",\n            \"order_id\": \"<string>\"\n        }\n    }\n}\n```\n"
                     },
                     "dynamic_variable_values": {
-                        "oneOf": [
-                            {},
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "description": "Generated values for the agent's dynamic variables for this scenario. Keys are variable names; values are the generated values."
+                        "readOnly": true,
+                        "description": "REMOVED FROM API. Reads return the historical value for legacy rows (`null` for new rows). Writes are no longer accepted — supplying a non-null value yields a 400 error. Put dynamic-variable values in `test_profile_data.information.main_agent_variables` instead: create the test profile via POST /test-profiles/ and attach it via the `test_profile` field on the scenario."
+                    },
+                    "generated_mock_tool_entries": {
+                        "readOnly": true,
+                        "description": "Expected mock tool calls generated for this evaluator during scenario auto-generation when the agent has mock tools attached. Each entry has shape {tool_id, tool_name, new_entry: {input, output}}."
                     },
                     "folder_path": {
                         "type": [


### PR DESCRIPTION
Auto-generated docs sync for backend PR [#9437](https://github.com/cekura-ai/vocera.backend/pull/9437).

Reviewers: @dileep-chagam, @cekurarsan

## Summary

**Spec/overlay:** Spec sync for backend PR #9437 (Remove Scenario.dynamic_variable_values from API). 6 exposed operations updated with revised documentation for test profile information sectioning (main_agent_variables / testing_agent_variables). 1 overlay added (test_profiles_create: multipart/form-data transport note). No newly exposed operations, no retractions, no renames.

**Conceptual docs:** Backend PR #9437 removes Scenario.dynamic_variable_values from the API and introduces sectioned test profile structure (main_agent_variables / testing_agent_variables). Updated test-profile.mdx with new "Test Profile Information Structure" section explaining the two-section model and when each is used. Updated dynamic-variables.mdx example and relationship table to show correct storage in test_profile.information.main_agent_variables. Both pages preserve existing content with surgical edits — no other sections changed.

## Changes

- `openapi.json` — regenerate_from_backend
- `cekura-mcp-server/mcp_tools.json` — patch_json
- `documentation/key-concepts/evaluators/test-profile.mdx` — update
- `documentation/key-concepts/evaluators/dynamic-variables.mdx` — update

## Overlay notes (stale prose, manual review)

- `scenarios_generate_bg`: Existing mcp_tools.json overlay present; transport-quirk signals fired (multipart_file_upload, async_progress_pairing) but D2 precedence preserves the existing entry. Review manually if stale.
- `test_profiles_partial_update`: Existing mcp_tools.json overlay present; transport-quirk signals fired (multipart_file_upload) but D2 precedence preserves the existing entry. Review manually if stale.

---
*Auto-generated from backend PR #9437.*

<!-- mcp-sync:file-hashes -->
```json
{
  "documentation/key-concepts/evaluators/dynamic-variables.mdx": "a6deb7f7d5040a9274d15eb87cc2a5e3131e5eeb88ad140769b5abb57c7ab4d1",
  "documentation/key-concepts/evaluators/test-profile.mdx": "4ad5ea3005cbe1ea95f78a72d6a762cff180f44c4e37dc9fcd1ea4ac5bf8efd0"
}
```
<!-- /mcp-sync:file-hashes -->