### PR TITLE
docs: explain Mock Tool Call Accuracy metric is transcript-based

### DIFF
--- a/documentation/integrations/custom-integration.mdx
+++ b/documentation/integrations/custom-integration.mdx
@@ -271,6 +271,59 @@ If your webhook integration isn't working as expected:
 - Check that phone numbers follow the correct format (+ followed by digits, max 15 chars)
 - Ensure `messages` is an array with dictionaries containing role and content fields
 
+## Mock Tools (optional)
+
+If your agent calls tools and you want to test it without hitting live third-party services, use [Mock Tools](/documentation/key-concepts/evaluators/mock-tools). With a custom integration there are two independent pieces — both are required for tool-based evaluation to work.
+
+### 1. Call the Cekura mock endpoint during the call
+
+Point the tool at its Cekura mock endpoint instead of the real service. During the call, your agent makes a normal HTTP request and gets back the mock output you configured.
+
+- **Method:** `POST`
+- **Body:** the tool's arguments as a flat JSON object — the same shape as the `input` in your mock configuration. For example, a tool whose mock entry is `{"input": {"user_id": 1}, ...}` is called with body `{"user_id": 1}`.
+- **Authentication:** include your `X-CEKURA-API-KEY` header. A missing or wrong key is the most common cause of a mock call failing.
+- The endpoint matches your request against the configured input/output mappings and returns the matching `output`.
+
+See the [Mock Tool API reference](/api-reference/test_framework/post-mock-tool) for the exact endpoint and request/response schema.
+
+### 2. Report the tool call in your transcript
+
+Calling the mock endpoint makes the tool *respond* correctly during the call, but it does **not** by itself tell Cekura's metrics that a tool was used. The [Mock Tool Call Accuracy](/documentation/key-concepts/evaluators/mock-tools#verifying-tool-calls-the-mock-tool-call-accuracy-metric) metric (and any tool-based metric) reads the **transcript** to determine what was called.
+
+So your webhook `messages` array must include a `function_call` message for each tool call, carrying the tool `name` and `arguments` in its `data` object:
+
+```json
+{
+  "role": "function_call",
+  "content": "",
+  "data": {
+    "id": "call_abc",
+    "name": "pre_call_lookup",
+    "arguments": {}
+  }
+}
+```
+
+Include the paired result as well (recommended):
+
+```json
+{
+  "role": "function_call_result",
+  "content": "",
+  "data": {
+    "id": "call_abc",
+    "name": "pre_call_lookup",
+    "result": { "account_id": "TEST-90210", "account_tier": "Premium" }
+  }
+}
+```
+
+<Warning>
+If you omit these `function_call` messages, the Mock Tool Call Accuracy metric will report the tool as **not called** and the result will fail — even when the tool was actually called and used correctly during the call. The mock endpoint being hit is not visible to the metric; only the transcript is.
+</Warning>
+
+A tool that takes no input must still send `"arguments": {}`. See [Transcript Format](/documentation/advanced/transcript-format) for a complete transcript example with function calls.
+
 ## Next Steps
 
 - Learn about [custom metrics](/documentation/key-concepts/metrics/custom-metrics)

