### PR TITLE
fix(mcp): drop obsolete pipecat_data overlay on agent tools

### DIFF
--- a/cekura-mcp-server/mcp_tools.json
+++ b/cekura-mcp-server/mcp_tools.json
@@ -46,18 +46,10 @@
     "description_suffix": "Lower-level instruction refiner: takes `agent` + `extra_instructions` and rewrites a scenario's `instructions` text. For multi-scenario or higher-level natural-language refinement use `scenarios_agent_create` instead. Async — poll via `scenarios_instructions_progress_retrieve`."
   },
   "aiagents_create": {
-    "description_suffix": "When the goal is to *improve* an existing agent based on test results or natural-language feedback, prefer `scenarios_agent_create` (it can update agent fields as part of the improvement loop). Use this raw create only when the user has given concrete field values to write.",
-    "_property_types_note": "pipecat_data is a JSON object the spec mistypes as string; coerced to object so the client sends a dict. Only needed for Pipecat agents — other providers omit pipecat_data, so it's a no-op for them.",
-    "property_types": {
-      "pipecat_data": "object"
-    }
+    "description_suffix": "When the goal is to *improve* an existing agent based on test results or natural-language feedback, prefer `scenarios_agent_create` (it can update agent fields as part of the improvement loop). Use this raw create only when the user has given concrete field values to write."
   },
   "aiagents_partial_update": {
-    "description_suffix": "When refining an existing agent based on test results or natural-language feedback, prefer `scenarios_agent_create` or `runs_improve_prompt_create` / `runs_improve_prompt_bg_create` (run-driven prompt improvement). Use this raw patch only when the user has explicitly given concrete field values to write.",
-    "_property_types_note": "pipecat_data is a JSON object the spec mistypes as string; coerced to object so the client sends a dict. Only needed for Pipecat agents — other providers omit pipecat_data, so it's a no-op for them.",
-    "property_types": {
-      "pipecat_data": "object"
-    }
+    "description_suffix": "When refining an existing agent based on test results or natural-language feedback, prefer `scenarios_agent_create` or `runs_improve_prompt_create` / `runs_improve_prompt_bg_create` (run-driven prompt improvement). Use this raw patch only when the user has explicitly given concrete field values to write."
   },
   "metrics_list": {
     "description_suffix": "Always pass `agent_id` or `project_id` — omitting both returns all metrics in your account (potentially hundreds, exceeding response limits). `metrics_list(agent_id=1234)` returns metrics accessible to that agent including both agent-level and project-level metrics."

--- a/cekura-mcp-server/tests/test_overlays.py
+++ b/cekura-mcp-server/tests/test_overlays.py
@@ -138,25 +138,3 @@ def test_generate_improve_tools_have_clarifying_suffix(tool):
     )
     suffix = overlays[tool].get("description_suffix", "")
     assert suffix, f"{tool} overlay must define a non-empty description_suffix."
-
-
-def test_pipecat_data_overlaid_to_object_for_agent_tools():
-    """pipecat_data is typed `string` in the spec but the backend wants an
-    object. The overlay forces it to `object` on the agent create/patch tools
-    so the HTTP client coerces the model's stringified JSON to a dict."""
-    from tool_generator import apply_overlay_to_schema
-
-    for tool in ("aiagents_create", "aiagents_partial_update"):
-        schema = {
-            "type": "object",
-            "properties": {
-                "pipecat_data": {"type": "string", "description": "x"},
-                "name": {"type": "string"},
-            },
-            "required": [],
-        }
-        out = apply_overlay_to_schema(tool, schema)
-        assert out["properties"]["pipecat_data"]["type"] == "object", tool
-        assert out["properties"]["pipecat_data"].get("additionalProperties") is True, tool
-        # unrelated fields are untouched
-        assert out["properties"]["name"]["type"] == "string", tool

--- a/cekura-mcp-server/tool_generator.py
+++ b/cekura-mcp-server/tool_generator.py
@@ -98,10 +98,10 @@ def apply_overlay_to_schema(tool_name: str, schema: Dict[str, Any]) -> Dict[str,
         schema['required'] = sorted(existing)
 
     # Force specific body fields to a given JSON-schema type. For fields the
-    # backend stores as JSON objects but the OpenAPI spec types as `string`
-    # (e.g. AIAgent.pipecat_data), declaring `object` makes the HTTP client
-    # coerce the model's stringified value to a dict before sending — the
-    # backend rejects a raw string. Scoped per-tool via mcp_tools.json.
+    # backend stores as JSON objects but the OpenAPI spec types as `string`,
+    # declaring `object` makes the HTTP client coerce the model's stringified
+    # value to a dict before sending — the backend rejects a raw string.
+    # Scoped per-tool via mcp_tools.json.
     for field_name, ptype in (overlay.get('property_types') or {}).items():
         prop = (schema.get('properties') or {}).get(field_name)
         if isinstance(prop, dict):


### PR DESCRIPTION
## Problem
The May-30 temporary fix coerced `pipecat_data` (`string`→`object`) on the agent create/patch overlays. The v2 agent API has **no** flat `pipecat_data` field (provider config is nested under `provider.credentials.config`), so the coercion is dead, and the `aiagents_create` / `aiagents_partial_update` overlays are orphaned against the current spec.

## Fix
- `mcp_tools.json` — remove the dead `property_types: {pipecat_data: object}` from both agent overlays (kept the preference-steering `description_suffix`).
- `tests/test_overlays.py` — delete the obsolete pipecat-coercion test.
- `tool_generator.py` — refresh the now-generic `property_types` comment (mechanism kept for future string-typed-JSON fields).

## Sequencing ⚠️
Depends on backend **`vocera.backend#9450`** (clean `aiagents-*` operationIds). `test_no_orphan_overlays` only goes green once `sync-docs` regenerates `openapi.json` with the new names — at which point `aiagents_create` / `aiagents_partial_update` bind to the v2 tools and the orphan drift clears. **Merge after the backend PR + spec sync land.**

Verified locally against the regenerated spec: **0 error-level findings, 0 orphans**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)