### PR TITLE
fix(mcp): seamless OAuth across token refresh and restarts — per-request credentials + stateless streamable HTTP

### DIFF
--- a/cekura-mcp-server/http_client.py
+++ b/cekura-mcp-server/http_client.py
@@ -15,7 +15,6 @@ class CekuraAPIClient:
         mcp_tool: Optional[str] = None,
         mcp_skill: Optional[str] = None,
         conversation_id: Optional[str] = None,
-        mcp_session_id: Optional[str] = None,
     ):
         self.base_url = base_url
         self.credential_type = credential_type
@@ -32,7 +31,6 @@ class CekuraAPIClient:
                 ("X-MCP-Tool", mcp_tool),
                 ("X-MCP-Skill", mcp_skill),
                 ("X-Cekura-Conversation-Id", conversation_id),
-                ("X-MCP-Session-Id", mcp_session_id),
             )
             if value
         }
@@ -193,7 +191,6 @@ def create_client(
     mcp_tool: Optional[str] = None,
     mcp_skill: Optional[str] = None,
     conversation_id: Optional[str] = None,
-    mcp_session_id: Optional[str] = None,
 ) -> CekuraAPIClient:
     return CekuraAPIClient(
         base_url,
@@ -205,5 +202,4 @@ def create_client(
         mcp_tool=mcp_tool,
         mcp_skill=mcp_skill,
         conversation_id=conversation_id,
-        mcp_session_id=mcp_session_id,
     )

--- a/cekura-mcp-server/openapi_mcp_server.py
+++ b/cekura-mcp-server/openapi_mcp_server.py
@@ -60,11 +60,6 @@ request_base_url: ContextVar[str] = ContextVar('request_base_url', default=None)
 # wires its conversation_id here). Per-call `_meta["com.cekura/conversation_id"]`
 # wins when both are present.
 request_conversation_id: ContextVar[str] = ContextVar('request_conversation_id', default=None)
-# MCP streamable-http session id (``Mcp-Session-Id``). Captured so external
-# analytics can group an external client's tool calls into a chat session
-# without relying on a per-call conversation id.
-request_mcp_session_id: ContextVar[str] = ContextVar('request_mcp_session_id', default=None)
-
 # X-CEKURA-BASE-URL override is only allowed when explicitly enabled (dev/staging only)
 _ALLOW_BASE_URL_OVERRIDE = os.environ.get("ALLOW_BASE_URL_OVERRIDE", "").lower() in ("1", "true", "yes")
 
@@ -101,7 +96,10 @@ transport_security = TransportSecuritySettings(
     allowed_hosts=_allowed_hosts,
 )
 
-mcp = FastMCP("Cekura API", transport_security=transport_security)
+# Stateless: every request is self-contained, so restarts/redeploys and
+# horizontal scaling don't invalidate client sessions, and per-request
+# credentials always apply (no session-task contextvar snapshots).
+mcp = FastMCP("Cekura API", transport_security=transport_security, stateless_http=True)
 
 server_config = None
 openapi_parser = None
@@ -729,7 +727,10 @@ def get_request_credential() -> tuple[str, str]:
 def _resolve_client_identifier() -> str:
     """Best-effort client identifier from the active request context.
 
-    Falls back to ``unknown`` when the context isn't available (e.g. unit tests).
+    Prefers ``clientInfo`` from the MCP ``initialize`` params; in stateless
+    mode tool calls run in sessions that never saw ``initialize``, so fall
+    back to the HTTP ``User-Agent`` header. ``unknown`` when neither is
+    available (e.g. unit tests).
     """
     try:
         # `request_context` is a property that returns the current RequestContext
@@ -738,11 +739,16 @@ def _resolve_client_identifier() -> str:
         session = getattr(req_ctx, "session", None)
         params = getattr(session, "client_params", None) if session else None
         ci = getattr(params, "clientInfo", None) if params else None
-        if ci is None:
-            return "unknown"
-        name = getattr(ci, "name", None) or "unknown"
-        version = getattr(ci, "version", None) or "unknown"
-        return f"{name}/{version}"
+        if ci is not None:
+            name = getattr(ci, "name", None) or "unknown"
+            version = getattr(ci, "version", None) or "unknown"
+            return f"{name}/{version}"
+        headers = getattr(getattr(req_ctx, "request", None), "headers", None)
+        if headers is not None:
+            user_agent = headers.get("User-Agent") or headers.get("user-agent")
+            if user_agent:
+                return user_agent[:80]
+        return "unknown"
     except (LookupError, AttributeError):
         return "unknown"
 
@@ -784,13 +790,11 @@ def _resolve_telemetry() -> Dict[str, Optional[str]]:
     meta = _read_request_meta()
     skill = meta.get("com.cekura/skill")
     conversation_id = meta.get("com.cekura/conversation_id") or request_conversation_id.get()
-    mcp_session_id = request_mcp_session_id.get()
     return {
         "call_id": f"call_{uuid.uuid4().hex[:16]}",
         "client_id": _resolve_client_identifier(),
         "skill": skill if isinstance(skill, str) and skill else None,
         "conversation_id": conversation_id if isinstance(conversation_id, str) and conversation_id else None,
-        "mcp_session_id": mcp_session_id if isinstance(mcp_session_id, str) and mcp_session_id else None,
     }
 
 
@@ -890,7 +894,6 @@ def setup_dynamic_tool_handlers():
                 mcp_tool=name,
                 mcp_skill=telemetry["skill"],
                 conversation_id=telemetry["conversation_id"],
-                mcp_session_id=telemetry["mcp_session_id"],
             )
 
             # Forward the resolved per-property types so the HTTP client can respect
