### PR TITLE
[Auto] Sync docs for backend PR #9437

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -11076,7 +11076,7 @@
         },
         "/test_framework/v1/aiagents/": {
             "get": {
-                "operationId": "aiagents-list",
+                "operationId": "aiagents-v1-list",
                 "description": "aiagents_list: List AI voice agents in your account. Filter by `project_id` to scope to one project, or omit to list every agent the caller can access. Returns a paginated list of agent summaries (id, name, provider, contact number, created/updated timestamps).\n\nPerformance tip: passing `project_id` from your workspace context narrows the result. Try `page_size=20` first — you can paginate or raise the page size if you actually need more.",
                 "summary": "List AI voice agents",
                 "parameters": [
@@ -11144,7 +11144,7 @@
                 }
             },
             "post": {
-                "operationId": "aiagents-create",
+                "operationId": "aiagents-v1-create",
                 "description": "aiagents_create: Register a new AI voice agent with Cekura for testing / observability. Required: `agent_name`, `project` (project ID), `assistant_provider`. Other fields depend on the provider (see below).\n\n**Most common case:** you already have an agent running on your own provider stack with a dedicated phone number. Pass `agent_name`, `description`, `inbound`, `project`, `contact_number` (E.164 format, e.g. `+14155551234`), and `language` — Cekura observes that number without needing provider credentials. Set `assistant_provider=\"self_hosted\"` (optionally `websocket_url` for text-mode runs).\n\n**Provider integrations:** set `assistant_provider` to one of the valid values below and pass the matching credentials. `assistant_id` alone does NOT substitute for provider credentials — providers like VAPI, Retell, and Bland validate their api_key on create.\n\n**Valid `assistant_provider` values** (live enum — superset of prose docs you may see elsewhere):\n- `self_hosted` — websocket or observation-only; no api_key needed. Use `websocket_url` + `websocket_headers` for text-mode runs.\n- `vapi` — requires `vapi_api_key`; optional `assistant_id`, `vapi_data.public_key`.\n- `retell` — requires `retell_api_key` AND `chat_assistant_id` (yes — Retell uses this field even for voice).\n- `bland` — requires `bland_api_key` AND `chat_assistant_id` (Bland internally calls this `pathway_id`); `bland_data.encrypted_key` for Twilio.\n- `livekit` — requires `livekit_api_key` + `livekit_data.api_secret` + `livekit_data.url`.\n- `elevenlabs` — requires `elevenlabs_api_key`.\n- `agentforce` — Salesforce Agentforce; needs `agentforce_client_secret` + `agentforce_data` (client_id, domain, agent_id).\n- `cisco` — Cisco Webex.\n- `vocera` — Cekura-hosted agent.\n- `sms` — text-only SMS channel; use `chat_assistant_id`.\n- `whatsapp` — text-only WhatsApp channel; use `chat_assistant_id`.\n- `\"\"` (empty string) — unset; agent is not runnable until a provider is configured.\n\n**Note:** the serializer exposes fields for some providers (`pipecat_*`, `synthflow_*`, `koreai_*`, `genesys_*`, `custom_provider_*`) that are NOT currently in the `assistant_provider` enum. Those fields exist for response/config purposes but the matching provider value cannot be selected today.\n\n**Outbound agents:** set `inbound=false`. Actual call placement uses the scenario's configured phone number or a number from the org's provisioned pool — `outbound_numbers` is not required for calls to be placed (it is used for webhook validation only).\n\n**Other fields to know:**\n- `language` — BCP-47 locale (`en`, `es`, `fr`, …). Must match the personalities used for evaluators.\n- `transcript_provider` — STT vendor (`vapi | retell | synthflow | elevenlabs | bland | livekit | pipecat | koreai | custom | cisco | genesys`). Does NOT auto-pair with `assistant_provider`; set both independently when needed.\n- `llm_model`, `llm_temperature`, `llm_max_tokens`, `llm_system_prompt` — simulation LLM settings (used by Cekura when simulating callers in test runs; NOT your agent's own LLM).\n- `auto_fetch_calls_enabled` — auto-import calls from the provider every 30s (VAPI/Retell only).\n- `auto_sync_prompt_enabled` — auto-sync prompts from the provider every 30s.\n\n**Read-only status fields** like `vapi_api_key_configured`, `retell_api_key_configured` appear in the response to indicate which provider credentials are stored (credentials themselves are masked).",
                 "summary": "Create an AI voice agent",
                 "tags": [
@@ -13692,7 +13692,7 @@
         },
         "/test_framework/v1/aiagents/{id}/": {
             "get": {
-                "operationId": "aiagents-retrieve",
+                "operationId": "aiagents-v1-retrieve",
                 "description": "Retrieve an AI voice agent by ID",
                 "parameters": [
                     {
@@ -13742,7 +13742,7 @@
                 }
             },
             "put": {
-                "operationId": "aiagents-update",
+                "operationId": "aiagents-v1-update",
                 "description": "Fully replace an AI agent's fields. Prefer `PATCH` (partial_update) unless you need full-replacement semantics. See `aiagents_create` for the field shape and per-provider examples.",
                 "summary": "Replace an AI voice agent (full update)",
                 "parameters": [
@@ -13830,7 +13830,7 @@
                 }
             },
             "patch": {
-                "operationId": "aiagents-partial-update",
+                "operationId": "aiagents-v1-partial-update",
                 "description": "Partially update an AI agent. Same field shape as create — see `aiagents_create` for details and per-provider examples.",
                 "summary": "Update an AI voice agent (partial)",
                 "parameters": [
@@ -13912,7 +13912,7 @@
                 }
             },
             "delete": {
-                "operationId": "aiagents-destroy",
+                "operationId": "aiagents-v1-destroy",
                 "description": "⚠ Irreversible. Deletes the agent.\n\n**Cascade behaviour (controlled by `delete_related` query param):**\n- `delete_related=true` (default) — also deletes the agent's evaluators, results, and runs.\n- `delete_related=false` — detaches evaluators (sets agent=null) and leaves results untouched.",
                 "summary": "Delete an AI voice agent",
                 "parameters": [
@@ -13969,8 +13969,8 @@
         },
         "/test_framework/v1/aiagents/{id}/delete_knowledge_base/": {
             "delete": {
-                "operationId": "aiagents-delete-knowledge-base-destroy",
-                "description": "Aiagents delete knowledge base",
+                "operationId": "aiagents-v1-delete-knowledge-base-destroy",
+                "description": "Aiagents v1 delete knowledge base",
                 "parameters": [
                     {
                         "in": "path",
@@ -14029,8 +14029,8 @@
         },
         "/test_framework/v1/aiagents/{id}/disable_personalities/": {
             "post": {
-                "operationId": "aiagents-disable-personalities-create",
-                "description": "Aiagents disable personalities",
+                "operationId": "aiagents-v1-disable-personalities-create",
+                "description": "Aiagents v1 disable personalities",
                 "parameters": [
                     {
                         "in": "path",
@@ -14086,8 +14086,8 @@
         },
         "/test_framework/v1/aiagents/{id}/duplicate/": {
             "post": {
-                "operationId": "aiagents-duplicate-create",
-                "description": "Duplicate an AI voice agent with all its configuration",
+                "operationId": "aiagents-v1-duplicate-create",
+                "description": "Aiagents v1 duplicate",
                 "parameters": [
                     {
                         "in": "path",
@@ -14160,8 +14160,8 @@
         },
         "/test_framework/v1/aiagents/{id}/enable_personalities/": {
             "post": {
-                "operationId": "aiagents-enable-personalities-create",
-                "description": "Aiagents enable personalities",
+                "operationId": "aiagents-v1-enable-personalities-create",
+                "description": "Aiagents v1 enable personalities",
                 "parameters": [
                     {
                         "in": "path",
@@ -14217,8 +14217,8 @@
         },
         "/test_framework/v1/aiagents/{id}/knowledge_base/": {
             "get": {
-                "operationId": "aiagents-knowledge-base-list",
-                "description": "Aiagents knowledge base",
+                "operationId": "aiagents-v1-knowledge-base-list",
+                "description": "Aiagents v1 knowledge base",
                 "parameters": [
                     {
                         "in": "path",
@@ -14287,8 +14287,8 @@
         },
         "/test_framework/v1/aiagents/{id}/personalities/": {
             "get": {
-                "operationId": "aiagents-personalities-retrieve",
-                "description": "Aiagents personalities",
+                "operationId": "aiagents-v1-personalities-retrieve",
+                "description": "Aiagents v1 personalities",
                 "parameters": [
                     {
                         "in": "path",
@@ -14324,8 +14324,8 @@
         },
         "/test_framework/v1/aiagents/{id}/runs_overview/": {
             "get": {
-                "operationId": "aiagents-runs-overview-retrieve",
-                "description": "Aiagents runs overview",
+                "operationId": "aiagents-v1-runs-overview-retrieve",
+                "description": "Aiagents v1 runs overview",
                 "parameters": [
                     {
                         "in": "path",
@@ -14488,8 +14488,8 @@
         },
         "/test_framework/v1/aiagents/runs_overview_project/": {
             "get": {
-                "operationId": "aiagents-runs-overview-project-retrieve",
-                "description": "Aiagents runs overview project",
+                "operationId": "aiagents-v1-runs-overview-project-retrieve",
+                "description": "Aiagents v1 runs overview project",
                 "tags": [
                     "test_framework"
                 ],
@@ -14514,8 +14514,8 @@
         },
         "/test_framework/v1/aiagents/short_list/": {
             "get": {
-                "operationId": "aiagents-short-list-list",
-                "description": "Aiagents short list",
+                "operationId": "aiagents-v1-short-list-list",
+                "description": "Aiagents v1 short list",
                 "parameters": [
                     {
                         "name": "page",
@@ -38966,7 +38966,7 @@
         },
         "/test_framework/v2/aiagents/": {
             "get": {
-                "operationId": "test-framework-v2-aiagents-list",
+                "operationId": "aiagents-list",
                 "description": "List AI voice agents. Filter by project_id to scope to one project. Returns agents in the v2 format with a nested provider block.",
                 "summary": "List AI voice agents",
                 "parameters": [
@@ -39021,13 +39021,13 @@
                 "x-mint": {
                     "mcp": {
                         "enabled": true,
-                        "name": "test-framework-v2-aiagents-list",
+                        "name": "aiagents-list",
                         "description": "List AI voice agents. Filter by project_id to scope to one project. Returns agents in the v2 format with a nested provider block."
                     }
                 }
             },
             "post": {
-                "operationId": "test-framework-v2-aiagents-create",
+                "operationId": "aiagents-create",
                 "description": "Register a new AI voice agent. Required fields: name, description, project, inbound. Provider credentials are nested under provider.{type, agent_id, credentials} instead of flat fields. transcript_provider defaults to provider.type when omitted.\n\n**provider.credentials keys by type (voice providers only):**\n- vapi: api_key + config.{public_key, trigger_url}\n- retell: api_key + agent_id + optional chat_agent_details.config.agent_id\n- elevenlabs: api_key + config.{trigger_url}\n- bland: api_key + agent_id (pathway_id) + config.{encrypted_key} for Twilio\n- livekit: api_key + config.{api_secret (required), url (required)}\n- pipecat: api_key + config.{webhook_url}\n- cisco: no credentials needed\n- self_hosted: credentials.config.{url (wss://), headers}\nNote: agentforce goes in chat_agent_details; koreai/genesys/synthflow use the v1 API.\n\n**Auto-import from a cloud provider** — set `provider.configure_from_provider: true` (vapi/retell/elevenlabs/synthflow) with `provider.agent_id` + `provider.credentials.api_key`. Cekura fetches the prompt, name, language, who-speaks-first, phone number, tool calls, dynamic variables and knowledge base and configures the agent automatically — `name` and `description` become optional (auto-fetched). The response is **202** with the created agent plus a `progress_id`; poll `import-progress/` to follow the staged import.\n\nSee examples below for full per-provider payloads.",
                 "summary": "Create an AI voice agent",
                 "tags": [
@@ -39255,7 +39255,7 @@
                 "x-mint": {
                     "mcp": {
                         "enabled": true,
-                        "name": "test-framework-v2-aiagents-create",
+                        "name": "aiagents-create",
                         "description": "Register a new AI voice agent. Required fields: name, description, project, inbound. Provider credentials are nested under provider.{type, agent_id, credentials} instead of flat fields. transcript_provider defaults to provider.type when omitted.\n\n**provider.credentials keys by type (voice providers only):**\n- vapi: api_key + config.{public_key, trigger_url}\n- retell: api_key + agent_id + optional chat_agent_details.config.agent_id\n- elevenlabs: api_key + config.{trigger_url}\n- bland: api_key + agent_id (pathway_id) + config.{encrypted_key} for Twilio\n- livekit: api_key + config.{api_secret (required), url (required)}\n- pipecat: api_key + config.{webhook_url}\n- cisco: no credentials needed\n- self_hosted: credentials.config.{url (wss://), headers}\nNote: agentforce goes in chat_agent_details; koreai/genesys/synthflow use the v1 API.\n\n**Auto-import from a cloud provider** — set `provider.configure_from_provider: true` (vapi/retell/elevenlabs/synthflow) with `provider.agent_id` + `provider.credentials.api_key`. Cekura fetches the prompt, name, language, who-speaks-first, phone number, tool calls, dynamic variables and knowledge base and configures the agent automatically — `name` and `description` become optional (auto-fetched). The response is **202** with the created agent plus a `progress_id`; poll `import-progress/` to follow the staged import.\n\nSee examples below for full per-provider payloads."
                     }
                 }
@@ -39263,7 +39263,7 @@
         },
         "/test_framework/v2/aiagents/{id}/": {
             "get": {
-                "operationId": "test-framework-v2-aiagents-retrieve",
+                "operationId": "aiagents-retrieve",
                 "description": "Retrieve an AI voice agent",
                 "summary": "Retrieve an AI voice agent",
                 "parameters": [
@@ -39316,13 +39316,13 @@
                 "x-mint": {
                     "mcp": {
                         "enabled": true,
-                        "name": "test-framework-v2-aiagents-retrieve",
+                        "name": "aiagents-retrieve",
                         "description": "Retrieve an AI voice agent"
                     }
                 }
             },
             "put": {
-                "operationId": "test-framework-v2-aiagents-update",
+                "operationId": "aiagents-update",
                 "description": "Fully replace an agent's fields. Prefer PATCH unless you need full-replacement semantics.",
                 "summary": "Replace an AI voice agent (full update)",
                 "parameters": [
@@ -39412,13 +39412,13 @@
                 "x-mint": {
                     "mcp": {
                         "enabled": true,
-                        "name": "test-framework-v2-aiagents-update",
+                        "name": "aiagents-update",
                         "description": "Fully replace an agent's fields. Prefer PATCH unless you need full-replacement semantics."
                     }
                 }
             },
             "patch": {
-                "operationId": "test-framework-v2-aiagents-partial-update",
+                "operationId": "aiagents-partial-update",
                 "description": "Partially update an agent. Only fields included in the request body are modified.",
                 "summary": "Update an AI voice agent (partial)",
                 "parameters": [
@@ -39502,13 +39502,13 @@
                 "x-mint": {
                     "mcp": {
                         "enabled": true,
-                        "name": "test-framework-v2-aiagents-partial-update",
+                        "name": "aiagents-partial-update",
                         "description": "Partially update an agent. Only fields included in the request body are modified."
                     }
                 }
             },
             "delete": {
-                "operationId": "test-framework-v2-aiagents-destroy",
+                "operationId": "aiagents-destroy",
                 "description": "⚠ Irreversible. Deletes the agent. Pass delete_related=false to detach evaluators instead of deleting them.",
                 "summary": "Delete an AI voice agent",
                 "parameters": [
@@ -39565,7 +39565,7 @@
                 "x-mint": {
                     "mcp": {
                         "enabled": true,
-                        "name": "test-framework-v2-aiagents-destroy",
+                        "name": "aiagents-destroy",
                         "description": "⚠ Irreversible. Deletes the agent. Pass delete_related=false to detach evaluators instead of deleting them."
                     }
                 }
@@ -39573,7 +39573,7 @@
         },
         "/test_framework/v2/aiagents/{id}/delete_knowledge_base/": {
             "delete": {
-                "operationId": "test-framework-v2-aiagents-delete-knowledge-base-destroy",
+                "operationId": "aiagents-delete-knowledge-base-destroy",
                 "description": "Aiagents delete knowledge base",
                 "parameters": [
                     {
@@ -39633,8 +39633,9 @@
         },
         "/test_framework/v2/aiagents/{id}/disable_personalities/": {
             "post": {
-                "operationId": "test-framework-v2-aiagents-disable-personalities-create",
-                "description": "Aiagents disable personalities",
+                "operationId": "aiagents-disable-personalities-create",
+                "description": "Disable personalities for the agent's project. Pass `personalities` as a list of personality IDs, or the string \"all\". Returns the project's personalities.",
+                "summary": "Disable personalities for an agent's project",
                 "parameters": [
                     {
                         "in": "path",
@@ -39644,6 +39645,24 @@
                         },
                         "description": "A unique integer value identifying this ai agent.",
                         "required": true
+                    },
+                    {
+                        "name": "page",
+                        "required": false,
+                        "in": "query",
+                        "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
                     }
                 ],
                 "tags": [
@@ -39679,18 +39698,44 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/AIAgentV2"
+                                    "$ref": "#/components/schemas/PaginatedPersonalityList"
                                 }
                             }
                         },
                         "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "aiagents-disable-personalities-create",
+                        "description": "Disable personalities for the agent's project. Pass `personalities` as a list of personality IDs, or the string \"all\". Returns the project's personalities."
                     }
                 }
             }
         },
         "/test_framework/v2/aiagents/{id}/duplicate/": {
             "post": {
-                "operationId": "test-framework-v2-aiagents-duplicate-create",
+                "operationId": "aiagents-duplicate-create",
                 "description": "Create a copy of the agent with all its configuration. Returns the new agent in v2 format.",
                 "summary": "Duplicate an AI voice agent",
                 "parameters": [
@@ -39765,7 +39810,7 @@
                 "x-mint": {
                     "mcp": {
                         "enabled": true,
-                        "name": "test-framework-v2-aiagents-duplicate-create",
+                        "name": "aiagents-duplicate-create",
                         "description": "Create a copy of the agent with all its configuration. Returns the new agent in v2 format."
                     }
                 }
@@ -39773,8 +39818,9 @@
         },
         "/test_framework/v2/aiagents/{id}/enable_personalities/": {
             "post": {
-                "operationId": "test-framework-v2-aiagents-enable-personalities-create",
-                "description": "Aiagents enable personalities",
+                "operationId": "aiagents-enable-personalities-create",
+                "description": "Enable personalities for the agent's project. Pass `personalities` as a list of personality IDs, or the string \"all\". Returns the project's personalities.",
+                "summary": "Enable personalities for an agent's project",
                 "parameters": [
                     {
                         "in": "path",
@@ -39784,6 +39830,24 @@
                         },
                         "description": "A unique integer value identifying this ai agent.",
                         "required": true
+                    },
+                    {
+                        "name": "page",
+                        "required": false,
+                        "in": "query",
+                        "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
                     }
                 ],
                 "tags": [
@@ -39819,18 +39883,44 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/AIAgentV2"
+                                    "$ref": "#/components/schemas/PaginatedPersonalityList"
                                 }
                             }
                         },
                         "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "aiagents-enable-personalities-create",
+                        "description": "Enable personalities for the agent's project. Pass `personalities` as a list of personality IDs, or the string \"all\". Returns the project's personalities."
                     }
                 }
             }
         },
         "/test_framework/v2/aiagents/{id}/knowledge_base/": {
             "get": {
-                "operationId": "test-framework-v2-aiagents-knowledge-base-list",
+                "operationId": "aiagents-knowledge-base-list",
                 "description": "Aiagents knowledge base",
                 "parameters": [
                     {
@@ -39900,8 +39990,9 @@
         },
         "/test_framework/v2/aiagents/{id}/personalities/": {
             "get": {
-                "operationId": "test-framework-v2-aiagents-personalities-retrieve",
-                "description": "Aiagents personalities",
+                "operationId": "aiagents-personalities-list",
+                "description": "List the caller/tester personalities available to this agent's project. Filter with query params: type, language, enabled_only=true (only the personalities currently enabled for the project).",
+                "summary": "List personalities available to an agent",
                 "parameters": [
                     {
                         "in": "path",
@@ -39911,6 +40002,24 @@
                         },
                         "description": "A unique integer value identifying this ai agent.",
                         "required": true
+                    },
+                    {
+                        "name": "page",
+                        "required": false,
+                        "in": "query",
+                        "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
                     }
                 ],
                 "tags": [
@@ -39926,18 +40035,26 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/AIAgentV2"
+                                    "$ref": "#/components/schemas/PaginatedPersonalityList"
                                 }
                             }
                         },
                         "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "aiagents-personalities-list",
+                        "description": "List the caller/tester personalities available to this agent's project. Filter with query params: type, language, enabled_only=true (only the personalities currently enabled for the project)."
                     }
                 }
             }
         },
         "/test_framework/v2/aiagents/{id}/runs_overview/": {
             "get": {
-                "operationId": "test-framework-v2-aiagents-runs-overview-retrieve",
+                "operationId": "aiagents-runs-overview-retrieve",
                 "description": "Aiagents runs overview",
                 "parameters": [
                     {
@@ -40109,7 +40226,7 @@
         },
         "/test_framework/v2/aiagents/import-progress/": {
             "get": {
-                "operationId": "test-framework-v2-aiagents-import-progress-retrieve",
+                "operationId": "aiagents-import-progress-retrieve",
                 "description": "Returns the staged status of a background agent import started via `configure_from_provider`. Each stage reports pending / in_progress / completed / skipped / failed so a step-by-step loader can be rendered.",
                 "summary": "Poll cloud-provider import progress",
                 "parameters": [
@@ -40164,7 +40281,7 @@
         },
         "/test_framework/v2/aiagents/runs_overview_project/": {
             "get": {
-                "operationId": "test-framework-v2-aiagents-runs-overview-project-retrieve",
+                "operationId": "aiagents-runs-overview-project-retrieve",
                 "description": "Aiagents runs overview project",
                 "tags": [
                     "test_framework"
@@ -40190,7 +40307,7 @@
         },
         "/test_framework/v2/aiagents/short_list/": {
             "get": {
-                "operationId": "test-framework-v2-aiagents-short-list-list",
+                "operationId": "aiagents-short-list-list",
                 "description": "Aiagents short list",
                 "parameters": [
                     {
@@ -53301,6 +53418,7 @@
             },
             "CallLogDetail": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -53492,6 +53610,7 @@
             },
             "CallLogList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -54685,6 +54804,7 @@
             },
             "Dashboard": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -54816,6 +54936,7 @@
             },
             "DashboardList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -57088,6 +57209,7 @@
             },
             "MetricList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -59277,6 +59399,37 @@
                     }
                 }
             },
+            "PaginatedPersonalityList": {
+                "type": "object",
+                "required": [
+                    "count",
+                    "results"
+                ],
+                "properties": {
+                    "count": {
+                        "type": "integer",
+                        "example": 123
+                    },
+                    "next": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "https://api.cekura.ai/example/v1/example-external/?page=4"
+                    },
+                    "previous": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "https://api.cekura.ai/example/v1/example-external/?page=3"
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Personality"
+                        }
+                    }
+                }
+            },
             "PaginatedResultList": {
                 "type": "object",
                 "required": [
@@ -59758,6 +59911,7 @@
             },
             "PatchedCallLogDetail": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -60215,6 +60369,7 @@
             },
             "PatchedDashboard": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -62492,6 +62647,7 @@
             },
             "PatchedSchemaPostScenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "agent": {
                         "type": [
@@ -63225,7 +63381,7 @@
                     },
                     "name": {
                         "type": "string",
-                        "description": "Name of the tool - must be less than 64 characters and contain only alphanumerics, underscores, and hyphens",
+                        "description": "Name of the tool - must be less than 64 characters and contain only alphanumerics, underscores, hyphens, and spaces between words (no leading or trailing spaces)",
                         "maxLength": 255
                     },
                     "description": {
@@ -63809,6 +63965,177 @@
                         "readOnly": true
                     }
                 }
+            },
+            "Personality": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "forked_from": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
+                    },
+                    "organization": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "\nName of the personality\nExample: `\"Customer Service\"`\n",
+                        "maxLength": 255
+                    },
+                    "prompt": {
+                        "type": "string",
+                        "description": "\nPrompt of the personality\nExample: `\"You are a friendly and helpful customer service agent who is always willing to help\"`\n"
+                    },
+                    "language": {
+                        "enum": [
+                            "af",
+                            "ar",
+                            "bn",
+                            "bg",
+                            "zh",
+                            "cs",
+                            "da",
+                            "nl",
+                            "en",
+                            "et",
+                            "fi",
+                            "fr",
+                            "de",
+                            "el",
+                            "gu",
+                            "hi",
+                            "he",
+                            "hu",
+                            "id",
+                            "it",
+                            "ja",
+                            "kn",
+                            "ko",
+                            "ms",
+                            "ml",
+                            "mr",
+                            "multi",
+                            "no",
+                            "pl",
+                            "pa",
+                            "pt",
+                            "ro",
+                            "ru",
+                            "sk",
+                            "es",
+                            "sv",
+                            "th",
+                            "tr",
+                            "tl",
+                            "ta",
+                            "te",
+                            "uk",
+                            "vi"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "b822ad429c7b7fec",
+                        "description": "\nLanguage of the personality\n\n\n* `af` - Afrikaans\n* `ar` - Arabic\n* `bn` - Bengali\n* `bg` - Bulgarian\n* `zh` - Chinese Simplified\n* `cs` - Czech\n* `da` - Danish\n* `nl` - Dutch\n* `en` - English\n* `et` - Estonian\n* `fi` - Finnish\n* `fr` - French\n* `de` - German\n* `el` - Greek\n* `gu` - Gujarati\n* `hi` - Hindi\n* `he` - Hebrew\n* `hu` - Hungarian\n* `id` - Indonesian\n* `it` - Italian\n* `ja` - Japanese\n* `kn` - Kannada\n* `ko` - Korean\n* `ms` - Malay\n* `ml` - Malayalam\n* `mr` - Marathi\n* `multi` - Multilingual\n* `no` - Norwegian\n* `pl` - Polish\n* `pa` - Punjabi\n* `pt` - Portuguese\n* `ro` - Romanian\n* `ru` - Russian\n* `sk` - Slovak\n* `es` - Spanish\n* `sv` - Swedish\n* `th` - Thai\n* `tr` - Turkish\n* `tl` - Tagalog\n* `ta` - Tamil\n* `te` - Telugu\n* `uk` - Ukrainian\n* `vi` - Vietnamese"
+                    },
+                    "accent": {
+                        "type": "string",
+                        "description": "\nAccent of the personality\nExample: `\"American\"`\n",
+                        "maxLength": 255
+                    },
+                    "gender": {
+                        "enum": [
+                            "male",
+                            "female",
+                            "neutral"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "427cb1f56db21620",
+                        "description": "\nGender of the personality\n\n\n* `male` - Male\n* `female` - Female\n* `neutral` - Neutral"
+                    },
+                    "enabled": {
+                        "type": "boolean",
+                        "readOnly": true,
+                        "default": false
+                    },
+                    "call_service_provider": {
+                        "enum": [
+                            "vapi",
+                            "patronus"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "f442d6949d5b96ff",
+                        "description": "\nCall service provider\n\n\n* `vapi` - VAPI\n* `patronus` - Patronus"
+                    },
+                    "background_noise": {
+                        "type": "string"
+                    },
+                    "voice_model": {
+                        "type": "string"
+                    },
+                    "voice_id": {
+                        "type": "string"
+                    },
+                    "interruption_level": {
+                        "type": "string"
+                    },
+                    "speed": {
+                        "type": "string"
+                    },
+                    "generation_config": {
+                        "type": "string"
+                    },
+                    "network_simulation": {
+                        "type": "string"
+                    },
+                    "message_plan": {
+                        "type": "string"
+                    },
+                    "start_speaking_plan": {
+                        "type": "string"
+                    },
+                    "stop_speaking_plan": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "background_sound_volume": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "patronus_settings": {
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "provider_agent_id": {
+                        "type": "string",
+                        "description": "\nProvider agent ID\nExample: `\"assistant_123\"`\n",
+                        "maxLength": 255
+                    },
+                    "is_starred": {
+                        "type": "boolean",
+                        "description": "\nWhether the personality is starred\n"
+                    }
+                },
+                "required": [
+                    "background_noise",
+                    "name",
+                    "prompt",
+                    "voice_model"
+                ]
             },
             "PhoneNumber": {
                 "type": "object",
@@ -65488,6 +65815,7 @@
             },
             "RunList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -65912,6 +66240,7 @@
             },
             "Scenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -66780,6 +67109,7 @@
             },
             "ScenarioList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -66999,6 +67329,7 @@
             },
             "ScenarioSerializerV2": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -68443,6 +68774,7 @@
             },
             "SchemaPostRunScenarios": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "agent_id": {
                         "type": "integer",
@@ -68691,6 +69023,7 @@
             },
             "SchemaPostScenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "agent": {
                         "type": [
@@ -68850,6 +69183,7 @@
             },
             "SchemaScenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -70224,7 +70558,7 @@
                     },
                     "name": {
                         "type": "string",
-                        "description": "Name of the tool - must be less than 64 characters and contain only alphanumerics, underscores, and hyphens",
+                        "description": "Name of the tool - must be less than 64 characters and contain only alphanumerics, underscores, hyphens, and spaces between words (no leading or trailing spaces)",
                         "maxLength": 255
                     },
                     "description": {

--- a/openapi.json
+++ b/openapi.json
@@ -27894,7 +27894,8 @@
         "/test_framework/v1/scenarios-external/{id}/": {
             "get": {
                 "operationId": "scenarios-external-retrieve",
-                "description": "Retrieve a test scenario by ID",
+                "description": "Fetch a single evaluator by id. Returns full configuration including instructions, expected outcome, metrics, test profile, and — when the agent has mock tools attached and the scenario was auto-generated — the expected mock tool calls (`generated_mock_tool_entries`) with their inputs and outputs.",
+                "summary": "Retrieve an evaluator (scenario)",
                 "parameters": [
                     {
                         "in": "path",
@@ -29456,7 +29457,7 @@
         "/test_framework/v1/scenarios-external/generate-bg/": {
             "post": {
                 "operationId": "scenarios-generate-bg",
-                "description": "Generate scenarios for a given agent in the background. Returns a `progress_id` immediately; poll GET /scenarios/generate-progress/?progress_id={id} until `total_scenarios == completed_scenarios`.\n\n**What happens automatically on generation:**\n- A default test profile is created for the agent if none exists. Each generated scenario will have `test_profile_data` populated with synthetic caller information (name, address, phone, email).\n- 10 project-level evaluation metrics are attached to every generated scenario automatically (e.g. Latency, Pitch, Interruption Score). Scenarios created manually via `scenarios_create` start with no metrics attached.\n\n**Response fields:** `progress_id` (UUID string) for polling; `session_id` is always null.",
+                "description": "Generate scenarios for a given agent in the background. Returns a `progress_id` immediately; poll GET /scenarios/generate-progress/?progress_id={id} until `total_scenarios == completed_scenarios`.\n\n**What happens automatically on generation:**\n- A scenario-specific test profile is created and its `information` is populated using the sectioned shape: `main_agent_variables` (dynamic-variable values that reach the agent under test at call time — e.g. `user_id`, `account_id`) and `testing_agent_variables` (persona/context used by the simulated caller — e.g. `customer_name`, `date_of_birth`). Section values are kept consistent with any generated mock-tool data.\n- 10 project-level evaluation metrics are attached to every generated scenario automatically (e.g. Latency, Pitch, Interruption Score). Scenarios created manually via `scenarios_create` start with no metrics attached.\n\n**Response fields:** `progress_id` (UUID string) for polling; `session_id` is always null.",
                 "tags": [
                     "test_framework"
                 ],
@@ -32704,7 +32705,8 @@
         "/test_framework/v1/scenarios/{id}/": {
             "get": {
                 "operationId": "scenarios-retrieve",
-                "description": "Retrieve a test scenario by ID",
+                "description": "Fetch a single evaluator by id. Returns full configuration including instructions, expected outcome, metrics, test profile, and — when the agent has mock tools attached and the scenario was auto-generated — the expected mock tool calls (`generated_mock_tool_entries`) with their inputs and outputs.",
+                "summary": "Retrieve an evaluator (scenario)",
                 "parameters": [
                     {
                         "in": "path",
@@ -32756,7 +32758,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-retrieve",
-                        "description": "Retrieve a test scenario by ID"
+                        "description": "Fetch a single evaluator by id. Returns full configuration including instructions, expected outcome, metrics, test profile, and — when the agent has mock tools attached and the scenario was auto-generated — the expected mock tool calls (`generated_mock_tool_entries`) with their inputs and outputs."
                     }
                 }
             },
@@ -34346,7 +34348,7 @@
         "/test_framework/v1/scenarios/generate-bg/": {
             "post": {
                 "operationId": "scenarios-generate-bg_2",
-                "description": "Generate scenarios for a given agent in the background. Returns a `progress_id` immediately; poll GET /scenarios/generate-progress/?progress_id={id} until `total_scenarios == completed_scenarios`.\n\n**What happens automatically on generation:**\n- A default test profile is created for the agent if none exists. Each generated scenario will have `test_profile_data` populated with synthetic caller information (name, address, phone, email).\n- 10 project-level evaluation metrics are attached to every generated scenario automatically (e.g. Latency, Pitch, Interruption Score). Scenarios created manually via `scenarios_create` start with no metrics attached.\n\n**Response fields:** `progress_id` (UUID string) for polling; `session_id` is always null.",
+                "description": "Generate scenarios for a given agent in the background. Returns a `progress_id` immediately; poll GET /scenarios/generate-progress/?progress_id={id} until `total_scenarios == completed_scenarios`.\n\n**What happens automatically on generation:**\n- A scenario-specific test profile is created and its `information` is populated using the sectioned shape: `main_agent_variables` (dynamic-variable values that reach the agent under test at call time — e.g. `user_id`, `account_id`) and `testing_agent_variables` (persona/context used by the simulated caller — e.g. `customer_name`, `date_of_birth`). Section values are kept consistent with any generated mock-tool data.\n- 10 project-level evaluation metrics are attached to every generated scenario automatically (e.g. Latency, Pitch, Interruption Score). Scenarios created manually via `scenarios_create` start with no metrics attached.\n\n**Response fields:** `progress_id` (UUID string) for polling; `session_id` is always null.",
                 "tags": [
                     "test_framework"
                 ],
@@ -34415,7 +34417,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-generate-bg",
-                        "description": "Generate scenarios for a given agent in the background. Returns a `progress_id` immediately; poll GET /scenarios/generate-progress/?progress_id={id} until `total_scenarios == completed_scenarios`.\n\n**What happens automatically on generation:**\n- A default test profile is created for the agent if none exists. Each generated scenario will have `test_profile_data` populated with synthetic caller information (name, address, phone, email).\n- 10 project-level evaluation metrics are attached to every generated scenario automatically (e.g. Latency, Pitch, Interruption Score). Scenarios created manually via `scenarios_create` start with no metrics attached.\n\n**Response fields:** `progress_id` (UUID string) for polling; `session_id` is always null."
+                        "description": "Generate scenarios for a given agent in the background. Returns a `progress_id` immediately; poll GET /scenarios/generate-progress/?progress_id={id} until `total_scenarios == completed_scenarios`.\n\n**What happens automatically on generation:**\n- A scenario-specific test profile is created and its `information` is populated using the sectioned shape: `main_agent_variables` (dynamic-variable values that reach the agent under test at call time — e.g. `user_id`, `account_id`) and `testing_agent_variables` (persona/context used by the simulated caller — e.g. `customer_name`, `date_of_birth`). Section values are kept consistent with any generated mock-tool data.\n- 10 project-level evaluation metrics are attached to every generated scenario automatically (e.g. Latency, Pitch, Interruption Score). Scenarios created manually via `scenarios_create` start with no metrics attached.\n\n**Response fields:** `progress_id` (UUID string) for polling; `session_id` is always null."
                     }
                 }
             }
@@ -37835,8 +37837,14 @@
                                                 "agent": 123,
                                                 "name": "<string>",
                                                 "information": {
-                                                    "user_name": "<string>",
-                                                    "user_email": "<string>"
+                                                    "main_agent_variables": {
+                                                        "user_id": "<string>",
+                                                        "account_id": "<string>"
+                                                    },
+                                                    "testing_agent_variables": {
+                                                        "user_name": "<string>",
+                                                        "user_email": "<string>"
+                                                    }
                                                 }
                                             }
                                         ],
@@ -37875,8 +37883,14 @@
                                         "agent": 123,
                                         "name": "<string>",
                                         "information": {
-                                            "user_name": "<string>",
-                                            "user_email": "<string>"
+                                            "main_agent_variables": {
+                                                "user_id": "<string>",
+                                                "account_id": "<string>"
+                                            },
+                                            "testing_agent_variables": {
+                                                "user_name": "<string>",
+                                                "user_email": "<string>"
+                                            }
                                         }
                                     },
                                     "summary": "Create Test Profile with Agent"
@@ -37886,8 +37900,14 @@
                                         "project": 456,
                                         "name": "<string>",
                                         "information": {
-                                            "user_name": "<string>",
-                                            "user_email": "<string>"
+                                            "main_agent_variables": {
+                                                "user_id": "<string>",
+                                                "account_id": "<string>"
+                                            },
+                                            "testing_agent_variables": {
+                                                "user_name": "<string>",
+                                                "user_email": "<string>"
+                                            }
                                         }
                                     },
                                     "summary": "Create Test Profile with Project"
@@ -37927,8 +37947,14 @@
                                             "agent": null,
                                             "name": "<string>",
                                             "information": {
-                                                "user_name": "John Doe",
-                                                "user_email": "john.doe@example.com"
+                                                "main_agent_variables": {
+                                                    "user_id": "U-42",
+                                                    "account_id": "ACC-4521"
+                                                },
+                                                "testing_agent_variables": {
+                                                    "user_name": "John Doe",
+                                                    "user_email": "john.doe@example.com"
+                                                }
                                             }
                                         },
                                         "summary": "Create Test Profile Response"
@@ -38014,8 +38040,14 @@
                                                 "agent": 123,
                                                 "name": "<string>",
                                                 "information": {
-                                                    "user_name": "<string>",
-                                                    "user_email": "<string>"
+                                                    "main_agent_variables": {
+                                                        "user_id": "<string>",
+                                                        "account_id": "<string>"
+                                                    },
+                                                    "testing_agent_variables": {
+                                                        "user_name": "<string>",
+                                                        "user_email": "<string>"
+                                                    }
                                                 }
                                             }
                                         ],
@@ -38046,8 +38078,14 @@
                                         "agent": 123,
                                         "name": "<string>",
                                         "information": {
-                                            "user_name": "<string>",
-                                            "user_email": "<string>"
+                                            "main_agent_variables": {
+                                                "user_id": "<string>",
+                                                "account_id": "<string>"
+                                            },
+                                            "testing_agent_variables": {
+                                                "user_name": "<string>",
+                                                "user_email": "<string>"
+                                            }
                                         }
                                     },
                                     "summary": "Create Test Profile with Agent"
@@ -38057,8 +38095,14 @@
                                         "project": 456,
                                         "name": "<string>",
                                         "information": {
-                                            "user_name": "<string>",
-                                            "user_email": "<string>"
+                                            "main_agent_variables": {
+                                                "user_id": "<string>",
+                                                "account_id": "<string>"
+                                            },
+                                            "testing_agent_variables": {
+                                                "user_name": "<string>",
+                                                "user_email": "<string>"
+                                            }
                                         }
                                     },
                                     "summary": "Create Test Profile with Project"
@@ -38098,8 +38142,14 @@
                                             "agent": null,
                                             "name": "<string>",
                                             "information": {
-                                                "user_name": "John Doe",
-                                                "user_email": "john.doe@example.com"
+                                                "main_agent_variables": {
+                                                    "user_id": "U-42",
+                                                    "account_id": "ACC-4521"
+                                                },
+                                                "testing_agent_variables": {
+                                                    "user_name": "John Doe",
+                                                    "user_email": "john.doe@example.com"
+                                                }
                                             }
                                         },
                                         "summary": "Create Test Profile Response"
@@ -38167,8 +38217,14 @@
                                             "agent": 123,
                                             "name": "<string>",
                                             "information": {
-                                                "user_name": "<string>",
-                                                "user_email": "<string>"
+                                                "main_agent_variables": {
+                                                    "user_id": "<string>",
+                                                    "account_id": "<string>"
+                                                },
+                                                "testing_agent_variables": {
+                                                    "user_name": "<string>",
+                                                    "user_email": "<string>"
+                                                }
                                             }
                                         },
                                         "summary": "Get Test Profile"
@@ -38263,8 +38319,14 @@
                                     "value": {
                                         "name": "<string>",
                                         "information": {
-                                            "user_name": "<string>",
-                                            "user_email": "<string>"
+                                            "main_agent_variables": {
+                                                "user_id": "<string>",
+                                                "account_id": "<string>"
+                                            },
+                                            "testing_agent_variables": {
+                                                "user_name": "<string>",
+                                                "user_email": "<string>"
+                                            }
                                         }
                                     },
                                     "summary": "Partial Update Test Profile"
@@ -38302,8 +38364,14 @@
                                             "agent": 123,
                                             "name": "<string>",
                                             "information": {
-                                                "user_name": "<string>",
-                                                "user_email": "<string>"
+                                                "main_agent_variables": {
+                                                    "user_id": "<string>",
+                                                    "account_id": "<string>"
+                                                },
+                                                "testing_agent_variables": {
+                                                    "user_name": "<string>",
+                                                    "user_email": "<string>"
+                                                }
                                             }
                                         },
                                         "summary": "Partial Update Test Profile Response"
@@ -38397,8 +38465,14 @@
                                             "agent": 123,
                                             "name": "<string>",
                                             "information": {
-                                                "user_name": "<string>",
-                                                "user_email": "<string>"
+                                                "main_agent_variables": {
+                                                    "user_id": "<string>",
+                                                    "account_id": "<string>"
+                                                },
+                                                "testing_agent_variables": {
+                                                    "user_name": "<string>",
+                                                    "user_email": "<string>"
+                                                }
                                             }
                                         },
                                         "summary": "Get Test Profile"
@@ -38501,8 +38575,14 @@
                                     "value": {
                                         "name": "<string>",
                                         "information": {
-                                            "user_name": "<string>",
-                                            "user_email": "<string>"
+                                            "main_agent_variables": {
+                                                "user_id": "<string>",
+                                                "account_id": "<string>"
+                                            },
+                                            "testing_agent_variables": {
+                                                "user_name": "<string>",
+                                                "user_email": "<string>"
+                                            }
                                         }
                                     },
                                     "summary": "Partial Update Test Profile"
@@ -38540,8 +38620,14 @@
                                             "agent": 123,
                                             "name": "<string>",
                                             "information": {
-                                                "user_name": "<string>",
-                                                "user_email": "<string>"
+                                                "main_agent_variables": {
+                                                    "user_id": "<string>",
+                                                    "account_id": "<string>"
+                                                },
+                                                "testing_agent_variables": {
+                                                    "user_name": "<string>",
+                                                    "user_email": "<string>"
+                                                }
                                             }
                                         },
                                         "summary": "Partial Update Test Profile Response"
@@ -40402,7 +40488,8 @@
         "/test_framework/v2/scenarios/{id}/": {
             "get": {
                 "operationId": "test-framework-v2-scenarios-retrieve",
-                "description": "Retrieve a test scenario by ID",
+                "description": "Fetch a single evaluator by id. Returns full configuration including instructions, expected outcome, metrics, test profile, and — when the agent has mock tools attached and the scenario was auto-generated — the expected mock tool calls (`generated_mock_tool_entries`) with their inputs and outputs.",
+                "summary": "Retrieve an evaluator (scenario)",
                 "parameters": [
                     {
                         "in": "path",
@@ -41964,7 +42051,7 @@
         "/test_framework/v2/scenarios/generate-bg/": {
             "post": {
                 "operationId": "scenarios-generate-bg_3",
-                "description": "Generate scenarios for a given agent in the background. Returns a `progress_id` immediately; poll GET /scenarios/generate-progress/?progress_id={id} until `total_scenarios == completed_scenarios`.\n\n**What happens automatically on generation:**\n- A default test profile is created for the agent if none exists. Each generated scenario will have `test_profile_data` populated with synthetic caller information (name, address, phone, email).\n- 10 project-level evaluation metrics are attached to every generated scenario automatically (e.g. Latency, Pitch, Interruption Score). Scenarios created manually via `scenarios_create` start with no metrics attached.\n\n**Response fields:** `progress_id` (UUID string) for polling; `session_id` is always null.",
+                "description": "Generate scenarios for a given agent in the background. Returns a `progress_id` immediately; poll GET /scenarios/generate-progress/?progress_id={id} until `total_scenarios == completed_scenarios`.\n\n**What happens automatically on generation:**\n- A scenario-specific test profile is created and its `information` is populated using the sectioned shape: `main_agent_variables` (dynamic-variable values that reach the agent under test at call time — e.g. `user_id`, `account_id`) and `testing_agent_variables` (persona/context used by the simulated caller — e.g. `customer_name`, `date_of_birth`). Section values are kept consistent with any generated mock-tool data.\n- 10 project-level evaluation metrics are attached to every generated scenario automatically (e.g. Latency, Pitch, Interruption Score). Scenarios created manually via `scenarios_create` start with no metrics attached.\n\n**Response fields:** `progress_id` (UUID string) for polling; `session_id` is always null.",
                 "tags": [
                     "test_framework"
                 ],
@@ -53214,7 +53301,6 @@
             },
             "CallLogDetail": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -53406,7 +53492,6 @@
             },
             "CallLogList": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -54600,7 +54685,6 @@
             },
             "Dashboard": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -54732,7 +54816,6 @@
             },
             "DashboardList": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -57005,7 +57088,6 @@
             },
             "MetricList": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -59676,7 +59758,6 @@
             },
             "PatchedCallLogDetail": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -60134,7 +60215,6 @@
             },
             "PatchedDashboard": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -62120,7 +62200,7 @@
                     "information": {
                         "type": "object",
                         "additionalProperties": {},
-                        "description": "Information fields of the test profile"
+                        "description": "Test profile information. Use the sectioned shape — `main_agent_variables` (sent to the agent under test as dynamic variables at call time) and `testing_agent_variables` (persona/context used by the simulated caller, not sent to the agent). Legacy flat dicts (no section keys) are still accepted and delivered to both sides for backward compatibility. Example: {\"main_agent_variables\": {\"user_id\": \"U-42\"}, \"testing_agent_variables\": {\"customer_name\": \"John Doe\"}}."
                     }
                 }
             },
@@ -62412,7 +62492,6 @@
             },
             "PatchedSchemaPostScenario": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "agent": {
                         "type": [
@@ -65409,7 +65488,6 @@
             },
             "RunList": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -65834,7 +65912,6 @@
             },
             "Scenario": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -66029,16 +66106,15 @@
                             }
                         ],
                         "readOnly": true,
-                        "description": "\nDetails of the test profile associated with this scenario\nExample:\n```json\n{\n    \"id\": \"<integer>\",\n    \"agent_id\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"information\": {\n        \"user_name\": \"<string>\",\n        \"user_email\": \"<string>\",\n        \"order_id\": \"<string>\",\n    },\n}\n```\n"
+                        "description": "\nDetails of the test profile associated with this scenario. `information` uses the\nsectioned shape: `main_agent_variables` are sent to the agent under test as\ndynamic variables at call time; `testing_agent_variables` are persona/context\nused by Cekura's simulated caller. Legacy flat dicts (no section keys) still\nwork — at call time they are delivered to both sides for backward compatibility.\nExample:\n```json\n{\n    \"id\": \"<integer>\",\n    \"agent_id\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"information\": {\n        \"main_agent_variables\": {\n            \"user_id\": \"<string>\",\n            \"account_id\": \"<string>\"\n        },\n        \"testing_agent_variables\": {\n            \"user_name\": \"<string>\",\n            \"user_email\": \"<string>\",\n            \"order_id\": \"<string>\"\n        }\n    }\n}\n```\n"
                     },
                     "dynamic_variable_values": {
-                        "oneOf": [
-                            {},
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "description": "Generated values for the agent's dynamic variables for this scenario. Keys are variable names; values are the generated values."
+                        "readOnly": true,
+                        "description": "REMOVED FROM API. Reads return the historical value for legacy rows (`null` for new rows). Writes are no longer accepted — supplying a non-null value yields a 400 error. Put dynamic-variable values in `test_profile_data.information.main_agent_variables` instead: create the test profile via POST /test-profiles/ and attach it via the `test_profile` field on the scenario."
+                    },
+                    "generated_mock_tool_entries": {
+                        "readOnly": true,
+                        "description": "Expected mock tool calls generated for this evaluator during scenario auto-generation when the agent has mock tools attached. Each entry has shape {tool_id, tool_name, new_entry: {input, output}}."
                     },
                     "folder_path": {
                         "type": [
@@ -66488,7 +66564,7 @@
                                 "type": "null"
                             }
                         ],
-                        "description": "Generated values for the agent's dynamic variables for this scenario. Keys are variable names; values are the generated values."
+                        "description": "REMOVED FROM API. Historically stored a flat copy of the agent's dynamic-variable values for the scenario. The column is retained read-only for legacy rows; reads still return its historical value, but writes via the API are rejected with a 400. At call time the Run-level helper consults this column ONLY when the attached test_profile is legacy-flat (or absent) — sectioned test profiles are the canonical source and ignore this column. Put dynamic-variable values in `test_profile.information.main_agent_variables` for new scenarios."
                     },
                     "phone_number": {
                         "type": [
@@ -66704,7 +66780,6 @@
             },
             "ScenarioList": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -66872,7 +66947,7 @@
                                 "type": "null"
                             }
                         ],
-                        "description": "Generated values for the agent's dynamic variables for this scenario. Keys are variable names; values are the generated values."
+                        "description": "REMOVED FROM API. Historically stored a flat copy of the agent's dynamic-variable values for the scenario. The column is retained read-only for legacy rows; reads still return its historical value, but writes via the API are rejected with a 400. At call time the Run-level helper consults this column ONLY when the attached test_profile is legacy-flat (or absent) — sectioned test profiles are the canonical source and ignore this column. Put dynamic-variable values in `test_profile.information.main_agent_variables` for new scenarios."
                     },
                     "created_at": {
                         "type": "string",
@@ -66924,7 +66999,6 @@
             },
             "ScenarioSerializerV2": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -67122,16 +67196,15 @@
                             }
                         ],
                         "readOnly": true,
-                        "description": "\nDetails of the test profile associated with this scenario\nExample:\n```json\n{\n    \"id\": \"<integer>\",\n    \"agent_id\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"information\": {\n        \"user_name\": \"<string>\",\n        \"user_email\": \"<string>\",\n        \"order_id\": \"<string>\",\n    },\n}\n```\n"
+                        "description": "\nDetails of the test profile associated with this scenario. `information` uses the\nsectioned shape: `main_agent_variables` are sent to the agent under test as\ndynamic variables at call time; `testing_agent_variables` are persona/context\nused by Cekura's simulated caller. Legacy flat dicts (no section keys) still\nwork — at call time they are delivered to both sides for backward compatibility.\nExample:\n```json\n{\n    \"id\": \"<integer>\",\n    \"agent_id\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"information\": {\n        \"main_agent_variables\": {\n            \"user_id\": \"<string>\",\n            \"account_id\": \"<string>\"\n        },\n        \"testing_agent_variables\": {\n            \"user_name\": \"<string>\",\n            \"user_email\": \"<string>\",\n            \"order_id\": \"<string>\"\n        }\n    }\n}\n```\n"
                     },
                     "dynamic_variable_values": {
-                        "oneOf": [
-                            {},
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "description": "Generated values for the agent's dynamic variables for this scenario. Keys are variable names; values are the generated values."
+                        "readOnly": true,
+                        "description": "REMOVED FROM API. Reads return the historical value for legacy rows (`null` for new rows). Writes are no longer accepted — supplying a non-null value yields a 400 error. Put dynamic-variable values in `test_profile_data.information.main_agent_variables` instead: create the test profile via POST /test-profiles/ and attach it via the `test_profile` field on the scenario."
+                    },
+                    "generated_mock_tool_entries": {
+                        "readOnly": true,
+                        "description": "Expected mock tool calls generated for this evaluator during scenario auto-generation when the agent has mock tools attached. Each entry has shape {tool_id, tool_name, new_entry: {input, output}}."
                     },
                     "folder_path": {
                         "type": [
@@ -67661,7 +67734,7 @@
                     "information": {
                         "type": "object",
                         "additionalProperties": {},
-                        "description": "Information fields of the test profile"
+                        "description": "Test profile information. Use the sectioned shape — `main_agent_variables` (sent to the agent under test as dynamic variables at call time) and `testing_agent_variables` (persona/context used by the simulated caller, not sent to the agent). Legacy flat dicts (no section keys) are still accepted and delivered to both sides for backward compatibility. Example: {\"main_agent_variables\": {\"user_id\": \"U-42\"}, \"testing_agent_variables\": {\"customer_name\": \"John Doe\"}}."
                     }
                 },
                 "required": [
@@ -68370,7 +68443,6 @@
             },
             "SchemaPostRunScenarios": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "agent_id": {
                         "type": "integer",
@@ -68619,7 +68691,6 @@
             },
             "SchemaPostScenario": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "agent": {
                         "type": [
@@ -68779,7 +68850,6 @@
             },
             "SchemaScenario": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -68974,16 +69044,15 @@
                             }
                         ],
                         "readOnly": true,
-                        "description": "\nDetails of the test profile associated with this scenario\nExample:\n```json\n{\n    \"id\": \"<integer>\",\n    \"agent_id\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"information\": {\n        \"user_name\": \"<string>\",\n        \"user_email\": \"<string>\",\n        \"order_id\": \"<string>\",\n    },\n}\n```\n"
+                        "description": "\nDetails of the test profile associated with this scenario. `information` uses the\nsectioned shape: `main_agent_variables` are sent to the agent under test as\ndynamic variables at call time; `testing_agent_variables` are persona/context\nused by Cekura's simulated caller. Legacy flat dicts (no section keys) still\nwork — at call time they are delivered to both sides for backward compatibility.\nExample:\n```json\n{\n    \"id\": \"<integer>\",\n    \"agent_id\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"information\": {\n        \"main_agent_variables\": {\n            \"user_id\": \"<string>\",\n            \"account_id\": \"<string>\"\n        },\n        \"testing_agent_variables\": {\n            \"user_name\": \"<string>\",\n            \"user_email\": \"<string>\",\n            \"order_id\": \"<string>\"\n        }\n    }\n}\n```\n"
                     },
                     "dynamic_variable_values": {
-                        "oneOf": [
-                            {},
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "description": "Generated values for the agent's dynamic variables for this scenario. Keys are variable names; values are the generated values."
+                        "readOnly": true,
+                        "description": "REMOVED FROM API. Reads return the historical value for legacy rows (`null` for new rows). Writes are no longer accepted — supplying a non-null value yields a 400 error. Put dynamic-variable values in `test_profile_data.information.main_agent_variables` instead: create the test profile via POST /test-profiles/ and attach it via the `test_profile` field on the scenario."
+                    },
+                    "generated_mock_tool_entries": {
+                        "readOnly": true,
+                        "description": "Expected mock tool calls generated for this evaluator during scenario auto-generation when the agent has mock tools attached. Each entry has shape {tool_id, tool_name, new_entry: {input, output}}."
                     },
                     "folder_path": {
                         "type": [


### PR DESCRIPTION
Auto-generated docs sync for backend PR [#9437](https://github.com/cekura-ai/vocera.backend/pull/9437).

Reviewers: @dileep-chagam, @cekurarsan

## Summary

**Spec/overlay:** Spec updated with documentation-only changes. 1 MCP operation modified: scenarios-generate-bg_2 (description clarified test profile sectioned shape — from 'default test profile' to 'scenario-specific test profile' with main_agent_variables/testing_agent_variables split). No schema changes. No overlay needed — the description update carries via spec regeneration.

**Conceptual docs:** Updated dynamic-variables.mdx to reflect that dynamic-variable values are now stored in test_profile.information.main_agent_variables (not in a separate dynamic_variable_values field, which is now read-only and serves as a legacy fallback). The page now documents the sectioned test profile shape as canonical: main_agent_variables (sent to the agent under test) vs testing_agent_variables (persona for the simulated caller). test-profile.mdx already accurately documented the sectioned shape in its 'Profile Sections' section, so no changes were needed there.

## Changes

- `openapi.json` — regenerate_from_backend
- `documentation/key-concepts/evaluators/dynamic-variables.mdx` — update

## Applied with notes

- documentation/key-concepts/evaluators/dynamic-variables.mdx: branch diverged from both main and prior skill output; left existing in place — human intervention needed

---
*Auto-generated from backend PR #9437.*

<!-- mcp-sync:file-hashes -->
```json
{}
```
<!-- /mcp-sync:file-hashes -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cekura-ai/docs/pull/681" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->