### PR TITLE
[Auto] Sync docs for backend PR #9450

### DIFF
--- a/cekura-mcp-server/mcp_tools.json
+++ b/cekura-mcp-server/mcp_tools.json
@@ -117,5 +117,8 @@
   },
   "aiagents_destroy": {
     "description_suffix": "Deletes the agent and all associated resources (scenarios, runs, results, call logs). Cannot be undone."
+  },
+  "aiagents_duplicate_create": {
+    "description_suffix": "File uploads not supported via MCP. Use the Cekura dashboard or Python SDK for knowledge base file uploads. Call without file parameters to duplicate agent configuration only."
   }
 }

--- a/cekura-mcp-server/mcp_tools.json
+++ b/cekura-mcp-server/mcp_tools.json
@@ -120,5 +120,8 @@
   },
   "aiagents_duplicate_create": {
     "description_suffix": "File uploads not supported via MCP. Use the Cekura dashboard or Python SDK for knowledge base file uploads. Call without file parameters to duplicate agent configuration only."
+  },
+  "aiagents_update": {
+    "description_suffix": "File uploads not supported via MCP. Use the Cekura dashboard or Python SDK to upload knowledge base files. Updates without file parameters modify agent configuration only."
   }
 }

--- a/cekura-mcp-server/mcp_tools.json
+++ b/cekura-mcp-server/mcp_tools.json
@@ -114,5 +114,8 @@
   },
   "aiagents_tools_enable_mock_progress_retrieve": {
     "description_suffix": "Poll with the progress_id from aiagents_tools_enable_mock_create. Status values: in_progress, completed (with mcp_endpoints[]), failed (with error). The mcp_endpoints array is populated only after completion."
+  },
+  "aiagents_destroy": {
+    "description_suffix": "Deletes the agent and all associated resources (scenarios, runs, results, call logs). Cannot be undone."
   }
 }

--- a/openapi.json
+++ b/openapi.json
@@ -39550,7 +39550,8 @@
         "/test_framework/v2/aiagents/{id}/disable_personalities/": {
             "post": {
                 "operationId": "aiagents-disable-personalities-create",
-                "description": "Aiagents disable personalities",
+                "description": "Disable personalities for the agent's project. Pass `personalities` as a list of personality IDs, or the string \"all\". Returns the project's personalities.",
+                "summary": "Disable personalities for an agent's project",
                 "parameters": [
                     {
                         "in": "path",
@@ -39560,6 +39561,24 @@
                         },
                         "description": "A unique integer value identifying this ai agent.",
                         "required": true
+                    },
+                    {
+                        "name": "page",
+                        "required": false,
+                        "in": "query",
+                        "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
                     }
                 ],
                 "tags": [
@@ -39595,11 +39614,37 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/AIAgentV2"
+                                    "$ref": "#/components/schemas/PaginatedPersonalityList"
                                 }
                             }
                         },
                         "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "aiagents-disable-personalities-create",
+                        "description": "Disable personalities for the agent's project. Pass `personalities` as a list of personality IDs, or the string \"all\". Returns the project's personalities."
                     }
                 }
             }
@@ -39690,7 +39735,8 @@
         "/test_framework/v2/aiagents/{id}/enable_personalities/": {
             "post": {
                 "operationId": "aiagents-enable-personalities-create",
-                "description": "Aiagents enable personalities",
+                "description": "Enable personalities for the agent's project. Pass `personalities` as a list of personality IDs, or the string \"all\". Returns the project's personalities.",
+                "summary": "Enable personalities for an agent's project",
                 "parameters": [
                     {
                         "in": "path",
@@ -39700,6 +39746,24 @@
                         },
                         "description": "A unique integer value identifying this ai agent.",
                         "required": true
+                    },
+                    {
+                        "name": "page",
+                        "required": false,
+                        "in": "query",
+                        "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
                     }
                 ],
                 "tags": [
@@ -39735,11 +39799,37 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/AIAgentV2"
+                                    "$ref": "#/components/schemas/PaginatedPersonalityList"
                                 }
                             }
                         },
                         "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "aiagents-enable-personalities-create",
+                        "description": "Enable personalities for the agent's project. Pass `personalities` as a list of personality IDs, or the string \"all\". Returns the project's personalities."
                     }
                 }
             }
