### PR TITLE
[Auto] Sync docs for backend PR #9439

### DIFF
--- a/api-reference/observability/delete-deep-research-insight.mdx
+++ b/api-reference/observability/delete-deep-research-insight.mdx
@@ -1,0 +1,6 @@
+---
+title: Delete Deep Research Insight
+description: "Delete a deep research insight"
+openapi: delete /observability/v1/deep-research-insights/{id}/
+slug: delete-deep-research-insight
+---

--- a/api-reference/observability/dismiss-deep-research-insight-mode.mdx
+++ b/api-reference/observability/dismiss-deep-research-insight-mode.mdx
@@ -1,0 +1,6 @@
+---
+title: Dismiss Deep Research Insight Mode
+description: "Record a thumbs-down on one failure mode."
+openapi: post /observability/v1/deep-research-insights/dismiss_mode/
+slug: dismiss-deep-research-insight-mode
+---

--- a/api-reference/observability/generate-deep-research-insights.mdx
+++ b/api-reference/observability/generate-deep-research-insights.mdx
@@ -1,0 +1,6 @@
+---
+title: Generate Deep Research Insights
+description: "Queue a Deep Research audit; returns the new row in ``pending``."
+openapi: post /observability/v1/deep-research-insights/generate/
+slug: generate-deep-research-insights
+---

--- a/api-reference/observability/get-deep-research-insight.mdx
+++ b/api-reference/observability/get-deep-research-insight.mdx
@@ -1,0 +1,6 @@
+---
+title: Get Deep Research Insight
+description: "Retrieve a deep research insight by ID"
+openapi: get /observability/v1/deep-research-insights/{id}/
+slug: get-deep-research-insight
+---

--- a/api-reference/observability/get-metric-failure-mode-insights-available-dates.mdx
+++ b/api-reference/observability/get-metric-failure-mode-insights-available-dates.mdx
@@ -1,0 +1,6 @@
+---
+title: Get Metric Failure Mode Insights Available Dates
+description: "Distinct calendar dates (newest first) that have a generated"
+openapi: get /observability/v1/metric-failure-mode-insights/available_dates/
+slug: get-metric-failure-mode-insights-available-dates
+---

--- a/api-reference/observability/list-deep-research-insights.mdx
+++ b/api-reference/observability/list-deep-research-insights.mdx
@@ -1,0 +1,6 @@
+---
+title: List Deep Research Insights
+description: "List deep research insights"
+openapi: get /observability/v1/deep-research-insights/
+slug: list-deep-research-insights
+---

--- a/documentation/integrations/livekit/testing.mdx
+++ b/documentation/integrations/livekit/testing.mdx
@@ -140,6 +140,10 @@ Each scenario object contains:
 
 **frequency** (number, optional): Number of times to run each scenario. Defaults to 1 if not specified.
 
+**personality_ids** (array of integers, optional): List of personality IDs to override for this run. If not provided, uses each scenario's default personality. When specified, applies the same personality override to all scenarios in this run.
+
+**test_profile_ids** (array of integers, optional): List of test profile IDs to override for this run. If not provided, uses each scenario's default test profile. When specified, applies the same test profile override to all scenarios in this run.
+
 ## Examples
 
 ### Single Run (cURL)
@@ -179,6 +183,25 @@ curl -X POST \
   }'
 ```
 
+### With Personality and Test Profile Overrides (cURL)
+
+```bash
+curl -X POST \
+  'https://api.cekura.ai/test_framework/v1/scenarios-external/run_scenarios_livekit_v2/' \
+  -H 'X-CEKURA-API-KEY: <YOUR_API_KEY>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "scenarios": [
+      {
+        "scenario": 30
+      }
+    ],
+    "frequency": 1,
+    "personality_ids": [5, 8],
+    "test_profile_ids": [12]
+  }'
+```
+
 ### Python Example
 
 ```python
@@ -202,6 +225,39 @@ payload = {
         },
     ],
     "frequency": 1,
+}
+
+resp = requests.post(
+    f"{BASE_URL}/v1/scenarios-external/run_scenarios_livekit_v2/",
+    headers=headers,
+    json=payload,
+)
+result = resp.json()
+print(result)
+```
+
+### Python Example with Overrides
+
+```python
+import requests
+
+API_KEY = "<YOUR_API_KEY>"
+BASE_URL = "https://api.cekura.ai/test_framework"
+
+headers = {
+    "X-CEKURA-API-KEY": API_KEY,
+    "Content-Type": "application/json",
+}
+
+payload = {
+    "scenarios": [
+        {
+            "scenario": 30,
+        },
+    ],
+    "frequency": 1,
+    "personality_ids": [5, 8],
+    "test_profile_ids": [12],
 }
 
 resp = requests.post(

--- a/documentation/integrations/pipecat/automated.mdx
+++ b/documentation/integrations/pipecat/automated.mdx
@@ -144,6 +144,10 @@ Each scenario object contains:
 
 **frequency** (number, optional): Number of times to run each scenario. Defaults to 1 if not specified.
 
+**personality_ids** (array of integers, optional): List of personality IDs to override for this run. If not provided, uses each scenario's default personality. When specified, applies the same personality override to all scenarios in this run.
+
+**test_profile_ids** (array of integers, optional): List of test profile IDs to override for this run. If not provided, uses each scenario's default test profile. When specified, applies the same test profile override to all scenarios in this run.
+
 ## Examples
 
 ### Single Run (cURL)
@@ -183,6 +187,25 @@ curl -X POST \
   }'
 ```
 
+### With Personality and Test Profile Overrides (cURL)
+
+```bash
+curl -X POST \
+  'https://api.cekura.ai/test_framework/v1/scenarios/run_scenarios_pipecat_v2/' \
+  -H 'X-CEKURA-API-KEY: <YOUR_API_KEY>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "scenarios": [
+      {
+        "scenario": 30
+      }
+    ],
+    "frequency": 1,
+    "personality_ids": [5, 8],
+    "test_profile_ids": [12]
+  }'
+```
+
 ### Python Example
 
 ```python
@@ -206,6 +229,39 @@ payload = {
         },
     ],
     "frequency": 1,
+}
+
+resp = requests.post(
+    f"{BASE_URL}/v1/scenarios/run_scenarios_pipecat_v2/",
+    headers=headers,
+    json=payload,
+)
+result = resp.json()
+print(result)
+```
+
+### Python Example with Overrides
+
+```python
+import requests
+
+API_KEY = "<YOUR_API_KEY>"
+BASE_URL = "https://api.cekura.ai/test_framework"
+
+headers = {
+    "X-CEKURA-API-KEY": API_KEY,
+    "Content-Type": "application/json",
+}
+
+payload = {
+    "scenarios": [
+        {
+            "scenario": 30,
+        },
+    ],
+    "frequency": 1,
+    "personality_ids": [5, 8],
+    "test_profile_ids": [12],
 }
 
 resp = requests.post(

--- a/documentation/key-concepts/evaluators/personality.mdx
+++ b/documentation/key-concepts/evaluators/personality.mdx
@@ -57,6 +57,10 @@ When creating or editing an evaluator, you can select from:
 
 Each evaluator can have one personality assigned to it, ensuring consistent behavior across multiple test runs.
 
+<Note>
+**Run-level overrides**: When using Pipecat or LiveKit automated testing, you can override the evaluator's default personality at the run level using the `personality_ids` parameter. This allows you to test the same scenarios with different personalities without modifying the evaluator configuration. See [Pipecat Automated Testing](/documentation/integrations/pipecat/automated) and [LiveKit Automated Testing](/documentation/integrations/livekit/testing) for details.
+</Note>
+
 ## Creating Custom Personalities
 
 For detailed instructions on creating your own personalities, see [Creating Custom Personalities](/documentation/advanced/creating-custom-personalities).

--- a/documentation/key-concepts/evaluators/test-profile.mdx
+++ b/documentation/key-concepts/evaluators/test-profile.mdx
@@ -42,6 +42,10 @@ Test profiles are essential when your AI agent needs to:
 3. **Attach to Evaluator**: Assign the test profile to your evaluator
 4. **Run Tests**: The evaluator will use the profile information during conversations
 
+<Note>
+**Run-level overrides**: When using Pipecat or LiveKit automated testing, you can override the evaluator's default test profile at the run level using the `test_profile_ids` parameter. This allows you to test the same scenarios with different test profiles without modifying the evaluator configuration. See [Pipecat Automated Testing](/documentation/integrations/pipecat/automated) and [LiveKit Automated Testing](/documentation/integrations/livekit/testing) for details.
+</Note>
+
 ### Example: Clinic Receptionist
 
 Let's say you have a clinic receptionist AI agent that can cancel appointments. The agent verifies identity by asking for the patient's date of birth before cancellation.

--- a/mint.json
+++ b/mint.json
@@ -485,7 +485,13 @@
             "api-reference/observability/list-alerts-for-review",
             "api-reference/observability/get-alert-summarization-progress",
             "api-reference/observability/trigger-alert-summary",
-            "api-reference/observability/bulk-generate-metric-failure-mode-insights"
+            "api-reference/observability/bulk-generate-metric-failure-mode-insights",
+            "api-reference/observability/list-deep-research-insights",
+            "api-reference/observability/get-deep-research-insight",
+            "api-reference/observability/delete-deep-research-insight",
+            "api-reference/observability/dismiss-deep-research-insight-mode",
+            "api-reference/observability/generate-deep-research-insights",
+            "api-reference/observability/get-metric-failure-mode-insights-available-dates"
           ]
         }
       ]

