### PR TITLE
[Auto] Sync docs for backend PR #9519

### DIFF
--- a/api-reference/observability/retrieve-deep-research-insights-pricing.mdx
+++ b/api-reference/observability/retrieve-deep-research-insights-pricing.mdx
@@ -1,0 +1,6 @@
+---
+title: Retrieve Deep Research Insights Pricing
+description: "Flat credit cost of a Deep Research ``Generate`` press."
+openapi: get /observability/v1/deep-research-insights/pricing/
+slug: retrieve-deep-research-insights-pricing
+---

--- a/mint.json
+++ b/mint.json
@@ -504,7 +504,8 @@
             "api-reference/observability/delete-deep-research-insight",
             "api-reference/observability/dismiss-deep-research-insight-mode",
             "api-reference/observability/generate-deep-research-insights",
-            "api-reference/observability/get-metric-failure-mode-insights-available-dates"
+            "api-reference/observability/get-metric-failure-mode-insights-available-dates",
+            "api-reference/observability/retrieve-deep-research-insights-pricing"
           ]
         }
       ]

--- a/openapi.json
+++ b/openapi.json
@@ -25,42 +25,6 @@
                 "description": ".well known oauth authorization server"
             }
         },
-        "/a8c8aef15013e2e52ccf6000350258a1eab6cd2a11e62f592c5e19092d7204d7/run/": {
-            "get": {
-                "operationId": "a8c8aef15013e2e52ccf6000350258a1eab6cd2a11e62f592c5e19092d7204d7",
-                "tags": [
-                    "a8c8aef15013e2e52ccf6000350258a1eab6cd2a11e62f592c5e19092d7204d7"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "No response body"
-                    }
-                },
-                "description": "A8c8aef15013e2e52ccf6000350258a1eab6cd2a11e62f592c5e19092d7204d7"
-            },
-            "post": {
-                "operationId": "a8c8aef15013e2e52ccf6000350258a1eab6cd2a11e62f592c5e19092d7204d7_2",
-                "tags": [
-                    "a8c8aef15013e2e52ccf6000350258a1eab6cd2a11e62f592c5e19092d7204d7"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "No response body"
-                    }
-                },
-                "description": "A8c8aef15013e2e52ccf6000350258a1eab6cd2a11e62f592c5e19092d7204d7"
-            }
-        },
         "/app/otel/validate/": {
             "get": {
                 "operationId": "app-otel-validate-retrieve",
@@ -5878,7 +5842,7 @@
         "/observability/v1/deep-research-insights/generate/": {
             "post": {
                 "operationId": "deep-research-insights-generate-create",
-                "description": "Queue a Deep Research audit; returns the new row in ``pending``.",
+                "description": "Queue a Deep Research audit; returns the new row in ``pending``.\n\nCost: ``get_deep_research_cost()`` credits per press that actually\nqueues a fresh audit — spam protection for an expensive\nModal-sandboxed agent run. The price is admin-configurable via the\n``DEEP_RESEARCH_GENERATION_COST`` SettingValue. Insufficient\nbalance → HTTP 402 from the global exception handler before any\nwork is queued. A press that only gets an already-in-flight row\nback (double-click while one is still running) is not charged.",
                 "tags": [
                     "observability"
                 ],
@@ -5921,10 +5885,10 @@
                 }
             }
         },
-        "/observability/v1/elevenlabs/observe/": {
-            "post": {
-                "operationId": "elevenlabs-observe-create",
-                "description": "Handle incoming ElevenLabs webhook requests.\n\nThis endpoint processes webhook requests from the ElevenLabs service, validates the request data,\nand creates a call log entry based on the received data. ElevenLabs sends webhooks at the end of the call,\nproviding important information about the interaction.",
+        "/observability/v1/deep-research-insights/pricing/": {
+            "get": {
+                "operationId": "deep-research-insights-pricing-retrieve",
+                "description": "Flat credit cost of a Deep Research ``Generate`` press.\n\nLets the FE label the button with the live price (e.g. \"Generate\n(20 credits)\") instead of hardcoding a number that would drift\nfrom the admin-set ``DEEP_RESEARCH_GENERATION_COST``. Scoped by\n``?project=<id>`` so the standard project-access permission check\napplies; the price itself is global.",
                 "tags": [
                     "observability"
                 ],
@@ -5935,7 +5899,14 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "No response body"
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/DeepResearchInsight"
+                                }
+                            }
+                        },
+                        "description": ""
                     }
                 }
             }
@@ -10394,25 +10365,6 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No response body"
-                    }
-                }
-            }
-        },
-        "/test_framework/test-outbound-caller/": {
-            "post": {
-                "operationId": "test-framework-test-outbound-caller-create",
-                "description": "API view to test outbound calls.\nThis view allows users to run scenarios associated with a specific agent\nby updating the phone number in the VAPI system.",
-                "tags": [
-                    "test_framework"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
                         "description": "No response body"
                     }
                 }
@@ -30084,148 +30036,10 @@
                 }
             }
         },
