### PR TITLE
Harden MCP server: path-param encoding, CI injection, redaction, error/credential hygiene

### DIFF
--- a/.github/workflows/update-linear-status.yml
+++ b/.github/workflows/update-linear-status.yml
@@ -24,9 +24,10 @@ jobs:
           PREV_TAG=$(git describe --tags --abbrev=0 ${CURRENT_TAG}^ 2>/dev/null || echo "")
           COMMITS=$(git log --pretty=format:"%s" ${PREV_TAG}..${CURRENT_TAG})
 
-          echo "COMMITS<<EOF" >> $GITHUB_ENV
+          DELIM="EOF_$(openssl rand -hex 16)"
+          echo "COMMITS<<$DELIM" >> $GITHUB_ENV
           echo "$COMMITS" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
+          echo "$DELIM" >> $GITHUB_ENV
 
       - name: Collect active PR tickets
         id: tickets

--- a/cekura-mcp-server/http_client.py
+++ b/cekura-mcp-server/http_client.py
@@ -174,7 +174,7 @@ class CekuraAPIClient:
             raise Exception(f"Rate limit exceeded (429). Retry after: {retry_after}")
 
         if response.status_code >= 500:
-            raise Exception(f"Server error ({response.status_code}): {response.text[:200]}")
+            raise Exception(f"Server error ({response.status_code}). The service failed to process the request; please retry.")
 
         try:
             error_detail = response.json()

--- a/cekura-mcp-server/openapi_mcp_server.py
+++ b/cekura-mcp-server/openapi_mcp_server.py
@@ -75,7 +75,7 @@ MCP_SERVER_URL = os.environ.get("MCP_SERVER_URL", "https://api.cekura.ai/mcp")
 OAUTH_EXP_SKEW_SECONDS = 10
 
 # Derive allowed hosts from MCP_ISSUER_URL and MCP_SERVER_URL (covers prod, ngrok, local).
-from urllib.parse import urlparse as _urlparse
+from urllib.parse import quote as _quote, urlparse as _urlparse
 
 _issuer_host = _urlparse(MCP_ISSUER_URL).netloc
 _server_host = _urlparse(MCP_SERVER_URL).netloc