--- a/openapi.json
+++ b/openapi.json
@@ -27894,7 +27894,8 @@
         "/test_framework/v1/scenarios-external/{id}/": {
             "get": {
                 "operationId": "scenarios-external-retrieve",
-                "description": "Retrieve a test scenario by ID",
+                "description": "Fetch a single evaluator by id. Returns full configuration including instructions, expected outcome, metrics, test profile, and — when the agent has mock tools attached and the scenario was auto-generated — the expected mock tool calls (`generated_mock_tool_entries`) with their inputs and outputs.",
+                "summary": "Retrieve an evaluator (scenario)",
                 "parameters": [
                     {
                         "in": "path",
@@ -32704,7 +32705,8 @@
         "/test_framework/v1/scenarios/{id}/": {
             "get": {
                 "operationId": "scenarios-retrieve",
-                "description": "Retrieve a test scenario by ID",
+                "description": "Fetch a single evaluator by id. Returns full configuration including instructions, expected outcome, metrics, test profile, and — when the agent has mock tools attached and the scenario was auto-generated — the expected mock tool calls (`generated_mock_tool_entries`) with their inputs and outputs.",
+                "summary": "Retrieve an evaluator (scenario)",
                 "parameters": [
                     {
                         "in": "path",
@@ -32756,7 +32758,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-retrieve",
-                        "description": "Retrieve a test scenario by ID"
+                        "description": "Fetch a single evaluator by id. Returns full configuration including instructions, expected outcome, metrics, test profile, and — when the agent has mock tools attached and the scenario was auto-generated — the expected mock tool calls (`generated_mock_tool_entries`) with their inputs and outputs."
                     }
                 }
             },
@@ -40402,7 +40404,8 @@
         "/test_framework/v2/scenarios/{id}/": {
             "get": {
                 "operationId": "test-framework-v2-scenarios-retrieve",
-                "description": "Retrieve a test scenario by ID",
+                "description": "Fetch a single evaluator by id. Returns full configuration including instructions, expected outcome, metrics, test profile, and — when the agent has mock tools attached and the scenario was auto-generated — the expected mock tool calls (`generated_mock_tool_entries`) with their inputs and outputs.",
+                "summary": "Retrieve an evaluator (scenario)",
                 "parameters": [
                     {
                         "in": "path",
@@ -66040,6 +66043,10 @@
                         ],
                         "description": "Generated values for the agent's dynamic variables for this scenario. Keys are variable names; values are the generated values."
                     },
+                    "generated_mock_tool_entries": {
+                        "readOnly": true,
+                        "description": "Expected mock tool calls generated for this evaluator during scenario auto-generation when the agent has mock tools attached. Each entry has shape {tool_id, tool_name, new_entry: {input, output}}."
+                    },
                     "folder_path": {
                         "type": [
                             "string",
@@ -67132,6 +67139,10 @@
                             }
                         ],
                         "description": "Generated values for the agent's dynamic variables for this scenario. Keys are variable names; values are the generated values."
+                    },
+                    "generated_mock_tool_entries": {
+                        "readOnly": true,
+                        "description": "Expected mock tool calls generated for this evaluator during scenario auto-generation when the agent has mock tools attached. Each entry has shape {tool_id, tool_name, new_entry: {input, output}}."
                     },
                     "folder_path": {
                         "type": [
@@ -68984,6 +68995,10 @@
                             }
                         ],
                         "description": "Generated values for the agent's dynamic variables for this scenario. Keys are variable names; values are the generated values."
+                    },
+                    "generated_mock_tool_entries": {
+                        "readOnly": true,
+                        "description": "Expected mock tool calls generated for this evaluator during scenario auto-generation when the agent has mock tools attached. Each entry has shape {tool_id, tool_name, new_entry: {input, output}}."
                     },
                     "folder_path": {
                         "type": [

--- a/openapi.json
+++ b/openapi.json
@@ -5735,6 +5735,192 @@
                 }
             }
         },
+        "/observability/v1/deep-research-insights/": {
+            "get": {
+                "operationId": "deep-research-insights-list",
+                "description": "List deep research insights",
+                "tags": [
+                    "observability"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/DeepResearchInsight"
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/observability/v1/deep-research-insights/{id}/": {
+            "get": {
+                "operationId": "deep-research-insights-retrieve",
+                "description": "Retrieve a deep research insight by ID",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this deep research insight.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "observability"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/DeepResearchInsight"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "deep-research-insights-destroy",
+                "description": "Delete a deep research insight",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this deep research insight.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "observability"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No response body"
+                    }
+                }
+            }
+        },
+        "/observability/v1/deep-research-insights/dismiss_mode/": {
+            "post": {
+                "operationId": "deep-research-insights-dismiss-mode-create",
+                "description": "Record a thumbs-down on one failure mode.\n\nProject-scoped: the dismissal hides the mode (matched by\nnormalized title) from every subsequent render of every\ninsight in the project. No undo via this API in v1 — admin\nonly.",
+                "tags": [
+                    "observability"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/DeepResearchModeDismissalCreate"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/DeepResearchModeDismissalCreate"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/DeepResearchModeDismissalCreate"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/DeepResearchModeDismissalCreate"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/observability/v1/deep-research-insights/generate/": {
+            "post": {
+                "operationId": "deep-research-insights-generate-create",
+                "description": "Queue a Deep Research audit; returns the new row in ``pending``.",
+                "tags": [
+                    "observability"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/DeepResearchInsightGenerate"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/DeepResearchInsightGenerate"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/DeepResearchInsightGenerate"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/DeepResearchInsightGenerate"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/observability/v1/elevenlabs/observe/": {
             "post": {
                 "operationId": "elevenlabs-observe-create",
@@ -5863,6 +6049,32 @@
                 "responses": {
                     "204": {
                         "description": "No response body"
+                    }
+                }
+            }
+        },
+        "/observability/v1/metric-failure-mode-insights/available_dates/": {
+            "get": {
+                "operationId": "metric-failure-mode-insights-available-dates-retrieve",
+                "description": "Distinct calendar dates (newest first) that have a generated\ninsight for the project, so the UI can offer a date picker for\nbrowsing historical daily insights. Only dates with a definitive\nresult row (succeeded / no-failures marker) are listed.",
+                "tags": [
+                    "observability"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricFailureModeInsight"
+                                }
+                            }
+                        },
+                        "description": ""
                     }
                 }
             }
@@ -30353,8 +30565,8 @@
         "/test_framework/v1/scenarios-external/run_scenarios_chirp/": {
             "post": {
                 "operationId": "scenarios-run-chirp",
-                "description": "CHIRP RAW-PCM WEBSOCKET VOICE RUN: Execute evaluators against an agent that exposes a raw-PCM WebSocket endpoint (16 kHz, 16-bit mono, binary frames). The agent must have `chirp_data.chirp_websocket_url` configured. Optional Basic Auth via `chirp_basic_auth_username` / `chirp_basic_auth_password` in `chirp_data`.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_websocket` — JSON/text WebSocket protocol (per-scenario URLs)\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC",
-                "summary": "Run evaluators against a CHIRP WebSocket voice endpoint",
+                "description": "RAW-PCM WEBSOCKET VOICE RUN: Execute evaluators against an agent that exposes a raw-PCM WebSocket endpoint (16 kHz, 16-bit mono, binary frames). The agent must have a websocket endpoint configured (`telephony.websocket_url`); optional Basic Auth lives in `telephony.websocket_auth`. Pass `websocket_url` to override the agent's stored endpoint for this run.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_websocket` — JSON/text WebSocket protocol (per-scenario URLs)\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC",
+                "summary": "Run evaluators against a raw-PCM WebSocket voice endpoint",
                 "tags": [
                     "Evaluators"
                 ],
@@ -30365,7 +30577,7 @@
                                 "$ref": "#/components/schemas/SchemaPostRunScenarios"
                             },
                             "examples": {
-                                "CHIRPRun": {
+                                "WebsocketVoiceRun": {
                                     "value": {
                                         "agent_id": 12,
                                         "scenarios": [
@@ -30373,7 +30585,7 @@
                                         ],
                                         "frequency": 1
                                     },
-                                    "summary": "CHIRP run"
+                                    "summary": "Websocket voice run"
                                 }
                             }
                         },
@@ -31786,7 +31998,7 @@
         "/test_framework/v1/scenarios-external/run_scenarios_text/": {
             "post": {
                 "operationId": "scenarios-run-text",
-                "description": "TEXT / SMS / CHAT RUN: Execute evaluators against your agent using text-only simulation (SMS, chat, or an agent-hosted websocket). Cheaper than voice — billed at the text-simulation rate.\n\n**Run-count math:** total conversations = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**Concurrency:** use `concurrency_limit` to cap parallel conversations. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Websocket override:** if the agent exposes a plain websocket URL for text, pass it as `websocket_url` — this bypasses the agent's standard text-readiness check.\n\n**When to use this vs others:**\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL (bulk)\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**`self_hosted` agents:** agents with `assistant_provider=\"self_hosted\"` require a websocket URL. Either pre-configure `websocket_url` on the agent, or pass it directly in this request. Without it, the run fails with `[\"Agent does not have a websocket URL\"]`. Passing `websocket_url` here changes the result's `run_type` to `\"WebSocket\"` instead of `\"Text\"`.\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"text\"` instead.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.",
+                "description": "TEXT / SMS / CHAT RUN: Execute evaluators against your agent using text-only simulation (SMS, chat, or an agent-hosted websocket). Cheaper than voice — billed at the text-simulation rate.\n\n**Run-count math:** total conversations = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**Concurrency:** use `concurrency_limit` to cap parallel conversations. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Websocket override:** if the agent exposes a plain websocket URL for text, pass it as `websocket_url` — this bypasses the agent's standard text-readiness check. Pass `websocket_headers` (JSON object) to override connection headers for this run — merged over the agent's configured headers, with the per-run values winning.\n\n**When to use this vs others:**\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL (bulk)\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**`self_hosted` agents:** agents with `assistant_provider=\"self_hosted\"` require a websocket URL. Either pre-configure `websocket_url` on the agent, or pass it directly in this request. Without it, the run fails with `[\"Agent does not have a websocket URL\"]`. Passing `websocket_url` here changes the result's `run_type` to `\"WebSocket\"` instead of `\"Text\"`.\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"text\"` instead.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.",
                 "summary": "Run evaluators in text / SMS / chat mode",
                 "tags": [
                     "Evaluators"
@@ -35315,8 +35527,8 @@
         "/test_framework/v1/scenarios/run_scenarios_chirp/": {
             "post": {
                 "operationId": "scenarios-run-chirp_2",
-                "description": "CHIRP RAW-PCM WEBSOCKET VOICE RUN: Execute evaluators against an agent that exposes a raw-PCM WebSocket endpoint (16 kHz, 16-bit mono, binary frames). The agent must have `chirp_data.chirp_websocket_url` configured. Optional Basic Auth via `chirp_basic_auth_username` / `chirp_basic_auth_password` in `chirp_data`.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_websocket` — JSON/text WebSocket protocol (per-scenario URLs)\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC",
-                "summary": "Run evaluators against a CHIRP WebSocket voice endpoint",
+                "description": "RAW-PCM WEBSOCKET VOICE RUN: Execute evaluators against an agent that exposes a raw-PCM WebSocket endpoint (16 kHz, 16-bit mono, binary frames). The agent must have a websocket endpoint configured (`telephony.websocket_url`); optional Basic Auth lives in `telephony.websocket_auth`. Pass `websocket_url` to override the agent's stored endpoint for this run.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_websocket` — JSON/text WebSocket protocol (per-scenario URLs)\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC",
+                "summary": "Run evaluators against a raw-PCM WebSocket voice endpoint",
                 "tags": [
                     "Evaluators"
                 ],
@@ -35327,7 +35539,7 @@
                                 "$ref": "#/components/schemas/SchemaPostRunScenarios"
                             },
                             "examples": {
-                                "CHIRPRun": {
+                                "WebsocketVoiceRun": {
                                     "value": {
                                         "agent_id": 12,
                                         "scenarios": [
@@ -35335,7 +35547,7 @@
                                         ],
                                         "frequency": 1
                                     },
-                                    "summary": "CHIRP run"
+                                    "summary": "Websocket voice run"
                                 }
                             }
                         },
@@ -35491,7 +35703,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-run-chirp",
-                        "description": "CHIRP RAW-PCM WEBSOCKET VOICE RUN: Execute evaluators against an agent that exposes a raw-PCM WebSocket endpoint (16 kHz, 16-bit mono, binary frames). The agent must have `chirp_data.chirp_websocket_url` configured. Optional Basic Auth via `chirp_basic_auth_username` / `chirp_basic_auth_password` in `chirp_data`.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_websocket` — JSON/text WebSocket protocol (per-scenario URLs)\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC"
+                        "description": "RAW-PCM WEBSOCKET VOICE RUN: Execute evaluators against an agent that exposes a raw-PCM WebSocket endpoint (16 kHz, 16-bit mono, binary frames). The agent must have a websocket endpoint configured (`telephony.websocket_url`); optional Basic Auth lives in `telephony.websocket_auth`. Pass `websocket_url` to override the agent's stored endpoint for this run.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_websocket` — JSON/text WebSocket protocol (per-scenario URLs)\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC"
                     }
                 }
             }
@@ -36804,7 +37016,7 @@
         "/test_framework/v1/scenarios/run_scenarios_text/": {
             "post": {
                 "operationId": "scenarios-run-text_2",
-                "description": "TEXT / SMS / CHAT RUN: Execute evaluators against your agent using text-only simulation (SMS, chat, or an agent-hosted websocket). Cheaper than voice — billed at the text-simulation rate.\n\n**Run-count math:** total conversations = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**Concurrency:** use `concurrency_limit` to cap parallel conversations. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Websocket override:** if the agent exposes a plain websocket URL for text, pass it as `websocket_url` — this bypasses the agent's standard text-readiness check.\n\n**When to use this vs others:**\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL (bulk)\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**`self_hosted` agents:** agents with `assistant_provider=\"self_hosted\"` require a websocket URL. Either pre-configure `websocket_url` on the agent, or pass it directly in this request. Without it, the run fails with `[\"Agent does not have a websocket URL\"]`. Passing `websocket_url` here changes the result's `run_type` to `\"WebSocket\"` instead of `\"Text\"`.\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"text\"` instead.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.",
+                "description": "TEXT / SMS / CHAT RUN: Execute evaluators against your agent using text-only simulation (SMS, chat, or an agent-hosted websocket). Cheaper than voice — billed at the text-simulation rate.\n\n**Run-count math:** total conversations = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**Concurrency:** use `concurrency_limit` to cap parallel conversations. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Websocket override:** if the agent exposes a plain websocket URL for text, pass it as `websocket_url` — this bypasses the agent's standard text-readiness check. Pass `websocket_headers` (JSON object) to override connection headers for this run — merged over the agent's configured headers, with the per-run values winning.\n\n**When to use this vs others:**\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL (bulk)\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**`self_hosted` agents:** agents with `assistant_provider=\"self_hosted\"` require a websocket URL. Either pre-configure `websocket_url` on the agent, or pass it directly in this request. Without it, the run fails with `[\"Agent does not have a websocket URL\"]`. Passing `websocket_url` here changes the result's `run_type` to `\"WebSocket\"` instead of `\"Text\"`.\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"text\"` instead.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.",
                 "summary": "Run evaluators in text / SMS / chat mode",
                 "tags": [
                     "Evaluators"
@@ -37003,7 +37215,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-run-text",
-                        "description": "TEXT / SMS / CHAT RUN: Execute evaluators against your agent using text-only simulation (SMS, chat, or an agent-hosted websocket). Cheaper than voice — billed at the text-simulation rate.\n\n**Run-count math:** total conversations = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**Concurrency:** use `concurrency_limit` to cap parallel conversations. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Websocket override:** if the agent exposes a plain websocket URL for text, pass it as `websocket_url` — this bypasses the agent's standard text-readiness check.\n\n**When to use this vs others:**\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL (bulk)\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**`self_hosted` agents:** agents with `assistant_provider=\"self_hosted\"` require a websocket URL. Either pre-configure `websocket_url` on the agent, or pass it directly in this request. Without it, the run fails with `[\"Agent does not have a websocket URL\"]`. Passing `websocket_url` here changes the result's `run_type` to `\"WebSocket\"` instead of `\"Text\"`.\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"text\"` instead.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors."
+                        "description": "TEXT / SMS / CHAT RUN: Execute evaluators against your agent using text-only simulation (SMS, chat, or an agent-hosted websocket). Cheaper than voice — billed at the text-simulation rate.\n\n**Run-count math:** total conversations = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**Concurrency:** use `concurrency_limit` to cap parallel conversations. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Websocket override:** if the agent exposes a plain websocket URL for text, pass it as `websocket_url` — this bypasses the agent's standard text-readiness check. Pass `websocket_headers` (JSON object) to override connection headers for this run — merged over the agent's configured headers, with the per-run values winning.\n\n**When to use this vs others:**\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL (bulk)\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**`self_hosted` agents:** agents with `assistant_provider=\"self_hosted\"` require a websocket URL. Either pre-configure `websocket_url` on the agent, or pass it directly in this request. Without it, the run fails with `[\"Agent does not have a websocket URL\"]`. Passing `websocket_url` here changes the result's `run_type` to `\"WebSocket\"` instead of `\"Text\"`.\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"text\"` instead.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors."
                     }
                 }
             }
@@ -42861,8 +43073,8 @@
         "/test_framework/v2/scenarios/run_scenarios_chirp/": {
             "post": {
                 "operationId": "scenarios-run-chirp_3",
-                "description": "CHIRP RAW-PCM WEBSOCKET VOICE RUN: Execute evaluators against an agent that exposes a raw-PCM WebSocket endpoint (16 kHz, 16-bit mono, binary frames). The agent must have `chirp_data.chirp_websocket_url` configured. Optional Basic Auth via `chirp_basic_auth_username` / `chirp_basic_auth_password` in `chirp_data`.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_websocket` — JSON/text WebSocket protocol (per-scenario URLs)\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC",
-                "summary": "Run evaluators against a CHIRP WebSocket voice endpoint",
+                "description": "RAW-PCM WEBSOCKET VOICE RUN: Execute evaluators against an agent that exposes a raw-PCM WebSocket endpoint (16 kHz, 16-bit mono, binary frames). The agent must have a websocket endpoint configured (`telephony.websocket_url`); optional Basic Auth lives in `telephony.websocket_auth`. Pass `websocket_url` to override the agent's stored endpoint for this run.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_websocket` — JSON/text WebSocket protocol (per-scenario URLs)\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC",
+                "summary": "Run evaluators against a raw-PCM WebSocket voice endpoint",
                 "tags": [
                     "Evaluators"
                 ],
@@ -42873,7 +43085,7 @@
                                 "$ref": "#/components/schemas/SchemaPostRunScenarios"
                             },
                             "examples": {
-                                "CHIRPRun": {
+                                "WebsocketVoiceRun": {
                                     "value": {
                                         "agent_id": 12,
                                         "scenarios": [
@@ -42881,7 +43093,7 @@
                                         ],
                                         "frequency": 1
                                     },
-                                    "summary": "CHIRP run"
+                                    "summary": "Websocket voice run"
                                 }
                             }
                         },
@@ -44294,7 +44506,7 @@
         "/test_framework/v2/scenarios/run_scenarios_text/": {
             "post": {
                 "operationId": "scenarios-run-text_3",
-                "description": "TEXT / SMS / CHAT RUN: Execute evaluators against your agent using text-only simulation (SMS, chat, or an agent-hosted websocket). Cheaper than voice — billed at the text-simulation rate.\n\n**Run-count math:** total conversations = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**Concurrency:** use `concurrency_limit` to cap parallel conversations. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Websocket override:** if the agent exposes a plain websocket URL for text, pass it as `websocket_url` — this bypasses the agent's standard text-readiness check.\n\n**When to use this vs others:**\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL (bulk)\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**`self_hosted` agents:** agents with `assistant_provider=\"self_hosted\"` require a websocket URL. Either pre-configure `websocket_url` on the agent, or pass it directly in this request. Without it, the run fails with `[\"Agent does not have a websocket URL\"]`. Passing `websocket_url` here changes the result's `run_type` to `\"WebSocket\"` instead of `\"Text\"`.\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"text\"` instead.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.",
+                "description": "TEXT / SMS / CHAT RUN: Execute evaluators against your agent using text-only simulation (SMS, chat, or an agent-hosted websocket). Cheaper than voice — billed at the text-simulation rate.\n\n**Run-count math:** total conversations = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**Concurrency:** use `concurrency_limit` to cap parallel conversations. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Websocket override:** if the agent exposes a plain websocket URL for text, pass it as `websocket_url` — this bypasses the agent's standard text-readiness check. Pass `websocket_headers` (JSON object) to override connection headers for this run — merged over the agent's configured headers, with the per-run values winning.\n\n**When to use this vs others:**\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL (bulk)\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**`self_hosted` agents:** agents with `assistant_provider=\"self_hosted\"` require a websocket URL. Either pre-configure `websocket_url` on the agent, or pass it directly in this request. Without it, the run fails with `[\"Agent does not have a websocket URL\"]`. Passing `websocket_url` here changes the result's `run_type` to `\"WebSocket\"` instead of `\"Text\"`.\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"text\"` instead.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.",
                 "summary": "Run evaluators in text / SMS / chat mode",
                 "tags": [
                     "Evaluators"
@@ -50871,6 +51083,23 @@
                         ],
                         "description": "\nSIP authentication credentials\nExample: `{\"username\": \"user123\", \"password\": \"pass123\"}`\n"
                     },
+                    "websocket_voice_url": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "Raw-PCM (16kHz 16-bit mono) websocket endpoint for direct websocket-based voice calls",
+                        "maxLength": 255
+                    },
+                    "websocket_auth": {
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "\nWebsocket Basic Auth credentials\nExample: `{\"username\": \"user123\", \"password\": \"pass123\"}`\n"
+                    },
                     "predefined_metrics": {
                         "writeOnly": true,
                         "description": "predefined metrics to use for the agent"
@@ -50893,14 +51122,14 @@
                             "custom",
                             "cisco",
                             "genesys",
-                            "chirp",
                             "agora",
+                            "telnyx",
                             ""
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "5ea2faa74e8025b2",
+                        "x-spec-enum-id": "eaf4e8ebc9a5bda2",
                         "default": "",
-                        "description": "\nService provider for speech-to-text transcription\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `synthflow` - Synthflow\n* `elevenlabs` - Elevenlabs\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `koreai` - Kore\n* `custom` - Custom\n* `cisco` - Cisco\n* `genesys` - Genesys\n* `chirp` - Chirp\n* `agora` - Agora"
+                        "description": "\nService provider for speech-to-text transcription\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `synthflow` - Synthflow\n* `elevenlabs` - Elevenlabs\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `koreai` - Kore\n* `custom` - Custom\n* `cisco` - Cisco\n* `genesys` - Genesys\n* `agora` - Agora\n* `telnyx` - Telnyx"
                     },
                     "assistant_provider": {
                         "enum": [
@@ -50917,17 +51146,17 @@
                             "livekit",
                             "pipecat",
                             "synthflow",
-                            "chirp",
                             "agora",
                             "koreai",
                             "genesys",
                             "amazon_connect",
+                            "telnyx",
                             ""
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "fdfb946e8335fe4e",
+                        "x-spec-enum-id": "adeb892ced4d9eb0",
                         "default": "",
-                        "description": "\nService provider for the AI assistant functionality. Valid values (live enum):\n\n- `self_hosted` — websocket or observation-only; no api_key needed. Use `websocket_url` + `websocket_headers` for text-mode runs.\n- `vapi` — requires `vapi_api_key`; optional `assistant_id`, `vapi_data.public_key`.\n- `retell` — requires `retell_api_key` AND `chat_assistant_id` (used for voice too).\n- `bland` — requires `bland_api_key` AND `chat_assistant_id` (Bland calls this `pathway_id`); `bland_data.encrypted_key` for Twilio.\n- `livekit` — requires `livekit_api_key` + `livekit_data.api_secret` + `livekit_data.url`.\n- `elevenlabs` — requires `elevenlabs_api_key`.\n- `agentforce` — requires `agentforce_client_secret` + `agentforce_data`.\n- `amazon_connect` — requires `amazon_connect_data` with `snippet_id` and `connect_host`; optional `amazon_connect_security_token` and `region`.\n- `cisco` — Cisco Webex.\n- `vocera` — Cekura-hosted.\n- `sms` / `whatsapp` — text-only channels; use `chat_assistant_id`.\n- `\"\"` (empty) — unset; agent is not runnable until a provider is configured.\n\nNote: the serializer also exposes `pipecat_*`, `synthflow_*`, `koreai_*`, `genesys_*`, `custom_provider_*` fields, but those provider values are not currently selectable in this enum.\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `elevenlabs` - Elevenlabs\n* `vocera` - Vocera\n* `sms` - Sms\n* `whatsapp` - Whatsapp\n* `self_hosted` - Self Hosted\n* `agentforce` - Agentforce\n* `cisco` - Cisco\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `synthflow` - Synthflow\n* `chirp` - Chirp\n* `agora` - Agora\n* `koreai` - Koreai\n* `genesys` - Genesys\n* `amazon_connect` - Amazon Connect"
+                        "description": "\nService provider for the AI assistant functionality. Valid values (live enum):\n\n- `self_hosted` — websocket or observation-only; no api_key needed. Use `websocket_url` + `websocket_headers` for text-mode runs.\n- `vapi` — requires `vapi_api_key`; optional `assistant_id`, `vapi_data.public_key`.\n- `retell` — requires `retell_api_key` AND `chat_assistant_id` (used for voice too).\n- `bland` — requires `bland_api_key` AND `chat_assistant_id` (Bland calls this `pathway_id`); `bland_data.encrypted_key` for Twilio.\n- `livekit` — requires `livekit_api_key` + `livekit_data.api_secret` + `livekit_data.url`.\n- `elevenlabs` — requires `elevenlabs_api_key`.\n- `agentforce` — requires `agentforce_client_secret` + `agentforce_data`.\n- `amazon_connect` — requires `amazon_connect_data` with `snippet_id` and `connect_host`; optional `amazon_connect_security_token` and `region`.\n- `cisco` — Cisco Webex.\n- `vocera` — Cekura-hosted.\n- `sms` / `whatsapp` — text-only channels; use `chat_assistant_id`.\n- `\"\"` (empty) — unset; agent is not runnable until a provider is configured.\n\nNote: the serializer also exposes `pipecat_*`, `synthflow_*`, `koreai_*`, `genesys_*`, `custom_provider_*` fields, but those provider values are not currently selectable in this enum.\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `elevenlabs` - Elevenlabs\n* `vocera` - Vocera\n* `sms` - Sms\n* `whatsapp` - Whatsapp\n* `self_hosted` - Self Hosted\n* `agentforce` - Agentforce\n* `cisco` - Cisco\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `synthflow` - Synthflow\n* `agora` - Agora\n* `koreai` - Koreai\n* `genesys` - Genesys\n* `amazon_connect` - Amazon Connect\n* `telnyx` - Telnyx"
                     },
                     "vapi_api_key": {
                         "type": "string",
@@ -51008,9 +51237,13 @@
                         "type": "string",
                         "readOnly": true
                     },
+                    "koreai_api_key_configured": {
+                        "type": "string",
+                        "readOnly": true
+                    },
                     "koreai_data": {
                         "type": "string",
-                        "description": "\nKore.ai additional data - client_id, bot_id, and host (optional)\n"
+                        "description": "\nKore.ai additional data.\nFor the RTM runner: {\"api_secret\": \"<xo-webclient API key>\", \"host\": \"platform.kore.ai\"}\nFor transcript fetch: {\"client_id\": \"cs-...\", \"bot_id\": \"st-...\", \"host\": \"bots.kore.ai\"}\napi_secret is encrypted at rest automatically.\n"
                     },
                     "genesys_client_secret": {
                         "type": "string",
@@ -51076,10 +51309,6 @@
                         "type": "string",
                         "description": "\nElevenLabs additional configuration data\nExample: `{\"trigger_url\": \"https://example.com/trigger\"}`\n"
                     },
-                    "chirp_data": {
-                        "type": "string",
-                        "description": "\nConfiguration for CHIRP WebSocket voice integration.\nSupported keys:\n  `chirp_websocket_url` (required): the wss:// endpoint to dial.\n  `chirp_basic_auth_username` (optional): username for Basic Auth on WS upgrade.\n  `chirp_basic_auth_password` (optional): password for Basic Auth on WS upgrade.\nExample: `{\"chirp_websocket_url\": \"wss://your-host/voice\", \"chirp_basic_auth_username\": \"user\", \"chirp_basic_auth_password\": \"secret\"}`\n"
-                    },
                     "agora_api_key": {
                         "type": "string",
                         "writeOnly": true,
@@ -51101,6 +51330,15 @@
                     "synthflow_data": {
                         "type": "string",
                         "description": "\nSynthflow additional configuration data\nExample: `{\"synthflow_base_url_override\": \"https://api.synthflow.ai\"}`\n"
+                    },
+                    "telnyx_api_key": {
+                        "type": "string",
+                        "writeOnly": true,
+                        "description": "\nAPI key for Telnyx AI Assistants\nExample: `\"telnyx_api_key_123\"`\n"
+                    },
+                    "telnyx_api_key_configured": {
+                        "type": "string",
+                        "readOnly": true
                     },
                     "enabled_personalities": {
                         "type": "array",
@@ -51624,7 +51862,7 @@
                     "api_key": {
                         "type": "string",
                         "writeOnly": true,
-                        "description": "API key or client secret for the provider (write-only — never returned). Required for: vapi, retell, elevenlabs, bland, livekit, pipecat, synthflow. koreai uses client_secret (passed as api_key). Not needed for: cisco, chirp, self_hosted."
+                        "description": "API key or client secret for the provider (write-only — never returned). Required for: vapi, retell, elevenlabs, bland, livekit, pipecat, synthflow. koreai uses client_secret (passed as api_key). Not needed for: cisco, self_hosted."
                     },
                     "config": {
                         "oneOf": [
@@ -51652,16 +51890,16 @@
                             "livekit",
                             "pipecat",
                             "synthflow",
-                            "chirp",
                             "agora",
                             "koreai",
                             "genesys",
+                            "telnyx",
                             "custom",
                             ""
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "021e7ebf960fc84b",
-                        "description": "Voice/inbound platform provider type. Valid values: vapi, retell, elevenlabs, bland, livekit, cisco, synthflow, chirp, koreai, genesys, self_hosted, pipecat, custom. Use 'custom' (or omit) for chat-only agents with no voice provider — the chat channel goes in chat_agent_details.type. Text-only channels (sms, whatsapp, agentforce, amazon_connect) belong in chat_agent_details.type, not here.\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `elevenlabs` - Elevenlabs\n* `self_hosted` - Self Hosted\n* `cisco` - Cisco\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `synthflow` - Synthflow\n* `chirp` - Chirp\n* `agora` - Agora\n* `koreai` - Koreai\n* `genesys` - Genesys\n* `custom` - Custom (chat-only, no voice provider)"
+                        "x-spec-enum-id": "acf2b20623442583",
+                        "description": "Voice/inbound platform provider type. Valid values: vapi, retell, elevenlabs, bland, livekit, cisco, synthflow, koreai, genesys, self_hosted, pipecat, custom. Use 'custom' (or omit) for chat-only agents with no voice provider — the chat channel goes in chat_agent_details.type. For a raw-PCM websocket voice agent you host yourself, use type='custom' and put the endpoint in telephony.websocket_url. Text-only channels (sms, whatsapp, agentforce, amazon_connect) belong in chat_agent_details.type, not here.\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `elevenlabs` - Elevenlabs\n* `self_hosted` - Self Hosted\n* `cisco` - Cisco\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `synthflow` - Synthflow\n* `agora` - Agora\n* `koreai` - Koreai\n* `genesys` - Genesys\n* `telnyx` - Telnyx\n* `custom` - Custom (chat-only, no voice provider)"
                     },
                     "agent_id": {
                         "type": [
@@ -51723,7 +51961,7 @@
             },
             "AgentTelephony": {
                 "type": "object",
-                "description": "Phone/SIP channel configuration for the agent.",
+                "description": "Phone / SIP / websocket voice channel configuration for the agent.",
                 "properties": {
                     "phone_number": {
                         "type": "string",
@@ -51749,6 +51987,22 @@
                             }
                         ],
                         "description": "SIP credentials: {username, password}."
+                    },
+                    "websocket_url": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "Raw-PCM (16kHz 16-bit mono) websocket endpoint Cekura dials to run the whole call over a websocket you host, e.g. wss://your-host/voice."
+                    },
+                    "websocket_auth": {
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "HTTP Basic Auth credentials for the websocket upgrade: {username, password}."
                     },
                     "outbound_numbers": {
                         "type": "array",
@@ -52960,6 +53214,7 @@
             },
             "CallLogDetail": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -53151,6 +53406,7 @@
             },
             "CallLogList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -53432,11 +53688,12 @@
                             "self_hosted",
                             "agentforce",
                             "amazon_connect",
+                            "koreai",
                             ""
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "07933949d9325983",
-                        "description": "Chat provider type. Must be compatible with the voice provider.type. Valid values: retell, bland, vapi, elevenlabs, livekit, agora, sms, whatsapp, self_hosted, agentforce, amazon_connect. Pass an empty string \"\" (or send chat_agent_details: null) to clear the chat overlay.\n\n* `retell` - retell\n* `bland` - bland\n* `vapi` - vapi\n* `elevenlabs` - elevenlabs\n* `livekit` - livekit\n* `agora` - agora\n* `sms` - sms\n* `whatsapp` - whatsapp\n* `self_hosted` - self_hosted\n* `agentforce` - agentforce\n* `amazon_connect` - amazon_connect"
+                        "x-spec-enum-id": "0a46c52849d3f58d",
+                        "description": "Chat provider type. Must be compatible with the voice provider.type. Valid values: retell, bland, vapi, elevenlabs, livekit, agora, sms, whatsapp, self_hosted, agentforce, amazon_connect, koreai. Pass an empty string \"\" (or send chat_agent_details: null) to clear the chat overlay.\n\n* `retell` - retell\n* `bland` - bland\n* `vapi` - vapi\n* `elevenlabs` - elevenlabs\n* `livekit` - livekit\n* `agora` - agora\n* `sms` - sms\n* `whatsapp` - whatsapp\n* `self_hosted` - self_hosted\n* `agentforce` - agentforce\n* `amazon_connect` - amazon_connect\n* `koreai` - koreai"
                     },
                     "config": {
                         "oneOf": [
@@ -53595,28 +53852,6 @@
                         "readOnly": true
                     }
                 }
-            },
-            "ChirpConfig": {
-                "type": "object",
-                "description": "CHIRP WebSocket voice configuration.",
-                "properties": {
-                    "chirp_websocket_url": {
-                        "type": "string",
-                        "description": "WebSocket endpoint your CHIRP agent listens on (Raw PCM 16kHz 16-bit mono), e.g. wss://your-host/voice."
-                    },
-                    "chirp_basic_auth_username": {
-                        "type": "string",
-                        "description": "Optional username for HTTP Basic Auth on the WebSocket upgrade."
-                    },
-                    "chirp_basic_auth_password": {
-                        "type": "string",
-                        "description": "Optional password for HTTP Basic Auth on the WebSocket upgrade (write-only — masked in responses)."
-                    }
-                },
-                "required": [
-                    "chirp_websocket_url"
-                ],
-                "title": "CHIRP"
             },
             "CleanMetricDescriptionRequest": {
                 "type": "object",
@@ -54365,6 +54600,7 @@
             },
             "Dashboard": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -54496,6 +54732,7 @@
             },
             "DashboardList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -54617,6 +54854,136 @@
                         "description": "When the dashboard was last updated"
                     }
                 }
+            },
+            "DeepResearchInsight": {
+                "type": "object",
+                "description": "Project-level Deep Research audit row exposed to the Insights tab.\n\n`failure_modes` is filtered against the project's dismissed mode\ntitles — a thumbs-down on a mode hides it from every subsequent\nrender of every insight in the project (project-scoped, not\ninsight-scoped).",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "project": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "window_start": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "window_end": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "num_calls_analyzed": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "status": {
+                        "enum": [
+                            "pending",
+                            "running",
+                            "succeeded",
+                            "failed",
+                            "skipped_not_enough_data"
+                        ],
+                        "type": "string",
+                        "description": "* `pending` - Pending\n* `running` - Running\n* `succeeded` - Succeeded\n* `failed` - Failed\n* `skipped_not_enough_data` - Skipped Not Enough Data",
+                        "x-spec-enum-id": "128862fca689ae44",
+                        "readOnly": true
+                    },
+                    "failure_modes": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "error_message": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "duration_seconds": {
+                        "type": [
+                            "number",
+                            "null"
+                        ],
+                        "format": "double",
+                        "readOnly": true
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    }
+                }
+            },
+            "DeepResearchInsightGenerate": {
+                "type": "object",
+                "description": "Request body for ``POST /deep-research-insights/generate/``.",
+                "properties": {
+                    "project": {
+                        "type": "integer",
+                        "description": "Project ID to generate Deep Research for."
+                    },
+                    "window_days": {
+                        "type": "integer",
+                        "maximum": 30,
+                        "minimum": 1,
+                        "default": 7
+                    },
+                    "max_calls": {
+                        "type": "integer",
+                        "maximum": 1000,
+                        "minimum": 10,
+                        "default": 200
+                    }
+                },
+                "required": [
+                    "project"
+                ]
+            },
+            "DeepResearchModeDismissalCreate": {
+                "type": "object",
+                "description": "Request body for thumbs-down submission.",
+                "properties": {
+                    "project": {
+                        "type": "integer"
+                    },
+                    "insight": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
+                    },
+                    "mode_title": {
+                        "type": "string",
+                        "description": "Exact title of the failure mode to suppress.",
+                        "maxLength": 200
+                    },
+                    "mode_details": {
+                        "type": "string",
+                        "default": ""
+                    },
+                    "mode_severity": {
+                        "type": "string",
+                        "default": "",
+                        "maxLength": 20
+                    },
+                    "note": {
+                        "type": "string",
+                        "default": "",
+                        "description": "Optional reason. Empty is fine — a bare thumbs-down still dismisses."
+                    }
+                },
+                "required": [
+                    "mode_title",
+                    "project"
+                ]
             },
             "DeleteCallLogs": {
                 "type": "object",
@@ -56638,6 +57005,7 @@
             },
             "MetricList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -59308,6 +59676,7 @@
             },
             "PatchedCallLogDetail": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -59765,6 +60134,7 @@
             },
             "PatchedDashboard": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -60940,6 +61310,10 @@
                         "type": "boolean",
                         "description": "\nEnable client side testing\nExample: `true` or `false`\n"
                     },
