### PR TITLE
Refresh docs videos with latest YouTube walkthroughs

### DIFF
--- a/documentation/key-concepts/metrics/pre-defined-metrics.mdx
+++ b/documentation/key-concepts/metrics/pre-defined-metrics.mdx
@@ -291,6 +291,8 @@ These metrics evaluate the Testing Agent's experience and satisfaction with the 
 
 These metrics evaluate the audio and speech characteristics of the Main Agent.
 
+<iframe src="https://www.youtube.com/embed/_ntVTPKuFSI" title="Speech Quality Metrics in Cekura" frameborder="0" className="w-full aspect-video rounded-xl" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen />
+
 <AccordionGroup>
   <Accordion title="Average Pitch (in Hz)">
     **Result**: Numeric (Hertz) | **Cost**: 0 credits

--- a/documentation/video_tutorials.mdx
+++ b/documentation/video_tutorials.mdx
@@ -12,6 +12,9 @@ import { CopyPageButton } from "/snippets/copy-page-button.mdx";
 
 
 <CardGroup cols={2}>
+  <Card title="Cekura with Claude Code" icon="robot" color="#A6A7EA" href="https://youtu.be/uhqsdYiJFhc">
+    See how to test and improve your voice agents using Cekura with Claude Code
+  </Card>
   <Card title="Getting Started Guide" icon="play" color="#A6A7EA" href="https://www.cekura.ai/intro-guide">
     Master the basics of AI voice agent testing
   </Card>
@@ -21,14 +24,26 @@ import { CopyPageButton } from "/snippets/copy-page-button.mdx";
   <Card title="Observability Workflow" icon="graduation-cap" color="#A6A7EA" href="https://www.tella.tv/video/building-good-metrics-on-cekura-0taa">
     Learn to create metrics and observe live calls
   </Card>
-  <Card title="VAPI Integration Guide" icon="plug" color="#A6A7EA" href="https://www.tella.tv/video/testing-agents-built-on-vapi-apwk">
+  <Card title="VAPI Integration Guide" icon="plug" color="#A6A7EA" href="https://youtu.be/z1RGhQ9CUTE">
     Learn how to test agents built on the VAPI platform
   </Card>
-  <Card title="Retell Integration Setup" icon="link" color="#A6A7EA" href="https://www.tella.tv/video/cekura-retell-integration-90mo">
+  <Card title="Retell Integration Setup" icon="link" color="#A6A7EA" href="https://youtu.be/xLgi9xLOfj4">
     Connect and test your Retell-powered voice agents
   </Card>
-  <Card title="LiveKit Integration Guide" icon="/logo/livekit_icon.svg" color="#A6A7EA" href="https://www.tella.tv/video/vid_cmmti31kk00hu04jm0ua3d0qg/view">
+  <Card title="LiveKit Integration Guide" icon="/logo/livekit_icon.svg" color="#A6A7EA" href="https://youtu.be/VxDJPk-BoXo">
     Enable deep observability for LiveKit agents with SDK integration
+  </Card>
+  <Card title="Pipecat Integration Guide" icon="microphone" color="#A6A7EA" href="https://youtu.be/MqR5yRJWI0E">
+    Enable tracing and testing for agents built on Pipecat
+  </Card>
+  <Card title="ElevenLabs Integration Guide" icon="waveform" color="#A6A7EA" href="https://youtu.be/o7ZqAGMuYQY">
+    Connect and test your ElevenLabs conversational AI agents
+  </Card>
+  <Card title="Speech Quality Metrics" icon="gauge-high" color="#A6A7EA" href="https://youtu.be/_ntVTPKuFSI">
+    Understand and evaluate speech quality metrics for your agents
+  </Card>
+  <Card title="Self-Improving Agents" icon="arrows-rotate" color="#A6A7EA" href="https://youtu.be/S2ofbIM91qo">
+    Learn how to automatically improve your agents from test results
   </Card>
   <Card title="Text Mode Testing" icon="message" color="#A6A7EA" href="https://www.tella.tv/video/testing-voice-agents-via-text-mode-1-44un">
     Test your voice agents efficiently using text mode

--- a/mcp/claude-code-guide.mdx
+++ b/mcp/claude-code-guide.mdx
@@ -19,12 +19,12 @@ Watch how we evaluated [Gradient Bang](https://www.gradient-bang.com/)—an open
     borderRadius: "8px",
     marginBottom: "20px",
   }}
-  src="https://www.tella.tv/video/evaluating-gradient-bang-agents-gr1g/embed"
+  src="https://www.youtube.com/embed/uhqsdYiJFhc"
   width="100%"
   frameborder="0"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
   allowfullscreen
-  title="Evaluating Gradient Bang Agents with Cekura"
+  title="Using Cekura with Claude Code"
 />
 
 ## Quick Guide

--- a/mcp/claude-code-guide.mdx
+++ b/mcp/claude-code-guide.mdx
@@ -10,7 +10,7 @@ import { CopyPageButton } from "/snippets/copy-page-button.mdx";
 <CopyPageButton />
 
 
-Watch how we evaluated [Gradient Bang](https://www.gradient-bang.com/)—an open-source multiplayer space game by the Daily and Pipecat team, with voice agents running 25+ tools across multiple coordinating agents—using Claude Code, the Cekura MCP, and Cekura Skills end-to-end.
+Watch an end-to-end walkthrough of evaluating complex voice agents—running multiple tools across coordinating agents—using Claude Code, the Cekura MCP, and Cekura Skills.
 
 <iframe
   style={{


### PR DESCRIPTION
## What changed

Refreshes the video content across the docs to use the latest YouTube walkthroughs and fills gaps where sections had no video.

- **Video Tutorials** ([video_tutorials.mdx](documentation/video_tutorials.mdx)): replaced stale `tella.tv` links for VAPI / Retell / LiveKit with the current YouTube links, and added cards for **Cekura with Claude Code** (now the first card), **Pipecat**, **ElevenLabs**, **Speech Quality Metrics**, and **Self-Improving Agents**.
- **Claude Code Guide** ([mcp/claude-code-guide.mdx](mcp/claude-code-guide.mdx)): replaced the `tella.tv` Gradient Bang embed with the **Cekura with Claude Code** YouTube walkthrough.
- **Pre-Defined Metrics** ([pre-defined-metrics.mdx](documentation/key-concepts/metrics/pre-defined-metrics.mdx)): embedded the **Speech Quality Metrics** walkthrough in the Speech Quality Metrics section (previously had no video).

The integration page embeds (Retell, LiveKit, VAPI, Pipecat, ElevenLabs) already used the correct YouTube IDs, so no change there.

## Reviewer notes

- ⚠️ The Claude Code guide's intro line still references the *Gradient Bang* example. If the new video is a different/general walkthrough, that copy should be updated — flagging for confirmation.
- **Self-Improving Agents** (`S2ofbIM91qo`) has no dedicated guide page, so it currently lives only in the tutorials grid. Open question whether to create a standalone page or embed it in `guides/prompting.mdx`.
- Left the `building-good-metrics-on-cekura` tella videos (metric-lab, creating-good-metric, metrics/overview) untouched — they're general metric-building, not one of the refreshed categories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)