@@ -39816,8 +39906,9 @@
         },
         "/test_framework/v2/aiagents/{id}/personalities/": {
             "get": {
-                "operationId": "aiagents-personalities-retrieve",
-                "description": "Aiagents personalities",
+                "operationId": "aiagents-personalities-list",
+                "description": "List the caller/tester personalities available to this agent's project. Filter with query params: type, language, enabled_only=true (only the personalities currently enabled for the project).",
+                "summary": "List personalities available to an agent",
                 "parameters": [
                     {
                         "in": "path",
@@ -39827,6 +39918,24 @@
                         },
                         "description": "A unique integer value identifying this ai agent.",
                         "required": true
+                    },
+                    {
+                        "name": "page",
+                        "required": false,
+                        "in": "query",
+                        "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
                     }
                 ],
                 "tags": [
@@ -39842,11 +39951,19 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/AIAgentV2"
+                                    "$ref": "#/components/schemas/PaginatedPersonalityList"
                                 }
                             }
                         },
                         "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "aiagents-personalities-list",
+                        "description": "List the caller/tester personalities available to this agent's project. Filter with query params: type, language, enabled_only=true (only the personalities currently enabled for the project)."
                     }
                 }
             }
@@ -59198,6 +59315,37 @@
                     }
                 }
             },
+            "PaginatedPersonalityList": {
+                "type": "object",
+                "required": [
+                    "count",
+                    "results"
+                ],
+                "properties": {
+                    "count": {
+                        "type": "integer",
+                        "example": 123
+                    },
+                    "next": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "https://api.cekura.ai/example/v1/example-external/?page=4"
+                    },
+                    "previous": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "https://api.cekura.ai/example/v1/example-external/?page=3"
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Personality"
+                        }
+                    }
+                }
+            },
             "PaginatedResultList": {
                 "type": "object",
                 "required": [
@@ -63733,6 +63881,177 @@
                         "readOnly": true
                     }
                 }