+                    "use_provider_transcript": {
+                        "type": "boolean",
+                        "description": "When true, evaluations use the provider transcript instead of Cekura transcript with provider side tool calls. Defaults to false."
+                    },
                     "should_show_powered_by": {
                         "type": "boolean",
                         "description": "\nShould show powered by\nExample: `true` or `false`\n"
@@ -61190,13 +61564,13 @@
                             "custom",
                             "agentforce",
                             "genesys",
-                            "chirp",
                             "amazon_connect",
-                            "agora"
+                            "agora",
+                            "telnyx"
                         ],
                         "type": "string",
-                        "description": "* `vapi` - Vapi\n* `retell` - Retell\n* `synthflow` - Synthflow\n* `elevenlabs` - Elevenlabs\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `koreai` - Kore\n* `custom` - Custom\n* `agentforce` - Agentforce\n* `genesys` - Genesys\n* `chirp` - Chirp\n* `amazon_connect` - Amazon Connect\n* `agora` - Agora",
-                        "x-spec-enum-id": "7c6fd551a493a2f1"
+                        "description": "* `vapi` - Vapi\n* `retell` - Retell\n* `synthflow` - Synthflow\n* `elevenlabs` - Elevenlabs\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `koreai` - Kore\n* `custom` - Custom\n* `agentforce` - Agentforce\n* `genesys` - Genesys\n* `amazon_connect` - Amazon Connect\n* `agora` - Agora\n* `telnyx` - Telnyx",
+                        "x-spec-enum-id": "01712a275b463713"
                     },
                     "key": {
                         "type": "string",
@@ -62038,6 +62412,7 @@
             },
             "PatchedSchemaPostScenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "agent": {
                         "type": [
@@ -62292,6 +62667,23 @@
                         ],
                         "description": "\nSIP authentication credentials\nExample: `{\"username\": \"user123\", \"password\": \"pass123\"}`\n"
                     },