@@ -395,6 +395,8 @@ _escalation_history: Dict[Tuple[str, str], List[float]] = {}
 
 _PII_PATTERNS: Tuple[Tuple[re.Pattern, str], ...] = (
     (re.compile(r"[\w.+-]+@[\w-]+\.[\w.-]+"), "[email]"),
+    (re.compile(r"\b\d{3}-\d{2}-\d{4}\b"), "[ssn]"),
+    (re.compile(r"\b(?:\d[ -]?){13,16}\b"), "[card]"),
     (re.compile(r"\+?\d[\d\s().-]{7,}\d"), "[phone]"),
     (re.compile(r"\b(?:sk|pk|api)[-_][A-Za-z0-9]{8,}\b"), "[token]"),
     (re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._\-]+"), "[bearer]"),
@@ -801,7 +803,7 @@ def _dispatch_args(op, arguments: Dict[str, Any]) -> Tuple[str, Dict[str, Any], 
         if value is None:
             continue
         if key in path_param_names:
-            resolved_path = resolved_path.replace(f"{{{key}}}", str(value))
+            resolved_path = resolved_path.replace(f"{{{key}}}", _quote(str(value), safe=""))
         elif key in query_param_names:
             query_args[key] = value
         elif has_body:
@@ -949,78 +951,84 @@ def main():
             if path in NO_AUTH_PATHS:
                 return await call_next(request)
 
-            # Bearer token — OAuth web users or agent/CLI JWT passthrough
-            has_bearer = False
-            auth_header = request.headers.get('Authorization') or request.headers.get('authorization')
-            if auth_header and auth_header.lower().startswith('bearer '):
-                token = auth_header[7:]
-                request_bearer_token.set(token)
-                has_bearer = True
-                logger.debug("Bearer token credential set for request")
+            reset_tokens: List[Tuple[ContextVar, Any]] = []
+            try:
+                # Bearer token — OAuth web users or agent/CLI JWT passthrough
+                has_bearer = False
+                auth_header = request.headers.get('Authorization') or request.headers.get('authorization')
+                if auth_header and auth_header.lower().startswith('bearer '):
+                    token = auth_header[7:]
+                    reset_tokens.append((request_bearer_token, request_bearer_token.set(token)))
+                    has_bearer = True
 
-                # Short-circuit expired oauth_access JWTs with 401 +
-                # WWW-Authenticate so the MCP client refreshes the token.
-                # Signature validation stays the backend's job.
-                try:
-                    claims = jwt.decode(token, options={"verify_signature": False})
-                except jwt.PyJWTError:
-                    claims = None
-                if claims and claims.get("type") == "oauth_access":
-                    exp = claims.get("exp")
-                    if isinstance(exp, (int, float)) and exp < time.time() - OAUTH_EXP_SKEW_SECONDS:
-                        return JSONResponse(
-                            {"error": "invalid_token",
-                             "error_description": "OAuth access token expired"},
-                            status_code=401,
-                            headers={"WWW-Authenticate": WWW_AUTH_HEADER},
-                        )
+                    # Short-circuit expired oauth_access JWTs with 401 +
+                    # WWW-Authenticate so the MCP client refreshes the token.
+                    # Signature validation stays the backend's job.
+                    try:
+                        claims = jwt.decode(token, options={"verify_signature": False})
+                    except jwt.PyJWTError:
+                        claims = None
+                    if claims and claims.get("type") == "oauth_access":
+                        exp = claims.get("exp")
+                        if isinstance(exp, (int, float)) and exp < time.time() - OAUTH_EXP_SKEW_SECONDS:
+                            return JSONResponse(
+                                {"error": "invalid_token",
+                                 "error_description": "OAuth access token expired"},
+                                status_code=401,
+                                headers={"WWW-Authenticate": WWW_AUTH_HEADER},
+                            )
 
-            # API key header — legacy mcp-remote / Claude Desktop
-            has_api_key = False
-            api_key = request.headers.get('X-CEKURA-API-KEY') or request.headers.get('x-cekura-api-key')
-            if api_key:
-                request_api_key.set(api_key)
-                has_api_key = True
-                logger.debug("API key credential set for request")
+                # API key header — legacy mcp-remote / Claude Desktop
+                has_api_key = False
+                api_key = request.headers.get('X-CEKURA-API-KEY') or request.headers.get('x-cekura-api-key')
+                if api_key:
+                    reset_tokens.append((request_api_key, request_api_key.set(api_key)))
+                    has_api_key = True
 
-            # Base URL override — only honoured when ALLOW_BASE_URL_OVERRIDE=true (dev/staging)
-            if _ALLOW_BASE_URL_OVERRIDE:
-                base_url_override = request.headers.get('X-CEKURA-BASE-URL') or request.headers.get('x-cekura-base-url')
-                if base_url_override:
-                    request_base_url.set(base_url_override.rstrip("/"))
+                # Base URL override — only honoured when ALLOW_BASE_URL_OVERRIDE=true (dev/staging)
+                if _ALLOW_BASE_URL_OVERRIDE:
+                    base_url_override = request.headers.get('X-CEKURA-BASE-URL') or request.headers.get('x-cekura-base-url')
+                    if base_url_override:
+                        request_base_url.set(base_url_override.rstrip("/"))
 
-            # Connection-level conversation identifier (e.g. set by the Cekura
-            # sandbox at sandbox start). Per-call ``_meta`` overrides this.
-            conversation_header = (
-                request.headers.get('X-Cekura-Conversation-Id')
-                or request.headers.get('x-cekura-conversation-id')
-            )
-            if conversation_header:
-                request_conversation_id.set(conversation_header)
-
-            # MCP protocol session identifier (issued on `initialize`).
-            mcp_session_header = (
-                request.headers.get('Mcp-Session-Id')
-                or request.headers.get('mcp-session-id')
-            )
-            if mcp_session_header:
-                request_mcp_session_id.set(mcp_session_header)
-
-            # Enforce auth at the transport layer for MCP traffic. Without this,
-            # FastMCP's `initialize` and `tools/list` succeed unauthenticated,
-            # which makes Claude Desktop's connector flow conclude "no auth
-            # required" and skip the OAuth handshake entirely.
-            if path.startswith("/mcp") and not has_bearer and not has_api_key:
-                return JSONResponse(
-                    {
-                        "error": "unauthorized",
-                        "error_description": "Authenticate via OAuth (Bearer) or X-CEKURA-API-KEY",
-                    },
-                    status_code=401,
-                    headers={"WWW-Authenticate": WWW_AUTH_HEADER},
+                # Connection-level conversation identifier (e.g. set by the Cekura
+                # sandbox at sandbox start). Per-call ``_meta`` overrides this.
+                conversation_header = (
+                    request.headers.get('X-Cekura-Conversation-Id')
+                    or request.headers.get('x-cekura-conversation-id')
                 )
+                if conversation_header:
+                    reset_tokens.append((request_conversation_id, request_conversation_id.set(conversation_header)))
 
-            return await call_next(request)
+                # MCP protocol session identifier (issued on `initialize`).
+                mcp_session_header = (
+                    request.headers.get('Mcp-Session-Id')
+                    or request.headers.get('mcp-session-id')
+                )
+                if mcp_session_header:
+                    reset_tokens.append((request_mcp_session_id, request_mcp_session_id.set(mcp_session_header)))
+
+                # Enforce auth at the transport layer for MCP traffic. Without this,
+                # FastMCP's `initialize` and `tools/list` succeed unauthenticated,
+                # which makes Claude Desktop's connector flow conclude "no auth
+                # required" and skip the OAuth handshake entirely.
+                if path.startswith("/mcp") and not has_bearer and not has_api_key:
+                    return JSONResponse(
+                        {
+                            "error": "unauthorized",
+                            "error_description": "Authenticate via OAuth (Bearer) or X-CEKURA-API-KEY",
+                        },
+                        status_code=401,
+                        headers={"WWW-Authenticate": WWW_AUTH_HEADER},
+                    )
+
+                return await call_next(request)
+            finally:
+                for var, tok in reversed(reset_tokens):
+                    try:
+                        var.reset(tok)
+                    except (ValueError, LookupError):
+                        pass
 
     async def health_check(request):
         return JSONResponse({


### PR DESCRIPTION
## Summary

Addresses a security review of the MCP server and release workflow. **5 findings fixed** here; 2 dismissed as non-issues; **1 (the confused-deputy on `/mcp/monitoring/sessions`) intentionally left out** pending a decision (see below).

## Fixed in this PR

| Finding | File | Change |
|---|---|---|
| **Path-param injection → allowlist bypass** | `openapi_mcp_server.py` | URL-encode path params with `quote(safe="")`. A value with `/`, `?`, or `..` can no longer escape the tool's mapped endpoint to reach a non-exposed/blocked endpoint of the same method. Backend authz always applied; this restores the registration-time MCP allowlist as a real gate. |
| **GitHub Actions env-injection** | `update-linear-status.yml` | Random heredoc delimiter (`EOF_$(openssl rand -hex 16)`). A commit message body equal to `EOF` can no longer terminate the block early and inject attacker-controlled vars into `$GITHUB_ENV`. |
| **ContextVar credential hygiene** | `openapi_mcp_server.py` | Request credentials are now set with reset tokens cleared in a `finally`, eliminating any possible cross-request bleed of a bearer/api-key. |
| **Incomplete PII redaction** | `openapi_mcp_server.py` | Added `[ssn]` and `[card]` patterns to the telemetry redactor. |
| **Upstream error leakage** | `http_client.py` | 5xx responses now return a generic message instead of echoing the raw upstream body to the model. (4xx detail stays, already bounded to 200 chars — it's the caller's own validation error.) |

## Dismissed (no change)

- **Gate checks credential presence, not validity** — fine for the dynamic API tools: the backend re-validates every forwarded key. Its only real impact was via the monitoring endpoint below.
- **`X-CEKURA-BASE-URL` SSRF** — correctly gated behind `ALLOW_BASE_URL_OVERRIDE`, which is not enabled in the prod task def.
- **Trusting Mintlify docs-search response** — first-party, low risk; accepted.

## Open — needs a decision (NOT in this PR)

**Confused deputy on `/mcp/monitoring/sessions`:** the endpoint only checks that *some* API-key header is present (not that it's valid), then writes the caller-supplied transcript as a CallLog using the server's own `CEKURA_OBSERVE_API_KEY` into the agent named by `CEKURA_OBSERVE_AGENT_ID`. So anyone who can reach it can inject arbitrary CallLogs into that configured agent under our master key. **Confirmed reproducible locally** (a garbage key passes auth and reaches the privileged handler; only the missing local `CEKURA_OBSERVE_AGENT_ID` stops the write).

The fix depends on two things to confirm first:
1. What credential does the Claude Code Stop-hook actually send to this endpoint? (user's real key → use the caller's credential for the write; shared key → require it to equal `CEKURA_OBSERVE_API_KEY`.)
2. Are `CEKURA_OBSERVE_AGENT_ID` / `CEKURA_OBSERVE_API_KEY` set in the prod secret? (Determines whether this is live or dormant today.)

## Testing

- Full test suite: dispatch / http_client / overlays gates pass (46/46 targeted). The only failures are 6 pre-existing `.env`-contaminated `test_config` / `test_tool_generator` tests, unrelated to this change (verified identical with the changes stashed).
- Live MCP regression on the running server (new code): tool listing (160 tools), authenticated `aiagents_retrieve`/`aiagents_list` (proves credential propagation through the new reset-token middleware), path routing, and the redaction path — all working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)