+            },
+            "Personality": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "forked_from": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
+                    },
+                    "organization": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "\nName of the personality\nExample: `\"Customer Service\"`\n",
+                        "maxLength": 255
+                    },
+                    "prompt": {
+                        "type": "string",
+                        "description": "\nPrompt of the personality\nExample: `\"You are a friendly and helpful customer service agent who is always willing to help\"`\n"
+                    },
+                    "language": {
+                        "enum": [
+                            "af",
+                            "ar",
+                            "bn",
+                            "bg",
+                            "zh",
+                            "cs",
+                            "da",
+                            "nl",
+                            "en",
+                            "et",
+                            "fi",
+                            "fr",
+                            "de",
+                            "el",
+                            "gu",
+                            "hi",
+                            "he",
+                            "hu",
+                            "id",
+                            "it",
+                            "ja",
+                            "kn",
+                            "ko",
+                            "ms",
+                            "ml",
+                            "mr",
+                            "multi",
+                            "no",
+                            "pl",
+                            "pa",
+                            "pt",
+                            "ro",
+                            "ru",
+                            "sk",
+                            "es",
+                            "sv",
+                            "th",
+                            "tr",
+                            "tl",
+                            "ta",
+                            "te",
+                            "uk",
+                            "vi"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "b822ad429c7b7fec",
+                        "description": "\nLanguage of the personality\n\n\n* `af` - Afrikaans\n* `ar` - Arabic\n* `bn` - Bengali\n* `bg` - Bulgarian\n* `zh` - Chinese Simplified\n* `cs` - Czech\n* `da` - Danish\n* `nl` - Dutch\n* `en` - English\n* `et` - Estonian\n* `fi` - Finnish\n* `fr` - French\n* `de` - German\n* `el` - Greek\n* `gu` - Gujarati\n* `hi` - Hindi\n* `he` - Hebrew\n* `hu` - Hungarian\n* `id` - Indonesian\n* `it` - Italian\n* `ja` - Japanese\n* `kn` - Kannada\n* `ko` - Korean\n* `ms` - Malay\n* `ml` - Malayalam\n* `mr` - Marathi\n* `multi` - Multilingual\n* `no` - Norwegian\n* `pl` - Polish\n* `pa` - Punjabi\n* `pt` - Portuguese\n* `ro` - Romanian\n* `ru` - Russian\n* `sk` - Slovak\n* `es` - Spanish\n* `sv` - Swedish\n* `th` - Thai\n* `tr` - Turkish\n* `tl` - Tagalog\n* `ta` - Tamil\n* `te` - Telugu\n* `uk` - Ukrainian\n* `vi` - Vietnamese"
+                    },
+                    "accent": {
+                        "type": "string",
+                        "description": "\nAccent of the personality\nExample: `\"American\"`\n",
+                        "maxLength": 255
+                    },
+                    "gender": {
+                        "enum": [
+                            "male",
+                            "female",
+                            "neutral"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "427cb1f56db21620",
+                        "description": "\nGender of the personality\n\n\n* `male` - Male\n* `female` - Female\n* `neutral` - Neutral"
+                    },
+                    "enabled": {
+                        "type": "boolean",
+                        "readOnly": true,
+                        "default": false
+                    },
+                    "call_service_provider": {
+                        "enum": [
+                            "vapi",
+                            "patronus"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "f442d6949d5b96ff",
+                        "description": "\nCall service provider\n\n\n* `vapi` - VAPI\n* `patronus` - Patronus"
+                    },
+                    "background_noise": {
+                        "type": "string"
+                    },
+                    "voice_model": {
+                        "type": "string"
+                    },
+                    "voice_id": {
+                        "type": "string"
+                    },
+                    "interruption_level": {
+                        "type": "string"
+                    },
+                    "speed": {
+                        "type": "string"
+                    },
+                    "generation_config": {
+                        "type": "string"
+                    },
+                    "network_simulation": {
+                        "type": "string"
+                    },
+                    "message_plan": {
+                        "type": "string"
+                    },
+                    "start_speaking_plan": {
+                        "type": "string"
+                    },
+                    "stop_speaking_plan": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "background_sound_volume": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "patronus_settings": {
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "provider_agent_id": {
+                        "type": "string",
+                        "description": "\nProvider agent ID\nExample: `\"assistant_123\"`\n",
+                        "maxLength": 255
+                    },
+                    "is_starred": {
+                        "type": "boolean",
+                        "description": "\nWhether the personality is starred\n"
+                    }
+                },
+                "required": [
+                    "background_noise",
+                    "name",
+                    "prompt",
+                    "voice_model"
+                ]
             },
             "PhoneNumber": {
                 "type": "object",

--- a/openapi.json
+++ b/openapi.json
@@ -11076,7 +11076,7 @@
         },
         "/test_framework/v1/aiagents/": {
             "get": {
-                "operationId": "aiagents-list",
+                "operationId": "aiagents-v1-list",
                 "description": "aiagents_list: List AI voice agents in your account. Filter by `project_id` to scope to one project, or omit to list every agent the caller can access. Returns a paginated list of agent summaries (id, name, provider, contact number, created/updated timestamps).\n\nPerformance tip: passing `project_id` from your workspace context narrows the result. Try `page_size=20` first — you can paginate or raise the page size if you actually need more.",
                 "summary": "List AI voice agents",
                 "parameters": [
@@ -11144,7 +11144,7 @@
                 }
             },
             "post": {
-                "operationId": "aiagents-create",
+                "operationId": "aiagents-v1-create",
                 "description": "aiagents_create: Register a new AI voice agent with Cekura for testing / observability. Required: `agent_name`, `project` (project ID), `assistant_provider`. Other fields depend on the provider (see below).\n\n**Most common case:** you already have an agent running on your own provider stack with a dedicated phone number. Pass `agent_name`, `description`, `inbound`, `project`, `contact_number` (E.164 format, e.g. `+14155551234`), and `language` — Cekura observes that number without needing provider credentials. Set `assistant_provider=\"self_hosted\"` (optionally `websocket_url` for text-mode runs).\n\n**Provider integrations:** set `assistant_provider` to one of the valid values below and pass the matching credentials. `assistant_id` alone does NOT substitute for provider credentials — providers like VAPI, Retell, and Bland validate their api_key on create.\n\n**Valid `assistant_provider` values** (live enum — superset of prose docs you may see elsewhere):\n- `self_hosted` — websocket or observation-only; no api_key needed. Use `websocket_url` + `websocket_headers` for text-mode runs.\n- `vapi` — requires `vapi_api_key`; optional `assistant_id`, `vapi_data.public_key`.\n- `retell` — requires `retell_api_key` AND `chat_assistant_id` (yes — Retell uses this field even for voice).\n- `bland` — requires `bland_api_key` AND `chat_assistant_id` (Bland internally calls this `pathway_id`); `bland_data.encrypted_key` for Twilio.\n- `livekit` — requires `livekit_api_key` + `livekit_data.api_secret` + `livekit_data.url`.\n- `elevenlabs` — requires `elevenlabs_api_key`.\n- `agentforce` — Salesforce Agentforce; needs `agentforce_client_secret` + `agentforce_data` (client_id, domain, agent_id).\n- `cisco` — Cisco Webex.\n- `vocera` — Cekura-hosted agent.\n- `sms` — text-only SMS channel; use `chat_assistant_id`.\n- `whatsapp` — text-only WhatsApp channel; use `chat_assistant_id`.\n- `\"\"` (empty string) — unset; agent is not runnable until a provider is configured.\n\n**Note:** the serializer exposes fields for some providers (`pipecat_*`, `synthflow_*`, `koreai_*`, `genesys_*`, `custom_provider_*`) that are NOT currently in the `assistant_provider` enum. Those fields exist for response/config purposes but the matching provider value cannot be selected today.\n\n**Outbound agents:** set `inbound=false`. Actual call placement uses the scenario's configured phone number or a number from the org's provisioned pool — `outbound_numbers` is not required for calls to be placed (it is used for webhook validation only).\n\n**Other fields to know:**\n- `language` — BCP-47 locale (`en`, `es`, `fr`, …). Must match the personalities used for evaluators.\n- `transcript_provider` — STT vendor (`vapi | retell | synthflow | elevenlabs | bland | livekit | pipecat | koreai | custom | cisco | genesys`). Does NOT auto-pair with `assistant_provider`; set both independently when needed.\n- `llm_model`, `llm_temperature`, `llm_max_tokens`, `llm_system_prompt` — simulation LLM settings (used by Cekura when simulating callers in test runs; NOT your agent's own LLM).\n- `auto_fetch_calls_enabled` — auto-import calls from the provider every 30s (VAPI/Retell only).\n- `auto_sync_prompt_enabled` — auto-sync prompts from the provider every 30s.\n\n**Read-only status fields** like `vapi_api_key_configured`, `retell_api_key_configured` appear in the response to indicate which provider credentials are stored (credentials themselves are masked).",
                 "summary": "Create an AI voice agent",
                 "tags": [
@@ -13692,7 +13692,7 @@
         },
         "/test_framework/v1/aiagents/{id}/": {
             "get": {
-                "operationId": "aiagents-retrieve",
+                "operationId": "aiagents-v1-retrieve",
                 "description": "Retrieve an AI voice agent by ID",
                 "parameters": [
                     {
@@ -13742,7 +13742,7 @@
                 }
             },
             "put": {
-                "operationId": "aiagents-update",
+                "operationId": "aiagents-v1-update",
                 "description": "Fully replace an AI agent's fields. Prefer `PATCH` (partial_update) unless you need full-replacement semantics. See `aiagents_create` for the field shape and per-provider examples.",
                 "summary": "Replace an AI voice agent (full update)",
                 "parameters": [
@@ -13830,7 +13830,7 @@
                 }
             },
             "patch": {
-                "operationId": "aiagents-partial-update",
+                "operationId": "aiagents-v1-partial-update",
                 "description": "Partially update an AI agent. Same field shape as create — see `aiagents_create` for details and per-provider examples.",
                 "summary": "Update an AI voice agent (partial)",
                 "parameters": [
@@ -13912,7 +13912,7 @@
                 }
             },
             "delete": {
-                "operationId": "aiagents-destroy",
+                "operationId": "aiagents-v1-destroy",
                 "description": "⚠ Irreversible. Deletes the agent.\n\n**Cascade behaviour (controlled by `delete_related` query param):**\n- `delete_related=true` (default) — also deletes the agent's evaluators, results, and runs.\n- `delete_related=false` — detaches evaluators (sets agent=null) and leaves results untouched.",
                 "summary": "Delete an AI voice agent",
                 "parameters": [
@@ -13969,8 +13969,8 @@
         },
         "/test_framework/v1/aiagents/{id}/delete_knowledge_base/": {
             "delete": {
-                "operationId": "aiagents-delete-knowledge-base-destroy",
-                "description": "Aiagents delete knowledge base",
+                "operationId": "aiagents-v1-delete-knowledge-base-destroy",
+                "description": "Aiagents v1 delete knowledge base",
                 "parameters": [
                     {
                         "in": "path",
@@ -14029,8 +14029,8 @@
         },
         "/test_framework/v1/aiagents/{id}/disable_personalities/": {
             "post": {
-                "operationId": "aiagents-disable-personalities-create",
-                "description": "Aiagents disable personalities",
+                "operationId": "aiagents-v1-disable-personalities-create",
+                "description": "Aiagents v1 disable personalities",
                 "parameters": [
                     {
                         "in": "path",
@@ -14086,8 +14086,8 @@
         },
         "/test_framework/v1/aiagents/{id}/duplicate/": {
             "post": {
-                "operationId": "aiagents-duplicate-create",
-                "description": "Duplicate an AI voice agent with all its configuration",
+                "operationId": "aiagents-v1-duplicate-create",
+                "description": "Aiagents v1 duplicate",
                 "parameters": [
                     {
                         "in": "path",
@@ -14160,8 +14160,8 @@
         },
         "/test_framework/v1/aiagents/{id}/enable_personalities/": {
             "post": {
-                "operationId": "aiagents-enable-personalities-create",
-                "description": "Aiagents enable personalities",
+                "operationId": "aiagents-v1-enable-personalities-create",
+                "description": "Aiagents v1 enable personalities",
                 "parameters": [
                     {
                         "in": "path",
@@ -14217,8 +14217,8 @@
         },
         "/test_framework/v1/aiagents/{id}/knowledge_base/": {
             "get": {
-                "operationId": "aiagents-knowledge-base-list",
-                "description": "Aiagents knowledge base",
+                "operationId": "aiagents-v1-knowledge-base-list",
+                "description": "Aiagents v1 knowledge base",
                 "parameters": [
                     {
                         "in": "path",
@@ -14287,8 +14287,8 @@
         },
         "/test_framework/v1/aiagents/{id}/personalities/": {
             "get": {
-                "operationId": "aiagents-personalities-retrieve",
-                "description": "Aiagents personalities",
+                "operationId": "aiagents-v1-personalities-retrieve",
+                "description": "Aiagents v1 personalities",
                 "parameters": [
                     {
                         "in": "path",
@@ -14324,8 +14324,8 @@
         },
         "/test_framework/v1/aiagents/{id}/runs_overview/": {
             "get": {
-                "operationId": "aiagents-runs-overview-retrieve",
-                "description": "Aiagents runs overview",
+                "operationId": "aiagents-v1-runs-overview-retrieve",
+                "description": "Aiagents v1 runs overview",
                 "parameters": [
                     {
                         "in": "path",
@@ -14488,8 +14488,8 @@
         },
         "/test_framework/v1/aiagents/runs_overview_project/": {
             "get": {
-                "operationId": "aiagents-runs-overview-project-retrieve",
-                "description": "Aiagents runs overview project",
+                "operationId": "aiagents-v1-runs-overview-project-retrieve",
+                "description": "Aiagents v1 runs overview project",
                 "tags": [
                     "test_framework"
                 ],
@@ -14514,8 +14514,8 @@
         },
         "/test_framework/v1/aiagents/short_list/": {
             "get": {
-                "operationId": "aiagents-short-list-list",
-                "description": "Aiagents short list",
+                "operationId": "aiagents-v1-short-list-list",
+                "description": "Aiagents v1 short list",
                 "parameters": [
                     {
                         "name": "page",
@@ -27894,7 +27894,8 @@
         "/test_framework/v1/scenarios-external/{id}/": {
             "get": {
                 "operationId": "scenarios-external-retrieve",
-                "description": "Retrieve a test scenario by ID",
+                "description": "Fetch a single evaluator by id. Returns full configuration including instructions, expected outcome, metrics, test profile, and — when the agent has mock tools attached and the scenario was auto-generated — the expected mock tool calls (`generated_mock_tool_entries`) with their inputs and outputs.",
+                "summary": "Retrieve an evaluator (scenario)",
                 "parameters": [
                     {
                         "in": "path",
@@ -32704,7 +32705,8 @@
         "/test_framework/v1/scenarios/{id}/": {
             "get": {
                 "operationId": "scenarios-retrieve",
-                "description": "Retrieve a test scenario by ID",
+                "description": "Fetch a single evaluator by id. Returns full configuration including instructions, expected outcome, metrics, test profile, and — when the agent has mock tools attached and the scenario was auto-generated — the expected mock tool calls (`generated_mock_tool_entries`) with their inputs and outputs.",
+                "summary": "Retrieve an evaluator (scenario)",
                 "parameters": [
                     {
                         "in": "path",
@@ -32756,7 +32758,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-retrieve",
-                        "description": "Retrieve a test scenario by ID"
+                        "description": "Fetch a single evaluator by id. Returns full configuration including instructions, expected outcome, metrics, test profile, and — when the agent has mock tools attached and the scenario was auto-generated — the expected mock tool calls (`generated_mock_tool_entries`) with their inputs and outputs."
                     }
                 }
             },
@@ -38880,7 +38882,7 @@
         },
         "/test_framework/v2/aiagents/": {
             "get": {
-                "operationId": "test-framework-v2-aiagents-list",
+                "operationId": "aiagents-list",
                 "description": "List AI voice agents. Filter by project_id to scope to one project. Returns agents in the v2 format with a nested provider block.",
                 "summary": "List AI voice agents",
                 "parameters": [
@@ -38935,13 +38937,13 @@
                 "x-mint": {
                     "mcp": {
                         "enabled": true,
-                        "name": "test-framework-v2-aiagents-list",
+                        "name": "aiagents-list",
                         "description": "List AI voice agents. Filter by project_id to scope to one project. Returns agents in the v2 format with a nested provider block."
                     }
                 }
             },
             "post": {
-                "operationId": "test-framework-v2-aiagents-create",
+                "operationId": "aiagents-create",
                 "description": "Register a new AI voice agent. Required fields: name, description, project, inbound. Provider credentials are nested under provider.{type, agent_id, credentials} instead of flat fields. transcript_provider defaults to provider.type when omitted.\n\n**provider.credentials keys by type (voice providers only):**\n- vapi: api_key + config.{public_key, trigger_url}\n- retell: api_key + agent_id + optional chat_agent_details.config.agent_id\n- elevenlabs: api_key + config.{trigger_url}\n- bland: api_key + agent_id (pathway_id) + config.{encrypted_key} for Twilio\n- livekit: api_key + config.{api_secret (required), url (required)}\n- pipecat: api_key + config.{webhook_url}\n- cisco: no credentials needed\n- self_hosted: credentials.config.{url (wss://), headers}\nNote: agentforce goes in chat_agent_details; koreai/genesys/synthflow use the v1 API.\n\n**Auto-import from a cloud provider** — set `provider.configure_from_provider: true` (vapi/retell/elevenlabs/synthflow) with `provider.agent_id` + `provider.credentials.api_key`. Cekura fetches the prompt, name, language, who-speaks-first, phone number, tool calls, dynamic variables and knowledge base and configures the agent automatically — `name` and `description` become optional (auto-fetched). The response is **202** with the created agent plus a `progress_id`; poll `import-progress/` to follow the staged import.\n\nSee examples below for full per-provider payloads.",
                 "summary": "Create an AI voice agent",
                 "tags": [
@@ -39169,7 +39171,7 @@
                 "x-mint": {
                     "mcp": {
                         "enabled": true,
-                        "name": "test-framework-v2-aiagents-create",
+                        "name": "aiagents-create",
                         "description": "Register a new AI voice agent. Required fields: name, description, project, inbound. Provider credentials are nested under provider.{type, agent_id, credentials} instead of flat fields. transcript_provider defaults to provider.type when omitted.\n\n**provider.credentials keys by type (voice providers only):**\n- vapi: api_key + config.{public_key, trigger_url}\n- retell: api_key + agent_id + optional chat_agent_details.config.agent_id\n- elevenlabs: api_key + config.{trigger_url}\n- bland: api_key + agent_id (pathway_id) + config.{encrypted_key} for Twilio\n- livekit: api_key + config.{api_secret (required), url (required)}\n- pipecat: api_key + config.{webhook_url}\n- cisco: no credentials needed\n- self_hosted: credentials.config.{url (wss://), headers}\nNote: agentforce goes in chat_agent_details; koreai/genesys/synthflow use the v1 API.\n\n**Auto-import from a cloud provider** — set `provider.configure_from_provider: true` (vapi/retell/elevenlabs/synthflow) with `provider.agent_id` + `provider.credentials.api_key`. Cekura fetches the prompt, name, language, who-speaks-first, phone number, tool calls, dynamic variables and knowledge base and configures the agent automatically — `name` and `description` become optional (auto-fetched). The response is **202** with the created agent plus a `progress_id`; poll `import-progress/` to follow the staged import.\n\nSee examples below for full per-provider payloads."
                     }
                 }
@@ -39177,7 +39179,7 @@
         },
         "/test_framework/v2/aiagents/{id}/": {
             "get": {
-                "operationId": "test-framework-v2-aiagents-retrieve",
+                "operationId": "aiagents-retrieve",
                 "description": "Retrieve an AI voice agent",
                 "summary": "Retrieve an AI voice agent",
                 "parameters": [
@@ -39230,13 +39232,13 @@
                 "x-mint": {
                     "mcp": {
                         "enabled": true,
-                        "name": "test-framework-v2-aiagents-retrieve",
+                        "name": "aiagents-retrieve",
                         "description": "Retrieve an AI voice agent"
                     }
                 }
             },
             "put": {
-                "operationId": "test-framework-v2-aiagents-update",
+                "operationId": "aiagents-update",
                 "description": "Fully replace an agent's fields. Prefer PATCH unless you need full-replacement semantics.",
                 "summary": "Replace an AI voice agent (full update)",
                 "parameters": [
@@ -39326,13 +39328,13 @@
                 "x-mint": {
                     "mcp": {
                         "enabled": true,
-                        "name": "test-framework-v2-aiagents-update",
+                        "name": "aiagents-update",
                         "description": "Fully replace an agent's fields. Prefer PATCH unless you need full-replacement semantics."
                     }
                 }
             },
             "patch": {
-                "operationId": "test-framework-v2-aiagents-partial-update",
+                "operationId": "aiagents-partial-update",
                 "description": "Partially update an agent. Only fields included in the request body are modified.",
                 "summary": "Update an AI voice agent (partial)",
                 "parameters": [
@@ -39416,13 +39418,13 @@
                 "x-mint": {
                     "mcp": {
                         "enabled": true,
-                        "name": "test-framework-v2-aiagents-partial-update",
+                        "name": "aiagents-partial-update",
                         "description": "Partially update an agent. Only fields included in the request body are modified."
                     }
                 }
             },
             "delete": {
-                "operationId": "test-framework-v2-aiagents-destroy",
+                "operationId": "aiagents-destroy",
                 "description": "⚠ Irreversible. Deletes the agent. Pass delete_related=false to detach evaluators instead of deleting them.",
                 "summary": "Delete an AI voice agent",
                 "parameters": [
@@ -39479,7 +39481,7 @@
                 "x-mint": {
                     "mcp": {
                         "enabled": true,
-                        "name": "test-framework-v2-aiagents-destroy",
+                        "name": "aiagents-destroy",
                         "description": "⚠ Irreversible. Deletes the agent. Pass delete_related=false to detach evaluators instead of deleting them."
                     }
                 }
@@ -39487,7 +39489,7 @@
         },
         "/test_framework/v2/aiagents/{id}/delete_knowledge_base/": {
             "delete": {
-                "operationId": "test-framework-v2-aiagents-delete-knowledge-base-destroy",
+                "operationId": "aiagents-delete-knowledge-base-destroy",
                 "description": "Aiagents delete knowledge base",
                 "parameters": [
                     {
@@ -39547,7 +39549,7 @@
         },
         "/test_framework/v2/aiagents/{id}/disable_personalities/": {
             "post": {
-                "operationId": "test-framework-v2-aiagents-disable-personalities-create",
+                "operationId": "aiagents-disable-personalities-create",
                 "description": "Aiagents disable personalities",
                 "parameters": [
                     {
@@ -39604,7 +39606,7 @@
         },
         "/test_framework/v2/aiagents/{id}/duplicate/": {
             "post": {
-                "operationId": "test-framework-v2-aiagents-duplicate-create",
+                "operationId": "aiagents-duplicate-create",
                 "description": "Create a copy of the agent with all its configuration. Returns the new agent in v2 format.",
                 "summary": "Duplicate an AI voice agent",
                 "parameters": [
@@ -39679,7 +39681,7 @@
                 "x-mint": {
                     "mcp": {
                         "enabled": true,
-                        "name": "test-framework-v2-aiagents-duplicate-create",
+                        "name": "aiagents-duplicate-create",
                         "description": "Create a copy of the agent with all its configuration. Returns the new agent in v2 format."
                     }
                 }
@@ -39687,7 +39689,7 @@
         },
         "/test_framework/v2/aiagents/{id}/enable_personalities/": {
             "post": {
-                "operationId": "test-framework-v2-aiagents-enable-personalities-create",
+                "operationId": "aiagents-enable-personalities-create",
                 "description": "Aiagents enable personalities",
                 "parameters": [
                     {
@@ -39744,7 +39746,7 @@
         },
         "/test_framework/v2/aiagents/{id}/knowledge_base/": {
             "get": {
-                "operationId": "test-framework-v2-aiagents-knowledge-base-list",
+                "operationId": "aiagents-knowledge-base-list",
                 "description": "Aiagents knowledge base",
                 "parameters": [
                     {
@@ -39814,7 +39816,7 @@
         },
         "/test_framework/v2/aiagents/{id}/personalities/": {
             "get": {
-                "operationId": "test-framework-v2-aiagents-personalities-retrieve",
+                "operationId": "aiagents-personalities-retrieve",
                 "description": "Aiagents personalities",
                 "parameters": [
                     {
@@ -39851,7 +39853,7 @@
         },
         "/test_framework/v2/aiagents/{id}/runs_overview/": {
             "get": {
-                "operationId": "test-framework-v2-aiagents-runs-overview-retrieve",
+                "operationId": "aiagents-runs-overview-retrieve",
                 "description": "Aiagents runs overview",
                 "parameters": [
                     {
@@ -40023,7 +40025,7 @@
         },
         "/test_framework/v2/aiagents/import-progress/": {
             "get": {
-                "operationId": "test-framework-v2-aiagents-import-progress-retrieve",
+                "operationId": "aiagents-import-progress-retrieve",
                 "description": "Returns the staged status of a background agent import started via `configure_from_provider`. Each stage reports pending / in_progress / completed / skipped / failed so a step-by-step loader can be rendered.",
                 "summary": "Poll cloud-provider import progress",
                 "parameters": [
@@ -40078,7 +40080,7 @@
         },
         "/test_framework/v2/aiagents/runs_overview_project/": {
             "get": {
-                "operationId": "test-framework-v2-aiagents-runs-overview-project-retrieve",
+                "operationId": "aiagents-runs-overview-project-retrieve",
                 "description": "Aiagents runs overview project",
                 "tags": [
                     "test_framework"
@@ -40104,7 +40106,7 @@
         },
         "/test_framework/v2/aiagents/short_list/": {
             "get": {
-                "operationId": "test-framework-v2-aiagents-short-list-list",
+                "operationId": "aiagents-short-list-list",
                 "description": "Aiagents short list",
                 "parameters": [
                     {
@@ -40402,7 +40404,8 @@
         "/test_framework/v2/scenarios/{id}/": {
             "get": {
                 "operationId": "test-framework-v2-scenarios-retrieve",
-                "description": "Retrieve a test scenario by ID",
+                "description": "Fetch a single evaluator by id. Returns full configuration including instructions, expected outcome, metrics, test profile, and — when the agent has mock tools attached and the scenario was auto-generated — the expected mock tool calls (`generated_mock_tool_entries`) with their inputs and outputs.",
+                "summary": "Retrieve an evaluator (scenario)",
                 "parameters": [
                     {
                         "in": "path",
@@ -66040,6 +66043,10 @@
                         ],
                         "description": "Generated values for the agent's dynamic variables for this scenario. Keys are variable names; values are the generated values."
                     },
+                    "generated_mock_tool_entries": {
+                        "readOnly": true,
+                        "description": "Expected mock tool calls generated for this evaluator during scenario auto-generation when the agent has mock tools attached. Each entry has shape {tool_id, tool_name, new_entry: {input, output}}."
+                    },
                     "folder_path": {
                         "type": [
                             "string",
@@ -67132,6 +67139,10 @@
                             }
                         ],
                         "description": "Generated values for the agent's dynamic variables for this scenario. Keys are variable names; values are the generated values."
+                    },
+                    "generated_mock_tool_entries": {
+                        "readOnly": true,
+                        "description": "Expected mock tool calls generated for this evaluator during scenario auto-generation when the agent has mock tools attached. Each entry has shape {tool_id, tool_name, new_entry: {input, output}}."
                     },
                     "folder_path": {
                         "type": [
@@ -68984,6 +68995,10 @@
                             }
                         ],
                         "description": "Generated values for the agent's dynamic variables for this scenario. Keys are variable names; values are the generated values."
+                    },
+                    "generated_mock_tool_entries": {
+                        "readOnly": true,
+                        "description": "Expected mock tool calls generated for this evaluator during scenario auto-generation when the agent has mock tools attached. Each entry has shape {tool_id, tool_name, new_entry: {input, output}}."
                     },
                     "folder_path": {
                         "type": [


### PR DESCRIPTION
Auto-generated docs sync for backend PR [#9450](https://github.com/cekura-ai/vocera.backend/pull/9450).

Reviewers: @dileep-chagam

## Summary

**Spec/overlay:** 3 newly exposed v2 agent personality management operations. No overlays needed — all operations have clear spec-derived descriptions. 3 SDK/CLI follow-ups queued.

## Changes

- `openapi.json` — regenerate_from_backend

## SDK / CLI parity follow-ups

- `aiagents_personalities_list` (GET `/test_framework/v2/aiagents/{id}/personalities/`) — add
- `aiagents_enable_personalities_create` (POST `/test_framework/v2/aiagents/{id}/enable_personalities/`) — add
- `aiagents_disable_personalities_create` (POST `/test_framework/v2/aiagents/{id}/disable_personalities/`) — add

---
*Auto-generated from backend PR #9450.*

<!-- mcp-sync:file-hashes -->
```json
{}
```
<!-- /mcp-sync:file-hashes -->