+                    "websocket_voice_url": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "Raw-PCM (16kHz 16-bit mono) websocket endpoint for direct websocket-based voice calls",
+                        "maxLength": 255
+                    },
+                    "websocket_auth": {
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "\nWebsocket Basic Auth credentials\nExample: `{\"username\": \"user123\", \"password\": \"pass123\"}`\n"
+                    },
                     "predefined_metrics": {
                         "writeOnly": true,
                         "description": "predefined metrics to use for the agent"
@@ -62314,14 +62706,14 @@
                             "custom",
                             "cisco",
                             "genesys",
-                            "chirp",
                             "agora",
+                            "telnyx",
                             ""
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "5ea2faa74e8025b2",
+                        "x-spec-enum-id": "eaf4e8ebc9a5bda2",
                         "default": "",
-                        "description": "\nService provider for speech-to-text transcription\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `synthflow` - Synthflow\n* `elevenlabs` - Elevenlabs\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `koreai` - Kore\n* `custom` - Custom\n* `cisco` - Cisco\n* `genesys` - Genesys\n* `chirp` - Chirp\n* `agora` - Agora"
+                        "description": "\nService provider for speech-to-text transcription\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `synthflow` - Synthflow\n* `elevenlabs` - Elevenlabs\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `koreai` - Kore\n* `custom` - Custom\n* `cisco` - Cisco\n* `genesys` - Genesys\n* `agora` - Agora\n* `telnyx` - Telnyx"
                     },
                     "assistant_provider": {
                         "enum": [
@@ -62338,17 +62730,17 @@
                             "livekit",
                             "pipecat",
                             "synthflow",
-                            "chirp",
                             "agora",
                             "koreai",
                             "genesys",
                             "amazon_connect",
+                            "telnyx",
                             ""
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "fdfb946e8335fe4e",
+                        "x-spec-enum-id": "adeb892ced4d9eb0",
                         "default": "",
-                        "description": "\nService provider for the AI assistant functionality. Valid values (live enum):\n\n- `self_hosted` — websocket or observation-only; no api_key needed. Use `websocket_url` + `websocket_headers` for text-mode runs.\n- `vapi` — requires `vapi_api_key`; optional `assistant_id`, `vapi_data.public_key`.\n- `retell` — requires `retell_api_key` AND `chat_assistant_id` (used for voice too).\n- `bland` — requires `bland_api_key` AND `chat_assistant_id` (Bland calls this `pathway_id`); `bland_data.encrypted_key` for Twilio.\n- `livekit` — requires `livekit_api_key` + `livekit_data.api_secret` + `livekit_data.url`.\n- `elevenlabs` — requires `elevenlabs_api_key`.\n- `agentforce` — requires `agentforce_client_secret` + `agentforce_data`.\n- `amazon_connect` — requires `amazon_connect_data` with `snippet_id` and `connect_host`; optional `amazon_connect_security_token` and `region`.\n- `cisco` — Cisco Webex.\n- `vocera` — Cekura-hosted.\n- `sms` / `whatsapp` — text-only channels; use `chat_assistant_id`.\n- `\"\"` (empty) — unset; agent is not runnable until a provider is configured.\n\nNote: the serializer also exposes `pipecat_*`, `synthflow_*`, `koreai_*`, `genesys_*`, `custom_provider_*` fields, but those provider values are not currently selectable in this enum.\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `elevenlabs` - Elevenlabs\n* `vocera` - Vocera\n* `sms` - Sms\n* `whatsapp` - Whatsapp\n* `self_hosted` - Self Hosted\n* `agentforce` - Agentforce\n* `cisco` - Cisco\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `synthflow` - Synthflow\n* `chirp` - Chirp\n* `agora` - Agora\n* `koreai` - Koreai\n* `genesys` - Genesys\n* `amazon_connect` - Amazon Connect"
+                        "description": "\nService provider for the AI assistant functionality. Valid values (live enum):\n\n- `self_hosted` — websocket or observation-only; no api_key needed. Use `websocket_url` + `websocket_headers` for text-mode runs.\n- `vapi` — requires `vapi_api_key`; optional `assistant_id`, `vapi_data.public_key`.\n- `retell` — requires `retell_api_key` AND `chat_assistant_id` (used for voice too).\n- `bland` — requires `bland_api_key` AND `chat_assistant_id` (Bland calls this `pathway_id`); `bland_data.encrypted_key` for Twilio.\n- `livekit` — requires `livekit_api_key` + `livekit_data.api_secret` + `livekit_data.url`.\n- `elevenlabs` — requires `elevenlabs_api_key`.\n- `agentforce` — requires `agentforce_client_secret` + `agentforce_data`.\n- `amazon_connect` — requires `amazon_connect_data` with `snippet_id` and `connect_host`; optional `amazon_connect_security_token` and `region`.\n- `cisco` — Cisco Webex.\n- `vocera` — Cekura-hosted.\n- `sms` / `whatsapp` — text-only channels; use `chat_assistant_id`.\n- `\"\"` (empty) — unset; agent is not runnable until a provider is configured.\n\nNote: the serializer also exposes `pipecat_*`, `synthflow_*`, `koreai_*`, `genesys_*`, `custom_provider_*` fields, but those provider values are not currently selectable in this enum.\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `elevenlabs` - Elevenlabs\n* `vocera` - Vocera\n* `sms` - Sms\n* `whatsapp` - Whatsapp\n* `self_hosted` - Self Hosted\n* `agentforce` - Agentforce\n* `cisco` - Cisco\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `synthflow` - Synthflow\n* `agora` - Agora\n* `koreai` - Koreai\n* `genesys` - Genesys\n* `amazon_connect` - Amazon Connect\n* `telnyx` - Telnyx"
                     },
                     "vapi_api_key": {
                         "type": "string",
@@ -62429,9 +62821,13 @@
                         "type": "string",
                         "readOnly": true
                     },
+                    "koreai_api_key_configured": {
+                        "type": "string",
+                        "readOnly": true
+                    },
                     "koreai_data": {
                         "type": "string",
-                        "description": "\nKore.ai additional data - client_id, bot_id, and host (optional)\n"
+                        "description": "\nKore.ai additional data.\nFor the RTM runner: {\"api_secret\": \"<xo-webclient API key>\", \"host\": \"platform.kore.ai\"}\nFor transcript fetch: {\"client_id\": \"cs-...\", \"bot_id\": \"st-...\", \"host\": \"bots.kore.ai\"}\napi_secret is encrypted at rest automatically.\n"
                     },
                     "genesys_client_secret": {
                         "type": "string",
@@ -62497,10 +62893,6 @@
                         "type": "string",
                         "description": "\nElevenLabs additional configuration data\nExample: `{\"trigger_url\": \"https://example.com/trigger\"}`\n"
                     },
-                    "chirp_data": {
-                        "type": "string",
-                        "description": "\nConfiguration for CHIRP WebSocket voice integration.\nSupported keys:\n  `chirp_websocket_url` (required): the wss:// endpoint to dial.\n  `chirp_basic_auth_username` (optional): username for Basic Auth on WS upgrade.\n  `chirp_basic_auth_password` (optional): password for Basic Auth on WS upgrade.\nExample: `{\"chirp_websocket_url\": \"wss://your-host/voice\", \"chirp_basic_auth_username\": \"user\", \"chirp_basic_auth_password\": \"secret\"}`\n"
-                    },
                     "agora_api_key": {
                         "type": "string",
                         "writeOnly": true,
@@ -62522,6 +62914,15 @@
                     "synthflow_data": {
                         "type": "string",
                         "description": "\nSynthflow additional configuration data\nExample: `{\"synthflow_base_url_override\": \"https://api.synthflow.ai\"}`\n"
+                    },
+                    "telnyx_api_key": {
+                        "type": "string",
+                        "writeOnly": true,
+                        "description": "\nAPI key for Telnyx AI Assistants\nExample: `\"telnyx_api_key_123\"`\n"
+                    },
+                    "telnyx_api_key_configured": {
+                        "type": "string",
+                        "readOnly": true
                     },
                     "enabled_personalities": {
                         "type": "array",
@@ -63932,6 +64333,10 @@
                         "type": "boolean",
                         "description": "\nEnable client side testing\nExample: `true` or `false`\n"
                     },
+                    "use_provider_transcript": {
+                        "type": "boolean",
+                        "description": "When true, evaluations use the provider transcript instead of Cekura transcript with provider side tool calls. Defaults to false."
+                    },
                     "should_show_powered_by": {
                         "type": "boolean",
                         "description": "\nShould show powered by\nExample: `true` or `false`\n"
@@ -64221,13 +64626,13 @@
                             "custom",
                             "agentforce",
                             "genesys",
-                            "chirp",
                             "amazon_connect",
-                            "agora"
+                            "agora",
+                            "telnyx"
                         ],
                         "type": "string",
-                        "description": "* `vapi` - Vapi\n* `retell` - Retell\n* `synthflow` - Synthflow\n* `elevenlabs` - Elevenlabs\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `koreai` - Kore\n* `custom` - Custom\n* `agentforce` - Agentforce\n* `genesys` - Genesys\n* `chirp` - Chirp\n* `amazon_connect` - Amazon Connect\n* `agora` - Agora",
-                        "x-spec-enum-id": "7c6fd551a493a2f1"
+                        "description": "* `vapi` - Vapi\n* `retell` - Retell\n* `synthflow` - Synthflow\n* `elevenlabs` - Elevenlabs\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `koreai` - Kore\n* `custom` - Custom\n* `agentforce` - Agentforce\n* `genesys` - Genesys\n* `amazon_connect` - Amazon Connect\n* `agora` - Agora\n* `telnyx` - Telnyx",
+                        "x-spec-enum-id": "01712a275b463713"
                     },
                     "key": {
                         "type": "string",
@@ -64276,13 +64681,13 @@
                             "custom",
                             "agentforce",
                             "genesys",
-                            "chirp",
                             "amazon_connect",
-                            "agora"
+                            "agora",
+                            "telnyx"
                         ],
                         "type": "string",
-                        "description": "* `vapi` - Vapi\n* `retell` - Retell\n* `synthflow` - Synthflow\n* `elevenlabs` - Elevenlabs\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `koreai` - Kore\n* `custom` - Custom\n* `agentforce` - Agentforce\n* `genesys` - Genesys\n* `chirp` - Chirp\n* `amazon_connect` - Amazon Connect\n* `agora` - Agora",
-                        "x-spec-enum-id": "7c6fd551a493a2f1"
+                        "description": "* `vapi` - Vapi\n* `retell` - Retell\n* `synthflow` - Synthflow\n* `elevenlabs` - Elevenlabs\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `koreai` - Kore\n* `custom` - Custom\n* `agentforce` - Agentforce\n* `genesys` - Genesys\n* `amazon_connect` - Amazon Connect\n* `agora` - Agora\n* `telnyx` - Telnyx",
+                        "x-spec-enum-id": "01712a275b463713"
                     },
                     "created_at": {
                         "type": "string",
@@ -64319,9 +64724,6 @@
                     },
                     {
                         "$ref": "#/components/schemas/PipecatConfig"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ChirpConfig"
                     },
                     {
                         "$ref": "#/components/schemas/SelfHostedConfig"
@@ -65007,6 +65409,7 @@
             },
             "RunList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -65248,6 +65651,26 @@
                             "null"
                         ],
                         "description": "Agent to use. Required if none of the scenarios have an agent."