-        "/test_framework/v1/scenarios-external/run_full_scenario_demo/": {
-            "post": {
-                "operationId": "scenarios-external-run-full-scenario-demo-create",
-                "description": "Complete demo flow for \"try it yourself\" free report feature.\n\nThis endpoint handles:\n1. OTP generation and validation for work email\n2. Agent creation under demo project\n3. Scenario generation\n4. Phone call execution\n5. Email report delivery",
-                "tags": [
-                    "test_framework"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Scenario"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Scenario"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Scenario"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Scenario"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
-        },
-        "/test_framework/v1/scenarios-external/run_full_scenario_demo_details/": {
-            "post": {
-                "operationId": "scenarios-external-run-full-scenario-demo-details-create",
-                "description": "Scenarios run full scenario demo details",
-                "tags": [
-                    "test_framework"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Scenario"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Scenario"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Scenario"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Scenario"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
-        },
-        "/test_framework/v1/scenarios-external/run_full_scenario_demo_email/": {
-            "post": {
-                "operationId": "scenarios-external-run-full-scenario-demo-email-create",
-                "description": "Scenarios run full scenario demo email",
-                "tags": [
-                    "test_framework"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Scenario"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Scenario"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Scenario"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Scenario"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
-        },
         "/test_framework/v1/scenarios-external/run_scenarios/": {
             "post": {
                 "operationId": "scenarios-run-voice",
-                "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing.\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others:**\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.",
+                "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing. Requires `telephony.phone_number` configured on the agent (any provider).\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.",
                 "summary": "Run evaluators over a voice call",
                 "tags": [
                     "Evaluators"
@@ -30484,7 +30298,7 @@
         "/test_framework/v1/scenarios-external/run_scenarios_agora/": {
             "post": {
                 "operationId": "scenarios-run-agora",
-                "description": "AGORA RTC VOICE RUN: Execute evaluators against an agent reachable in an Agora RTC channel. Cekura joins the channel as a participant and converses. The agent must have `agora_data.session_endpoint_url` configured — an endpoint that mints the per-call channel and token; Cekura calls it at run time and never stores the join details.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC",
+                "description": "AGORA RTC VOICE RUN: Execute evaluators against an agent reachable in an Agora RTC channel. Cekura joins the channel as a participant and converses. The agent must have `agora_data.session_endpoint_url` configured — an endpoint that mints the per-call channel and token; Cekura calls it at run time and never stores the join details.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC",
                 "summary": "Run evaluators against an agent in an Agora RTC channel",
                 "tags": [
                     "Evaluators"
@@ -30660,7 +30474,7 @@
         "/test_framework/v1/scenarios-external/run_scenarios_chirp/": {
             "post": {
                 "operationId": "scenarios-run-chirp",
-                "description": "RAW-PCM WEBSOCKET VOICE RUN: Execute evaluators against an agent that exposes a raw-PCM WebSocket endpoint (16 kHz, 16-bit mono, binary frames). The agent must have a websocket endpoint configured (`telephony.websocket_url`); optional Basic Auth lives in `telephony.websocket_auth`. Pass `websocket_url` to override the agent's stored endpoint for this run.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_websocket` — JSON/text WebSocket protocol (per-scenario URLs)\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC",
+                "description": "RAW-PCM WEBSOCKET VOICE RUN: Execute evaluators against an agent that exposes a raw-PCM WebSocket endpoint (16 kHz, 16-bit mono, binary frames). The agent must have a websocket endpoint configured (`telephony.websocket_url`); optional Basic Auth lives in `telephony.websocket_auth`. Pass `websocket_url` to override the agent's stored endpoint for this run.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_websocket` — JSON/text WebSocket protocol (per-scenario URLs)\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC",
                 "summary": "Run evaluators against a raw-PCM WebSocket voice endpoint",
                 "tags": [
                     "Evaluators"
@@ -30836,7 +30650,7 @@
         "/test_framework/v1/scenarios-external/run_scenarios_elevenlabs/": {
             "post": {
                 "operationId": "scenarios-run-elevenlabs",
-                "description": "ELEVENLABS CONVERSATIONAL VOICE RUN: Execute evaluators against an ElevenLabs Conversational AI agent. The agent must have ElevenLabs credentials configured AND `assistant_id` set to the ElevenLabs agent ID.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)",
+                "description": "ELEVENLABS CONVERSATIONAL VOICE RUN: Execute evaluators against an ElevenLabs Conversational AI agent. The agent must have ElevenLabs credentials configured AND `assistant_id` set to the ElevenLabs agent ID.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)",
                 "summary": "Run evaluators against an ElevenLabs Conversational agent",
                 "tags": [
                     "Evaluators"
@@ -31197,7 +31011,7 @@
         "/test_framework/v1/scenarios-external/run_scenarios_livekit_v2/": {
             "post": {
                 "operationId": "scenarios-run-livekit-v2",
-                "description": "LIVEKIT VOICE RUN (project credentials, v2): Execute evaluators against a LiveKit agent using credentials configured at the project (or agent) level. Cekura creates the rooms; you don't pass URLs per-scenario. Requires `livekit_api_key`, `livekit_data.api_secret`, and `livekit_data.url` on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `room_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_websocket` — JSON/text WebSocket runs",
+                "description": "LIVEKIT VOICE RUN (project credentials, v2): Execute evaluators against a LiveKit agent using credentials configured at the project (or agent) level. Cekura creates the rooms; you don't pass URLs per-scenario. Requires `livekit_api_key`, `livekit_data.api_secret`, and `livekit_data.url` on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `room_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_websocket` — JSON/text WebSocket runs",
                 "summary": "Run evaluators against a LiveKit agent (project credentials, v2)",
                 "tags": [
                     "Evaluators"
@@ -31378,7 +31192,7 @@
         "/test_framework/v1/scenarios-external/run_scenarios_pipecat/": {
             "post": {
                 "operationId": "scenarios-run-pipecat-v1",
-                "description": "PIPECAT WEBRTC RUN (manual room URLs, v1): Execute evaluators against an agent running on Pipecat / Daily.co WebRTC. Each scenario entry carries its own `pipecat_room_url` and optional token. For project-credential-based runs (no per-scenario URL), use `scenarios_run_pipecat_v2` instead.\n\n**Run-count:** one run per entry in `scenarios` — this endpoint does not support `frequency` or personality/test-profile multipliers. To run the same scenario multiple times, include it multiple times in the `scenarios` list.\n\n**When to use this vs others:**\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_text` — text / SMS / chat mode\n- `run_scenarios_with_websockets` — agent exposes a plain websocket URL (non-Pipecat)\n\n**Scheduled runs:** WebRTC sessions are not generally scheduled. Use `run_scenarios` or `run_scenarios_text` via CronJob for recurring evaluator runs.",
+                "description": "PIPECAT WEBRTC RUN (manual room URLs, v1): Execute evaluators against an agent running on Pipecat / Daily.co WebRTC. Each scenario entry carries its own `pipecat_room_url` and optional token. For project-credential-based runs (no per-scenario URL), use `scenarios_run_pipecat_v2` instead.\n\n**Run-count:** one run per entry in `scenarios` — this endpoint does not support `frequency` or personality/test-profile multipliers. To run the same scenario multiple times, include it multiple times in the `scenarios` list.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_text` — text / SMS / chat mode\n- `run_scenarios_with_websockets` — agent exposes a plain websocket URL (non-Pipecat)\n\n**Scheduled runs:** WebRTC sessions are not generally scheduled. Use `run_scenarios` or `run_scenarios_text` via CronJob for recurring evaluator runs.",
                 "summary": "Run evaluators against a Pipecat WebRTC deployment (manual room URLs, v1)",
                 "tags": [
                     "Evaluators"
@@ -31558,7 +31372,7 @@
         "/test_framework/v1/scenarios-external/run_scenarios_pipecat_v2/": {
             "post": {
                 "operationId": "scenarios-run-pipecat-v2",
-                "description": "PIPECAT CLOUD VOICE RUN (project credentials, v2): Execute evaluators against an agent deployed on Pipecat Cloud using credentials configured at the project level. Cekura creates the sessions; you don't pass per-scenario room URLs (that's the v1 endpoint). Requires Pipecat Cloud credentials with `pipecat_agent_name` set on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `session_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others:**\n- `scenarios_run_pipecat_v1` — manual room URLs per scenario\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
+                "description": "PIPECAT CLOUD VOICE RUN (project credentials, v2): Execute evaluators against an agent deployed on Pipecat Cloud using credentials configured at the project level. Cekura creates the sessions; you don't pass per-scenario room URLs (that's the v1 endpoint). Requires Pipecat Cloud credentials with `pipecat_agent_name` set on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `session_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_pipecat_v1` — manual room URLs per scenario\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
                 "summary": "Run evaluators against a Pipecat Cloud deployment (project credentials, v2)",
                 "tags": [
                     "Evaluators"
@@ -31739,7 +31553,7 @@
         "/test_framework/v1/scenarios-external/run_scenarios_retell_webrtc/": {
             "post": {
                 "operationId": "scenarios-run-retell-webrtc",
-                "description": "RETELL WEBRTC VOICE RUN: Execute evaluators against a Retell agent over WebRTC (LiveKit infrastructure). The agent must have Retell credentials configured. `retell_agent_id` is optional and defaults to `agent.assistant_id` if not provided.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
+                "description": "RETELL WEBRTC VOICE RUN: Execute evaluators against a Retell agent over WebRTC (LiveKit infrastructure). The agent must have Retell credentials configured. `retell_agent_id` is optional and defaults to `agent.assistant_id` if not provided.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
                 "summary": "Run evaluators against a Retell agent over WebRTC",
                 "tags": [
                     "Evaluators"
@@ -31917,7 +31731,7 @@
         "/test_framework/v1/scenarios-external/run_scenarios_sip/": {
             "post": {
                 "operationId": "scenarios-run-sip",
-                "description": "SIP VOICE RUN (direct SIP): Execute evaluators against an agent over a direct SIP connection (orchestrated by Cekura's SIP voice service). The agent must have `sip_endpoint` configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone calls via Cekura's standard voice path\n- `scenarios_run_vapi_webrtc` / `_retell_webrtc` — provider-managed WebRTC\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
+                "description": "SIP VOICE RUN (direct SIP): Execute evaluators against an agent over a direct SIP connection (orchestrated by Cekura's SIP voice service). The agent must have a SIP endpoint configured (`telephony.sip_uri` on the v2 agent).\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone calls via Cekura's standard voice path\n- `scenarios_run_vapi_webrtc` / `_retell_webrtc` — provider-managed WebRTC\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
                 "summary": "Run evaluators over a direct SIP connection",
                 "tags": [
                     "Evaluators"
@@ -32093,7 +31907,7 @@
         "/test_framework/v1/scenarios-external/run_scenarios_text/": {
             "post": {
                 "operationId": "scenarios-run-text",
-                "description": "TEXT / SMS / CHAT RUN: Execute evaluators against your agent using text-only simulation (SMS, chat, or an agent-hosted websocket). Cheaper than voice — billed at the text-simulation rate.\n\n**Run-count math:** total conversations = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**Concurrency:** use `concurrency_limit` to cap parallel conversations. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Websocket override:** if the agent exposes a plain websocket URL for text, pass it as `websocket_url` — this bypasses the agent's standard text-readiness check. Pass `websocket_headers` (JSON object) to override connection headers for this run — merged over the agent's configured headers, with the per-run values winning.\n\n**When to use this vs others:**\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL (bulk)\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**`self_hosted` agents:** agents with `assistant_provider=\"self_hosted\"` require a websocket URL. Either pre-configure `websocket_url` on the agent, or pass it directly in this request. Without it, the run fails with `[\"Agent does not have a websocket URL\"]`. Passing `websocket_url` here changes the result's `run_type` to `\"WebSocket\"` instead of `\"Text\"`.\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"text\"` instead.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.",
+                "description": "TEXT / SMS / CHAT RUN: Execute evaluators against your agent using text-only simulation (SMS, chat, or an agent-hosted websocket). Cheaper than voice — billed at the text-simulation rate. Requires a chat connection (`provider.chat_agent_details`) on the agent, or a websocket URL for `self_hosted` agents.\n\n**Run-count math:** total conversations = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**Concurrency:** use `concurrency_limit` to cap parallel conversations. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Websocket override:** if the agent exposes a plain websocket URL for text, pass it as `websocket_url` — this bypasses the agent's standard text-readiness check. Pass `websocket_headers` (JSON object) to override connection headers for this run — merged over the agent's configured headers, with the per-run values winning.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL (bulk)\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**`self_hosted` agents:** agents with `assistant_provider=\"self_hosted\"` require a websocket URL. Either pre-configure `websocket_url` on the agent, or pass it directly in this request. Without it, the run fails with `[\"Agent does not have a websocket URL\"]`. Passing `websocket_url` here changes the result's `run_type` to `\"WebSocket\"` instead of `\"Text\"`.\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"text\"` instead.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.",
                 "summary": "Run evaluators in text / SMS / chat mode",
                 "tags": [
                     "Evaluators"
@@ -32292,7 +32106,7 @@
         "/test_framework/v1/scenarios-external/run_scenarios_vapi_webrtc/": {
             "post": {
                 "operationId": "scenarios-run-vapi-webrtc",
-                "description": "VAPI WEBRTC VOICE RUN: Execute evaluators against a VAPI agent over WebRTC. Required: `vapi_assistant_id` (the VAPI assistant). The agent (looked up via `agent_id` or inferred from the first scenario) must have VAPI credentials configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_text` — text/SMS/chat (cheaper)\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
+                "description": "VAPI WEBRTC VOICE RUN: Execute evaluators against a VAPI agent over WebRTC. Required: `vapi_assistant_id` (the VAPI assistant). The agent (looked up via `agent_id` or inferred from the first scenario) must have VAPI credentials configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_text` — text/SMS/chat (cheaper)\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
                 "summary": "Run evaluators against a VAPI WebRTC agent",
                 "tags": [
                     "Evaluators"
@@ -32471,7 +32285,7 @@
         "/test_framework/v1/scenarios-external/run_scenarios_with_websockets/": {
             "post": {
                 "operationId": "scenarios-run-websocket",
-                "description": "WEBSOCKET RUN (per-scenario URLs, bulk): Execute evaluators where each scenario carries its own websocket URL. Useful when you have a fleet of agents or stateful websocket sessions to test in a single batch.\n\n**Run-count:** total conversations = `len(scenarios) × frequency`. (Personality and test-profile multipliers are not supported on this endpoint.)\n\n**`frequency` is required** on this endpoint (no default).\n\n**When to use this vs others:**\n- `run_scenarios_text` — single websocket URL or SMS/chat mode (simpler)\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'.\n\n**Known limitation:** `result.run_type` may show 'Text' instead of 'WebSocket' for runs triggered via this endpoint — this is a display issue only and does not affect execution.",
+                "description": "WEBSOCKET RUN (per-scenario URLs, bulk): Execute evaluators where each scenario carries its own websocket URL. Useful when you have a fleet of agents or stateful websocket sessions to test in a single batch.\n\n**Run-count:** total conversations = `len(scenarios) × frequency`. (Personality and test-profile multipliers are not supported on this endpoint.)\n\n**`frequency` is required** on this endpoint (no default).\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — single websocket URL or SMS/chat mode (simpler)\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'.\n\n**Known limitation:** `result.run_type` may show 'Text' instead of 'WebSocket' for runs triggered via this endpoint — this is a display issue only and does not affect execution.",
                 "summary": "Run evaluators against per-scenario websocket URLs (bulk)",
                 "tags": [
                     "Evaluators"
@@ -35031,148 +34845,10 @@
                 }
             }
         },
-        "/test_framework/v1/scenarios/run_full_scenario_demo/": {
-            "post": {
-                "operationId": "scenarios-run-full-scenario-demo-create",
-                "description": "Complete demo flow for \"try it yourself\" free report feature.\n\nThis endpoint handles:\n1. OTP generation and validation for work email\n2. Agent creation under demo project\n3. Scenario generation\n4. Phone call execution\n5. Email report delivery",
-                "tags": [
-                    "test_framework"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Scenario"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Scenario"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Scenario"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Scenario"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
-        },
-        "/test_framework/v1/scenarios/run_full_scenario_demo_details/": {
-            "post": {
-                "operationId": "scenarios-run-full-scenario-demo-details-create",
-                "description": "Scenarios run full scenario demo details",
-                "tags": [
-                    "test_framework"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Scenario"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Scenario"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Scenario"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Scenario"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
-        },
-        "/test_framework/v1/scenarios/run_full_scenario_demo_email/": {
-            "post": {
-                "operationId": "scenarios-run-full-scenario-demo-email-create",
-                "description": "Scenarios run full scenario demo email",
-                "tags": [
-                    "test_framework"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Scenario"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Scenario"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Scenario"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Scenario"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
-        },
         "/test_framework/v1/scenarios/run_scenarios/": {
             "post": {
                 "operationId": "scenarios-run-voice_2",
-                "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing.\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others:**\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.",
+                "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing. Requires `telephony.phone_number` configured on the agent (any provider).\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.",
                 "summary": "Run evaluators over a voice call",
                 "tags": [
                     "Evaluators"
@@ -35431,7 +35107,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-run-voice",
-                        "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing.\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others:**\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors."
+                        "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing. Requires `telephony.phone_number` configured on the agent (any provider).\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors."
                     }
                 }
             }
@@ -35439,7 +35115,7 @@
         "/test_framework/v1/scenarios/run_scenarios_agora/": {
             "post": {
                 "operationId": "scenarios-run-agora_2",
-                "description": "AGORA RTC VOICE RUN: Execute evaluators against an agent reachable in an Agora RTC channel. Cekura joins the channel as a participant and converses. The agent must have `agora_data.session_endpoint_url` configured — an endpoint that mints the per-call channel and token; Cekura calls it at run time and never stores the join details.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC",
+                "description": "AGORA RTC VOICE RUN: Execute evaluators against an agent reachable in an Agora RTC channel. Cekura joins the channel as a participant and converses. The agent must have `agora_data.session_endpoint_url` configured — an endpoint that mints the per-call channel and token; Cekura calls it at run time and never stores the join details.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC",
                 "summary": "Run evaluators against an agent in an Agora RTC channel",
                 "tags": [
                     "Evaluators"
@@ -35615,7 +35291,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-run-agora",
-                        "description": "AGORA RTC VOICE RUN: Execute evaluators against an agent reachable in an Agora RTC channel. Cekura joins the channel as a participant and converses. The agent must have `agora_data.session_endpoint_url` configured — an endpoint that mints the per-call channel and token; Cekura calls it at run time and never stores the join details.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC"
+                        "description": "AGORA RTC VOICE RUN: Execute evaluators against an agent reachable in an Agora RTC channel. Cekura joins the channel as a participant and converses. The agent must have `agora_data.session_endpoint_url` configured — an endpoint that mints the per-call channel and token; Cekura calls it at run time and never stores the join details.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC"
                     }
                 }
             }
@@ -35623,7 +35299,7 @@
         "/test_framework/v1/scenarios/run_scenarios_chirp/": {
             "post": {
                 "operationId": "scenarios-run-chirp_2",
-                "description": "RAW-PCM WEBSOCKET VOICE RUN: Execute evaluators against an agent that exposes a raw-PCM WebSocket endpoint (16 kHz, 16-bit mono, binary frames). The agent must have a websocket endpoint configured (`telephony.websocket_url`); optional Basic Auth lives in `telephony.websocket_auth`. Pass `websocket_url` to override the agent's stored endpoint for this run.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_websocket` — JSON/text WebSocket protocol (per-scenario URLs)\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC",
+                "description": "RAW-PCM WEBSOCKET VOICE RUN: Execute evaluators against an agent that exposes a raw-PCM WebSocket endpoint (16 kHz, 16-bit mono, binary frames). The agent must have a websocket endpoint configured (`telephony.websocket_url`); optional Basic Auth lives in `telephony.websocket_auth`. Pass `websocket_url` to override the agent's stored endpoint for this run.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_websocket` — JSON/text WebSocket protocol (per-scenario URLs)\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC",
                 "summary": "Run evaluators against a raw-PCM WebSocket voice endpoint",
                 "tags": [
                     "Evaluators"
@@ -35799,7 +35475,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-run-chirp",
-                        "description": "RAW-PCM WEBSOCKET VOICE RUN: Execute evaluators against an agent that exposes a raw-PCM WebSocket endpoint (16 kHz, 16-bit mono, binary frames). The agent must have a websocket endpoint configured (`telephony.websocket_url`); optional Basic Auth lives in `telephony.websocket_auth`. Pass `websocket_url` to override the agent's stored endpoint for this run.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_websocket` — JSON/text WebSocket protocol (per-scenario URLs)\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC"
+                        "description": "RAW-PCM WEBSOCKET VOICE RUN: Execute evaluators against an agent that exposes a raw-PCM WebSocket endpoint (16 kHz, 16-bit mono, binary frames). The agent must have a websocket endpoint configured (`telephony.websocket_url`); optional Basic Auth lives in `telephony.websocket_auth`. Pass `websocket_url` to override the agent's stored endpoint for this run.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_websocket` — JSON/text WebSocket protocol (per-scenario URLs)\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC"
                     }
                 }
             }
@@ -35807,7 +35483,7 @@
         "/test_framework/v1/scenarios/run_scenarios_elevenlabs/": {
             "post": {
                 "operationId": "scenarios-run-elevenlabs_2",
-                "description": "ELEVENLABS CONVERSATIONAL VOICE RUN: Execute evaluators against an ElevenLabs Conversational AI agent. The agent must have ElevenLabs credentials configured AND `assistant_id` set to the ElevenLabs agent ID.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)",
+                "description": "ELEVENLABS CONVERSATIONAL VOICE RUN: Execute evaluators against an ElevenLabs Conversational AI agent. The agent must have ElevenLabs credentials configured AND `assistant_id` set to the ElevenLabs agent ID.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)",
                 "summary": "Run evaluators against an ElevenLabs Conversational agent",
                 "tags": [
                     "Evaluators"
@@ -35984,7 +35660,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-run-elevenlabs",
-                        "description": "ELEVENLABS CONVERSATIONAL VOICE RUN: Execute evaluators against an ElevenLabs Conversational AI agent. The agent must have ElevenLabs credentials configured AND `assistant_id` set to the ElevenLabs agent ID.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)"
+                        "description": "ELEVENLABS CONVERSATIONAL VOICE RUN: Execute evaluators against an ElevenLabs Conversational AI agent. The agent must have ElevenLabs credentials configured AND `assistant_id` set to the ElevenLabs agent ID.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)"
                     }
                 }
             }
@@ -36176,7 +35852,7 @@
         "/test_framework/v1/scenarios/run_scenarios_livekit_v2/": {
             "post": {
                 "operationId": "scenarios-run-livekit-v2_2",
-                "description": "LIVEKIT VOICE RUN (project credentials, v2): Execute evaluators against a LiveKit agent using credentials configured at the project (or agent) level. Cekura creates the rooms; you don't pass URLs per-scenario. Requires `livekit_api_key`, `livekit_data.api_secret`, and `livekit_data.url` on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `room_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_websocket` — JSON/text WebSocket runs",
+                "description": "LIVEKIT VOICE RUN (project credentials, v2): Execute evaluators against a LiveKit agent using credentials configured at the project (or agent) level. Cekura creates the rooms; you don't pass URLs per-scenario. Requires `livekit_api_key`, `livekit_data.api_secret`, and `livekit_data.url` on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `room_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_websocket` — JSON/text WebSocket runs",
                 "summary": "Run evaluators against a LiveKit agent (project credentials, v2)",
                 "tags": [
                     "Evaluators"
@@ -36357,7 +36033,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-run-livekit-v2",
-                        "description": "LIVEKIT VOICE RUN (project credentials, v2): Execute evaluators against a LiveKit agent using credentials configured at the project (or agent) level. Cekura creates the rooms; you don't pass URLs per-scenario. Requires `livekit_api_key`, `livekit_data.api_secret`, and `livekit_data.url` on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `room_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_websocket` — JSON/text WebSocket runs"
+                        "description": "LIVEKIT VOICE RUN (project credentials, v2): Execute evaluators against a LiveKit agent using credentials configured at the project (or agent) level. Cekura creates the rooms; you don't pass URLs per-scenario. Requires `livekit_api_key`, `livekit_data.api_secret`, and `livekit_data.url` on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `room_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_websocket` — JSON/text WebSocket runs"
                     }
                 }
             }
@@ -36365,7 +36041,7 @@
         "/test_framework/v1/scenarios/run_scenarios_pipecat/": {
             "post": {
                 "operationId": "scenarios-run-pipecat-v1_2",
-                "description": "PIPECAT WEBRTC RUN (manual room URLs, v1): Execute evaluators against an agent running on Pipecat / Daily.co WebRTC. Each scenario entry carries its own `pipecat_room_url` and optional token. For project-credential-based runs (no per-scenario URL), use `scenarios_run_pipecat_v2` instead.\n\n**Run-count:** one run per entry in `scenarios` — this endpoint does not support `frequency` or personality/test-profile multipliers. To run the same scenario multiple times, include it multiple times in the `scenarios` list.\n\n**When to use this vs others:**\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_text` — text / SMS / chat mode\n- `run_scenarios_with_websockets` — agent exposes a plain websocket URL (non-Pipecat)\n\n**Scheduled runs:** WebRTC sessions are not generally scheduled. Use `run_scenarios` or `run_scenarios_text` via CronJob for recurring evaluator runs.",
+                "description": "PIPECAT WEBRTC RUN (manual room URLs, v1): Execute evaluators against an agent running on Pipecat / Daily.co WebRTC. Each scenario entry carries its own `pipecat_room_url` and optional token. For project-credential-based runs (no per-scenario URL), use `scenarios_run_pipecat_v2` instead.\n\n**Run-count:** one run per entry in `scenarios` — this endpoint does not support `frequency` or personality/test-profile multipliers. To run the same scenario multiple times, include it multiple times in the `scenarios` list.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_text` — text / SMS / chat mode\n- `run_scenarios_with_websockets` — agent exposes a plain websocket URL (non-Pipecat)\n\n**Scheduled runs:** WebRTC sessions are not generally scheduled. Use `run_scenarios` or `run_scenarios_text` via CronJob for recurring evaluator runs.",
                 "summary": "Run evaluators against a Pipecat WebRTC deployment (manual room URLs, v1)",
                 "tags": [
                     "Evaluators"
@@ -36545,7 +36221,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-run-pipecat-v1",
-                        "description": "PIPECAT WEBRTC RUN (manual room URLs, v1): Execute evaluators against an agent running on Pipecat / Daily.co WebRTC. Each scenario entry carries its own `pipecat_room_url` and optional token. For project-credential-based runs (no per-scenario URL), use `scenarios_run_pipecat_v2` instead.\n\n**Run-count:** one run per entry in `scenarios` — this endpoint does not support `frequency` or personality/test-profile multipliers. To run the same scenario multiple times, include it multiple times in the `scenarios` list.\n\n**When to use this vs others:**\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_text` — text / SMS / chat mode\n- `run_scenarios_with_websockets` — agent exposes a plain websocket URL (non-Pipecat)\n\n**Scheduled runs:** WebRTC sessions are not generally scheduled. Use `run_scenarios` or `run_scenarios_text` via CronJob for recurring evaluator runs."
+                        "description": "PIPECAT WEBRTC RUN (manual room URLs, v1): Execute evaluators against an agent running on Pipecat / Daily.co WebRTC. Each scenario entry carries its own `pipecat_room_url` and optional token. For project-credential-based runs (no per-scenario URL), use `scenarios_run_pipecat_v2` instead.\n\n**Run-count:** one run per entry in `scenarios` — this endpoint does not support `frequency` or personality/test-profile multipliers. To run the same scenario multiple times, include it multiple times in the `scenarios` list.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_text` — text / SMS / chat mode\n- `run_scenarios_with_websockets` — agent exposes a plain websocket URL (non-Pipecat)\n\n**Scheduled runs:** WebRTC sessions are not generally scheduled. Use `run_scenarios` or `run_scenarios_text` via CronJob for recurring evaluator runs."
                     }
                 }
             }
@@ -36553,7 +36229,7 @@
         "/test_framework/v1/scenarios/run_scenarios_pipecat_v2/": {
             "post": {
                 "operationId": "scenarios-run-pipecat-v2_2",
-                "description": "PIPECAT CLOUD VOICE RUN (project credentials, v2): Execute evaluators against an agent deployed on Pipecat Cloud using credentials configured at the project level. Cekura creates the sessions; you don't pass per-scenario room URLs (that's the v1 endpoint). Requires Pipecat Cloud credentials with `pipecat_agent_name` set on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `session_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others:**\n- `scenarios_run_pipecat_v1` — manual room URLs per scenario\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
+                "description": "PIPECAT CLOUD VOICE RUN (project credentials, v2): Execute evaluators against an agent deployed on Pipecat Cloud using credentials configured at the project level. Cekura creates the sessions; you don't pass per-scenario room URLs (that's the v1 endpoint). Requires Pipecat Cloud credentials with `pipecat_agent_name` set on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `session_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_pipecat_v1` — manual room URLs per scenario\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
                 "summary": "Run evaluators against a Pipecat Cloud deployment (project credentials, v2)",
                 "tags": [
                     "Evaluators"
@@ -36734,7 +36410,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-run-pipecat-v2",
-                        "description": "PIPECAT CLOUD VOICE RUN (project credentials, v2): Execute evaluators against an agent deployed on Pipecat Cloud using credentials configured at the project level. Cekura creates the sessions; you don't pass per-scenario room URLs (that's the v1 endpoint). Requires Pipecat Cloud credentials with `pipecat_agent_name` set on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `session_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others:**\n- `scenarios_run_pipecat_v1` — manual room URLs per scenario\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)"
+                        "description": "PIPECAT CLOUD VOICE RUN (project credentials, v2): Execute evaluators against an agent deployed on Pipecat Cloud using credentials configured at the project level. Cekura creates the sessions; you don't pass per-scenario room URLs (that's the v1 endpoint). Requires Pipecat Cloud credentials with `pipecat_agent_name` set on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `session_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_pipecat_v1` — manual room URLs per scenario\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)"
                     }
                 }
             }
@@ -36742,7 +36418,7 @@
         "/test_framework/v1/scenarios/run_scenarios_retell_webrtc/": {
             "post": {
                 "operationId": "scenarios-run-retell-webrtc_2",
-                "description": "RETELL WEBRTC VOICE RUN: Execute evaluators against a Retell agent over WebRTC (LiveKit infrastructure). The agent must have Retell credentials configured. `retell_agent_id` is optional and defaults to `agent.assistant_id` if not provided.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
+                "description": "RETELL WEBRTC VOICE RUN: Execute evaluators against a Retell agent over WebRTC (LiveKit infrastructure). The agent must have Retell credentials configured. `retell_agent_id` is optional and defaults to `agent.assistant_id` if not provided.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
                 "summary": "Run evaluators against a Retell agent over WebRTC",
                 "tags": [
                     "Evaluators"
@@ -36920,7 +36596,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-run-retell-webrtc",
-                        "description": "RETELL WEBRTC VOICE RUN: Execute evaluators against a Retell agent over WebRTC (LiveKit infrastructure). The agent must have Retell credentials configured. `retell_agent_id` is optional and defaults to `agent.assistant_id` if not provided.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)"
+                        "description": "RETELL WEBRTC VOICE RUN: Execute evaluators against a Retell agent over WebRTC (LiveKit infrastructure). The agent must have Retell credentials configured. `retell_agent_id` is optional and defaults to `agent.assistant_id` if not provided.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)"
                     }
                 }
             }
@@ -36928,7 +36604,7 @@
         "/test_framework/v1/scenarios/run_scenarios_sip/": {
             "post": {
                 "operationId": "scenarios-run-sip_2",
-                "description": "SIP VOICE RUN (direct SIP): Execute evaluators against an agent over a direct SIP connection (orchestrated by Cekura's SIP voice service). The agent must have `sip_endpoint` configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone calls via Cekura's standard voice path\n- `scenarios_run_vapi_webrtc` / `_retell_webrtc` — provider-managed WebRTC\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
+                "description": "SIP VOICE RUN (direct SIP): Execute evaluators against an agent over a direct SIP connection (orchestrated by Cekura's SIP voice service). The agent must have a SIP endpoint configured (`telephony.sip_uri` on the v2 agent).\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone calls via Cekura's standard voice path\n- `scenarios_run_vapi_webrtc` / `_retell_webrtc` — provider-managed WebRTC\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
                 "summary": "Run evaluators over a direct SIP connection",
                 "tags": [
                     "Evaluators"
@@ -37104,7 +36780,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-run-sip",
-                        "description": "SIP VOICE RUN (direct SIP): Execute evaluators against an agent over a direct SIP connection (orchestrated by Cekura's SIP voice service). The agent must have `sip_endpoint` configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone calls via Cekura's standard voice path\n- `scenarios_run_vapi_webrtc` / `_retell_webrtc` — provider-managed WebRTC\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)"
+                        "description": "SIP VOICE RUN (direct SIP): Execute evaluators against an agent over a direct SIP connection (orchestrated by Cekura's SIP voice service). The agent must have a SIP endpoint configured (`telephony.sip_uri` on the v2 agent).\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone calls via Cekura's standard voice path\n- `scenarios_run_vapi_webrtc` / `_retell_webrtc` — provider-managed WebRTC\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)"
                     }
                 }
             }
@@ -37112,7 +36788,7 @@
         "/test_framework/v1/scenarios/run_scenarios_text/": {
             "post": {
                 "operationId": "scenarios-run-text_2",
-                "description": "TEXT / SMS / CHAT RUN: Execute evaluators against your agent using text-only simulation (SMS, chat, or an agent-hosted websocket). Cheaper than voice — billed at the text-simulation rate.\n\n**Run-count math:** total conversations = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**Concurrency:** use `concurrency_limit` to cap parallel conversations. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Websocket override:** if the agent exposes a plain websocket URL for text, pass it as `websocket_url` — this bypasses the agent's standard text-readiness check. Pass `websocket_headers` (JSON object) to override connection headers for this run — merged over the agent's configured headers, with the per-run values winning.\n\n**When to use this vs others:**\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL (bulk)\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**`self_hosted` agents:** agents with `assistant_provider=\"self_hosted\"` require a websocket URL. Either pre-configure `websocket_url` on the agent, or pass it directly in this request. Without it, the run fails with `[\"Agent does not have a websocket URL\"]`. Passing `websocket_url` here changes the result's `run_type` to `\"WebSocket\"` instead of `\"Text\"`.\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"text\"` instead.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.",
+                "description": "TEXT / SMS / CHAT RUN: Execute evaluators against your agent using text-only simulation (SMS, chat, or an agent-hosted websocket). Cheaper than voice — billed at the text-simulation rate. Requires a chat connection (`provider.chat_agent_details`) on the agent, or a websocket URL for `self_hosted` agents.\n\n**Run-count math:** total conversations = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**Concurrency:** use `concurrency_limit` to cap parallel conversations. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Websocket override:** if the agent exposes a plain websocket URL for text, pass it as `websocket_url` — this bypasses the agent's standard text-readiness check. Pass `websocket_headers` (JSON object) to override connection headers for this run — merged over the agent's configured headers, with the per-run values winning.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL (bulk)\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**`self_hosted` agents:** agents with `assistant_provider=\"self_hosted\"` require a websocket URL. Either pre-configure `websocket_url` on the agent, or pass it directly in this request. Without it, the run fails with `[\"Agent does not have a websocket URL\"]`. Passing `websocket_url` here changes the result's `run_type` to `\"WebSocket\"` instead of `\"Text\"`.\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"text\"` instead.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.",
                 "summary": "Run evaluators in text / SMS / chat mode",
                 "tags": [
                     "Evaluators"
@@ -37311,7 +36987,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-run-text",
-                        "description": "TEXT / SMS / CHAT RUN: Execute evaluators against your agent using text-only simulation (SMS, chat, or an agent-hosted websocket). Cheaper than voice — billed at the text-simulation rate.\n\n**Run-count math:** total conversations = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**Concurrency:** use `concurrency_limit` to cap parallel conversations. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Websocket override:** if the agent exposes a plain websocket URL for text, pass it as `websocket_url` — this bypasses the agent's standard text-readiness check. Pass `websocket_headers` (JSON object) to override connection headers for this run — merged over the agent's configured headers, with the per-run values winning.\n\n**When to use this vs others:**\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL (bulk)\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**`self_hosted` agents:** agents with `assistant_provider=\"self_hosted\"` require a websocket URL. Either pre-configure `websocket_url` on the agent, or pass it directly in this request. Without it, the run fails with `[\"Agent does not have a websocket URL\"]`. Passing `websocket_url` here changes the result's `run_type` to `\"WebSocket\"` instead of `\"Text\"`.\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"text\"` instead.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors."
+                        "description": "TEXT / SMS / CHAT RUN: Execute evaluators against your agent using text-only simulation (SMS, chat, or an agent-hosted websocket). Cheaper than voice — billed at the text-simulation rate. Requires a chat connection (`provider.chat_agent_details`) on the agent, or a websocket URL for `self_hosted` agents.\n\n**Run-count math:** total conversations = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**Concurrency:** use `concurrency_limit` to cap parallel conversations. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Websocket override:** if the agent exposes a plain websocket URL for text, pass it as `websocket_url` — this bypasses the agent's standard text-readiness check. Pass `websocket_headers` (JSON object) to override connection headers for this run — merged over the agent's configured headers, with the per-run values winning.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL (bulk)\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**`self_hosted` agents:** agents with `assistant_provider=\"self_hosted\"` require a websocket URL. Either pre-configure `websocket_url` on the agent, or pass it directly in this request. Without it, the run fails with `[\"Agent does not have a websocket URL\"]`. Passing `websocket_url` here changes the result's `run_type` to `\"WebSocket\"` instead of `\"Text\"`.\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"text\"` instead.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors."
                     }
                 }
             }
@@ -37319,7 +36995,7 @@
         "/test_framework/v1/scenarios/run_scenarios_vapi_webrtc/": {
             "post": {
                 "operationId": "scenarios-run-vapi-webrtc_2",
-                "description": "VAPI WEBRTC VOICE RUN: Execute evaluators against a VAPI agent over WebRTC. Required: `vapi_assistant_id` (the VAPI assistant). The agent (looked up via `agent_id` or inferred from the first scenario) must have VAPI credentials configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_text` — text/SMS/chat (cheaper)\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
+                "description": "VAPI WEBRTC VOICE RUN: Execute evaluators against a VAPI agent over WebRTC. Required: `vapi_assistant_id` (the VAPI assistant). The agent (looked up via `agent_id` or inferred from the first scenario) must have VAPI credentials configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_text` — text/SMS/chat (cheaper)\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
                 "summary": "Run evaluators against a VAPI WebRTC agent",
                 "tags": [
                     "Evaluators"
@@ -37498,7 +37174,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-run-vapi-webrtc",
-                        "description": "VAPI WEBRTC VOICE RUN: Execute evaluators against a VAPI agent over WebRTC. Required: `vapi_assistant_id` (the VAPI assistant). The agent (looked up via `agent_id` or inferred from the first scenario) must have VAPI credentials configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_text` — text/SMS/chat (cheaper)\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)"
+                        "description": "VAPI WEBRTC VOICE RUN: Execute evaluators against a VAPI agent over WebRTC. Required: `vapi_assistant_id` (the VAPI assistant). The agent (looked up via `agent_id` or inferred from the first scenario) must have VAPI credentials configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_text` — text/SMS/chat (cheaper)\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)"
                     }
                 }
             }
@@ -37506,7 +37182,7 @@
         "/test_framework/v1/scenarios/run_scenarios_with_websockets/": {
             "post": {
                 "operationId": "scenarios-run-websocket_2",
-                "description": "WEBSOCKET RUN (per-scenario URLs, bulk): Execute evaluators where each scenario carries its own websocket URL. Useful when you have a fleet of agents or stateful websocket sessions to test in a single batch.\n\n**Run-count:** total conversations = `len(scenarios) × frequency`. (Personality and test-profile multipliers are not supported on this endpoint.)\n\n**`frequency` is required** on this endpoint (no default).\n\n**When to use this vs others:**\n- `run_scenarios_text` — single websocket URL or SMS/chat mode (simpler)\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'.\n\n**Known limitation:** `result.run_type` may show 'Text' instead of 'WebSocket' for runs triggered via this endpoint — this is a display issue only and does not affect execution.",
+                "description": "WEBSOCKET RUN (per-scenario URLs, bulk): Execute evaluators where each scenario carries its own websocket URL. Useful when you have a fleet of agents or stateful websocket sessions to test in a single batch.\n\n**Run-count:** total conversations = `len(scenarios) × frequency`. (Personality and test-profile multipliers are not supported on this endpoint.)\n\n**`frequency` is required** on this endpoint (no default).\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — single websocket URL or SMS/chat mode (simpler)\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'.\n\n**Known limitation:** `result.run_type` may show 'Text' instead of 'WebSocket' for runs triggered via this endpoint — this is a display issue only and does not affect execution.",
                 "summary": "Run evaluators against per-scenario websocket URLs (bulk)",
                 "tags": [
                     "Evaluators"
@@ -37690,7 +37366,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-run-websocket",
-                        "description": "WEBSOCKET RUN (per-scenario URLs, bulk): Execute evaluators where each scenario carries its own websocket URL. Useful when you have a fleet of agents or stateful websocket sessions to test in a single batch.\n\n**Run-count:** total conversations = `len(scenarios) × frequency`. (Personality and test-profile multipliers are not supported on this endpoint.)\n\n**`frequency` is required** on this endpoint (no default).\n\n**When to use this vs others:**\n- `run_scenarios_text` — single websocket URL or SMS/chat mode (simpler)\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'.\n\n**Known limitation:** `result.run_type` may show 'Text' instead of 'WebSocket' for runs triggered via this endpoint — this is a display issue only and does not affect execution."
+                        "description": "WEBSOCKET RUN (per-scenario URLs, bulk): Execute evaluators where each scenario carries its own websocket URL. Useful when you have a fleet of agents or stateful websocket sessions to test in a single batch.\n\n**Run-count:** total conversations = `len(scenarios) × frequency`. (Personality and test-profile multipliers are not supported on this endpoint.)\n\n**`frequency` is required** on this endpoint (no default).\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — single websocket URL or SMS/chat mode (simpler)\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'.\n\n**Known limitation:** `result.run_type` may show 'Text' instead of 'WebSocket' for runs triggered via this endpoint — this is a display issue only and does not affect execution."
                     }
                 }
             }
@@ -39358,7 +39034,7 @@
         "/test_framework/v2/aiagents/{id}/": {
             "get": {
                 "operationId": "aiagents-retrieve",
-                "description": "Retrieve an AI voice agent",
+                "description": "Retrieve an AI voice agent, including its configured connections.\n\n**Configured connection → run endpoint** (call this before running scenarios; a run endpoint only works if its connection is configured on the agent):\n- `telephony.phone_number` → `scenarios-run-voice`\n- `telephony.sip_uri` → `scenarios-run-sip`\n- `telephony.websocket_url` → `scenarios-run-chirp` (raw-PCM voice websocket)\n- `provider.type` vapi / retell / livekit / pipecat / agora (WebRTC) → `scenarios-run-vapi-webrtc` / `-retell-webrtc` / `-livekit-v2` / `-pipecat-v2` / `-agora`\n- `provider.type` elevenlabs → `scenarios-run-elevenlabs`\n- `provider.chat_agent_details` (chat/SMS/WhatsApp) → `scenarios-run-text`",
                 "summary": "Retrieve an AI voice agent",
                 "parameters": [
                     {
@@ -39411,7 +39087,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "aiagents-retrieve",
-                        "description": "Retrieve an AI voice agent"
+                        "description": "Retrieve an AI voice agent, including its configured connections.\n\n**Configured connection → run endpoint** (call this before running scenarios; a run endpoint only works if its connection is configured on the agent):\n- `telephony.phone_number` → `scenarios-run-voice`\n- `telephony.sip_uri` → `scenarios-run-sip`\n- `telephony.websocket_url` → `scenarios-run-chirp` (raw-PCM voice websocket)\n- `provider.type` vapi / retell / livekit / pipecat / agora (WebRTC) → `scenarios-run-vapi-webrtc` / `-retell-webrtc` / `-livekit-v2` / `-pipecat-v2` / `-agora`\n- `provider.type` elevenlabs → `scenarios-run-elevenlabs`\n- `provider.chat_agent_details` (chat/SMS/WhatsApp) → `scenarios-run-text`"
                     }
                 }
             },
@@ -42795,148 +42471,10 @@
                 }
             }
         },
-        "/test_framework/v2/scenarios/run_full_scenario_demo/": {
-            "post": {
-                "operationId": "test-framework-v2-scenarios-run-full-scenario-demo-create",
-                "description": "Complete demo flow for \"try it yourself\" free report feature.\n\nThis endpoint handles:\n1. OTP generation and validation for work email\n2. Agent creation under demo project\n3. Scenario generation\n4. Phone call execution\n5. Email report delivery",
-                "tags": [
-                    "test_framework"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ScenarioSerializerV2"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ScenarioSerializerV2"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ScenarioSerializerV2"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ScenarioSerializerV2"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
-        },
-        "/test_framework/v2/scenarios/run_full_scenario_demo_details/": {
-            "post": {
-                "operationId": "test-framework-v2-scenarios-run-full-scenario-demo-details-creat",
-                "description": "Scenarios run full scenario demo details creat",
-                "tags": [
-                    "test_framework"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ScenarioSerializerV2"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ScenarioSerializerV2"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ScenarioSerializerV2"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ScenarioSerializerV2"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
-        },
-        "/test_framework/v2/scenarios/run_full_scenario_demo_email/": {
-            "post": {
-                "operationId": "test-framework-v2-scenarios-run-full-scenario-demo-email-create",
-                "description": "Scenarios run full scenario demo email",
-                "tags": [
-                    "test_framework"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ScenarioSerializerV2"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ScenarioSerializerV2"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ScenarioSerializerV2"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ScenarioSerializerV2"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
-        },
         "/test_framework/v2/scenarios/run_scenarios/": {
             "post": {
                 "operationId": "scenarios-run-voice_3",
-                "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing.\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others:**\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.",
+                "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing. Requires `telephony.phone_number` configured on the agent (any provider).\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.",
                 "summary": "Run evaluators over a voice call",
                 "tags": [
                     "Evaluators"
@@ -43195,7 +42733,7 @@
         "/test_framework/v2/scenarios/run_scenarios_agora/": {
             "post": {
                 "operationId": "scenarios-run-agora_3",
-                "description": "AGORA RTC VOICE RUN: Execute evaluators against an agent reachable in an Agora RTC channel. Cekura joins the channel as a participant and converses. The agent must have `agora_data.session_endpoint_url` configured — an endpoint that mints the per-call channel and token; Cekura calls it at run time and never stores the join details.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC",
+                "description": "AGORA RTC VOICE RUN: Execute evaluators against an agent reachable in an Agora RTC channel. Cekura joins the channel as a participant and converses. The agent must have `agora_data.session_endpoint_url` configured — an endpoint that mints the per-call channel and token; Cekura calls it at run time and never stores the join details.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC",
                 "summary": "Run evaluators against an agent in an Agora RTC channel",
                 "tags": [
                     "Evaluators"
@@ -43371,7 +42909,7 @@
         "/test_framework/v2/scenarios/run_scenarios_chirp/": {
             "post": {
                 "operationId": "scenarios-run-chirp_3",
-                "description": "RAW-PCM WEBSOCKET VOICE RUN: Execute evaluators against an agent that exposes a raw-PCM WebSocket endpoint (16 kHz, 16-bit mono, binary frames). The agent must have a websocket endpoint configured (`telephony.websocket_url`); optional Basic Auth lives in `telephony.websocket_auth`. Pass `websocket_url` to override the agent's stored endpoint for this run.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_websocket` — JSON/text WebSocket protocol (per-scenario URLs)\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC",
+                "description": "RAW-PCM WEBSOCKET VOICE RUN: Execute evaluators against an agent that exposes a raw-PCM WebSocket endpoint (16 kHz, 16-bit mono, binary frames). The agent must have a websocket endpoint configured (`telephony.websocket_url`); optional Basic Auth lives in `telephony.websocket_auth`. Pass `websocket_url` to override the agent's stored endpoint for this run.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_websocket` — JSON/text WebSocket protocol (per-scenario URLs)\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC",
                 "summary": "Run evaluators against a raw-PCM WebSocket voice endpoint",
                 "tags": [
                     "Evaluators"
@@ -43547,7 +43085,7 @@
         "/test_framework/v2/scenarios/run_scenarios_elevenlabs/": {
             "post": {
                 "operationId": "scenarios-run-elevenlabs_3",
-                "description": "ELEVENLABS CONVERSATIONAL VOICE RUN: Execute evaluators against an ElevenLabs Conversational AI agent. The agent must have ElevenLabs credentials configured AND `assistant_id` set to the ElevenLabs agent ID.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)",
+                "description": "ELEVENLABS CONVERSATIONAL VOICE RUN: Execute evaluators against an ElevenLabs Conversational AI agent. The agent must have ElevenLabs credentials configured AND `assistant_id` set to the ElevenLabs agent ID.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)",
                 "summary": "Run evaluators against an ElevenLabs Conversational agent",
                 "tags": [
                     "Evaluators"
@@ -43908,7 +43446,7 @@
         "/test_framework/v2/scenarios/run_scenarios_livekit_v2/": {
             "post": {
                 "operationId": "scenarios-run-livekit-v2_3",
-                "description": "LIVEKIT VOICE RUN (project credentials, v2): Execute evaluators against a LiveKit agent using credentials configured at the project (or agent) level. Cekura creates the rooms; you don't pass URLs per-scenario. Requires `livekit_api_key`, `livekit_data.api_secret`, and `livekit_data.url` on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `room_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_websocket` — JSON/text WebSocket runs",
+                "description": "LIVEKIT VOICE RUN (project credentials, v2): Execute evaluators against a LiveKit agent using credentials configured at the project (or agent) level. Cekura creates the rooms; you don't pass URLs per-scenario. Requires `livekit_api_key`, `livekit_data.api_secret`, and `livekit_data.url` on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `room_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_websocket` — JSON/text WebSocket runs",
                 "summary": "Run evaluators against a LiveKit agent (project credentials, v2)",
                 "tags": [
                     "Evaluators"
@@ -44089,7 +43627,7 @@
         "/test_framework/v2/scenarios/run_scenarios_pipecat/": {
             "post": {
                 "operationId": "scenarios-run-pipecat-v1_3",
-                "description": "PIPECAT WEBRTC RUN (manual room URLs, v1): Execute evaluators against an agent running on Pipecat / Daily.co WebRTC. Each scenario entry carries its own `pipecat_room_url` and optional token. For project-credential-based runs (no per-scenario URL), use `scenarios_run_pipecat_v2` instead.\n\n**Run-count:** one run per entry in `scenarios` — this endpoint does not support `frequency` or personality/test-profile multipliers. To run the same scenario multiple times, include it multiple times in the `scenarios` list.\n\n**When to use this vs others:**\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_text` — text / SMS / chat mode\n- `run_scenarios_with_websockets` — agent exposes a plain websocket URL (non-Pipecat)\n\n**Scheduled runs:** WebRTC sessions are not generally scheduled. Use `run_scenarios` or `run_scenarios_text` via CronJob for recurring evaluator runs.",
+                "description": "PIPECAT WEBRTC RUN (manual room URLs, v1): Execute evaluators against an agent running on Pipecat / Daily.co WebRTC. Each scenario entry carries its own `pipecat_room_url` and optional token. For project-credential-based runs (no per-scenario URL), use `scenarios_run_pipecat_v2` instead.\n\n**Run-count:** one run per entry in `scenarios` — this endpoint does not support `frequency` or personality/test-profile multipliers. To run the same scenario multiple times, include it multiple times in the `scenarios` list.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_text` — text / SMS / chat mode\n- `run_scenarios_with_websockets` — agent exposes a plain websocket URL (non-Pipecat)\n\n**Scheduled runs:** WebRTC sessions are not generally scheduled. Use `run_scenarios` or `run_scenarios_text` via CronJob for recurring evaluator runs.",
                 "summary": "Run evaluators against a Pipecat WebRTC deployment (manual room URLs, v1)",
                 "tags": [
                     "Evaluators"
@@ -44269,7 +43807,7 @@
         "/test_framework/v2/scenarios/run_scenarios_pipecat_v2/": {
             "post": {
                 "operationId": "scenarios-run-pipecat-v2_3",
-                "description": "PIPECAT CLOUD VOICE RUN (project credentials, v2): Execute evaluators against an agent deployed on Pipecat Cloud using credentials configured at the project level. Cekura creates the sessions; you don't pass per-scenario room URLs (that's the v1 endpoint). Requires Pipecat Cloud credentials with `pipecat_agent_name` set on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `session_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others:**\n- `scenarios_run_pipecat_v1` — manual room URLs per scenario\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
+                "description": "PIPECAT CLOUD VOICE RUN (project credentials, v2): Execute evaluators against an agent deployed on Pipecat Cloud using credentials configured at the project level. Cekura creates the sessions; you don't pass per-scenario room URLs (that's the v1 endpoint). Requires Pipecat Cloud credentials with `pipecat_agent_name` set on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `session_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_pipecat_v1` — manual room URLs per scenario\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
                 "summary": "Run evaluators against a Pipecat Cloud deployment (project credentials, v2)",
                 "tags": [
                     "Evaluators"
@@ -44450,7 +43988,7 @@
         "/test_framework/v2/scenarios/run_scenarios_retell_webrtc/": {
             "post": {
                 "operationId": "scenarios-run-retell-webrtc_3",
-                "description": "RETELL WEBRTC VOICE RUN: Execute evaluators against a Retell agent over WebRTC (LiveKit infrastructure). The agent must have Retell credentials configured. `retell_agent_id` is optional and defaults to `agent.assistant_id` if not provided.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
+                "description": "RETELL WEBRTC VOICE RUN: Execute evaluators against a Retell agent over WebRTC (LiveKit infrastructure). The agent must have Retell credentials configured. `retell_agent_id` is optional and defaults to `agent.assistant_id` if not provided.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
                 "summary": "Run evaluators against a Retell agent over WebRTC",
                 "tags": [
                     "Evaluators"
@@ -44628,7 +44166,7 @@
         "/test_framework/v2/scenarios/run_scenarios_sip/": {
             "post": {
                 "operationId": "scenarios-run-sip_3",
-                "description": "SIP VOICE RUN (direct SIP): Execute evaluators against an agent over a direct SIP connection (orchestrated by Cekura's SIP voice service). The agent must have `sip_endpoint` configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone calls via Cekura's standard voice path\n- `scenarios_run_vapi_webrtc` / `_retell_webrtc` — provider-managed WebRTC\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
+                "description": "SIP VOICE RUN (direct SIP): Execute evaluators against an agent over a direct SIP connection (orchestrated by Cekura's SIP voice service). The agent must have a SIP endpoint configured (`telephony.sip_uri` on the v2 agent).\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone calls via Cekura's standard voice path\n- `scenarios_run_vapi_webrtc` / `_retell_webrtc` — provider-managed WebRTC\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
                 "summary": "Run evaluators over a direct SIP connection",
                 "tags": [
                     "Evaluators"
@@ -44804,7 +44342,7 @@
         "/test_framework/v2/scenarios/run_scenarios_text/": {
             "post": {
                 "operationId": "scenarios-run-text_3",
-                "description": "TEXT / SMS / CHAT RUN: Execute evaluators against your agent using text-only simulation (SMS, chat, or an agent-hosted websocket). Cheaper than voice — billed at the text-simulation rate.\n\n**Run-count math:** total conversations = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**Concurrency:** use `concurrency_limit` to cap parallel conversations. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Websocket override:** if the agent exposes a plain websocket URL for text, pass it as `websocket_url` — this bypasses the agent's standard text-readiness check. Pass `websocket_headers` (JSON object) to override connection headers for this run — merged over the agent's configured headers, with the per-run values winning.\n\n**When to use this vs others:**\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL (bulk)\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**`self_hosted` agents:** agents with `assistant_provider=\"self_hosted\"` require a websocket URL. Either pre-configure `websocket_url` on the agent, or pass it directly in this request. Without it, the run fails with `[\"Agent does not have a websocket URL\"]`. Passing `websocket_url` here changes the result's `run_type` to `\"WebSocket\"` instead of `\"Text\"`.\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"text\"` instead.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.",
+                "description": "TEXT / SMS / CHAT RUN: Execute evaluators against your agent using text-only simulation (SMS, chat, or an agent-hosted websocket). Cheaper than voice — billed at the text-simulation rate. Requires a chat connection (`provider.chat_agent_details`) on the agent, or a websocket URL for `self_hosted` agents.\n\n**Run-count math:** total conversations = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**Concurrency:** use `concurrency_limit` to cap parallel conversations. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Websocket override:** if the agent exposes a plain websocket URL for text, pass it as `websocket_url` — this bypasses the agent's standard text-readiness check. Pass `websocket_headers` (JSON object) to override connection headers for this run — merged over the agent's configured headers, with the per-run values winning.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL (bulk)\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**`self_hosted` agents:** agents with `assistant_provider=\"self_hosted\"` require a websocket URL. Either pre-configure `websocket_url` on the agent, or pass it directly in this request. Without it, the run fails with `[\"Agent does not have a websocket URL\"]`. Passing `websocket_url` here changes the result's `run_type` to `\"WebSocket\"` instead of `\"Text\"`.\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"text\"` instead.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.",
                 "summary": "Run evaluators in text / SMS / chat mode",
                 "tags": [
                     "Evaluators"
@@ -45003,7 +44541,7 @@
         "/test_framework/v2/scenarios/run_scenarios_vapi_webrtc/": {
             "post": {
                 "operationId": "scenarios-run-vapi-webrtc_3",
-                "description": "VAPI WEBRTC VOICE RUN: Execute evaluators against a VAPI agent over WebRTC. Required: `vapi_assistant_id` (the VAPI assistant). The agent (looked up via `agent_id` or inferred from the first scenario) must have VAPI credentials configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_text` — text/SMS/chat (cheaper)\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
+                "description": "VAPI WEBRTC VOICE RUN: Execute evaluators against a VAPI agent over WebRTC. Required: `vapi_assistant_id` (the VAPI assistant). The agent (looked up via `agent_id` or inferred from the first scenario) must have VAPI credentials configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_text` — text/SMS/chat (cheaper)\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
                 "summary": "Run evaluators against a VAPI WebRTC agent",
                 "tags": [
                     "Evaluators"
@@ -45182,7 +44720,7 @@
         "/test_framework/v2/scenarios/run_scenarios_with_websockets/": {
             "post": {
                 "operationId": "scenarios-run-websocket_3",
-                "description": "WEBSOCKET RUN (per-scenario URLs, bulk): Execute evaluators where each scenario carries its own websocket URL. Useful when you have a fleet of agents or stateful websocket sessions to test in a single batch.\n\n**Run-count:** total conversations = `len(scenarios) × frequency`. (Personality and test-profile multipliers are not supported on this endpoint.)\n\n**`frequency` is required** on this endpoint (no default).\n\n**When to use this vs others:**\n- `run_scenarios_text` — single websocket URL or SMS/chat mode (simpler)\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'.\n\n**Known limitation:** `result.run_type` may show 'Text' instead of 'WebSocket' for runs triggered via this endpoint — this is a display issue only and does not affect execution.",
+                "description": "WEBSOCKET RUN (per-scenario URLs, bulk): Execute evaluators where each scenario carries its own websocket URL. Useful when you have a fleet of agents or stateful websocket sessions to test in a single batch.\n\n**Run-count:** total conversations = `len(scenarios) × frequency`. (Personality and test-profile multipliers are not supported on this endpoint.)\n\n**`frequency` is required** on this endpoint (no default).\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — single websocket URL or SMS/chat mode (simpler)\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'.\n\n**Known limitation:** `result.run_type` may show 'Text' instead of 'WebSocket' for runs triggered via this endpoint — this is a display issue only and does not affect execution.",
                 "summary": "Run evaluators against per-scenario websocket URLs (bulk)",
                 "tags": [
                     "Evaluators"


### PR DESCRIPTION
Auto-generated docs sync for backend PR [#9519](https://github.com/cekura-ai/vocera.backend/pull/9519).

Reviewers: @dileep-chagam

## Summary

**Spec/overlay:** 12 MCP-exposed operations had description updates (aiagents_retrieve + 11 run endpoints). No overlay edits needed — the changes add cross-references visible via the spec. Existing overlays for scenarios_run_voice, scenarios_run_text, scenarios_run_pipecat_v1, and scenarios_run_websocket remain accurate (D2 precedence).

**Conceptual docs:** No edits — backend PR #9519 adds API-spec-level guidance (configured-connection → run-endpoint mapping) to OpenAPI operation descriptions. Reviewed `documentation/key-concepts/agents/Agent_Setup_Guide.mdx`, `documentation/guides/testing-agents/overview.mdx`, `documentation/guides/agent-integration.mdx`, and provider-specific testing pages (`vapi/testing.mdx`, `retell/testing.mdx`, `livekit/testing.mdx`). None of these conceptual docs pages currently explain the connection-to-endpoint mapping, and none misrepresent the post-PR behavior. The pages are incomplete-but-not-wrong: they describe agent configuration and high-level testing workflows without enumerating specific API endpoints. This level of API detail belongs in the API reference (handled by `cekura-spec-update`), not in conceptual docs. The backend PR explicitly states "no behavior change" — the mapping was always true, now documented in the spec. All reviewed pages remain accurate at their intended level of abstraction.

## Changes

- `openapi.json` — regenerate_from_backend

---
*Auto-generated from backend PR #9519.*

<!-- mcp-sync:file-hashes -->
```json
{}
```
<!-- /mcp-sync:file-hashes -->