### PR TITLE
docs(guides): reorganize Guides into 4 sections

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -108,9 +108,6 @@
     {
       "group": "Guides",
       "pages": [
-        "documentation/guides/cekura-agent",
-        "documentation/guides/creating-good-metric",
-        "documentation/guides/optimise-prompt",
         {
           "group": "Testing",
           "icon": "flask",
@@ -118,6 +115,7 @@
             "documentation/guides/testing-agents/overview",
             "documentation/guides/testing-agents/infrastructure-suite",
             "documentation/guides/testing-agents/suggested-testing-approach",
+            "documentation/guides/organizing-projects",
             "documentation/guides/testing-agents/knowledge-base-testing",
             "documentation/guides/testing-agents/inbound-auto-call",
             "documentation/guides/testing-agents/outbound-evaluators",
@@ -129,10 +127,13 @@
             "documentation/guides/testing-agents/tool-call-testing",
             "documentation/guides/testing-agents/sms-during-call",
             "documentation/guides/testing-agents/whatsapp-testing",
-            "documentation/guides/testing-agents/dtmf-testing"
+            "documentation/guides/testing-agents/dtmf-testing",
+            "documentation/red-teaming/multi-turn",
+            "documentation/guides/prompting",
+            "documentation/guides/github-actions-ci-cd",
+            "documentation/guides/cronjob"
           ]
         },
-        "documentation/red-teaming/multi-turn",
         {
           "group": "Observability",
           "icon": "square-poll-vertical",
@@ -146,15 +147,21 @@
             "documentation/guides/dashboards"
           ]
         },
-        "documentation/guides/organizing-projects",
-        "documentation/guides/github-actions-ci-cd",
-        "documentation/guides/cronjob",
-        "documentation/guides/auto-optimise-metrics-schedule",
-        "documentation/guides/prompting",
         {
-          "group": "Agent Integration",
+          "group": "Self-Improve Loop",
+          "icon": "wand-magic-sparkles",
+          "pages": [
+            "documentation/guides/creating-good-metric",
+            "documentation/guides/metric-lab",
+            "documentation/guides/optimise-prompt",
+            "documentation/guides/auto-optimise-metrics-schedule"
+          ]
+        },
+        {
+          "group": "Cekura for Agents",
           "icon": "robot",
           "pages": [
+            "documentation/guides/cekura-agent",
             "documentation/guides/agent-integration",
             "documentation/guides/agents-md-template"
           ]

--- a/mint.json
+++ b/mint.json
@@ -109,7 +109,6 @@
       "group": "Guides",
       "pages": [
         "documentation/guides/organizing-projects",
-        "documentation/guides/prompting",
         {
           "group": "Testing",
           "icon": "flask",
@@ -516,6 +515,7 @@
         "documentation/advanced/knowledge-base-connectors",
         "documentation/advanced/ivr-voicemail",
         "documentation/advanced/call-end-reasons",
+        "documentation/guides/prompting",
         {
           "group": "Dashboard Embedding",
           "icon": "diagram-project",

--- a/mint.json
+++ b/mint.json
@@ -108,6 +108,8 @@
     {
       "group": "Guides",
       "pages": [
+        "documentation/guides/organizing-projects",
+        "documentation/guides/prompting",
         {
           "group": "Testing",
           "icon": "flask",
@@ -115,7 +117,6 @@
             "documentation/guides/testing-agents/overview",
             "documentation/guides/testing-agents/infrastructure-suite",
             "documentation/guides/testing-agents/suggested-testing-approach",
-            "documentation/guides/organizing-projects",
             "documentation/guides/testing-agents/knowledge-base-testing",
             "documentation/guides/testing-agents/inbound-auto-call",
             "documentation/guides/testing-agents/outbound-evaluators",
@@ -129,7 +130,6 @@
             "documentation/guides/testing-agents/whatsapp-testing",
             "documentation/guides/testing-agents/dtmf-testing",
             "documentation/red-teaming/multi-turn",
-            "documentation/guides/prompting",
             "documentation/guides/github-actions-ci-cd",
             "documentation/guides/cronjob"
           ]

--- a/mint.json
+++ b/mint.json
@@ -147,13 +147,19 @@
           ]
         },
         {
-          "group": "Self-Improve Loop",
-          "icon": "wand-magic-sparkles",
+          "group": "Metrics",
+          "icon": "chart-line",
           "pages": [
             "documentation/guides/creating-good-metric",
             "documentation/guides/metric-lab",
-            "documentation/guides/optimise-prompt",
             "documentation/guides/auto-optimise-metrics-schedule"
+          ]
+        },
+        {
+          "group": "Self-Improve Loop",
+          "icon": "wand-magic-sparkles",
+          "pages": [
+            "documentation/guides/optimise-prompt"
           ]
         },
         {

--- a/mint.json
+++ b/mint.json
@@ -78,7 +78,15 @@
             "documentation/key-concepts/evaluators/personality",
             "documentation/key-concepts/evaluators/test-profile",
             "documentation/key-concepts/evaluators/mock-tools",
-            "documentation/key-concepts/evaluators/dynamic-variables"
+            "documentation/key-concepts/evaluators/dynamic-variables",
+            {
+              "group": "Phone Numbers",
+              "icon": "phone",
+              "pages": [
+                "documentation/key-concepts/phone-numbers/twilio",
+                "documentation/key-concepts/phone-numbers/plivo"
+              ]
+            }
           ]
         },
         {
@@ -93,14 +101,6 @@
             "documentation/key-concepts/metrics/python-metric",
             "documentation/key-concepts/metrics/rubric",
             "documentation/key-concepts/metrics/sampling"
-          ]
-        },
-        {
-          "group": "Phone Numbers",
-          "icon": "phone",
-          "pages": [
-            "documentation/key-concepts/phone-numbers/twilio",
-            "documentation/key-concepts/phone-numbers/plivo"
           ]
         }
       ]


### PR DESCRIPTION
## What changed

Reorganized the **Guides** sidebar in `mint.json` into exactly 4 subsections, distributing all guide pages (nothing left loose at the top level):

| Section | Pages |
|---|---|
| **Testing** | All `testing-agents/*` + `red-teaming/multi-turn`, `prompting`, `organizing-projects`, `github-actions-ci-cd`, `cronjob` |
| **Observability** | All `observability/*` + `dashboards` |
| **Self-Improve Loop** *(new)* | `creating-good-metric`, `metric-lab`, `optimise-prompt`, `auto-optimise-metrics-schedule` |
| **Cekura for Agents** *(renamed from "Agent Integration")* | `cekura-agent`, `agent-integration`, `agents-md-template` |

## Why

Flatten the previously mixed list of loose pages + sub-groups into a consistent 4-section structure. Testing and Observability already existed; Self-Improve Loop and Cekura for Agents are new.

## Reviewer notes

- **`metric-lab`** was previously missing from the nav despite being linked from 4+ other guides — it's now surfaced under Self-Improve Loop.
- Judgment calls worth a look: `prompting` + `organizing-projects` placed under Testing; `github-actions-ci-cd` / `cronjob` under Testing (CI + scheduled test runs); `creating-good-metric` under Self-Improve Loop.
- No page content changed — nav-only. `mint.json` validated as well-formed JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)