+                    },
+                    "personality_ids": {
+                        "type": [
+                            "array",
+                            "null"
+                        ],
+                        "items": {
+                            "type": "integer"
+                        },
+                        "description": "List of personality IDs to override for this run. If not provided, uses the scenario's default personality."
+                    },
+                    "test_profile_ids": {
+                        "type": [
+                            "array",
+                            "null"
+                        ],
+                        "items": {
+                            "type": "integer"
+                        },
+                        "description": "List of test profile IDs to override for this run. If not provided, uses the scenario's default test profile."
                     }
                 },
                 "required": [
@@ -65411,6 +65834,7 @@
             },
             "Scenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -66280,6 +66704,7 @@
             },
             "ScenarioList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -66499,6 +66924,7 @@
             },
             "ScenarioSerializerV2": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -66863,16 +67289,16 @@
                             "livekit",
                             "pipecat",
                             "synthflow",
-                            "chirp",
                             "agora",
                             "koreai",
                             "genesys",
+                            "telnyx",
                             "custom",
                             ""
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "021e7ebf960fc84b",
-                        "description": "Voice/inbound platform provider type. Valid values: vapi, retell, elevenlabs, bland, livekit, cisco, synthflow, chirp, koreai, genesys, self_hosted, pipecat, custom. Use 'custom' (or omit) for chat-only agents with no voice provider — the chat channel goes in chat_agent_details.type. Text-only channels (sms, whatsapp, agentforce, amazon_connect) belong in chat_agent_details.type, not here.\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `elevenlabs` - Elevenlabs\n* `self_hosted` - Self Hosted\n* `cisco` - Cisco\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `synthflow` - Synthflow\n* `chirp` - Chirp\n* `agora` - Agora\n* `koreai` - Koreai\n* `genesys` - Genesys\n* `custom` - Custom (chat-only, no voice provider)"
+                        "x-spec-enum-id": "acf2b20623442583",
+                        "description": "Voice/inbound platform provider type. Valid values: vapi, retell, elevenlabs, bland, livekit, cisco, synthflow, koreai, genesys, self_hosted, pipecat, custom. Use 'custom' (or omit) for chat-only agents with no voice provider — the chat channel goes in chat_agent_details.type. For a raw-PCM websocket voice agent you host yourself, use type='custom' and put the endpoint in telephony.websocket_url. Text-only channels (sms, whatsapp, agentforce, amazon_connect) belong in chat_agent_details.type, not here.\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `elevenlabs` - Elevenlabs\n* `self_hosted` - Self Hosted\n* `cisco` - Cisco\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `synthflow` - Synthflow\n* `agora` - Agora\n* `koreai` - Koreai\n* `genesys` - Genesys\n* `telnyx` - Telnyx\n* `custom` - Custom (chat-only, no voice provider)"
                     },
                     "agent_id": {
                         "type": [
@@ -67944,6 +68370,7 @@
             },
             "SchemaPostRunScenarios": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "agent_id": {
                         "type": "integer",
@@ -68075,6 +68502,26 @@
                             "$ref": "#/components/schemas/SchemaPipecatV2Scenario"
                         },
                         "description": "List of scenarios to run with automated Pipecat Cloud session creation"
+                    },
+                    "personality_ids": {
+                        "type": [
+                            "array",
+                            "null"
+                        ],
+                        "items": {
+                            "type": "integer"
+                        },
+                        "description": "List of personality IDs to override for this run. If not provided, uses the scenario's default personality."
+                    },
+                    "test_profile_ids": {
+                        "type": [
+                            "array",
+                            "null"
+                        ],
+                        "items": {
+                            "type": "integer"
+                        },
+                        "description": "List of test profile IDs to override for this run. If not provided, uses the scenario's default test profile."
                     }
                 },
                 "required": [
@@ -68130,6 +68577,11 @@
                         "type": "string",
                         "description": "If provided, the simulated caller connects to this websocket URL instead of using the agent's configured text/SMS gateway. Use for agents that expose a websocket endpoint for text testing. Bypasses the normal `agent.can_run_as_text()` check."
                     },