--- a/documentation/integrations/elevenlabs/testing.mdx
+++ b/documentation/integrations/elevenlabs/testing.mdx
@@ -428,6 +428,12 @@ Poll for results using the [List Runs with IDs API](/api-reference/test_framewor
 </Tab>
 </Tabs>
 
+## Mock Tools (optional)
+
+If your ElevenLabs agent calls tools, you can test it without hitting live services using [Mock Tools](/documentation/key-concepts/evaluators/mock-tools). Use **Auto-Fetch** to pull your ElevenLabs tools and generate mock data, then enable the **Mock** toggle — Cekura updates the webhook tool URLs directly in your agent configuration and restores the originals when you disable the toggle.
+
+Tool calls made during a test are reported automatically as part of ElevenLabs' call data, so the [Mock Tool Call Accuracy](/documentation/key-concepts/evaluators/mock-tools#verifying-tool-calls-the-mock-tool-call-accuracy-metric) metric works out of the box — no transcript changes needed on your side.
+
 ## Next Steps
 
 - [Custom metrics](/documentation/key-concepts/metrics/custom-metrics)

--- a/documentation/integrations/elevenlabs/testing.mdx
+++ b/documentation/integrations/elevenlabs/testing.mdx
@@ -432,7 +432,7 @@ Poll for results using the [List Runs with IDs API](/api-reference/test_framewor
 
 If your ElevenLabs agent calls tools, you can test it without hitting live services using [Mock Tools](/documentation/key-concepts/evaluators/mock-tools). Use **Auto-Fetch** to pull your ElevenLabs tools and generate mock data, then enable the **Mock** toggle — Cekura updates the webhook tool URLs directly in your agent configuration and restores the originals when you disable the toggle.
 
-Tool calls made during a test are reported automatically as part of ElevenLabs' call data, so the [Mock Tool Call Accuracy](/documentation/key-concepts/evaluators/mock-tools#verifying-tool-calls-the-mock-tool-call-accuracy-metric) metric works out of the box — no transcript changes needed on your side.
+ElevenLabs' conversation data already includes the tool calls your agent made, and Cekura extracts those into the transcript automatically. So the [Mock Tool Call Accuracy](/documentation/key-concepts/evaluators/mock-tools#verifying-tool-calls-the-mock-tool-call-accuracy-metric) metric works out of the box — unlike a [custom integration](/documentation/integrations/custom-integration#mock-tools-optional), you don't assemble or send the transcript yourself.
 
 ## Next Steps
 

--- a/documentation/integrations/retell/testing.mdx
+++ b/documentation/integrations/retell/testing.mdx
@@ -231,6 +231,12 @@ To enable auto-sync, toggle on **Auto-sync Prompt** in the Retell voice integrat
 Auto-sync requires a valid Retell API Key and Assistant ID. If credentials become invalid or the assistant is deleted, auto-sync will automatically disable itself.
 </Note>
 
+## Mock Tools (optional)
+
+If your Retell agent calls tools, you can test it without hitting live services using [Mock Tools](/documentation/key-concepts/evaluators/mock-tools). Use **Auto-Fetch** to pull your Retell tools and generate mock data, then enable the **Mock** toggle — Cekura updates the tool URLs directly in your LLM/Flow configuration and restores the originals when you disable the toggle.
+
+Tool calls made during a test are reported automatically as part of Retell's call data, so the [Mock Tool Call Accuracy](/documentation/key-concepts/evaluators/mock-tools#verifying-tool-calls-the-mock-tool-call-accuracy-metric) metric works out of the box — no transcript changes needed on your side.
+
 ## Next Steps
 
 - Learn about [custom metrics](/documentation/key-concepts/metrics/custom-metrics)

--- a/documentation/integrations/retell/testing.mdx
+++ b/documentation/integrations/retell/testing.mdx
@@ -235,7 +235,7 @@ Auto-sync requires a valid Retell API Key and Assistant ID. If credentials becom
 
 If your Retell agent calls tools, you can test it without hitting live services using [Mock Tools](/documentation/key-concepts/evaluators/mock-tools). Use **Auto-Fetch** to pull your Retell tools and generate mock data, then enable the **Mock** toggle — Cekura updates the tool URLs directly in your LLM/Flow configuration and restores the originals when you disable the toggle.
 
-Tool calls made during a test are reported automatically as part of Retell's call data, so the [Mock Tool Call Accuracy](/documentation/key-concepts/evaluators/mock-tools#verifying-tool-calls-the-mock-tool-call-accuracy-metric) metric works out of the box — no transcript changes needed on your side.
+Retell's call data already includes the tool calls your agent made, and Cekura extracts those into the transcript automatically. So the [Mock Tool Call Accuracy](/documentation/key-concepts/evaluators/mock-tools#verifying-tool-calls-the-mock-tool-call-accuracy-metric) metric works out of the box — unlike a [custom integration](/documentation/integrations/custom-integration#mock-tools-optional), you don't assemble or send the transcript yourself.
 
 ## Next Steps
 

--- a/documentation/integrations/vapi/testing.mdx
+++ b/documentation/integrations/vapi/testing.mdx
@@ -207,7 +207,7 @@ Integrating your VAPI Assistant with Cekura unlocks powerful testing and observa
 
 If your VAPI agent calls tools, you can test it without hitting live services using [Mock Tools](/documentation/key-concepts/evaluators/mock-tools). Use **Auto-Fetch** to pull your VAPI tools and generate mock data, then enable the **Mock** toggle — Cekura creates cloned tools pointing at its mock endpoints (your original tools are preserved) and restores them when you disable the toggle.
 
-Tool calls made during a test are reported automatically as part of VAPI's call data, so the [Mock Tool Call Accuracy](/documentation/key-concepts/evaluators/mock-tools#verifying-tool-calls-the-mock-tool-call-accuracy-metric) metric works out of the box — no transcript changes needed on your side.
+VAPI's end-of-call report already includes the tool calls your agent made, and Cekura extracts those into the transcript automatically. So the [Mock Tool Call Accuracy](/documentation/key-concepts/evaluators/mock-tools#verifying-tool-calls-the-mock-tool-call-accuracy-metric) metric works out of the box — unlike a [custom integration](/documentation/integrations/custom-integration#mock-tools-optional), you don't assemble or send the transcript yourself.
 
 ## Next Steps
 

--- a/documentation/integrations/vapi/testing.mdx
+++ b/documentation/integrations/vapi/testing.mdx
@@ -203,6 +203,12 @@ Integrating your VAPI Assistant with Cekura unlocks powerful testing and observa
 
   </Accordion>
 
+## Mock Tools (optional)
+
+If your VAPI agent calls tools, you can test it without hitting live services using [Mock Tools](/documentation/key-concepts/evaluators/mock-tools). Use **Auto-Fetch** to pull your VAPI tools and generate mock data, then enable the **Mock** toggle — Cekura creates cloned tools pointing at its mock endpoints (your original tools are preserved) and restores them when you disable the toggle.
+
+Tool calls made during a test are reported automatically as part of VAPI's call data, so the [Mock Tool Call Accuracy](/documentation/key-concepts/evaluators/mock-tools#verifying-tool-calls-the-mock-tool-call-accuracy-metric) metric works out of the box — no transcript changes needed on your side.
+
 ## Next Steps
 
 - Learn about [custom metrics](/documentation/key-concepts/metrics/custom-metrics)

--- a/documentation/key-concepts/evaluators/mock-tools.mdx
+++ b/documentation/key-concepts/evaluators/mock-tools.mdx
@@ -244,6 +244,57 @@ To handle variable inputs reliably:
 - **Pin dynamic values in your evaluator instructions.** If a parameter like a date or appointment slot is completely open-ended, use [Test Profiles](/documentation/key-concepts/evaluators/test-profile) to fix the value: set `{{test_profile.appointment_date}}` in your evaluator scenario, and mock only for that pinned value. This makes both the mock matching and the evaluator assertion deterministic.
 - **Check the tool name matches exactly.** Any casing or underscore mismatch between the tool name in your mock config and the name in your provider (Retell LLM/Flow, VAPI, ElevenLabs) will silently prevent the mock from firing, regardless of the input.
 
+## Verifying Tool Calls: the Mock Tool Call Accuracy Metric
+
+The **Mock Tool Call Accuracy** metric checks whether your agent called the expected mock tools, with the expected inputs, during a run. Understanding how it detects tool calls is important — especially for custom and self-hosted integrations.
+
+### How the metric detects tool calls
+
+The metric reads the **run transcript** and looks only at entries whose role is `Function Call`:
+
+- **Called** — a `Function Call` entry with a matching tool `name` is present in the transcript.
+- **Correct input** — the `arguments` on that entry match one of the tool's expected inputs. Numeric and format variations are handled, and a tool whose expected input is `{}` matches any input.
+- The metric scores precision/recall across expected vs. actually-called vs. correctly-called tools (an F1-style score, 0–5). The explanation lists each tool as `called with correct input ✓`, `called but wrong input ✗`, or `not called ✗`.
+
+<Warning>
+Detection is **transcript-based**, not endpoint-based. A tool call that genuinely happened at runtime is still reported as **not called** if it is missing from the transcript Cekura evaluates. The mock endpoint returning the right data is not sufficient on its own — the function call must also appear in the transcript.
+</Warning>
+
+### Provider behavior
+
+- **VAPI, Retell, ElevenLabs (managed integrations):** function-call events are reported automatically as part of the call data, so `Function Call` entries appear in the transcript without extra work on your side.
+- **Custom / self-hosted integrations:** Cekura only knows what your webhook sends. You **must** include `function_call` (and ideally `function_call_result`) messages in the transcript you post — otherwise tool-based metrics have nothing to score against. See [Mock Tools with Custom Integration](/documentation/integrations/custom-integration#mock-tools-optional).
+
+### Required transcript shape
+
+Each tool call must be sent as a `function_call` message carrying the tool `name` and `arguments` in its `data` object. A tool that takes no input still needs `"arguments": {}`:
+
+```json
+{
+  "role": "function_call",
+  "data": {
+    "id": "call_abc",
+    "name": "pre_call_lookup",
+    "arguments": {}
+  }
+}
+```
+
+And, recommended, the paired result:
+
+```json
+{
+  "role": "function_call_result",
+  "data": {
+    "id": "call_abc",
+    "name": "pre_call_lookup",
+    "result": { "account_id": "TEST-90210", "account_tier": "Premium" }
+  }
+}
+```
+
+See [Transcript Format](/documentation/advanced/transcript-format) for a full transcript example including function calls.
+
 ## API Reference
 
 For programmatic access to mock tools:


### PR DESCRIPTION
## Why

A customer (custom integration) hit the mock tool endpoint successfully and the agent used the response correctly during the test, but the run was still marked **Failed** by the **Mock Tool Call Accuracy** metric. The reason: that metric detects tool calls from the **run transcript** (`Function Call` entries), not from whether the mock endpoint was hit. Their webhook transcript contained only the text turns and no `function_call` messages, so the metric reported `<tool>: not called ✗`.

Nothing in the docs connected the metric to this transcript requirement. This PR fixes that gap.

## Changes

**`documentation/key-concepts/evaluators/mock-tools.mdx`**
- New **"Verifying Tool Calls: the Mock Tool Call Accuracy Metric"** section: how the metric detects calls (transcript-based, `called` / correct-input, 0–5 score), a warning that a real runtime call still shows as "not called" if absent from the transcript, provider behavior, and the required `function_call` / `function_call_result` shape (incl. empty-input `"arguments": {}`).

**`documentation/integrations/custom-integration.mdx`**
- New **"Mock Tools (optional)"** section split into the two required pieces: (1) calling the Cekura mock endpoint during the call (flat JSON body, `X-CEKURA-API-KEY`), and (2) reporting the tool call in the transcript via `function_call` / `function_call_result`, with a warning about the silent-failure mode.

**`documentation/integrations/{vapi,retell,elevenlabs}/testing.mdx`**
- Short **"Mock Tools (optional)"** pointer on each provider's testing page. For these managed integrations, function calls are reported automatically, so Mock Tool Call Accuracy works **out of the box with no transcript changes** — the opposite of the manual step custom integration needs. Each notes the provider-specific Mock-toggle behavior (VAPI clones tools; Retell/ElevenLabs update URLs in place).

## Notes
- Public-safe per repo CLAUDE.md: only user-visible behavior (transcript roles, metric score/explanation) is described; no internal paths or service names. Example tool name is genericized.
- Cross-links between pages and to [Transcript Format] added; anchors verified. The `Function Call` Cekura format already existed on the Transcript Format page.

## Follow-ups (not in this PR)
- Backend: the mock endpoint returns `400 "Request body is required"` for a literally empty `{}` body, which conflicts with empty-input mock tools — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)