@@ -1019,14 +1022,6 @@ def main():
                 )
                 if conversation_header:
                     reset_tokens.append((request_conversation_id, request_conversation_id.set(conversation_header)))
-
-                # MCP protocol session identifier (issued on `initialize`).
-                mcp_session_header = (
-                    request.headers.get('Mcp-Session-Id')
-                    or request.headers.get('mcp-session-id')
-                )
-                if mcp_session_header:
-                    reset_tokens.append((request_mcp_session_id, request_mcp_session_id.set(mcp_session_header)))
 
                 # Enforce auth at the transport layer for MCP traffic. Without this,
                 # FastMCP's `initialize` and `tools/list` succeed unauthenticated,

--- a/cekura-mcp-server/openapi_mcp_server.py
+++ b/cekura-mcp-server/openapi_mcp_server.py
@@ -693,7 +693,27 @@ def _claude_jsonl_to_cekura_transcript(jsonl_text: str) -> List[Dict[str, object
 
 
 def get_request_credential() -> tuple[str, str]:
-    """Return (credential, type) from request context. Type is 'bearer' or 'api_key'."""
+    """Return (credential, type) from request context. Type is 'bearer' or 'api_key'.
+
+    Reads the headers of the HTTP request that delivered the current MCP
+    message. The session task's contextvars are snapshotted at session
+    creation, so a token refreshed mid-session would never reach handlers
+    through them; the contextvars remain only as a fallback for contexts
+    without an MCP request (e.g. unit tests).
+    """
+    headers = None
+    try:
+        req = mcp._mcp_server.request_context.request
+        headers = getattr(req, "headers", None)
+    except LookupError:
+        pass
+    if headers is not None:
+        auth = headers.get('Authorization') or headers.get('authorization')
+        if auth and auth.lower().startswith('bearer '):
+            return auth[7:], "bearer"
+        api_key = headers.get('X-CEKURA-API-KEY') or headers.get('x-cekura-api-key')
+        if api_key:
+            return api_key, "api_key"
     bearer = request_bearer_token.get()
     if bearer:
         return bearer, "bearer"

--- a/cekura-mcp-server/tests/test_request_credentials.py
+++ b/cekura-mcp-server/tests/test_request_credentials.py
@@ -1,0 +1,88 @@
+"""Tests for per-request credential resolution in tool handlers.
+
+Regression coverage for the session-staleness bug: in stateful streamable-HTTP
+mode the session task's contextvars are snapshotted when the session is
+created, so a bearer token refreshed mid-session never reaches tool handlers
+via the contextvar — handlers must read credentials from the HTTP request
+that delivered the current MCP message.
+"""
+import pytest
+
+import openapi_mcp_server as srv
+from mcp.server.lowlevel.server import request_ctx
+
+
+class _FakeRequest:
+    def __init__(self, headers):
+        self.headers = headers
+
+
+class _FakeRequestContext:
+    def __init__(self, request):
+        self.request = request
+
+
+@pytest.fixture
+def mcp_request(monkeypatch):
+    """Install a fake MCP request context carrying the given HTTP headers."""
+    tokens = []
+
+    def _install(headers):
+        ctx = _FakeRequestContext(_FakeRequest(headers) if headers is not None else None)
+        tokens.append(request_ctx.set(ctx))
+        return ctx
+
+    yield _install
+    for token in tokens:
+        request_ctx.reset(token)
+
+
+class TestGetRequestCredential:
+    def test_uses_current_request_token_over_session_snapshot(self, mcp_request):
+        # Session task captured the initialize-time token in the contextvar;
+        # the POST that delivered this tool call carries a refreshed token.
+        srv.request_bearer_token.set("stale-initialize-token")
+        mcp_request({"authorization": "Bearer fresh-refreshed-token"})
+
+        credential, credential_type = srv.get_request_credential()
+
+        assert credential_type == "bearer"
+        assert credential == "fresh-refreshed-token"
+
+    def test_uses_current_request_api_key_over_session_snapshot(self, mcp_request):
+        srv.request_api_key.set("stale-api-key")
+        srv.request_bearer_token.set(None)
+        mcp_request({"x-cekura-api-key": "fresh-api-key"})
+
+        credential, credential_type = srv.get_request_credential()
+
+        assert credential_type == "api_key"
+        assert credential == "fresh-api-key"
+
+    def test_falls_back_to_contextvar_without_mcp_request_context(self):
+        # Outside an MCP message (no request context set) the contextvar
+        # fallback must keep working.
+        srv.request_bearer_token.set("contextvar-token")
+
+        credential, credential_type = srv.get_request_credential()
+
+        assert credential_type == "bearer"
+        assert credential == "contextvar-token"
+
+    def test_falls_back_to_contextvar_when_request_has_no_credentials(self, mcp_request):
+        # e.g. a transport that doesn't attach an HTTP request to the message.
+        srv.request_bearer_token.set("contextvar-token")
+        mcp_request(None)
+
+        credential, credential_type = srv.get_request_credential()
+
+        assert credential_type == "bearer"
+        assert credential == "contextvar-token"
+
+    def test_raises_without_any_credential(self, mcp_request):
+        srv.request_bearer_token.set(None)
+        srv.request_api_key.set(None)
+        mcp_request({})
+
+        with pytest.raises(ValueError):
+            srv.get_request_credential()

--- a/cekura-mcp-server/tests/test_request_credentials.py
+++ b/cekura-mcp-server/tests/test_request_credentials.py
@@ -86,3 +86,16 @@ class TestGetRequestCredential:
 
         with pytest.raises(ValueError):
             srv.get_request_credential()
+
+
+class TestResolveClientIdentifier:
+    def test_falls_back_to_user_agent_without_initialize_session(self, mcp_request):
+        # Stateless mode: tool calls run in sessions that never saw
+        # `initialize`, so clientInfo is unavailable and the HTTP
+        # User-Agent header is the best client signal.
+        mcp_request({"user-agent": "claude-code/2.1.139"})
+
+        assert srv._resolve_client_identifier() == "claude-code/2.1.139"
+
+    def test_unknown_without_request_context(self):
+        assert srv._resolve_client_identifier() == "unknown"


### PR DESCRIPTION
## Problem

Stateful streamable-HTTP MCP sessions pinned per-connection state inside a long-lived in-process task:

1. **Stale credentials**: the session task snapshotted contextvars at `initialize`, so tool handlers reused the initialize-time bearer token forever. After the 1h access-token TTL, every call failed with `Authentication failed (401). Bearer token rejected — … Re-authenticate and retry.` even when the client had silently refreshed — until the user re-authenticated interactively.
2. **Session loss on deploy**: sessions lived in process memory, so every deploy/restart 404'd all live sessions (prod escalation: `metrics_create` → "Session not found" across 7+ consecutive attempts, 9 minutes after a deploy). Scaling past one replica would break sessions randomly.

## Fix

- `get_request_credential()` resolves `Authorization` / `X-CEKURA-API-KEY` from the HTTP request that delivered the current MCP message (`request_context.request`), with the contextvars kept only as a fallback outside a request context.
- `FastMCP(..., stateless_http=True)`: every request is self-contained — restarts, redeploys, and horizontal scaling are seamless, and the contextvar-snapshot bug class is structurally gone.
- Cleanup: removed dead `Mcp-Session-Id` plumbing (contextvar, telemetry field, `X-MCP-Session-Id` forwarding — no session ids exist anymore; the backend analytics column just stays null; `X-Cekura-Conversation-Id` remains the grouping signal). `client_id` telemetry falls back to `User-Agent`, since stateless tool calls never see initialize-time `clientInfo`.

## Auth-flow coverage (E2E, 25/25 ✅)

Run against the local dockerized backend with real backend-signed JWTs (token A = 30s TTL, token B = 1h, expired = −60s). Matrix script: `e2e_auth_matrix.py` (notes repo-script).

### MCP server — OAuth bearer

| # | Flow | Expected | Result |
|---|------|----------|--------|
| 1 | `initialize` with valid bearer | 200 | ✅ |
| 2 | Stateless semantics: no `Mcp-Session-Id` issued | header absent | ✅ |
| 3 | Bare `tools/call`, valid bearer, no prior `initialize` on the serving task | 200 + data | ✅ |
| 4 | `tools/list` with valid bearer | full registry (159 tools) | ✅ |
| 5 | **Server restarted mid-conversation**, same token, no re-init/re-auth | 200 + data | ✅ |
| 6 | `initialize` with short-TTL token A | 200 | ✅ |
| 7 | `tools/call` with token A while fresh | 200 + data | ✅ |
| 8 | **Token A expired → `tools/call` with refreshed token B** (the original bug) | 200 + data | ✅ |
| 9 | Expired bearer (past 10s skew) | transport **401** | ✅ |
| 10 | Expired bearer → `WWW-Authenticate` header (client auto-refresh trigger) | present, RFC 9728 `resource_metadata` | ✅ |
| 11 | Garbage (non-JWT) bearer | tool error "Bearer token rejected" | ✅ |

### MCP server — API key & no auth

| # | Flow | Expected | Result |
|---|------|----------|--------|
| 12 | No credentials on `POST /mcp` | 401 + `WWW-Authenticate` | ✅ |
| 13 | `initialize` with valid `X-CEKURA-API-KEY` | 200 | ✅ |
| 14 | `tools/call` with valid API key | 200 + data | ✅ |
| 15 | Wrong API key | tool error "API key rejected" | ✅ |

### MCP server — discovery & SSE channel

| # | Flow | Expected | Result |
|---|------|----------|--------|
| 16 | `GET /mcp/.well-known/oauth-protected-resource`, unauthenticated | 200 | ✅ |
| 17 | `GET /mcp/.well-known/oauth-authorization-server` | 200, advertises `/user/oauth/token` | ✅ |
| 18 | Discovery with API-key header (suppression for API-key clients) | 404 | ✅ |
| 19 | `GET /mcp` (SSE listen) without auth | 401 + `WWW-Authenticate` | ✅ |
| 20 | `GET /mcp` (SSE listen) with auth | 200 idle event-stream | ✅ |

### Backend token endpoint (`/user/oauth/token`)

| # | Flow | Expected | Result |
|---|------|----------|--------|
| 21 | `grant_type=refresh_token` with valid refresh token | 200, access + **rotated** refresh | ✅ |
| 22 | Reuse of rotated-out refresh token | 400 `invalid_grant` | ✅ (documents the no-grace-window race) |
| 23 | Access token from refresh grant used on `tools/call` | 200 + data | ✅ |
| 24 | `grant_type=authorization_code` + correct PKCE (S256) | 200, access + refresh | ✅ |
| 25 | `grant_type=authorization_code` + wrong PKCE verifier | 400 | ✅ |

Unit suite: **76 passed / 6 failed** — the same 6 fail on `origin/main` (pre-existing, unrelated: test_config / test_tool_generator / test_health_check). New regression tests in `tests/test_request_credentials.py` (7); the key one fails pre-fix with `assert 'stale-initialize-token' == 'fresh-refreshed-token'`.

## Not covered (known gaps)

| Flow | Why not covered | Risk / follow-up |
|------|-----------------|------------------|
| Interactive `/user/oauth/authorize` (login, consent, `redirect_uri` validation) | Browser flow; E2E crafted auth codes directly with the backend secret | Low — unchanged by this PR; exercised daily by real users |
| Real clients (claude.ai connector, Claude Desktop, Claude Code) against the stateless server | Local matrix speaks the same protocol, but not the actual clients | **Verify on staging before prod deploy** |
| Auth-code replay rejection | Codes are stateless JWTs, not single-use — replay currently returns 200 (PKCE-bound) | Backend fix, separate PR |
| Concurrent-refresh race (no rotation grace window) | Needs multi-client race simulation; reuse-after-rotation failure mode is covered (#22) | Backend fix, separate PR |
| Token expired 0–10s (inside skew window) | Reaches backend → tool error instead of transport 401; transient by design | Accepted; window is 10s |
| Revoked/expired refresh token (`is_valid=False` path) | Only rotation-reuse (`DoesNotExist`) exercised | Low — same 400 `invalid_grant` branch |
| `grant_type=client_credentials` (internal services) | No client credentials in the local env | Unchanged by this PR |
| `/user/oauth/revoke` endpoint | Advertised in discovery metadata, not exercised | Unchanged by this PR |
| `User-Agent` → `api_request_events.client` end-to-end | Local env routes analytics writes to a DB not readable locally | Unit-tested; header pipeline unchanged |

## Intentionally not doing

- Backend refresh-rotation grace window and single-use auth codes (both backend, separate PRs).
- Lengthening the 1h access-token TTL (product decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