+                    "websocket_headers": {
+                        "type": "object",
+                        "additionalProperties": {},
+                        "description": "Headers to send on the websocket connection for this run. Merged over the agent's configured `websocket_headers` — keys provided here win. System `X-VOCERA-*` headers cannot be overridden."
+                    },
                     "personality_ids": {
                         "type": [
                             "array",
@@ -68167,6 +68619,7 @@
             },
             "SchemaPostScenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "agent": {
                         "type": [
@@ -68326,6 +68779,7 @@
             },
             "SchemaScenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -68701,6 +69155,23 @@
                         ],
                         "description": "\nSIP authentication credentials\nExample: `{\"username\": \"user123\", \"password\": \"pass123\"}`\n"
                     },
+                    "websocket_voice_url": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "Raw-PCM (16kHz 16-bit mono) websocket endpoint for direct websocket-based voice calls",
+                        "maxLength": 255
+                    },
+                    "websocket_auth": {
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "\nWebsocket Basic Auth credentials\nExample: `{\"username\": \"user123\", \"password\": \"pass123\"}`\n"
+                    },
                     "predefined_metrics": {
                         "writeOnly": true,
                         "description": "predefined metrics to use for the agent"
@@ -68723,14 +69194,14 @@
                             "custom",
                             "cisco",
                             "genesys",
-                            "chirp",
                             "agora",
+                            "telnyx",
                             ""
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "5ea2faa74e8025b2",
+                        "x-spec-enum-id": "eaf4e8ebc9a5bda2",
                         "default": "",
-                        "description": "\nService provider for speech-to-text transcription\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `synthflow` - Synthflow\n* `elevenlabs` - Elevenlabs\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `koreai` - Kore\n* `custom` - Custom\n* `cisco` - Cisco\n* `genesys` - Genesys\n* `chirp` - Chirp\n* `agora` - Agora"
+                        "description": "\nService provider for speech-to-text transcription\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `synthflow` - Synthflow\n* `elevenlabs` - Elevenlabs\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `koreai` - Kore\n* `custom` - Custom\n* `cisco` - Cisco\n* `genesys` - Genesys\n* `agora` - Agora\n* `telnyx` - Telnyx"
                     },
                     "assistant_provider": {
                         "enum": [
@@ -68747,17 +69218,17 @@
                             "livekit",
                             "pipecat",
                             "synthflow",
-                            "chirp",
                             "agora",
                             "koreai",
                             "genesys",
                             "amazon_connect",
+                            "telnyx",
                             ""
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "fdfb946e8335fe4e",
+                        "x-spec-enum-id": "adeb892ced4d9eb0",
                         "default": "",
-                        "description": "\nService provider for the AI assistant functionality. Valid values (live enum):\n\n- `self_hosted` — websocket or observation-only; no api_key needed. Use `websocket_url` + `websocket_headers` for text-mode runs.\n- `vapi` — requires `vapi_api_key`; optional `assistant_id`, `vapi_data.public_key`.\n- `retell` — requires `retell_api_key` AND `chat_assistant_id` (used for voice too).\n- `bland` — requires `bland_api_key` AND `chat_assistant_id` (Bland calls this `pathway_id`); `bland_data.encrypted_key` for Twilio.\n- `livekit` — requires `livekit_api_key` + `livekit_data.api_secret` + `livekit_data.url`.\n- `elevenlabs` — requires `elevenlabs_api_key`.\n- `agentforce` — requires `agentforce_client_secret` + `agentforce_data`.\n- `amazon_connect` — requires `amazon_connect_data` with `snippet_id` and `connect_host`; optional `amazon_connect_security_token` and `region`.\n- `cisco` — Cisco Webex.\n- `vocera` — Cekura-hosted.\n- `sms` / `whatsapp` — text-only channels; use `chat_assistant_id`.\n- `\"\"` (empty) — unset; agent is not runnable until a provider is configured.\n\nNote: the serializer also exposes `pipecat_*`, `synthflow_*`, `koreai_*`, `genesys_*`, `custom_provider_*` fields, but those provider values are not currently selectable in this enum.\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `elevenlabs` - Elevenlabs\n* `vocera` - Vocera\n* `sms` - Sms\n* `whatsapp` - Whatsapp\n* `self_hosted` - Self Hosted\n* `agentforce` - Agentforce\n* `cisco` - Cisco\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `synthflow` - Synthflow\n* `chirp` - Chirp\n* `agora` - Agora\n* `koreai` - Koreai\n* `genesys` - Genesys\n* `amazon_connect` - Amazon Connect"
+                        "description": "\nService provider for the AI assistant functionality. Valid values (live enum):\n\n- `self_hosted` — websocket or observation-only; no api_key needed. Use `websocket_url` + `websocket_headers` for text-mode runs.\n- `vapi` — requires `vapi_api_key`; optional `assistant_id`, `vapi_data.public_key`.\n- `retell` — requires `retell_api_key` AND `chat_assistant_id` (used for voice too).\n- `bland` — requires `bland_api_key` AND `chat_assistant_id` (Bland calls this `pathway_id`); `bland_data.encrypted_key` for Twilio.\n- `livekit` — requires `livekit_api_key` + `livekit_data.api_secret` + `livekit_data.url`.\n- `elevenlabs` — requires `elevenlabs_api_key`.\n- `agentforce` — requires `agentforce_client_secret` + `agentforce_data`.\n- `amazon_connect` — requires `amazon_connect_data` with `snippet_id` and `connect_host`; optional `amazon_connect_security_token` and `region`.\n- `cisco` — Cisco Webex.\n- `vocera` — Cekura-hosted.\n- `sms` / `whatsapp` — text-only channels; use `chat_assistant_id`.\n- `\"\"` (empty) — unset; agent is not runnable until a provider is configured.\n\nNote: the serializer also exposes `pipecat_*`, `synthflow_*`, `koreai_*`, `genesys_*`, `custom_provider_*` fields, but those provider values are not currently selectable in this enum.\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `elevenlabs` - Elevenlabs\n* `vocera` - Vocera\n* `sms` - Sms\n* `whatsapp` - Whatsapp\n* `self_hosted` - Self Hosted\n* `agentforce` - Agentforce\n* `cisco` - Cisco\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `synthflow` - Synthflow\n* `agora` - Agora\n* `koreai` - Koreai\n* `genesys` - Genesys\n* `amazon_connect` - Amazon Connect\n* `telnyx` - Telnyx"
                     },
                     "vapi_api_key": {
                         "type": "string",
@@ -68838,9 +69309,13 @@
                         "type": "string",
                         "readOnly": true
                     },
+                    "koreai_api_key_configured": {
+                        "type": "string",
+                        "readOnly": true
+                    },
                     "koreai_data": {
                         "type": "string",
-                        "description": "\nKore.ai additional data - client_id, bot_id, and host (optional)\n"
+                        "description": "\nKore.ai additional data.\nFor the RTM runner: {\"api_secret\": \"<xo-webclient API key>\", \"host\": \"platform.kore.ai\"}\nFor transcript fetch: {\"client_id\": \"cs-...\", \"bot_id\": \"st-...\", \"host\": \"bots.kore.ai\"}\napi_secret is encrypted at rest automatically.\n"
                     },
                     "genesys_client_secret": {
                         "type": "string",
@@ -68906,10 +69381,6 @@
                         "type": "string",
                         "description": "\nElevenLabs additional configuration data\nExample: `{\"trigger_url\": \"https://example.com/trigger\"}`\n"
                     },
-                    "chirp_data": {
-                        "type": "string",
-                        "description": "\nConfiguration for CHIRP WebSocket voice integration.\nSupported keys:\n  `chirp_websocket_url` (required): the wss:// endpoint to dial.\n  `chirp_basic_auth_username` (optional): username for Basic Auth on WS upgrade.\n  `chirp_basic_auth_password` (optional): password for Basic Auth on WS upgrade.\nExample: `{\"chirp_websocket_url\": \"wss://your-host/voice\", \"chirp_basic_auth_username\": \"user\", \"chirp_basic_auth_password\": \"secret\"}`\n"
-                    },
                     "agora_api_key": {
                         "type": "string",
                         "writeOnly": true,
@@ -68931,6 +69402,15 @@
                     "synthflow_data": {
                         "type": "string",
                         "description": "\nSynthflow additional configuration data\nExample: `{\"synthflow_base_url_override\": \"https://api.synthflow.ai\"}`\n"
+                    },
+                    "telnyx_api_key": {
+                        "type": "string",
+                        "writeOnly": true,
+                        "description": "\nAPI key for Telnyx AI Assistants\nExample: `\"telnyx_api_key_123\"`\n"
+                    },
+                    "telnyx_api_key_configured": {
+                        "type": "string",
+                        "readOnly": true
                     },
                     "enabled_personalities": {
                         "type": "array",


### PR DESCRIPTION
Auto-generated docs sync for backend PR [#9439](https://github.com/cekura-ai/vocera.backend/pull/9439).

Reviewers: @dileep-chagam, @atulcekura

## Summary

**Spec/overlay:** 1 exposed operation (`scenarios-retrieve`) received a schema update adding the `generated_mock_tool_entries` response field for test profiles and personality overrides. No overlay additions required — the change is additive-only with no transport quirks or breaking behavior. 2 URL-variant duplicates (`-external/`, `/v2/scenarios/`) also updated but match retired patterns.

**Conceptual docs:** Updated Pipecat and LiveKit automated testing documentation to include new personality_ids and test_profile_ids override parameters. Updated personality and test-profile concept pages to mention run-level override capability for Pipecat and LiveKit integrations.

## Changes

- `openapi.json` — regenerate_from_backend
- `documentation/integrations/pipecat/automated.mdx` — update
- `documentation/integrations/livekit/testing.mdx` — update
- `documentation/key-concepts/evaluators/personality.mdx` — update
- `documentation/key-concepts/evaluators/test-profile.mdx` — update

---
*Auto-generated from backend PR #9439.*

<!-- mcp-sync:file-hashes -->
```json
{
  "documentation/integrations/livekit/testing.mdx": "9aed4d9d26b9c65d1ee60cf38a2d57c61b8501dad642d2a7bbd768e9c8757f6a",
  "documentation/integrations/pipecat/automated.mdx": "68f62929b2c92122af3a91f66f4025ed5a8cbbd780325b80c3dfea0f10d0e93f",
  "documentation/key-concepts/evaluators/personality.mdx": "f13ece3032dac76f0065f2036caa6f687b321962b74d38149635ee4e9259b882",
  "documentation/key-concepts/evaluators/test-profile.mdx": "74170e03bf9e608720f622b6228580df7f67839e739cd83dea7bc4d1b3c34e65"
}
```
<!-- /mcp-sync:file-hashes -->