### PR TITLE
[CEK-7539] Update metric docs for v2 + regenerate openapi

### DIFF
--- a/api-reference/observability/get-call.mdx
+++ b/api-reference/observability/get-call.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Call
 description: "Retrieve a call log by ID"
-openapi: get /observability/v1/call-logs/{id}/
+openapi: get /observability/v2/call-logs/{id}/
 slug: get-call
 ---

--- a/api-reference/observability/list-calls.mdx
+++ b/api-reference/observability/list-calls.mdx
@@ -1,6 +1,6 @@
 ---
 title: List Calls
 description: "List call logs"
-openapi: get /observability/v1/call-logs/
+openapi: get /observability/v2/call-logs/
 slug: list-calls
 ---

--- a/api-reference/test_framework/create-metric.mdx
+++ b/api-reference/test_framework/create-metric.mdx
@@ -1,6 +1,6 @@
 ---
 title: Create Metric
 description: "Create a quality metric for evaluating agent conversations."
-openapi: post /test_framework/v1/metrics/
+openapi: post /test_framework/v2/metrics/
 slug: create-metric
 ---

--- a/api-reference/test_framework/get-metric.mdx
+++ b/api-reference/test_framework/get-metric.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Metric
 description: "Retrieve a specific metric by ID or slug."
-openapi: get /test_framework/v1/metrics/{id}/
+openapi: get /test_framework/v2/metrics/{id}/
 slug: get-metric
 ---

--- a/api-reference/test_framework/get-result.mdx
+++ b/api-reference/test_framework/get-result.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Result
 description: "Retrieve a test result by ID"
-openapi: get /test_framework/v1/results/{id}/
+openapi: get /test_framework/v2/results/{id}/
 slug: get-result
 ---

--- a/api-reference/test_framework/list-metrics.mdx
+++ b/api-reference/test_framework/list-metrics.mdx
@@ -1,6 +1,6 @@
 ---
 title: List Metrics
 description: ""
-openapi: get /test_framework/v1/metrics/
+openapi: get /test_framework/v2/metrics/
 slug: list-metrics
 ---

--- a/api-reference/test_framework/list-results.mdx
+++ b/api-reference/test_framework/list-results.mdx
@@ -1,6 +1,6 @@
 ---
 title: List Results
 description: "List test results"
-openapi: get /test_framework/v1/results/
+openapi: get /test_framework/v2/results/
 slug: list-results
 ---

--- a/api-reference/test_framework/list-runs-with-ids.mdx
+++ b/api-reference/test_framework/list-runs-with-ids.mdx
@@ -1,6 +1,6 @@
 ---
 title: List Runs with IDs
 description: "Retrieve multiple runs in a single request"
-openapi: get /test_framework/v1/runs/bulk/
+openapi: get /test_framework/v2/runs/bulk/
 slug: list-runs-with-ids
 ---

--- a/api-reference/test_framework/update-metric.mdx
+++ b/api-reference/test_framework/update-metric.mdx
@@ -1,6 +1,6 @@
 ---
 title: Update Metric
 description: "Partially update a metric. Same field shape as create — see `metrics_create` for details."
-openapi: patch /test_framework/v1/metrics/{id}/
+openapi: patch /test_framework/v2/metrics/{id}/
 slug: update-metric
 ---

--- a/documentation/advanced/webhook-format.mdx
+++ b/documentation/advanced/webhook-format.mdx
@@ -18,6 +18,10 @@ import { CopyPageButton } from "/snippets/copy-page-button.mdx";
   All webhook requests includes `X-CEKURA-SECRET` header with your configured webhook secret.
 </Note>
 
+<Note>
+  Metric `type` values in the payload are `binary`, `continuous_qualitative`, `numeric`, or `enum`. For `binary` metrics, `score` is `true` or `false`.
+</Note>
+
 **Webhook JSON Example:**
 
 ## Result Notifications
@@ -98,8 +102,8 @@ import { CopyPageButton } from "/snippets/copy-page-button.mdx";
             {
               "id": 7,
               "name": "workflow-adherence-check",
-              "type": "binary_workflow_adherence",
-              "score": 0,
+              "type": "binary",
+              "score": false,
               "explanation": [
                 "This metric is designed to always return false for validation testing.",
                 "As such, it cannot be satisfied by the agent under normal conditions."
@@ -168,8 +172,8 @@ import { CopyPageButton } from "/snippets/copy-page-button.mdx";
             {
               "id": 7,
               "name": "workflow-adherence-check",
-              "type": "binary_workflow_adherence",
-              "score": 0,
+              "type": "binary",
+              "score": false,
               "explanation": [
                 "This metric explicitly requires a false outcome for validation."
               ],
@@ -233,8 +237,8 @@ import { CopyPageButton } from "/snippets/copy-page-button.mdx";
             {
               "id": 5,
               "name": "workflow-adherence-check",
-              "type": "binary_workflow_adherence",
-              "score": 5,
+              "type": "binary",
+              "score": true,
               "explanation": [
                 "This metric is designed to always return true, regardless of interaction content."
               ],
@@ -292,9 +296,9 @@ import { CopyPageButton } from "/snippets/copy-page-button.mdx";
         {
           "id": 5,
           "name": "workflow-adherence-check",
-          "type": "binary_workflow_adherence",
+          "type": "binary",
           "vocera_defined_metric_code": "string",
-          "score": 5,
+          "score": true,
           "explanation": [
             "This metric is defined to always return true.",
             "The AI agent, by definition of the metric, meets the criteria."
@@ -437,9 +441,9 @@ import { CopyPageButton } from "/snippets/copy-page-button.mdx";
         {
           "id": 6,
           "name": "workflow-boolean-check",
-          "type": "binary_workflow_adherence",
+          "type": "binary",
           "vocera_defined_metric_code": "string",
-          "score": 5,
+          "score": true,
           "explanation": [
             "The metric definition explicitly states 'Always return true'."
           ]

--- a/documentation/advanced/webhook-format.mdx
+++ b/documentation/advanced/webhook-format.mdx
@@ -19,7 +19,11 @@ import { CopyPageButton } from "/snippets/copy-page-button.mdx";
 </Note>
 
 <Note>
-  Metric `type` values in the payload are `binary`, `continuous_qualitative`, `numeric`, or `enum`. For `binary` metrics, `score` is `true` or `false`.
+  Non-binary metrics use `type` (`continuous_qualitative`, `numeric`, or `enum`) with a numeric or enum `score`.
+
+  Binary metrics use `eval_type: "binary"` with a boolean `passed` (`true` = pass, `false` = fail). Use these fields when integrating.
+
+  For backward compatibility, binary metrics also still include the deprecated legacy fields `type: "binary_workflow_adherence"` and `score: 5`/`0` (not shown in the examples below). These will be removed in a future version — new integrations should rely on `eval_type` and `passed`.
 </Note>
 
 **Webhook JSON Example:**
@@ -102,8 +106,8 @@ import { CopyPageButton } from "/snippets/copy-page-button.mdx";
             {
               "id": 7,
               "name": "workflow-adherence-check",
-              "type": "binary",
-              "score": false,
+              "eval_type": "binary",
+              "passed": false,
               "explanation": [
                 "This metric is designed to always return false for validation testing.",
                 "As such, it cannot be satisfied by the agent under normal conditions."
@@ -172,8 +176,8 @@ import { CopyPageButton } from "/snippets/copy-page-button.mdx";
             {
               "id": 7,
               "name": "workflow-adherence-check",
-              "type": "binary",
-              "score": false,
+              "eval_type": "binary",
+              "passed": false,
               "explanation": [
                 "This metric explicitly requires a false outcome for validation."
               ],
@@ -237,8 +241,8 @@ import { CopyPageButton } from "/snippets/copy-page-button.mdx";
             {
               "id": 5,
               "name": "workflow-adherence-check",
-              "type": "binary",
-              "score": true,
+              "eval_type": "binary",
+              "passed": true,
               "explanation": [
                 "This metric is designed to always return true, regardless of interaction content."
               ],
@@ -296,9 +300,9 @@ import { CopyPageButton } from "/snippets/copy-page-button.mdx";
         {
           "id": 5,
           "name": "workflow-adherence-check",
-          "type": "binary",
+          "eval_type": "binary",
           "vocera_defined_metric_code": "string",
-          "score": true,
+          "passed": true,
           "explanation": [
             "This metric is defined to always return true.",
             "The AI agent, by definition of the metric, meets the criteria."
@@ -441,9 +445,9 @@ import { CopyPageButton } from "/snippets/copy-page-button.mdx";
         {
           "id": 6,
           "name": "workflow-boolean-check",
-          "type": "binary",
+          "eval_type": "binary",
           "vocera_defined_metric_code": "string",
-          "score": true,
+          "passed": true,
           "explanation": [
             "The metric definition explicitly states 'Always return true'."
           ]

--- a/documentation/guides/creating-good-metric.mdx
+++ b/documentation/guides/creating-good-metric.mdx
@@ -29,8 +29,8 @@ Before building, clarify exactly what you are tracking. Understand the terminolo
 
 Navigate to the **Metrics** section and select **Create Metric**.
 
-1. **Name & Type:** Give your metric a descriptive name (e.g., `Correct End Call by Main Agent`). Select the **Metric Type** (usually **Boolean** for pass/fail checks).
-2. **Success Impact:** Toggle **Affects Call Success** to `True` if this metric is critical (i.e., if this fails, the entire call is considered a failure).
+1. **Name & Type:** Give your metric a descriptive name (e.g., `Correct End Call by Main Agent`). Select the **Metric Type** (usually **Binary** for pass/fail checks).
+2. **Success Impact:** Toggle **Add to rubric rule** to include this metric in your project's call-success rubric. Only metrics in the rubric contribute to a call's pass/fail outcome — fine-tune the threshold afterwards under **Settings → Rubric**.
 3. **Description (The Prompt):** Write a natural language description of what constitutes success.
 
 <Note>

--- a/documentation/key-concepts/metrics/llm-judge-metric.mdx
+++ b/documentation/key-concepts/metrics/llm-judge-metric.mdx
@@ -98,7 +98,7 @@ response = evaluate_llm_judge_metric(
     data,
     api_key,
     description="Did the agent speak clearly and at an appropriate pace?",
-    eval_type="binary_qualitative",
+    eval_type="binary",
     audio=True,
     audio_start_time=5.2,   # optional: clip start in seconds
     audio_end_time=12.8,    # optional: clip end in seconds

--- a/documentation/key-concepts/metrics/python-metric.mdx
+++ b/documentation/key-concepts/metrics/python-metric.mdx
@@ -696,8 +696,7 @@ def evaluate_llm_judge_metric(
 <ParamField path="eval_type" type="str" default="None">
   The type of evaluation to perform. Supported values:
 
-  - `"binary_workflow_adherence"` - Binary evaluation (returns 0 or 5)
-  - `"binary_qualitative"` - Binary qualitative assessment (returns 0 or 5)
+  - `"binary"` - Binary evaluation (returns `0` or `5`)
   - `"numeric"` - Numeric evaluation (returns integer or float)
   - `"continuous_qualitative"` - Continuous scale from 0 to 5
   - `"enum"` - Enumerated values (requires `enum_values` parameter)
@@ -761,7 +760,7 @@ if "main" not in call_end_reason.lower():
 
 description = get_not_early_end_call_description()
 
-response = evaluate_llm_judge_metric(data, key, description, "binary_workflow_adherence")
+response = evaluate_llm_judge_metric(data, key, description, "binary")
 _result = response.get("result")
 _explanation = response.get("explanation")
 ```
@@ -787,7 +786,7 @@ if "main" not in call_end_reason.lower():
 
 description = get_not_early_end_call_description()
 
-response = evaluate_basic_metric(data, key, description, "binary_workflow_adherence")
+response = evaluate_basic_metric(data, key, description, "binary")
 _result = response.get("result")
 _explanation = response.get("explanation")
 ```
@@ -838,7 +837,7 @@ if "main" not in call_end_reason.lower():
 
 prompt = get_not_early_end_call_prompt(data["transcript"], data["call_end_reason"])
 
-response = evaluate_advance_metric(data, key, prompt, "binary_workflow_adherence")
+response = evaluate_advance_metric(data, key, prompt, "binary")
 _result = response.get("result")
 _explanation = response.get("explanation")
 ```
@@ -902,7 +901,7 @@ else:
         data,
         key,
         description="Did the agent deliver this segment clearly, at an appropriate pace, and without unnatural pauses?",
-        eval_type="binary_qualitative",
+        eval_type="binary",
         audio=True,
         audio_start_time=segment_start,
         audio_end_time=segment_end,

--- a/documentation/key-concepts/metrics/rubric.mdx
+++ b/documentation/key-concepts/metrics/rubric.mdx
@@ -77,12 +77,12 @@ For Projects, all default predefined metrics are automatically added to your rub
 
 ### New Boolean Metrics
 
-When you create new boolean metrics (Binary Qualitative or Binary Workflow Adherence), they are automatically added to your rubric with a default success condition:
+When you create a new binary metric and enable the **Add to rubric rule** toggle, it is automatically added to your rubric with a default success condition:
 
-- **Operator**: greater than or equal
-- **Value**: 5
+- **Operator**: equals
+- **Value**: `true` (pass)
 
-This ensures new critical metrics are immediately included in your success evaluation.
+You can edit the rule afterwards under **Settings → Rubric**.
 
 ## Tips
 

--- a/openapi.json
+++ b/openapi.json
@@ -423,6 +423,302 @@
                 }
             }
         },
+        "/app/v2/product-chat/org-skills/": {
+            "get": {
+                "operationId": "app-v2-product-chat-org-skills-retrieve",
+                "description": "List all active custom skills for the org. Any member can read.",
+                "tags": [
+                    "app"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No response body"
+                    }
+                }
+            }
+        },
+        "/app/v2/product-chat/org-skills/{skill_id}/": {
+            "patch": {
+                "operationId": "app-v2-product-chat-org-skills-partial-update",
+                "description": "Toggle active/inactive or delete a single custom skill.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "skill_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "app"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No response body"
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "app-v2-product-chat-org-skills-destroy",
+                "description": "Toggle active/inactive or delete a single custom skill.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "skill_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "app"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No response body"
+                    }
+                }
+            }
+        },
+        "/app/v2/product-chat/org-skills/sources/": {
+            "get": {
+                "operationId": "app-v2-product-chat-org-skills-sources-retrieve",
+                "description": "List or create skill sources for the authenticated user's org.\n\nPOST accepts either:\n  - multipart/form-data with source_type=zip and file=<.zip|.tar.gz>\n  - application/json with source_type=github and github_url=<url>",
+                "tags": [
+                    "app"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No response body"
+                    }
+                }
+            },
+            "post": {
+                "operationId": "app-v2-product-chat-org-skills-sources-create",
+                "description": "List or create skill sources for the authenticated user's org.\n\nPOST accepts either:\n  - multipart/form-data with source_type=zip and file=<.zip|.tar.gz>\n  - application/json with source_type=github and github_url=<url>",
+                "tags": [
+                    "app"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No response body"
+                    }
+                }
+            }
+        },
+        "/app/v2/product-chat/org-skills/sources/{source_id}/": {
+            "get": {
+                "operationId": "app-v2-product-chat-org-skills-sources-retrieve_2",
+                "description": "Retrieve a re-sync , or delete a skill source by ID",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "source_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "app"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No response body"
+                    }
+                }
+            },
+            "post": {
+                "operationId": "app-v2-product-chat-org-skills-sources-create_2",
+                "description": "Re-sync a GitHub source (triggers a new Celery task).",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "source_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "app"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No response body"
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "app-v2-product-chat-org-skills-sources-destroy",
+                "description": "Delete a re-sync , or delete a skill source",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "source_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "app"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No response body"
+                    }
+                }
+            }
+        },
+        "/app/v2/product-chat/org-skills/sources/{source_id}/sync/": {
+            "get": {
+                "operationId": "app-v2-product-chat-org-skills-sources-sync-retrieve",
+                "description": "App v2 product chat org skills sources sync",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "source_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "app"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No response body"
+                    }
+                }
+            },
+            "post": {
+                "operationId": "app-v2-product-chat-org-skills-sources-sync-create",
+                "description": "Re-sync a GitHub source (triggers a new Celery task).",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "source_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "app"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No response body"
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "app-v2-product-chat-org-skills-sources-sync-destroy",
+                "description": "App v2 product chat org skills sources sync",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "source_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "app"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No response body"
+                    }
+                }
+            }
+        },
+        "/app/v2/product-chat/org-skills/upload/": {
+            "post": {
+                "operationId": "app-v2-product-chat-org-skills-upload-create",
+                "description": "Upload a single .md file as a skill or command.\n\nAccepts multipart/form-data with a single \"file\" field.\nThe file is scanned immediately (synchronously) — fast because it's\na single file, no git clone or zip extraction required.",
+                "tags": [
+                    "app"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No response body"
+                    }
+                }
+            }
+        },
         "/dashboards/dashboards/": {
             "get": {
                 "operationId": "dashboards-list",
@@ -22768,7 +23064,7 @@
         "/test_framework/v1/results-external/{id}/create_shareable_link_token/": {
             "post": {
                 "operationId": "create-shareable-link-token",
-                "description": "Generates a secure, time-limited shareable link that allows users to view test results without authentication. This feature requires an active subscription with whitelabel_reports enabled and provides both standard and custom branded URLs based on organization settings.",
+                "description": "Generates a secure, time-limited shareable link that allows users to view test results without authentication. Requires an active subscription.",
                 "summary": "Generate shareable link for result",
                 "parameters": [
                     {
@@ -23874,7 +24170,7 @@
         "/test_framework/v1/results/{id}/create_shareable_link_token/": {
             "post": {
                 "operationId": "create-shareable-link-token_2",
-                "description": "Generates a secure, time-limited shareable link that allows users to view test results without authentication. This feature requires an active subscription with whitelabel_reports enabled and provides both standard and custom branded URLs based on organization settings.",
+                "description": "Generates a secure, time-limited shareable link that allows users to view test results without authentication. Requires an active subscription.",
                 "summary": "Generate shareable link for result",
                 "parameters": [
                     {
@@ -23949,7 +24245,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "create-shareable-link-token",
-                        "description": "Generates a secure, time-limited shareable link that allows users to view test results without authentication. This feature requires an active subscription with whitelabel_reports enabled and provides both standard and custom branded URLs based on organization settings."
+                        "description": "Generates a secure, time-limited shareable link that allows users to view test results without authentication. Requires an active subscription."
                     }
                 }
             }
@@ -48373,61 +48669,6 @@
                 },
                 "description": "Retrieve an user membership by ID"
             },
-            "put": {
-                "operationId": "user-memberships-update",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "A unique integer value identifying this membership.",
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "user"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/UserMembership"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/UserMembership"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/UserMembership"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/UserMembership"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Update an user membership"
-            },
             "patch": {
                 "operationId": "user-memberships-partial-update",
                 "parameters": [
@@ -51750,1364 +51991,6 @@
                 },
                 "description": "Projects members"
             }
-        },
-        "/webpage/domain/": {
-            "get": {
-                "operationId": "webpage-domain-list",
-                "tags": [
-                    "webpage"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/CustomDomainList"
-                                    }
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "List webpage domain"
-            },
-            "post": {
-                "operationId": "webpage-domain-create",
-                "description": "Create a new custom domain",
-                "tags": [
-                    "webpage"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomDomainDetail"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomDomainDetail"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomDomainDetail"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/CustomDomainDetail"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
-        },
-        "/webpage/domain/{organization}/": {
-            "get": {
-                "operationId": "webpage-domain-retrieve",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "organization",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "webpage"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/CustomDomainDetail"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Retrieve a webpage domain by ID"
-            },
-            "put": {
-                "operationId": "webpage-domain-update",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "organization",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "webpage"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomDomainDetail"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomDomainDetail"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomDomainDetail"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/CustomDomainDetail"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Update a webpage domain"
-            },
-            "patch": {
-                "operationId": "webpage-domain-partial-update",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "organization",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "webpage"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchedCustomDomainDetail"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchedCustomDomainDetail"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchedCustomDomainDetail"
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/CustomDomainDetail"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Update a webpage domain"
-            },
-            "delete": {
-                "operationId": "webpage-domain-destroy",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "organization",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "webpage"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No response body"
-                    }
-                },
-                "description": "Delete a webpage domain"
-            }
-        },
-        "/webpage/domain/{organization}/verify/": {
-            "get": {
-                "operationId": "webpage-domain-verify-retrieve",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "organization",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "webpage"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/CustomDomainDetail"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Webpage domain verify"
-            }
-        },
-        "/webpage/page/": {
-            "post": {
-                "operationId": "webpage-page-create",
-                "description": "POST method to create/update a webpage\nExpected request data:\n{\n    \"domain\": \"example.com\", # Can be full URL like https://www.example.com\n    \"html_content\": \"<html>...</html>\"\n}",
-                "tags": [
-                    "webpage"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomDomainDetail"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomDomainDetail"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomDomainDetail"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/CustomDomainDetail"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
-        },
-        "/webpage/page/{organization}/": {
-            "get": {
-                "operationId": "webpage-page-retrieve",
-                "description": "GET method to retrieve a webpage's HTML content\npk should be the organization id",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "organization",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "webpage"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/CustomDomainDetail"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            },
-            "delete": {
-                "operationId": "webpage-page-destroy",
-                "description": "DELETE method to remove a webpage\npk should be the organization id",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "organization",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "webpage"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No response body"
-                    }
-                }
-            }
-        },
-        "/workflows/edges/": {
-            "get": {
-                "operationId": "workflows-edges-list",
-                "tags": [
-                    "workflows"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Edge"
-                                    }
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "List workflows edges"
-            },
-            "post": {
-                "operationId": "workflows-edges-create",
-                "tags": [
-                    "workflows"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Edge"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Edge"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Edge"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Edge"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Create a new workflows edge"
-            }
-        },
-        "/workflows/edges/{id}/": {
-            "get": {
-                "operationId": "workflows-edges-retrieve",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "workflows"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Edge"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Retrieve a workflows edge by ID"
-            },
-            "put": {
-                "operationId": "workflows-edges-update",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "workflows"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Edge"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Edge"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Edge"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Edge"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Update a workflows edge"
-            },
-            "patch": {
-                "operationId": "workflows-edges-partial-update",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "workflows"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchedEdge"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchedEdge"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchedEdge"
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Edge"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Update a workflows edge"
-            },
-            "delete": {
-                "operationId": "workflows-edges-destroy",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "workflows"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No response body"
-                    }
-                },
-                "description": "Delete a workflows edge"
-            }
-        },
-        "/workflows/node-metrics/": {
-            "get": {
-                "operationId": "workflows-node-metrics-list",
-                "tags": [
-                    "workflows"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/NodeMetric"
-                                    }
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "List workflows node metrics"
-            },
-            "post": {
-                "operationId": "workflows-node-metrics-create",
-                "tags": [
-                    "workflows"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/NodeMetricCreate"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/NodeMetricCreate"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/NodeMetricCreate"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/NodeMetricCreate"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Create a new workflows node metric"
-            }
-        },
-        "/workflows/node-metrics/{id}/": {
-            "get": {
-                "operationId": "workflows-node-metrics-retrieve",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "workflows"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/NodeMetric"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Retrieve a workflows node metric by ID"
-            },
-            "put": {
-                "operationId": "workflows-node-metrics-update",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "workflows"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/NodeMetric"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/NodeMetric"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/NodeMetric"
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/NodeMetric"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Update a workflows node metric"
-            },
-            "patch": {
-                "operationId": "workflows-node-metrics-partial-update",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "workflows"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchedNodeMetric"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchedNodeMetric"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchedNodeMetric"
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/NodeMetric"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Update a workflows node metric"
-            },
-            "delete": {
-                "operationId": "workflows-node-metrics-destroy",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "workflows"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No response body"
-                    }
-                },
-                "description": "Delete a workflows node metric"
-            }
-        },
-        "/workflows/nodes/": {
-            "get": {
-                "operationId": "workflows-nodes-list",
-                "tags": [
-                    "workflows"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Node"
-                                    }
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "List workflows nodes"
-            },
-            "post": {
-                "operationId": "workflows-nodes-create",
-                "tags": [
-                    "workflows"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/NodeCreate"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/NodeCreate"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/NodeCreate"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/NodeCreate"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Create a new workflows node"
-            }
-        },
-        "/workflows/nodes/{id}/": {
-            "get": {
-                "operationId": "workflows-nodes-retrieve",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "workflows"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Node"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Retrieve a workflows node by ID"
-            },
-            "put": {
-                "operationId": "workflows-nodes-update",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "workflows"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Node"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Node"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Node"
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Node"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Update a workflows node"
-            },
-            "patch": {
-                "operationId": "workflows-nodes-partial-update",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "workflows"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchedNode"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchedNode"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchedNode"
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Node"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Update a workflows node"
-            },
-            "delete": {
-                "operationId": "workflows-nodes-destroy",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "workflows"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No response body"
-                    }
-                },
-                "description": "Delete a workflows node"
-            }
-        },
-        "/workflows/workflows/": {
-            "get": {
-                "operationId": "workflows-workflows-list",
-                "tags": [
-                    "workflows"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Workflow"
-                                    }
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "List workflows workflows"
-            },
-            "post": {
-                "operationId": "workflows-workflows-create",
-                "tags": [
-                    "workflows"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Workflow"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Workflow"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Workflow"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Workflow"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Create a new workflows workflow"
-            }
-        },
-        "/workflows/workflows/{id}/": {
-            "get": {
-                "operationId": "workflows-workflows-retrieve",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "workflows"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkflowDetail"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Retrieve a workflows workflow by ID"
-            },
-            "put": {
-                "operationId": "workflows-workflows-update",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "workflows"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Workflow"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Workflow"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Workflow"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Workflow"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Update a workflows workflow"
-            },
-            "patch": {
-                "operationId": "workflows-workflows-partial-update",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "workflows"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchedWorkflow"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchedWorkflow"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchedWorkflow"
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Workflow"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Update a workflows workflow"
-            },
-            "delete": {
-                "operationId": "workflows-workflows-destroy",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "workflows"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No response body"
-                    }
-                },
-                "description": "Delete a workflows workflow"
-            }
         }
     },
     "components": {
@@ -53619,7 +52502,12 @@
                     },
                     "webhook_secret": {
                         "type": "string",
-                        "description": "Secret sent in X-CEKURA-SECRET header. Applies when agent webhook_url is set."
+                        "writeOnly": true,
+                        "description": "Secret sent in X-CEKURA-SECRET header. Applies when agent webhook_url is set. Write-only — never returned in API responses. Use `webhook_secret_configured` to check whether one is set."
+                    },
+                    "webhook_secret_configured": {
+                        "type": "string",
+                        "readOnly": true
                     }
                 },
                 "required": [
@@ -54032,7 +52920,12 @@
                     },
                     "webhook_secret": {
                         "type": "string",
-                        "description": "Secret sent in X-CEKURA-SECRET header. Applies when agent webhook_url is set."
+                        "writeOnly": true,
+                        "description": "Secret sent in X-CEKURA-SECRET header. Applies when agent webhook_url is set. Write-only — never returned in API responses. Use `webhook_secret_configured` to check whether one is set."
+                    },
+                    "webhook_secret_configured": {
+                        "type": "string",
+                        "readOnly": true
                     },
                     "mock_tools": {
                         "type": "array",
@@ -56109,12 +55002,8 @@
                         "description": "Full text transcript of the call.\nExample: \n```text\n[00:01] Testing Agent: Hello. \n[00:02] Main Agent: Hello, how can I help you today?\n[00:03] Testing Agent: Well, I mean, sure. What time exactly are we talking about here\n[00:04] Main Agent: 6 PM.\n[00:05] Testing Agent: Great. I'll book that for you. Just a sec.\n[00:06] Main Agent: Okay.\n```\n"
                     },
                     "transcript_object": {
-                        "oneOf": [
-                            {},
-                            {
-                                "type": "null"
-                            }
-                        ],
+                        "type": "string",
+                        "readOnly": true,
                         "description": "Structured transcript data with timestamps.\nExample: \n```json\n[\n    {\n        \"role\": \"Testing Agent\",\n        \"content\": \"Hello\",\n        \"start_time\": 1.2,\n        \"end_time\": 1.8\n    },\n    {\n        \"role\": \"Main Agent\",\n        \"content\": \"Hello, how can I help you today?\",\n        \"start_time\": 1.8,\n        \"end_time\": 2.5\n    }\n]`"
                     },
                     "evaluation": {
@@ -57107,70 +55996,6 @@
                     "crontab_expression"
                 ]
             },
-            "CustomDomainDetail": {
-                "type": "object",
-                "description": "",
-                "properties": {
-                    "organization": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
-                    "domain": {
-                        "type": "string",
-                        "maxLength": 255
-                    },
-                    "verification_token": {
-                        "type": "string",
-                        "readOnly": true
-                    },
-                    "verified": {
-                        "type": "boolean",
-                        "readOnly": true
-                    },
-                    "domain_logo": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "format": "uri"
-                    }
-                },
-                "required": [
-                    "domain"
-                ]
-            },
-            "CustomDomainList": {
-                "type": "object",
-                "description": "",
-                "properties": {
-                    "organization": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
-                    "domain": {
-                        "type": "string",
-                        "maxLength": 255
-                    },
-                    "verified": {
-                        "type": "boolean",
-                        "readOnly": true
-                    },
-                    "verification_token": {
-                        "type": "string",
-                        "readOnly": true
-                    },
-                    "domain_logo": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "format": "uri"
-                    }
-                },
-                "required": [
-                    "domain"
-                ]
-            },
             "CustomTokenObtainPair": {
                 "type": "object",
                 "properties": {
@@ -57753,36 +56578,6 @@
                         "maxLength": 255
                     }
                 }
-            },
-            "Edge": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
-                    "source_node": {
-                        "type": "integer"
-                    },
-                    "target_node": {
-                        "type": "integer"
-                    },
-                    "value": {},
-                    "created_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    },
-                    "updated_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    }
-                },
-                "required": [
-                    "source_node",
-                    "target_node"
-                ]
             },
             "ElevenLabsConfig": {
                 "type": "object",
@@ -58672,47 +57467,6 @@
                         "readOnly": true
                     }
                 }
-            },
-            "Metric": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
-                    "name": {
-                        "type": "string",
-                        "description": "\nName of the metric.\nExample: `\"Customer Satisfaction\"` or `\"Appointment Booking\"`\n        ",
-                        "maxLength": 255
-                    },
-                    "description": {
-                        "type": "string",
-                        "description": "\nDescription of what the metric measures.\nExample: `\"Measures how satisfied customers are with the service provided\"`\n        "
-                    },
-                    "eval_type": {
-                        "enum": [
-                            "binary",
-                            "continuous_qualitative",
-                            "numeric",
-                            "enum"
-                        ],
-                        "type": "string",
-                        "x-spec-enum-id": "b40eac6824409cc2",
-                        "description": "\nType of evaluation\n\n\n* `binary` - Binary\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum"
-                    },
-                    "enum_values": {
-                        "description": "\nList of possible enum values for enum type metrics.\nExample: `[\"satisfied\", \"unsatisfied\"]`\n"
-                    },
-                    "display_order": {
-                        "type": "integer",
-                        "maximum": 2147483647,
-                        "minimum": -2147483648,
-                        "description": "\nDisplay order for the metric.\nExample: `1`\n"
-                    }
-                },
-                "required": [
-                    "name"
-                ]
             },
             "MetricBasicList": {
                 "type": "object",
@@ -59631,6 +58385,11 @@
                         "type": "string",
                         "readOnly": true
                     },
+                    "is_triage": {
+                        "type": "boolean",
+                        "description": "Derived live from the metric's current `triage_enabled` + rubric\nmembership (not persisted) — the FE renders the triage section only\nwhen this is true.",
+                        "readOnly": true
+                    },
                     "window_start": {
                         "type": "string",
                         "format": "date-time",
@@ -59756,11 +58515,13 @@
                         "description": "Deprecated — audits now always use the last 24 hours."
                     },
                     "max_calls": {
-                        "type": "integer",
-                        "maximum": 50,
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
+                        "maximum": 500,
                         "minimum": 1,
-                        "default": 20,
-                        "description": "Upper bound on failing calls fed to the agent. If the 24h window has more than this, a random sample is taken."
+                        "description": "Upper-bound ceiling on failing calls fed to the agent. Omit to audit every failing call in the 24h window up to 500. If the window exceeds the cap a random sample is taken."
                     }
                 },
                 "required": [
@@ -61215,181 +59976,6 @@
                     "project_id"
                 ]
             },
-            "Node": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
-                    "workflow": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
-                    "is_root": {
-                        "type": "boolean"
-                    },
-                    "metrics": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/NodeMetric"
-                        },
-                        "readOnly": true
-                    },
-                    "created_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    },
-                    "updated_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    }
-                }
-            },
-            "NodeCreate": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
-                    "workflow": {
-                        "type": "integer"
-                    },
-                    "is_root": {
-                        "type": "boolean"
-                    },
-                    "metric": {
-                        "type": "integer",
-                        "writeOnly": true
-                    },
-                    "metrics": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/NodeMetric"
-                        },
-                        "readOnly": true
-                    },
-                    "created_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    },
-                    "updated_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    }
-                },
-                "required": [
-                    "metric",
-                    "workflow"
-                ]
-            },
-            "NodeInline": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
-                    "workflow": {
-                        "type": "integer"
-                    },
-                    "is_root": {
-                        "type": "boolean"
-                    },
-                    "main_metric": {
-                        "type": "string",
-                        "readOnly": true
-                    },
-                    "created_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    },
-                    "updated_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    }
-                },
-                "required": [
-                    "workflow"
-                ]
-            },
-            "NodeMetric": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
-                    "node": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
-                    "metric": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
-                    "metric_data": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Metric"
-                            }
-                        ],
-                        "readOnly": true
-                    },
-                    "is_main": {
-                        "type": "boolean"
-                    },
-                    "created_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    },
-                    "updated_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    }
-                }
-            },
-            "NodeMetricCreate": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
-                    "node": {
-                        "type": "integer"
-                    },
-                    "metric": {
-                        "type": "integer"
-                    },
-                    "is_main": {
-                        "type": "boolean"
-                    },
-                    "created_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    },
-                    "updated_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    }
-                },
-                "required": [
-                    "metric",
-                    "node"
-                ]
-            },
             "Organization": {
                 "type": "object",
                 "properties": {
@@ -61576,15 +60162,6 @@
                     "syntflow_api_key_configured": {
                         "type": "string",
                         "readOnly": true
-                    },
-                    "webhook_url": {
-                        "type": "string",
-                        "format": "uri",
-                        "maxLength": 200
-                    },
-                    "webhook_secret": {
-                        "type": "string",
-                        "maxLength": 255
                     },
                     "members": {
                         "type": "array",
@@ -63349,35 +61926,6 @@
                     }
                 }
             },
-            "PatchedCustomDomainDetail": {
-                "type": "object",
-                "description": "",
-                "properties": {
-                    "organization": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
-                    "domain": {
-                        "type": "string",
-                        "maxLength": 255
-                    },
-                    "verification_token": {
-                        "type": "string",
-                        "readOnly": true
-                    },
-                    "verified": {
-                        "type": "boolean",
-                        "readOnly": true
-                    },
-                    "domain_logo": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "format": "uri"
-                    }
-                }
-            },
             "PatchedDashboard": {
                 "type": "object",
                 "properties": {
@@ -63535,32 +62083,6 @@
                     },
                     "is_verified": {
                         "type": "boolean",
-                        "readOnly": true
-                    }
-                }
-            },
-            "PatchedEdge": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
-                    "source_node": {
-                        "type": "integer"
-                    },
-                    "target_node": {
-                        "type": "integer"
-                    },
-                    "value": {},
-                    "created_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    },
-                    "updated_at": {
-                        "type": "string",
-                        "format": "date-time",
                         "readOnly": true
                     }
                 }
@@ -64160,77 +62682,6 @@
                     }
                 }
             },
-            "PatchedNode": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
-                    "workflow": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
-                    "is_root": {
-                        "type": "boolean"
-                    },
-                    "metrics": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/NodeMetric"
-                        },
-                        "readOnly": true
-                    },
-                    "created_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    },
-                    "updated_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    }
-                }
-            },
-            "PatchedNodeMetric": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
-                    "node": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
-                    "metric": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
-                    "metric_data": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Metric"
-                            }
-                        ],
-                        "readOnly": true
-                    },
-                    "is_main": {
-                        "type": "boolean"
-                    },
-                    "created_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    },
-                    "updated_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    }
-                }
-            },
             "PatchedOrganization": {
                 "type": "object",
                 "properties": {
@@ -64417,15 +62868,6 @@
                     "syntflow_api_key_configured": {
                         "type": "string",
                         "readOnly": true
-                    },
-                    "webhook_url": {
-                        "type": "string",
-                        "format": "uri",
-                        "maxLength": 200
-                    },
-                    "webhook_secret": {
-                        "type": "string",
-                        "maxLength": 255
                     },
                     "members": {
                         "type": "array",
@@ -64812,7 +63254,12 @@
                     },
                     "webhook_secret": {
                         "type": "string",
-                        "description": "\nWebhook secret\nExample: `\"your-webhook-secret\"`\n"
+                        "writeOnly": true,
+                        "description": "\nWebhook secret. Sent in `X-CEKURA-SECRET` header when invoking `webhook_url`.\nWrite-only — never returned in API responses. Use `webhook_secret_configured`\nto check whether one is set.\nExample: `\"your-webhook-secret\"`\n"
+                    },
+                    "webhook_secret_configured": {
+                        "type": "string",
+                        "readOnly": true
                     },
                     "evaluate_relevant_metrics_enabled": {
                         "type": "boolean",
@@ -65361,7 +63808,10 @@
                         "default": "Scenario Deleted"
                     },
                     "personality": {
-                        "type": "integer",
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
                         "readOnly": true,
                         "description": "Personality this run belongs to"
                     },
@@ -65793,7 +64243,12 @@
                     },
                     "webhook_secret": {
                         "type": "string",
-                        "description": "Secret sent in X-CEKURA-SECRET header. Applies when agent webhook_url is set."
+                        "writeOnly": true,
+                        "description": "Secret sent in X-CEKURA-SECRET header. Applies when agent webhook_url is set. Write-only — never returned in API responses. Use `webhook_secret_configured` to check whether one is set."
+                    },
+                    "webhook_secret_configured": {
+                        "type": "string",
+                        "readOnly": true
                     },
                     "mock_tools": {
                         "type": "array",
@@ -66725,7 +65180,12 @@
                     },
                     "webhook_secret": {
                         "type": "string",
-                        "description": "Secret sent in X-CEKURA-SECRET header. Applies when agent webhook_url is set."
+                        "writeOnly": true,
+                        "description": "Secret sent in X-CEKURA-SECRET header. Applies when agent webhook_url is set. Write-only — never returned in API responses. Use `webhook_secret_configured` to check whether one is set."
+                    },
+                    "webhook_secret_configured": {
+                        "type": "string",
+                        "readOnly": true
                     }
                 }
             },
@@ -67363,32 +65823,6 @@
                     }
                 }
             },
-            "PatchedWorkflow": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
-                    "agent": {
-                        "type": "integer"
-                    },
-                    "name": {
-                        "type": "string",
-                        "maxLength": 255
-                    },
-                    "created_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    },
-                    "updated_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    }
-                }
-            },
             "PaymentHistory": {
                 "type": "object",
                 "properties": {
@@ -67724,10 +66158,6 @@
                 "properties": {
                     "id": {
                         "type": "integer",
-                        "readOnly": true
-                    },
-                    "metadata": {
-                        "type": "string",
                         "readOnly": true
                     },
                     "number": {
@@ -68198,7 +66628,12 @@
                     },
                     "webhook_secret": {
                         "type": "string",
-                        "description": "\nWebhook secret\nExample: `\"your-webhook-secret\"`\n"
+                        "writeOnly": true,
+                        "description": "\nWebhook secret. Sent in `X-CEKURA-SECRET` header when invoking `webhook_url`.\nWrite-only — never returned in API responses. Use `webhook_secret_configured`\nto check whether one is set.\nExample: `\"your-webhook-secret\"`\n"
+                    },
+                    "webhook_secret_configured": {
+                        "type": "string",
+                        "readOnly": true
                     },
                     "evaluate_relevant_metrics_enabled": {
                         "type": "boolean",
@@ -69107,7 +67542,10 @@
                         "default": "Scenario Deleted"
                     },
                     "personality": {
-                        "type": "integer",
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
                         "readOnly": true,
                         "description": "Personality this run belongs to"
                     },
@@ -69347,7 +67785,10 @@
                         "default": "Scenario Deleted"
                     },
                     "personality": {
-                        "type": "integer",
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
                         "readOnly": true
                     },
                     "personality_name": {
@@ -71321,19 +69762,9 @@
                     "shareable_link": {
                         "type": "string",
                         "description": "Complete URL for the shareable link that can be distributed to external users"
-                    },
-                    "custom_link": {
-                        "type": "string",
-                        "description": "Customized branded URL for the shareable link with organization-specific branding"
-                    },
-                    "custom_domain": {
-                        "type": "boolean",
-                        "description": "Whether the organization has whitelabel custom domain enabled for branded links"
                     }
                 },
                 "required": [
-                    "custom_domain",
-                    "custom_link",
                     "shareable_link",
                     "token"
                 ]
@@ -71698,7 +70129,12 @@
                     },
                     "webhook_secret": {
                         "type": "string",
-                        "description": "Secret sent in X-CEKURA-SECRET header. Applies when agent webhook_url is set."
+                        "writeOnly": true,
+                        "description": "Secret sent in X-CEKURA-SECRET header. Applies when agent webhook_url is set. Write-only — never returned in API responses. Use `webhook_secret_configured` to check whether one is set."
+                    },
+                    "webhook_secret_configured": {
+                        "type": "string",
+                        "readOnly": true
                     },
                     "mock_tools": {
                         "type": "array",
@@ -73434,7 +71870,12 @@
                     },
                     "webhook_secret": {
                         "type": "string",
-                        "description": "Secret sent in X-CEKURA-SECRET header. Applies when agent webhook_url is set."
+                        "writeOnly": true,
+                        "description": "Secret sent in X-CEKURA-SECRET header. Applies when agent webhook_url is set. Write-only — never returned in API responses. Use `webhook_secret_configured` to check whether one is set."
+                    },
+                    "webhook_secret_configured": {
+                        "type": "string",
+                        "readOnly": true
                     }
                 },
                 "required": [
@@ -74850,77 +73291,6 @@
                     "metadata",
                     "time_period",
                     "widget_id"
-                ]
-            },
-            "Workflow": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
-                    "agent": {
-                        "type": "integer"
-                    },
-                    "name": {
-                        "type": "string",
-                        "maxLength": 255
-                    },
-                    "created_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    },
-                    "updated_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    }
-                },
-                "required": [
-                    "agent",
-                    "name"
-                ]
-            },
-            "WorkflowDetail": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
-                    "agent": {
-                        "type": "integer"
-                    },
-                    "name": {
-                        "type": "string",
-                        "maxLength": 255
-                    },
-                    "nodes": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/NodeInline"
-                        },
-                        "readOnly": true
-                    },
-                    "edges": {
-                        "type": "string",
-                        "readOnly": true
-                    },
-                    "created_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    },
-                    "updated_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    }
-                },
-                "required": [
-                    "agent",
-                    "name"
                 ]
             }
         },

--- a/openapi.json
+++ b/openapi.json
@@ -2954,7 +2954,8 @@
                         "name": "call-logs-list",
                         "description": "List **production** call logs for an agent or project. Production-only — test/simulation runs triggered via `run_scenarios_*` do NOT create call logs; use `results_list` + `runs_bulk_retrieve` for simulation data instead.\n\nAlways pass `agent_id` or `project_id` to scope results — without one, the response may be very large. **`project_id` is required when using an organization-level API key.**\n\n**Filtering:**\n- `timestamp_from` / `timestamp_to` — ISO 8601 date range filter\n- `call_ids` — comma-separated **CallLog IDs** (integer DB IDs of call logs in this list response), e.g. `\"123,456\"`. Distinct from simulation `run_id`s and from each call log's own `call_id` field (which holds the provider's call identifier string).\n- `filters_v2` — structured JSON filter (same format as dashboard filters). Simple: `{\"field\": \"success\", \"op\": \"eq\", \"value\": true}`. Compound: `{\"operator\": \"and\", \"conditions\": [{...}, {...}]}`. Supported operators: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `contains`, `startswith`, `in`, `isnull`."
                     }
-                }
+                },
+                "deprecated": true
             },
             "post": {
                 "operationId": "call-logs-create",
@@ -3106,7 +3107,8 @@
                         },
                         "description": ""
                     }
-                }
+                },
+                "deprecated": true
             },
             "post": {
                 "operationId": "call-logs-external-create",
@@ -3202,7 +3204,8 @@
                         },
                         "description": ""
                     }
-                }
+                },
+                "deprecated": true
             },
             "put": {
                 "operationId": "call-logs-external-update",
@@ -4422,7 +4425,8 @@
                         "name": "call-logs-retrieve",
                         "description": "Retrieve a production CallLog by its integer **CallLog ID** (path parameter). This is distinct from simulation `run_id` (use `runs_retrieve` for those) and from the call log's own `call_id` string field (the provider's call identifier)."
                     }
-                }
+                },
+                "deprecated": true
             },
             "put": {
                 "operationId": "call-logs-update",
@@ -22915,7 +22919,8 @@
                         "name": "results-list",
                         "description": "List test results.\n\nTo filter by status, use `results_retrieve(id=result_id)` and inspect `status` directly ('running', 'completed', 'failed') — there is no list-level status filter.\n\n**Result status:** a result marked `failed` indicates infrastructure failures (e.g. connection errors, websocket handshake failures), not metric evaluation failures. `success_runs_count` counts runs that reached terminal state regardless of connection errors. See `results_retrieve().failed_reasons` for the breakdown.\n\n**Scenarios filter note:** filtering by `scenarios` may return duplicate result rows when a result contains multiple runs of the same scenario — deduplicate by `result.id` if needed.\n\nAfter triggering a run, poll `results_retrieve(id=result_id)` until `status` is 'completed' or 'failed'. For outbound runs, each run's `outbound_dial_window_closes_at` shows the deadline by which your agent must dial in."
                     }
-                }
+                },
+                "deprecated": true
             },
             "post": {
                 "operationId": "results-create",
@@ -23037,7 +23042,8 @@
                         },
                         "description": ""
                     }
-                }
+                },
+                "deprecated": true
             },
             "post": {
                 "operationId": "results-external-create",
@@ -23286,7 +23292,8 @@
                         },
                         "description": ""
                     }
-                }
+                },
+                "deprecated": true
             },
             "put": {
                 "operationId": "results-external-update",
@@ -24384,7 +24391,8 @@
                         "name": "results-retrieve",
                         "description": "`success` indicates whether the run passed its quality evaluation. A run with `success=false` either failed to connect (check `error_message`) or failed an evaluation check (check `evaluation`). `success_rate` is the percentage of runs with `success=true`.\n\nThe `runs` field is a dict keyed by run ID string (e.g. `{\"86368\": {...}, \"86367\": {...}}`), not an array — unlike the list endpoint. Each run also has a `call_id` STRING field (the provider's call identifier) — that is a data field, NOT an endpoint ID; do not pass it where `run_id` is expected."
                     }
-                }
+                },
+                "deprecated": true
             },
             "put": {
                 "operationId": "results-update",
@@ -25682,7 +25690,8 @@
                         },
                         "description": ""
                     }
-                }
+                },
+                "deprecated": true
             }
         },
         "/test_framework/v1/runs-external/": {
@@ -26047,7 +26056,8 @@
                         },
                         "description": ""
                     }
-                }
+                },
+                "deprecated": true
             }
         },
         "/test_framework/v1/runs-external/{id}/": {
@@ -26084,7 +26094,8 @@
                         },
                         "description": ""
                     }
-                }
+                },
+                "deprecated": true
             },
             "put": {
                 "operationId": "runs-external-update",
@@ -26714,7 +26725,8 @@
                         },
                         "description": ""
                     }
-                }
+                },
+                "deprecated": true
             }
         },
         "/test_framework/v1/runs-external/run_expected_outcome_progress/": {
@@ -26777,7 +26789,8 @@
                         },
                         "description": ""
                     }
-                }
+                },
+                "deprecated": true
             },
             "put": {
                 "operationId": "runs-update",
@@ -27487,7 +27500,8 @@
                         "name": "runs-bulk-retrieve",
                         "description": "Retrieve multiple runs in a single request.\n\n`success: true` indicates the run passed its quality evaluation. A run with `success=false` either failed to connect (check `error_message`) or failed an evaluation check. For detailed outcomes check: `error_message`, `metadata.ended_reason`, and `evaluation.metrics[].result`."
                     }
-                }
+                },
+                "deprecated": true
             }
         },
         "/test_framework/v1/runs/run_expected_outcome_progress/": {

--- a/openapi.json
+++ b/openapi.json
@@ -1269,15 +1269,6 @@
                         "schema": {
                             "type": "integer"
                         }
-                    },
-                    {
-                        "name": "dashboard_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `dashboard_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -2775,18 +2766,7 @@
                         "name": "alerts-review-retrieve",
                         "description": "Aggregate every alert's fire activity over a rolling window. Returns KPI totals (total fires, unique alerts that fired, top firing alert), a time-bucketed timeline (hourly for 24h, 3-hour for 3d, 6-hour for 7d), and a per-alert breakdown with a sparkline of fires-per-bucket. Use to answer 'what alerts fired this week?' or 'is anything noisy right now?'. Pass `hours` (default 24, capped at 168) to widen the window. The response shape lets you compose a written report in a single call."
                     }
-                },
-                "parameters": [
-                    {
-                        "name": "project_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    }
-                ]
+                }
             }
         },
         "/observability/v1/alerts/summarize_progress/": {
@@ -3765,7 +3745,7 @@
         "/observability/v1/call-logs-external/create_scenarios_progress/": {
             "get": {
                 "operationId": "call-logs-create-scenarios-progress",
-                "description": "Get the progress of background scenario creation by progress_id.",
+                "description": "Call logs create scenarios progress",
                 "parameters": [
                     {
                         "in": "query",
@@ -5038,7 +5018,7 @@
         "/observability/v1/call-logs/create_scenarios_progress/": {
             "get": {
                 "operationId": "call-logs-create-scenarios-progress_2",
-                "description": "Get the progress of background scenario creation by progress_id.",
+                "description": "Call logs create scenarios progress",
                 "parameters": [
                     {
                         "in": "query",
@@ -5049,24 +5029,6 @@
                         },
                         "description": "Progress ID returned from create_scenarios endpoint",
                         "required": true
-                    },
-                    {
-                        "name": "agent_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    },
-                    {
-                        "name": "project_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -5260,7 +5222,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "call-logs-create-scenarios-progress",
-                        "description": "Get the progress of background scenario creation by progress_id."
+                        "description": "Call logs create scenarios progress"
                     }
                 }
             }
@@ -6425,8 +6387,7 @@
         "/observability/v1/metric-failure-mode-insights/{id}/generate-scenario/": {
             "post": {
                 "operationId": "metric-failure-mode-insights-generate-scenario-create",
-                "description": "Turn one failure mode of a metric failure-mode insight into a test scenario that reproduces the issue against a target agent. Choose the failure mode with `failure_mode_index` and the agent with `agent`. Set `redact_transcripts` to strip personal identifiers from the source call transcripts before they are used to draft the scenario. Runs in the background and returns a `progress_id`; poll scenario generation progress to retrieve the generated scenario id.",
-                "summary": "Generate a test scenario from an insight failure mode",
+                "description": "Queue generation of a test scenario from one failure mode.\n\nReturns a ``progress_id`` the frontend polls via the existing\n``scenarios/generate-progress`` endpoint; the generated scenario\nid lands in that progress state's ``scenarios_list`` when done.",
                 "parameters": [
                     {
                         "in": "path",
@@ -6476,14 +6437,6 @@
                             }
                         },
                         "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "metric-failure-mode-insights-generate-scenario-create",
-                        "description": "Turn one failure mode of a metric failure-mode insight into a test scenario that reproduces the issue against a target agent. Choose the failure mode with `failure_mode_index` and the agent with `agent`. Set `redact_transcripts` to strip personal identifiers from the source call transcripts before they are used to draft the scenario. Runs in the background and returns a `progress_id`; poll scenario generation progress to retrieve the generated scenario id."
                     }
                 }
             }
@@ -7199,6 +7152,1434 @@
                 }
             }
         },
+        "/observability/v2/call-logs/": {
+            "get": {
+                "operationId": "observability-v2-call-logs-list",
+                "description": "List **production** call logs for an agent or project. Production-only — test/simulation runs triggered via `run_scenarios_*` do NOT create call logs; use `results_list` + `runs_bulk_retrieve` for simulation data instead.\n\nAlways pass `agent_id` or `project_id` to scope results — without one, the response may be very large. **`project_id` is required when using an organization-level API key.**\n\n**Filtering:**\n- `timestamp_from` / `timestamp_to` — ISO 8601 date range filter\n- `call_ids` — comma-separated **CallLog IDs** (integer DB IDs of call logs in this list response), e.g. `\"123,456\"`. Distinct from simulation `run_id`s and from each call log's own `call_id` field (which holds the provider's call identifier string).\n- `filters_v2` — structured JSON filter (same format as dashboard filters). Simple: `{\"field\": \"success\", \"op\": \"eq\", \"value\": true}`. Compound: `{\"operator\": \"and\", \"conditions\": [{...}, {...}]}`. Supported operators: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `contains`, `startswith`, `in`, `isnull`.",
+                "summary": "List call logs",
+                "parameters": [
+                    {
+                        "name": "page",
+                        "required": false,
+                        "in": "query",
+                        "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "timestamp_from",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "description": "\nFilter results from this timestamp (e.g. 2025-01-01T00:00:00Z)\nExample: `2025-01-01T00:00:00Z`\n"
+                    },
+                    {
+                        "in": "query",
+                        "name": "timestamp_to",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "description": "\nFilter results to this timestamp (e.g. 2025-01-31T23:59:59Z)\nExample: `2025-01-31T23:59:59Z`\n"
+                    },
+                    {
+                        "in": "query",
+                        "name": "call_ids",
+                        "schema": {
+                            "type": "string",
+                            "minLength": 1
+                        },
+                        "description": "Comma-separated list of call log IDs to filter by. Example: `\"5181749,5181752\"`"
+                    },
+                    {
+                        "in": "query",
+                        "name": "agent_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "\nFilter by agent ID. Either agent_id or project_id should be provided.\nExample: `2142`\n"
+                    },
+                    {
+                        "in": "query",
+                        "name": "project_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "\nFilter by project ID. Either agent_id or project_id should be provided.\n**Required when using an organization-level API key** to scope results to a specific project.\nExample: `1376`\n"
+                    },
+                    {
+                        "in": "query",
+                        "name": "assistant_id",
+                        "schema": {
+                            "type": "string",
+                            "minLength": 1
+                        },
+                        "description": "\nFilter by assistant ID\nExample:\n- `\"asst_1234567890\"`\n- `\"agent_xyz789\"`\n"
+                    },
+                    {
+                        "in": "query",
+                        "name": "filters_v2",
+                        "schema": {
+                            "type": "string",
+                            "minLength": 1
+                        },
+                        "description": "\nAdvanced JSON filters using CallLogQueryFilter format (same as dashboard filters).\nSupports nested AND/OR conditions, field comparisons, and related field filtering.\n\nExample - Simple filter:\n`{\"field\": \"success\", \"op\": \"eq\", \"value\": true}`\n\nExample - AND conditions:\n`{\"operator\": \"and\", \"conditions\": [{\"field\": \"success\", \"op\": \"eq\", \"value\": true}, {\"field\": \"duration\", \"op\": \"gte\", \"value\": 60}]}`\n\nExample - OR conditions:\n`{\"operator\": \"or\", \"conditions\": [{\"field\": \"call_ended_reason\", \"op\": \"eq\", \"value\": \"completed\"}, {\"field\": \"call_ended_reason\", \"op\": \"eq\", \"value\": \"hangup\"}]}`\n\nSupported fields: success, duration, call_id, timestamp, created_at, call_ended_reason, customer_number, etc.\nSupported operators: eq, neq, gt, gte, lt, lte, contains, startswith, in, isnull\n"
+                    }
+                ],
+                "tags": [
+                    "observability"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedCallLogListList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "observability-v2-call-logs-list",
+                        "description": "List **production** call logs for an agent or project. Production-only — test/simulation runs triggered via `run_scenarios_*` do NOT create call logs; use `results_list` + `runs_bulk_retrieve` for simulation data instead.\n\nAlways pass `agent_id` or `project_id` to scope results — without one, the response may be very large. **`project_id` is required when using an organization-level API key.**\n\n**Filtering:**\n- `timestamp_from` / `timestamp_to` — ISO 8601 date range filter\n- `call_ids` — comma-separated **CallLog IDs** (integer DB IDs of call logs in this list response), e.g. `\"123,456\"`. Distinct from simulation `run_id`s and from each call log's own `call_id` field (which holds the provider's call identifier string).\n- `filters_v2` — structured JSON filter (same format as dashboard filters). Simple: `{\"field\": \"success\", \"op\": \"eq\", \"value\": true}`. Compound: `{\"operator\": \"and\", \"conditions\": [{...}, {...}]}`. Supported operators: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `contains`, `startswith`, `in`, `isnull`."
+                    }
+                }
+            },
+            "post": {
+                "operationId": "observability-v2-call-logs-create",
+                "description": "Create a new Call logs with the canonical binary wire format (eval_type `binary`,",
+                "tags": [
+                    "observability"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CallLogDetail"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CallLogDetail"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CallLogDetail"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CallLogDetail"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/observability/v2/call-logs/{id}/": {
+            "get": {
+                "operationId": "observability-v2-call-logs-retrieve",
+                "description": "Retrieve a production CallLog by its integer **CallLog ID** (path parameter). This is distinct from simulation `run_id` (use `runs_retrieve` for those) and from the call log's own `call_id` string field (the provider's call identifier).",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this call log.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "observability"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CallLogDetail"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "detail": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "observability-v2-call-logs-retrieve",
+                        "description": "Retrieve a production CallLog by its integer **CallLog ID** (path parameter). This is distinct from simulation `run_id` (use `runs_retrieve` for those) and from the call log's own `call_id` string field (the provider's call identifier)."
+                    }
+                }
+            },
+            "put": {
+                "operationId": "observability-v2-call-logs-update",
+                "description": "Update a Call logs with the canonical binary wire format (eval_type `binary`,",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this call log.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "observability"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CallLogDetail"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CallLogDetail"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CallLogDetail"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CallLogDetail"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "patch": {
+                "operationId": "observability-v2-call-logs-partial-update",
+                "description": "Update a Call logs with the canonical binary wire format (eval_type `binary`,",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this call log.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "observability"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedCallLogDetail"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedCallLogDetail"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedCallLogDetail"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CallLogDetail"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "observability-v2-call-logs-destroy",
+                "description": "⚠ Irreversible. Deletes the call log along with its transcript and voice recording. By default metric evaluations are also deleted; set `retain_evaluations=true` to keep them and leave the call record un-soft-deleted.",
+                "summary": "Delete a call log",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this call log.",
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "retain_evaluations",
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "description": "If true, metric evaluations are retained and the call log is not soft-deleted. Default: false."
+                    }
+                ],
+                "tags": [
+                    "observability"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No response body"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "detail": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "observability-v2-call-logs-destroy",
+                        "description": "⚠ Irreversible. Deletes the call log along with its transcript and voice recording. By default metric evaluations are also deleted; set `retain_evaluations=true` to keep them and leave the call record un-soft-deleted."
+                    }
+                }
+            }
+        },
+        "/observability/v2/call-logs/{id}/mark_critical_scenario_wrong/": {
+            "post": {
+                "operationId": "observability-v2-call-logs-mark-critical-scenario-wrong-create",
+                "description": "Observability v2 call logs mark critical scenario wrong",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this call log.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "observability"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CallLogDetail"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CallLogDetail"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CallLogDetail"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CallLogDetail"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/observability/v2/call-logs/{id}/mark_metric_vote/": {
+            "post": {
+                "operationId": "observability-v2-call-logs-mark-metric-vote-create",
+                "description": "Record a thumbs-up or thumbs-down vote on a specific metric evaluation for this call log and optionally provide an expected value and free-text feedback. Updates the metric evaluation and marks the call log as reviewed.",
+                "summary": "Submit a metric vote for a call log",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this call log.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Call Logs"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MarkMetricVote"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MarkMetricVote"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MarkMetricVote"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MarkMetricVoteCallLogResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "detail": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "observability-v2-call-logs-mark-metric-vote-create",
+                        "description": "Record a thumbs-up or thumbs-down vote on a specific metric evaluation for this call log and optionally provide an expected value and free-text feedback. Updates the metric evaluation and marks the call log as reviewed."
+                    }
+                }
+            }
+        },
+        "/observability/v2/call-logs/{id}/unmark_critical_scenario_wrong/": {
+            "post": {
+                "operationId": "observability-v2-call-logs-unmark-critical-scenario-wrong-create",
+                "description": "Observability v2 call logs unmark critical scenario wrong",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this call log.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "observability"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CallLogDetail"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CallLogDetail"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CallLogDetail"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CallLogDetail"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/observability/v2/call-logs/analyze_call_logs/": {
+            "get": {
+                "operationId": "observability-v2-call-logs-analyze-call-logs-retrieve",
+                "description": "Analyze call logs using Claude Agent SDK.\n\nClaude uses Read/Bash tools to query the CSV file without loading it into context.\nThis allows analyzing large datasets efficiently.",
+                "tags": [
+                    "observability"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CallLogDetail"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/observability/v2/call-logs/complete-upload/": {
+            "post": {
+                "operationId": "observability-v2-call-logs-complete-upload-create",
+                "description": "Observability v2 call logs complete upload",
+                "tags": [
+                    "observability"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CallLogDetail"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CallLogDetail"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CallLogDetail"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CallLogDetail"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/observability/v2/call-logs/create_scenarios/": {
+            "post": {
+                "operationId": "call-logs-create-scenarios_3",
+                "description": "Generate test scenarios from real production call logs.\n\nReturns a `progress_id` immediately — the actual scenario creation runs in the background.\nPoll `GET /observability/v1/call-logs/create_scenarios_progress?progress_id=<id>` until\n`completed_scenarios + failed_scenarios >= total_scenarios`. The `scenarios_list` field\n(full Scenario objects) is populated only once processing is complete.\n\n**`call_logs` accepts:** a list of IDs `[1, 2, 3]` or `\"all\"` for every call log on the agent.\n\n**`copy_to_agent`:** optionally copy the generated scenarios to a different agent —\nuseful when your observation agent and your test agent are separate.\n\n**Prerequisite:** call logs must have a transcript (uploaded via `transcript_json`).\nAudio-only logs without a transcript cannot produce scenarios.",
+                "tags": [
+                    "observability"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostCreateScenarios"
+                            },
+                            "examples": {
+                                "Create-scenarios-with-agent-id": {
+                                    "value": {
+                                        "agent_id": 2142,
+                                        "call_logs": [
+                                            1,
+                                            2,
+                                            3
+                                        ],
+                                        "copy_to_agent": null
+                                    },
+                                    "summary": "create-scenarios-with-agent-id"
+                                },
+                                "Create-scenarios-with-assistant-id": {
+                                    "value": {
+                                        "assistant_id": "asst_1234567890",
+                                        "call_logs": "all"
+                                    },
+                                    "summary": "create-scenarios-with-assistant-id"
+                                },
+                                "Create-scenarios-with-copy-to-agent": {
+                                    "value": {
+                                        "agent_id": 2142,
+                                        "call_logs": [
+                                            1,
+                                            2,
+                                            3
+                                        ],
+                                        "copy_to_agent": 2143
+                                    },
+                                    "summary": "create-scenarios-with-copy-to-agent"
+                                }
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostCreateScenarios"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostCreateScenarios"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "progress_id": {
+                                            "type": "string",
+                                            "format": "uuid",
+                                            "description": "Unique identifier for tracking the progress of scenario creation"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "403": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "detail": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "call-logs-create-scenarios",
+                        "description": "Generate test scenarios from real production call logs.\n\nReturns a `progress_id` immediately — the actual scenario creation runs in the background.\nPoll `GET /observability/v1/call-logs/create_scenarios_progress?progress_id=<id>` until\n`completed_scenarios + failed_scenarios >= total_scenarios`. The `scenarios_list` field\n(full Scenario objects) is populated only once processing is complete.\n\n**`call_logs` accepts:** a list of IDs `[1, 2, 3]` or `\"all\"` for every call log on the agent.\n\n**`copy_to_agent`:** optionally copy the generated scenarios to a different agent —\nuseful when your observation agent and your test agent are separate.\n\n**Prerequisite:** call logs must have a transcript (uploaded via `transcript_json`).\nAudio-only logs without a transcript cannot produce scenarios."
+                    }
+                }
+            }
+        },
+        "/observability/v2/call-logs/create_scenarios_progress/": {
+            "get": {
+                "operationId": "call-logs-create-scenarios-progress_3",
+                "description": "Call logs create scenarios progress",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "progress_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "Progress ID returned from create_scenarios endpoint",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "observability"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SchemaCreateScenariosProgressResponse"
+                                },
+                                "examples": {
+                                    "Progress-in-progress": {
+                                        "value": {
+                                            "agent_id": 2142,
+                                            "completed_scenarios": 2,
+                                            "failed_scenarios": 0,
+                                            "total_scenarios": 5,
+                                            "scenarios_list": [],
+                                            "errors": []
+                                        },
+                                        "summary": "progress-in-progress"
+                                    },
+                                    "Progress-completed": {
+                                        "value": {
+                                            "agent_id": 2142,
+                                            "completed_scenarios": 4,
+                                            "failed_scenarios": 1,
+                                            "total_scenarios": 5,
+                                            "scenarios_list": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "id": {
+                                                            "type": "integer",
+                                                            "description": "Unique identifier for the scenario"
+                                                        },
+                                                        "name": {
+                                                            "type": "string",
+                                                            "description": "Name of the scenario"
+                                                        },
+                                                        "agent": {
+                                                            "type": "integer",
+                                                            "description": "ID of the AI agent this scenario belongs to"
+                                                        },
+                                                        "assistant_id": {
+                                                            "type": "string",
+                                                            "description": "Alternative to agent ID - the assistant ID to use for this scenario"
+                                                        },
+                                                        "personality": {
+                                                            "type": "integer",
+                                                            "description": "ID of the personality used in this scenario"
+                                                        },
+                                                        "personality_name": {
+                                                            "type": "string",
+                                                            "description": "Name of the personality used in this scenario"
+                                                        },
+                                                        "tags": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "string"
+                                                            },
+                                                            "description": "Tags associated with this scenario."
+                                                        },
+                                                        "runs": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "integer"
+                                                            },
+                                                            "description": "List of IDs for the last run of this scenario"
+                                                        },
+                                                        "metrics": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "integer"
+                                                            },
+                                                            "description": "List of metric IDs to associate with this scenario"
+                                                        },
+                                                        "metric_names": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "string"
+                                                            },
+                                                            "description": "List of metric names associated with this scenario"
+                                                        },
+                                                        "phone_number": {
+                                                            "type": "string",
+                                                            "description": "Phone number used for outbound calls in this scenario"
+                                                        },
+                                                        "phone_number_queue_length": {
+                                                            "type": "integer",
+                                                            "description": "Number of runs in queue for this phone number"
+                                                        },
+                                                        "first_message": {
+                                                            "type": "string",
+                                                            "description": "First message to be sent in the scenario"
+                                                        },
+                                                        "inbound_phone_number": {
+                                                            "type": "integer",
+                                                            "description": "ID of the phone number used for inbound calls"
+                                                        },
+                                                        "inbound_phone_number_data": {
+                                                            "type": "object",
+                                                            "description": "Details of the phone number used for inbound calls",
+                                                            "properties": {
+                                                                "id": {
+                                                                    "type": "integer",
+                                                                    "description": "ID of the inbound phone number"
+                                                                },
+                                                                "number": {
+                                                                    "type": "string",
+                                                                    "description": "The actual phone number"
+                                                                },
+                                                                "phone_number_id": {
+                                                                    "type": "string",
+                                                                    "description": "External ID of the phone number"
+                                                                }
+                                                            }
+                                                        },
+                                                        "instructions": {
+                                                            "type": "string",
+                                                            "description": "Instructions for the AI agent in this scenario"
+                                                        },
+                                                        "simulation_description": {
+                                                            "type": "string",
+                                                            "description": "Description of the simulation if this scenario was created by simulation"
+                                                        },
+                                                        "information_fields": {
+                                                            "type": "object",
+                                                            "description": "Additional information fields for the scenario"
+                                                        },
+                                                        "expected_outcome_prompt": {
+                                                            "type": "string",
+                                                            "description": "Expected outcome prompt for the scenario"
+                                                        },
+                                                        "scenario_language": {
+                                                            "type": "string",
+                                                            "description": "Language of the scenario"
+                                                        },
+                                                        "is_simulating": {
+                                                            "type": "boolean",
+                                                            "description": "Whether this scenario was created by simulation"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "errors": [
+                                                {
+                                                    "call_log_id": 3,
+                                                    "error": {
+                                                        "detail": "Transcript is missing"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "summary": "progress-completed"
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "call-logs-create-scenarios-progress",
+                        "description": "Call logs create scenarios progress"
+                    }
+                }
+            }
+        },
+        "/observability/v2/call-logs/delete_call_logs/": {
+            "post": {
+                "operationId": "call-logs-bulk-delete_3",
+                "description": "Call logs bulk delete",
+                "tags": [
+                    "observability"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/DeleteCallLogs"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/DeleteCallLogs"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/DeleteCallLogs"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No response body"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/observability/v2/call-logs/evaluate_metrics/": {
+            "post": {
+                "operationId": "observability-v2-call-logs-evaluate-metrics-create",
+                "description": "Evaluate one or more metrics against selected call logs. Unlike `rerun_evaluation` (which re-runs all assigned metrics), this endpoint lets you target specific metrics.\n\n**Scope:** provide either `agent_id` or `project_id` to identify which agent's call logs and metrics to use. Metrics must belong to the specified agent or project.\n\n**Credit check:** cost scales with the number of call logs and metrics selected. The request is rejected if your balance is insufficient — check your balance first via `test_framework_billing_info_retrieve`.\n\n**Async:** evaluation runs in the background. The response returns the call logs in their current state. Retrieve each call log individually to see updated metric results once evaluation completes.\n\n**Rate limited.** Respect 429 responses — wait for the `Retry-After` duration.",
+                "summary": "Run specific metrics against call logs",
+                "tags": [
+                    "observability"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/EvaluateMetrics"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/EvaluateMetrics"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/EvaluateMetrics"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/CallLogList"
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "observability-v2-call-logs-evaluate-metrics-create",
+                        "description": "Evaluate one or more metrics against selected call logs. Unlike `rerun_evaluation` (which re-runs all assigned metrics), this endpoint lets you target specific metrics.\n\n**Scope:** provide either `agent_id` or `project_id` to identify which agent's call logs and metrics to use. Metrics must belong to the specified agent or project.\n\n**Credit check:** cost scales with the number of call logs and metrics selected. The request is rejected if your balance is insufficient — check your balance first via `test_framework_billing_info_retrieve`.\n\n**Async:** evaluation runs in the background. The response returns the call logs in their current state. Retrieve each call log individually to see updated metric results once evaluation completes.\n\n**Rate limited.** Respect 429 responses — wait for the `Retry-After` duration."
+                    }
+                }
+            }
+        },
+        "/observability/v2/call-logs/export_call_logs/": {
+            "get": {
+                "operationId": "observability-v2-call-logs-export-call-logs-retrieve",
+                "description": "Observability v2 call logs export call logs",
+                "tags": [
+                    "observability"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CallLogDetail"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/observability/v2/call-logs/export_call_logs_progress/": {
+            "get": {
+                "operationId": "observability-v2-call-logs-export-call-logs-progress-retrieve",
+                "description": "Observability v2 call logs export call logs progress",
+                "tags": [
+                    "observability"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CallLogDetail"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/observability/v2/call-logs/filters/": {
+            "get": {
+                "operationId": "observability-v2-call-logs-filters-retrieve",
+                "description": "Observability v2 call logs filters",
+                "tags": [
+                    "observability"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CallLogDetail"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/observability/v2/call-logs/filters_call_id/": {
+            "get": {
+                "operationId": "observability-v2-call-logs-filters-call-id-retrieve",
+                "description": "Autocomplete-search the production CallLog `call_id` field (the provider's call identifier string). This is distinct from simulation `run_id` (integer; see `runs_list`) and from CallLog ID (integer DB ID).",
+                "tags": [
+                    "observability"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CallLogDetail"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/observability/v2/call-logs/filters_customer_number/": {
+            "get": {
+                "operationId": "observability-v2-call-logs-filters-customer-number-retrieve",
+                "description": "Observability v2 call logs filters customer number",
+                "tags": [
+                    "observability"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CallLogDetail"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/observability/v2/call-logs/get-upload-url/": {
+            "post": {
+                "operationId": "observability-v2-call-logs-get-upload-url-create",
+                "description": "Observability v2 call logs get upload url",
+                "tags": [
+                    "observability"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CallLogDetail"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CallLogDetail"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CallLogDetail"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CallLogDetail"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/observability/v2/call-logs/rerun_evaluation/": {
+            "post": {
+                "operationId": "observability-v2-call-logs-rerun-evaluation-create",
+                "description": "Trigger metric re-evaluation on one or more existing call logs. Provide either `agent_id` or `assistant_id` (not both) to identify the agent, then specify which call logs to re-evaluate.\n\n**`call_logs` accepts:**\n- A list of call log IDs: `[1, 2, 3]`\n- The string `\"all\"` to re-evaluate every call log for the agent\n\n**Side effect:** for non-reviewed call logs, `success` is reset to `null` before re-evaluation begins. Reviewed call logs retain their human-approved outcome.\n\n**Rate limited.** If the limit is exceeded you will receive a 429 response — wait for the `Retry-After` duration before retrying.",
+                "summary": "Re-run metric evaluation on call logs",
+                "tags": [
+                    "observability"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RerunEvaluation"
+                            },
+                            "examples": {
+                                "Re-evaluate-specific-call-logs": {
+                                    "value": {
+                                        "agent_id": 2142,
+                                        "call_logs": [
+                                            101,
+                                            102,
+                                            103
+                                        ]
+                                    },
+                                    "summary": "re-evaluate-specific-call-logs"
+                                },
+                                "Re-evaluate-all-call-logs": {
+                                    "value": {
+                                        "agent_id": 2142,
+                                        "call_logs": "all"
+                                    },
+                                    "summary": "re-evaluate-all-call-logs"
+                                },
+                                "Re-evaluate-using-assistant-id": {
+                                    "value": {
+                                        "assistant_id": 2143,
+                                        "call_logs": [
+                                            101,
+                                            102
+                                        ]
+                                    },
+                                    "summary": "re-evaluate-using-assistant-id"
+                                }
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RerunEvaluation"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RerunEvaluation"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/CallLogDetail"
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "observability-v2-call-logs-rerun-evaluation-create",
+                        "description": "Trigger metric re-evaluation on one or more existing call logs. Provide either `agent_id` or `assistant_id` (not both) to identify the agent, then specify which call logs to re-evaluate.\n\n**`call_logs` accepts:**\n- A list of call log IDs: `[1, 2, 3]`\n- The string `\"all\"` to re-evaluate every call log for the agent\n\n**Side effect:** for non-reviewed call logs, `success` is reset to `null` before re-evaluation begins. Reviewed call logs retain their human-approved outcome.\n\n**Rate limited.** If the limit is exceeded you will receive a 429 response — wait for the `Retry-After` duration before retrying."
+                    }
+                }
+            }
+        },
         "/schedules/v1/cron-jobs/": {
             "get": {
                 "operationId": "cron-jobs-list",
@@ -7219,15 +8600,6 @@
                             "type": "string"
                         },
                         "description": "\nFilter by project id\nExample: `123`\n"
-                    },
-                    {
-                        "name": "organization_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `organization_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -8276,18 +9648,7 @@
                         "name": "slack-slack-workspaces-list",
                         "description": "Return every Slack workspace connected to the project, with the bot's default `channel_id`, `team_name`, and verification status. Use to pick a `workspace_id` (and optionally a different `channel_id`) for the `notifications.slack` block on `alerts_create`. Access tokens and bot IDs are not returned."
                     }
-                },
-                "parameters": [
-                    {
-                        "name": "project_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    }
-                ]
+                }
             },
             "post": {
                 "operationId": "slack-slack-workspaces-create",
@@ -9569,18 +10930,7 @@
                         "name": "billing-info-retrieve",
                         "description": "Returns credits remaining, credits used, balance expiry, and subscription status for an organization. When called with an organization-scoped API key, the org is taken from the key. When called with a user session or OAuth bearer, pass `organization_id` as a query parameter — the caller must be an admin of that organization."
                     }
-                },
-                "parameters": [
-                    {
-                        "name": "organization_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `organization_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    }
-                ]
+                }
             }
         },
         "/test_framework/billing/metric-usage/": {
@@ -14683,33 +16033,6 @@
                         "schema": {
                             "type": "integer"
                         }
-                    },
-                    {
-                        "name": "agent_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `category_id`, `metric_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    },
-                    {
-                        "name": "category_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `category_id`, `metric_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    },
-                    {
-                        "name": "metric_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `category_id`, `metric_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -15565,7 +16888,7 @@
                                                 "description": "<string>",
                                                 "function_name": "<string>",
                                                 "type": "basic",
-                                                "eval_type": "binary_workflow_adherence",
+                                                "eval_type": "binary",
                                                 "enum_values": [
                                                     "<string>"
                                                 ],
@@ -15608,7 +16931,7 @@
                                                 "description": "<string>",
                                                 "function_name": "<string>",
                                                 "type": "basic",
-                                                "eval_type": "binary_workflow_adherence",
+                                                "eval_type": "binary",
                                                 "enum_values": [
                                                     "<string>"
                                                 ],
@@ -15649,14 +16972,6 @@
                             }
                         },
                         "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "metrics-list",
-                        "description": "\nmetrics_list: List quality metrics (LLM-judge prompts, custom code, or predefined metrics) used to evaluate AI voice agents. Filter by `agent_id` or `project_id` to scope results.\n\nFiltering behavior:\n- If only agent_id is provided: Returns metrics associated with that agent only\n- If only project_id is provided: Returns metrics associated with that project only\n- If both agent_id and project_id are provided: Returns metrics from both the agent and the project\n- If agents is provided: Returns metrics where any of the specified agents are in the M2M agents field\n- If slug is provided: Returns the metric with that specific slug\n\nPerformance tip: `agent_id` (when a specific agent is in context) or `project_id` will narrow the result. Orgs can accumulate hundreds of metrics so a filter usually helps.\n        "
                     }
                 }
             },
@@ -15762,14 +17077,6 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "metrics-create",
-                        "description": "Create a quality metric for evaluating agent conversations.\n\n**Two supported types on create** (the `BASIC` and `CUSTOM_PROMPT` values are deprecated and rejected on create):\n\n- `llm_judge` — an LLM-as-judge metric. Put the evaluation criterion in `description`. Most common choice for qualitative scoring (politeness, compliance, resolution quality, etc.).\n\n- `custom_code` — Python code that receives the transcript and returns a score. Put the code in `custom_code`. Use for deterministic checks (regex matches, tool-call ordering, structured-field extraction, etc.).\n\n**Scope:** metrics must be created at the project level — pass `project` (project ID). Agent-level metrics are deprecated; if you pass `agent`, the server silently creates a project-level metric and returns a deprecation warning.\n\n**Evaluation control:** `observability_enabled` runs the metric on production calls (via CallLog); `simulation_enabled` runs it on test runs; `sampling_enabled` enables statistical sampling. `eval_type` picks the output shape (`bool`, `int`, `float`, `enum`, `string`); when `eval_type=\"enum\"`, also pass `enum_values`.\n\n**Triggering:** pass `trigger_type` + `evaluation_trigger_prompt` to gate the metric to only fire on specific call patterns (see the metric-triggers guide)."
-                    }
                 }
             }
         },
@@ -15863,7 +17170,7 @@
                                                 "description": "<string>",
                                                 "function_name": "<string>",
                                                 "type": "basic",
-                                                "eval_type": "binary_workflow_adherence",
+                                                "eval_type": "binary",
                                                 "enum_values": [
                                                     "<string>"
                                                 ],
@@ -15906,7 +17213,7 @@
                                                 "description": "<string>",
                                                 "function_name": "<string>",
                                                 "type": "basic",
-                                                "eval_type": "binary_workflow_adherence",
+                                                "eval_type": "binary",
                                                 "enum_values": [
                                                     "<string>"
                                                 ],
@@ -16108,7 +17415,7 @@
             },
             "put": {
                 "operationId": "metrics-external-update",
-                "description": "Fully replace a metric's fields. Prefer `PATCH` (partial_update) unless you specifically need full-replacement semantics. Same field shape as create.",
+                "description": "Update a metric (full)",
                 "summary": "Update a metric (full)",
                 "parameters": [
                     {
@@ -16367,7 +17674,7 @@
         "/test_framework/v1/metrics-external/{id}/apply_optimisation_proposal/": {
             "post": {
                 "operationId": "metrics-external-apply-optimisation-proposal-create",
-                "description": "Copies the fields from `pending_optimisation_proposal` (description, evaluation_trigger, type, custom_code) into the live metric columns and clears the proposal. 400 if no pending proposal exists.",
+                "description": "Apply a pending optimisation proposal",
                 "summary": "Apply a pending optimisation proposal",
                 "parameters": [
                     {
@@ -16398,7 +17705,7 @@
         "/test_framework/v1/metrics-external/{id}/dismiss_optimisation_proposal/": {
             "post": {
                 "operationId": "metrics-external-dismiss-optimisation-proposal-create",
-                "description": "Discards the metric's `pending_optimisation_proposal` without applying. Idempotent — a metric with no pending proposal returns 200.",
+                "description": "Dismiss a pending optimisation proposal",
                 "summary": "Dismiss a pending optimisation proposal",
                 "parameters": [
                     {
@@ -16600,7 +17907,7 @@
         "/test_framework/v1/metrics-external/{id}/history/": {
             "get": {
                 "operationId": "metrics-external-history-list",
-                "description": "Return paginated change history for a metric, including agents snapshot at each point.",
+                "description": "Metrics history",
                 "parameters": [
                     {
                         "in": "path",
@@ -16707,7 +18014,7 @@
         "/test_framework/v1/metrics-external/{id}/restore/": {
             "post": {
                 "operationId": "metrics-external-restore-create",
-                "description": "Restore a metric to a previous historical state, creating a new history record.",
+                "description": "Metrics restore",
                 "parameters": [
                     {
                         "in": "path",
@@ -16764,7 +18071,7 @@
         "/test_framework/v1/metrics-external/{id}/run_reviews/": {
             "post": {
                 "operationId": "metrics-external-run-reviews-create",
-                "description": "Re-evaluate all test sets for this metric with optional overrides. Returns a progress_id to poll for completion.",
+                "description": "Run metric reviews to identify improvement opportunities",
                 "parameters": [
                     {
                         "in": "path",
@@ -16942,7 +18249,7 @@
         "/test_framework/v1/metrics-external/bulk_create/": {
             "post": {
                 "operationId": "metrics-bulk-create",
-                "description": "Atomic bulk creation of project-level metrics. Pass a JSON array of metric objects with the same field shape as `metrics_create`. All entries succeed together or the whole request fails validation.",
+                "description": "Create multiple metrics in a single request",
                 "summary": "Create multiple metrics in a single request",
                 "tags": [
                     "test_framework"
@@ -17019,7 +18326,7 @@
         "/test_framework/v1/metrics-external/bulk_manage_agents/": {
             "post": {
                 "operationId": "metrics-external-bulk-manage-agents-create",
-                "description": "Bulk enable or disable metrics for multiple agents",
+                "description": "Metrics bulk manage agents",
                 "tags": [
                     "test_framework"
                 ],
@@ -17163,7 +18470,7 @@
         "/test_framework/v1/metrics-external/generate_clean_description/": {
             "post": {
                 "operationId": "metrics-external-generate-clean-description-create",
-                "description": "Generate a clean metric description based on agent description and metric description.",
+                "description": "Metrics generate clean description",
                 "tags": [
                     "test_framework"
                 ],
@@ -17209,7 +18516,7 @@
         "/test_framework/v1/metrics-external/generate_clean_description_bg/": {
             "post": {
                 "operationId": "metrics-external-generate-clean-description-bg-create",
-                "description": "Enqueue a background job to generate a clean metric description. Returns a `progress_id`; poll `generate_clean_description_progress` until `status` is `completed` or `failed`.",
+                "description": "Start async clean description generation",
                 "summary": "Start async clean description generation",
                 "tags": [
                     "test_framework"
@@ -17256,7 +18563,7 @@
         "/test_framework/v1/metrics-external/generate_clean_description_progress/": {
             "get": {
                 "operationId": "metrics-external-generate-clean-description-progress-retrieve",
-                "description": "Poll the result of a `generate_clean_description_bg` job. `status` is one of: `queued`, `processing`, `completed`, `failed`. On `completed`, `clean_description` and `thinking` are present.",
+                "description": "Poll async clean description generation",
                 "summary": "Poll async clean description generation",
                 "parameters": [
                     {
@@ -17294,7 +18601,7 @@
         "/test_framework/v1/metrics-external/generate_evaluation_trigger/": {
             "post": {
                 "operationId": "metrics-external-generate-evaluation-trigger-create",
-                "description": "Generate an evaluation trigger based on agent description and metric description.",
+                "description": "Metrics generate evaluation trigger",
                 "tags": [
                     "test_framework"
                 ],
@@ -17403,7 +18710,7 @@
         "/test_framework/v1/metrics-external/generate_metrics_progress/": {
             "get": {
                 "operationId": "metrics-external-generate-metrics-progress-retrieve",
-                "description": "Poll the progress of metric generation. Returns current state including status and generated metrics.",
+                "description": "Metrics generate metrics progress",
                 "parameters": [
                     {
                         "in": "query",
@@ -17433,7 +18740,7 @@
         "/test_framework/v1/metrics-external/preview/": {
             "post": {
                 "operationId": "metrics-external-preview-create",
-                "description": "Preview metric evaluation on call logs or runs before creating it. Supports up to 10 items. Returns progress_id to poll for results.",
+                "description": "Preview metric evaluation against sample transcripts",
                 "tags": [
                     "test_framework"
                 ],
@@ -17472,7 +18779,7 @@
         "/test_framework/v1/metrics-external/preview-progress/": {
             "get": {
                 "operationId": "metrics-preview-progress",
-                "description": "Poll the progress of metric preview. Returns current state with evaluation results.",
+                "description": "Metrics preview progress",
                 "parameters": [
                     {
                         "in": "query",
@@ -17502,7 +18809,7 @@
         "/test_framework/v1/metrics-external/run_reviews_progress/": {
             "get": {
                 "operationId": "metrics-run-reviews-progress",
-                "description": "Poll the progress of metric re-evaluation. Returns current state and full metric data when complete.",
+                "description": "Metrics run reviews progress",
                 "parameters": [
                     {
                         "in": "query",
@@ -17594,7 +18901,7 @@
         "/test_framework/v1/metrics-external/simplify_prompt/": {
             "post": {
                 "operationId": "metrics-external-simplify-prompt-create",
-                "description": "Simplify a verbose metric prompt into a minimal algorithmic version. Returns immediately if metric is already optimized, otherwise returns a progress_id for polling.",
+                "description": "Metrics simplify prompt",
                 "tags": [
                     "test_framework"
                 ],
@@ -17640,7 +18947,7 @@
         "/test_framework/v1/metrics-external/simplify_prompt_progress/": {
             "get": {
                 "operationId": "metrics-external-simplify-prompt-progress-retrieve",
-                "description": "Poll the progress of async prompt simplification.",
+                "description": "Metrics simplify prompt progress",
                 "parameters": [
                     {
                         "in": "query",
@@ -17723,19 +19030,11 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "metrics-retrieve",
-                        "description": "Retrieve a specific metric by ID or slug."
-                    }
                 }
             },
             "put": {
                 "operationId": "metrics-update",
-                "description": "Fully replace a metric's fields. Prefer `PATCH` (partial_update) unless you specifically need full-replacement semantics. Same field shape as create.",
+                "description": "Update a metric (full)",
                 "summary": "Update a metric (full)",
                 "parameters": [
                     {
@@ -17887,14 +19186,6 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "metrics-partial-update",
-                        "description": "Partially update a metric. Same field shape as create — see `metrics_create` for details.\n\n**Note:** `project` and `agent` are read-only once set — you cannot move a metric between projects/agents after creation. To relocate, create a new metric and delete the old one."
-                    }
                 }
             },
             "delete": {
@@ -17938,14 +19229,6 @@
                             }
                         },
                         "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "metrics-destroy",
-                        "description": "⚠ Irreversible. Deletes the metric and detaches it from all agents and evaluators. Dashboard widgets that displayed this metric are also removed."
                     }
                 }
             }
@@ -18010,7 +19293,7 @@
         "/test_framework/v1/metrics/{id}/apply_optimisation_proposal/": {
             "post": {
                 "operationId": "metrics-apply-optimisation-proposal-create",
-                "description": "Copies the fields from `pending_optimisation_proposal` (description, evaluation_trigger, type, custom_code) into the live metric columns and clears the proposal. 400 if no pending proposal exists.",
+                "description": "Apply a pending optimisation proposal",
                 "summary": "Apply a pending optimisation proposal",
                 "parameters": [
                     {
@@ -18041,7 +19324,7 @@
         "/test_framework/v1/metrics/{id}/dismiss_optimisation_proposal/": {
             "post": {
                 "operationId": "metrics-dismiss-optimisation-proposal-create",
-                "description": "Discards the metric's `pending_optimisation_proposal` without applying. Idempotent — a metric with no pending proposal returns 200.",
+                "description": "Dismiss a pending optimisation proposal",
                 "summary": "Dismiss a pending optimisation proposal",
                 "parameters": [
                     {
@@ -18243,7 +19526,7 @@
         "/test_framework/v1/metrics/{id}/history/": {
             "get": {
                 "operationId": "metrics-history-list",
-                "description": "Return paginated change history for a metric, including agents snapshot at each point.",
+                "description": "Metrics history",
                 "parameters": [
                     {
                         "in": "path",
@@ -18350,7 +19633,7 @@
         "/test_framework/v1/metrics/{id}/restore/": {
             "post": {
                 "operationId": "metrics-restore-create",
-                "description": "Restore a metric to a previous historical state, creating a new history record.",
+                "description": "Metrics restore",
                 "parameters": [
                     {
                         "in": "path",
@@ -18407,7 +19690,7 @@
         "/test_framework/v1/metrics/{id}/run_reviews/": {
             "post": {
                 "operationId": "metrics-run-reviews-create",
-                "description": "Re-evaluate all test sets for this metric with optional overrides. Returns a progress_id to poll for completion.",
+                "description": "Run metric reviews to identify improvement opportunities",
                 "parameters": [
                     {
                         "in": "path",
@@ -18449,14 +19732,6 @@
                 "responses": {
                     "200": {
                         "description": "Returns progress_id for tracking progress"
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "metrics-run-reviews-create",
-                        "description": "Re-evaluate all test sets for this metric with optional overrides. Returns a progress_id to poll for completion."
                     }
                 }
             }
@@ -18593,7 +19868,7 @@
         "/test_framework/v1/metrics/bulk_create/": {
             "post": {
                 "operationId": "metrics-bulk-create_2",
-                "description": "Atomic bulk creation of project-level metrics. Pass a JSON array of metric objects with the same field shape as `metrics_create`. All entries succeed together or the whole request fails validation.",
+                "description": "Create multiple metrics in a single request",
                 "summary": "Create multiple metrics in a single request",
                 "tags": [
                     "test_framework"
@@ -18664,21 +19939,13 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "metrics-bulk-create",
-                        "description": "Atomic bulk creation of project-level metrics. Pass a JSON array of metric objects with the same field shape as `metrics_create`. All entries succeed together or the whole request fails validation."
-                    }
                 }
             }
         },
         "/test_framework/v1/metrics/bulk_manage_agents/": {
             "post": {
                 "operationId": "metrics-bulk-manage-agents-create",
-                "description": "Bulk enable or disable metrics for multiple agents",
+                "description": "Metrics bulk manage agents",
                 "tags": [
                     "test_framework"
                 ],
@@ -18822,7 +20089,7 @@
         "/test_framework/v1/metrics/generate_clean_description/": {
             "post": {
                 "operationId": "metrics-generate-clean-description-create",
-                "description": "Generate a clean metric description based on agent description and metric description.",
+                "description": "Metrics generate clean description",
                 "tags": [
                     "test_framework"
                 ],
@@ -18862,21 +20129,13 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "metrics-generate-clean-description-create",
-                        "description": "Generate a clean metric description based on agent description and metric description."
-                    }
                 }
             }
         },
         "/test_framework/v1/metrics/generate_clean_description_bg/": {
             "post": {
                 "operationId": "metrics-generate-clean-description-bg-create",
-                "description": "Enqueue a background job to generate a clean metric description. Returns a `progress_id`; poll `generate_clean_description_progress` until `status` is `completed` or `failed`.",
+                "description": "Start async clean description generation",
                 "summary": "Start async clean description generation",
                 "tags": [
                     "test_framework"
@@ -18917,21 +20176,13 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "metrics-generate-clean-description-bg-create",
-                        "description": "Enqueue a background job to generate a clean metric description. Returns a `progress_id`; poll `generate_clean_description_progress` until `status` is `completed` or `failed`."
-                    }
                 }
             }
         },
         "/test_framework/v1/metrics/generate_clean_description_progress/": {
             "get": {
                 "operationId": "metrics-generate-clean-description-progress-retrieve",
-                "description": "Poll the result of a `generate_clean_description_bg` job. `status` is one of: `queued`, `processing`, `completed`, `failed`. On `completed`, `clean_description` and `thinking` are present.",
+                "description": "Poll async clean description generation",
                 "summary": "Poll async clean description generation",
                 "parameters": [
                     {
@@ -18942,33 +20193,6 @@
                         },
                         "description": "progress_id returned from generate_clean_description_bg",
                         "required": true
-                    },
-                    {
-                        "name": "agent_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    },
-                    {
-                        "name": "project_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    },
-                    {
-                        "name": "assistant_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -18990,21 +20214,13 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "metrics-generate-clean-description-progress-retrieve",
-                        "description": "Poll the result of a `generate_clean_description_bg` job. `status` is one of: `queued`, `processing`, `completed`, `failed`. On `completed`, `clean_description` and `thinking` are present."
-                    }
                 }
             }
         },
         "/test_framework/v1/metrics/generate_evaluation_trigger/": {
             "post": {
                 "operationId": "metrics-generate-evaluation-trigger-create",
-                "description": "Generate an evaluation trigger based on agent description and metric description.",
+                "description": "Metrics generate evaluation trigger",
                 "tags": [
                     "test_framework"
                 ],
@@ -19043,14 +20259,6 @@
                             }
                         },
                         "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "metrics-generate-evaluation-trigger-create",
-                        "description": "Generate an evaluation trigger based on agent description and metric description."
                     }
                 }
             }
@@ -19115,21 +20323,13 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "metrics-generate",
-                        "description": "Generates suggested metrics for an AI agent. Returns a `progress_id` to poll via `generate_metrics_progress`. Results appear in the progress response but are not saved automatically — pass them to the metrics bulk create endpoint to persist. The agent must have a description of at least 100 characters."
-                    }
                 }
             }
         },
         "/test_framework/v1/metrics/generate_metrics_progress/": {
             "get": {
                 "operationId": "metrics-generate-metrics-progress-retrieve",
-                "description": "Poll the progress of metric generation. Returns current state including status and generated metrics.",
+                "description": "Metrics generate metrics progress",
                 "parameters": [
                     {
                         "in": "query",
@@ -19139,33 +20339,6 @@
                         },
                         "description": "Progress ID returned from the generate_metrics endpoint",
                         "required": true
-                    },
-                    {
-                        "name": "agent_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    },
-                    {
-                        "name": "project_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    },
-                    {
-                        "name": "assistant_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -19180,21 +20353,13 @@
                     "200": {
                         "description": "Returns generation state with status and generated metrics"
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "metrics-generate-metrics-progress-retrieve",
-                        "description": "Poll the progress of metric generation. Returns current state including status and generated metrics."
-                    }
                 }
             }
         },
         "/test_framework/v1/metrics/preview/": {
             "post": {
                 "operationId": "metrics-preview-create",
-                "description": "Preview metric evaluation on call logs or runs before creating it. Supports up to 10 items. Returns progress_id to poll for results.",
+                "description": "Preview metric evaluation against sample transcripts",
                 "tags": [
                     "test_framework"
                 ],
@@ -19227,21 +20392,13 @@
                     "200": {
                         "description": "Returns progress_id for tracking progress"
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "metrics-preview-create",
-                        "description": "Preview metric evaluation on call logs or runs before creating it. Supports up to 10 items. Returns progress_id to poll for results."
-                    }
                 }
             }
         },
         "/test_framework/v1/metrics/preview-progress/": {
             "get": {
                 "operationId": "metrics-preview-progress_2",
-                "description": "Poll the progress of metric preview. Returns current state with evaluation results.",
+                "description": "Metrics preview progress",
                 "parameters": [
                     {
                         "in": "query",
@@ -19251,33 +20408,6 @@
                         },
                         "description": "Progress ID returned from the preview endpoint",
                         "required": true
-                    },
-                    {
-                        "name": "agent_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    },
-                    {
-                        "name": "project_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    },
-                    {
-                        "name": "assistant_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -19292,21 +20422,13 @@
                     "200": {
                         "description": "Returns preview state with status and results"
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "metrics-preview-progress",
-                        "description": "Poll the progress of metric preview. Returns current state with evaluation results."
-                    }
                 }
             }
         },
         "/test_framework/v1/metrics/run_reviews_progress/": {
             "get": {
                 "operationId": "metrics-run-reviews-progress_2",
-                "description": "Poll the progress of metric re-evaluation. Returns current state and full metric data when complete.",
+                "description": "Metrics run reviews progress",
                 "parameters": [
                     {
                         "in": "query",
@@ -19332,15 +20454,6 @@
                             "type": "integer"
                         },
                         "description": "Project ID for permission validation"
-                    },
-                    {
-                        "name": "assistant_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -19354,14 +20467,6 @@
                 "responses": {
                     "200": {
                         "description": "Returns progress state with completed/failed counts and metric data when finished"
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "metrics-run-reviews-progress",
-                        "description": "Poll the progress of metric re-evaluation. Returns current state and full metric data when complete."
                     }
                 }
             }
@@ -19415,7 +20520,7 @@
         "/test_framework/v1/metrics/simplify_prompt/": {
             "post": {
                 "operationId": "metrics-simplify-prompt-create",
-                "description": "Simplify a verbose metric prompt into a minimal algorithmic version. Returns immediately if metric is already optimized, otherwise returns a progress_id for polling.",
+                "description": "Metrics simplify prompt",
                 "tags": [
                     "test_framework"
                 ],
@@ -19455,21 +20560,13 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "metrics-simplify-prompt-create",
-                        "description": "Simplify a verbose metric prompt into a minimal algorithmic version. Returns immediately if metric is already optimized, otherwise returns a progress_id for polling."
-                    }
                 }
             }
         },
         "/test_framework/v1/metrics/simplify_prompt_progress/": {
             "get": {
                 "operationId": "metrics-simplify-prompt-progress-retrieve",
-                "description": "Poll the progress of async prompt simplification.",
+                "description": "Metrics simplify prompt progress",
                 "parameters": [
                     {
                         "in": "query",
@@ -19479,33 +20576,6 @@
                         },
                         "description": "Progress ID returned from simplify_prompt endpoint",
                         "required": true
-                    },
-                    {
-                        "name": "agent_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    },
-                    {
-                        "name": "project_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    },
-                    {
-                        "name": "assistant_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -19526,14 +20596,6 @@
                             }
                         },
                         "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "metrics-simplify-prompt-progress-retrieve",
-                        "description": "Poll the progress of async prompt simplification."
                     }
                 }
             }
@@ -20913,18 +21975,7 @@
                         "name": "phone-numbers-inbound-list",
                         "description": "Phone numbers inbound"
                     }
-                },
-                "parameters": [
-                    {
-                        "name": "organization_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `organization_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    }
-                ]
+                }
             }
         },
         "/test_framework/v1/phone-numbers/providers/list/": {
@@ -21942,15 +22993,6 @@
                             "type": "string"
                         },
                         "description": "Filter by scenario IDs — comma-separated string (e.g. '24270,24271'), not a JSON array."
-                    },
-                    {
-                        "name": "assistant_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `assistant_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -22217,7 +23259,7 @@
                                                             {
                                                                 "id": "integer",
                                                                 "name": "string",
-                                                                "type": "binary_workflow_adherence | binary_qualitative | continuous_qualitative | numeric | enum",
+                                                                "type": "binary | continuous_qualitative | numeric | enum",
                                                                 "score": "number",
                                                                 "explanation": "string | array",
                                                                 "function_name": "string (optional)",
@@ -22494,7 +23536,7 @@
         "/test_framework/v1/results-external/{id}/ask_about_failures/": {
             "post": {
                 "operationId": "results-external-ask-about-failures-create",
-                "description": "Ask natural language questions about test failure data. Returns streaming AI-generated analysis based on failed run context.",
+                "description": "Query failed runs chatbot",
                 "summary": "Query failed runs chatbot",
                 "parameters": [
                     {
@@ -22561,7 +23603,7 @@
         "/test_framework/v1/results-external/{id}/create_shareable_link_token/": {
             "post": {
                 "operationId": "create-shareable-link-token",
-                "description": "Generates a secure, time-limited shareable link that allows users to view test results without authentication. Requires an active subscription.",
+                "description": "Generate shareable link for result",
                 "summary": "Generate shareable link for result",
                 "parameters": [
                     {
@@ -22720,7 +23762,7 @@
         "/test_framework/v1/results-external/{id}/end_calls/": {
             "post": {
                 "operationId": "end-calls",
-                "description": "Terminates ALL active phone calls / chat sessions across every non-deleted run in this result. Bulk operation — there is no per-call confirmation or dry-run.",
+                "description": "End all calls in result",
                 "summary": "End all calls in result",
                 "parameters": [
                     {
@@ -23010,7 +24052,7 @@
         "/test_framework/v1/results-external/bulk_export_progress/": {
             "get": {
                 "operationId": "results-external-bulk-export-progress-retrieve",
-                "description": "Get the progress of bulk export by progress_id.",
+                "description": "Results bulk export progress",
                 "tags": [
                     "test_framework"
                 ],
@@ -23114,7 +24156,7 @@
         "/test_framework/v1/results-external/reports/ask-about-failures/": {
             "post": {
                 "operationId": "results-external-reports-ask-about-failures-create",
-                "description": "Ask natural language questions about test failure data across multiple combined results. Returns streaming AI-generated analysis based on failed run context from all specified results.",
+                "description": "Query failed runs chatbot for combined reports",
                 "summary": "Query failed runs chatbot for combined reports",
                 "tags": [
                     "Results"
@@ -23307,7 +24349,7 @@
                                                             {
                                                                 "id": "integer",
                                                                 "name": "string",
-                                                                "type": "binary_workflow_adherence | binary_qualitative | continuous_qualitative | numeric | enum",
+                                                                "type": "binary | continuous_qualitative | numeric | enum",
                                                                 "score": "number",
                                                                 "explanation": "string | array",
                                                                 "function_name": "string (optional)",
@@ -23592,7 +24634,7 @@
         "/test_framework/v1/results/{id}/ask_about_failures/": {
             "post": {
                 "operationId": "results-ask-about-failures-create",
-                "description": "Ask natural language questions about test failure data. Returns streaming AI-generated analysis based on failed run context.",
+                "description": "Query failed runs chatbot",
                 "summary": "Query failed runs chatbot",
                 "parameters": [
                     {
@@ -23659,7 +24701,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "results-ask-about-failures-create",
-                        "description": "Ask natural language questions about test failure data. Returns streaming AI-generated analysis based on failed run context."
+                        "description": "Query failed runs chatbot"
                     }
                 }
             }
@@ -23667,7 +24709,7 @@
         "/test_framework/v1/results/{id}/create_shareable_link_token/": {
             "post": {
                 "operationId": "create-shareable-link-token_2",
-                "description": "Generates a secure, time-limited shareable link that allows users to view test results without authentication. Requires an active subscription.",
+                "description": "Generate shareable link for result",
                 "summary": "Generate shareable link for result",
                 "parameters": [
                     {
@@ -23742,7 +24784,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "create-shareable-link-token",
-                        "description": "Generates a secure, time-limited shareable link that allows users to view test results without authentication. Requires an active subscription."
+                        "description": "Generate shareable link for result"
                     }
                 }
             }
@@ -23842,7 +24884,7 @@
         "/test_framework/v1/results/{id}/end_calls/": {
             "post": {
                 "operationId": "end-calls_2",
-                "description": "Terminates ALL active phone calls / chat sessions across every non-deleted run in this result. Bulk operation — there is no per-call confirmation or dry-run.",
+                "description": "End all calls in result",
                 "summary": "End all calls in result",
                 "parameters": [
                     {
@@ -23888,7 +24930,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "end-calls",
-                        "description": "Terminates ALL active phone calls / chat sessions across every non-deleted run in this result. Bulk operation — there is no per-call confirmation or dry-run."
+                        "description": "End all calls in result"
                     }
                 }
             }
@@ -24156,7 +25198,7 @@
         "/test_framework/v1/results/bulk_export_progress/": {
             "get": {
                 "operationId": "results-bulk-export-progress-retrieve",
-                "description": "Get the progress of bulk export by progress_id.",
+                "description": "Results bulk export progress",
                 "tags": [
                     "test_framework"
                 ],
@@ -24260,7 +25302,7 @@
         "/test_framework/v1/results/reports/ask-about-failures/": {
             "post": {
                 "operationId": "results-reports-ask-about-failures-create",
-                "description": "Ask natural language questions about test failure data across multiple combined results. Returns streaming AI-generated analysis based on failed run context from all specified results.",
+                "description": "Query failed runs chatbot for combined reports",
                 "summary": "Query failed runs chatbot for combined reports",
                 "tags": [
                     "Results"
@@ -25291,7 +26333,7 @@
         "/test_framework/v1/runs-external/{id}/end_call/": {
             "post": {
                 "operationId": "end-call",
-                "description": "Terminates the active phone call or chat session for this specific run.",
+                "description": "End a single call",
                 "summary": "End a single call",
                 "parameters": [
                     {
@@ -25633,7 +26675,7 @@
         "/test_framework/v1/runs-external/{id}/run_expected_outcome_bg/": {
             "post": {
                 "operationId": "runs-external-run-expected-outcome-bg-create",
-                "description": "Async version of run_expected_outcome. Returns progress_id for both paths.",
+                "description": "Runs run expected outcome bg",
                 "parameters": [
                     {
                         "in": "path",
@@ -25984,7 +27026,7 @@
         "/test_framework/v1/runs/{id}/end_call/": {
             "post": {
                 "operationId": "end-call_2",
-                "description": "Terminates the active phone call or chat session for this specific run.",
+                "description": "End a single call",
                 "summary": "End a single call",
                 "parameters": [
                     {
@@ -26030,7 +27072,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "end-call",
-                        "description": "Terminates the active phone call or chat session for this specific run."
+                        "description": "End a single call"
                     }
                 }
             }
@@ -26342,7 +27384,7 @@
         "/test_framework/v1/runs/{id}/run_expected_outcome_bg/": {
             "post": {
                 "operationId": "runs-run-expected-outcome-bg-create",
-                "description": "Async version of run_expected_outcome. Returns progress_id for both paths.",
+                "description": "Runs run expected outcome bg",
                 "parameters": [
                     {
                         "in": "path",
@@ -26493,33 +27535,6 @@
                         },
                         "description": "\nComma-separated list of run IDs.\nExample: `1,2,3`\n\nMust be a plain comma-separated string, not a JSON array — passing a JSON array returns a 400 error.\n",
                         "required": true
-                    },
-                    {
-                        "name": "agent_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `result_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    },
-                    {
-                        "name": "result_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `result_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    },
-                    {
-                        "name": "project_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `result_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -26616,18 +27631,7 @@
                         "name": "scenario-improvement-sessions-list",
                         "description": "List scenario-improvement sessions for a project. Each session tracks an AI-assisted refinement run over the project's scenarios. Requires `project_id`."
                     }
-                },
-                "parameters": [
-                    {
-                        "name": "project_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    }
-                ]
+                }
             },
             "post": {
                 "operationId": "scenario-improvement-sessions-create",
@@ -34136,24 +35140,6 @@
                             "type": "string"
                         },
                         "description": "Search folders by name (case-insensitive)"
-                    },
-                    {
-                        "name": "agent_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    },
-                    {
-                        "name": "assistant_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -34847,36 +35833,7 @@
                         "name": "scenarios-instructions-progress-retrieve",
                         "description": "Scenarios instructions progress"
                     }
-                },
-                "parameters": [
-                    {
-                        "name": "agent_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    },
-                    {
-                        "name": "project_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    },
-                    {
-                        "name": "assistant_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    }
-                ]
+                }
             }
         },
         "/test_framework/v1/scenarios/move_folder/": {
@@ -39293,15 +40250,6 @@
                             "type": "string"
                         },
                         "description": "Search agents by name. A numeric value also matches the agent id."
-                    },
-                    {
-                        "name": "organization_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `project_id`, `organization_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -41145,6 +42093,4476 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/PaginatedAIAgentListList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/": {
+            "get": {
+                "operationId": "test-framework-v2-metrics-list",
+                "description": "List quality metrics. Filter by `project_id` or `agent_id` to scope results.",
+                "summary": "List quality metrics",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "agent_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "\nFilter by agent ID\nExample: `123`\n"
+                    },
+                    {
+                        "in": "query",
+                        "name": "project_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "\nFilter by project ID\nExample: `456`\n"
+                    },
+                    {
+                        "in": "query",
+                        "name": "assistant_id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "\nFilter by assistant ID\nExample: `asst_1234567890`\n"
+                    },
+                    {
+                        "in": "query",
+                        "name": "agents",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "\nFilter metrics by agent IDs. Supports comma-separated list.\nExample: `1,2,3` to filter metrics associated with any of these agents\n"
+                    },
+                    {
+                        "in": "query",
+                        "name": "slug",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "\nFilter by metric slug\nExample: `latency_metric` or `customer_satisfaction`\n"
+                    },
+                    {
+                        "in": "query",
+                        "name": "filters",
+                        "schema": {
+                            "type": "object"
+                        },
+                        "description": "JSON filter parameter for advanced filtering.\n\nExample:\n```json\n{\"operator\":\"and\",\"conditions\":[{\"field\":\"agents__id\",\"op\":\"in\",\"value\":[1,2,3]}]}\n```\n\nSupported fields: agents__id, eval_type, type, name\nSupported operators: in, eq, contains"
+                    },
+                    {
+                        "in": "query",
+                        "name": "include_scores",
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "description": "\nInclude Overall and Total scores in Metric List\nExample: `true` or `false`\n                "
+                    }
+                ],
+                "tags": [
+                    "Metrics"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/MetricListSerializerV2"
+                                    }
+                                },
+                                "examples": {
+                                    "MetricList": {
+                                        "value": [
+                                            {
+                                                "id": 123,
+                                                "name": "<string>",
+                                                "description": "<string>",
+                                                "function_name": "<string>",
+                                                "type": "basic",
+                                                "eval_type": "binary",
+                                                "enum_values": [
+                                                    "<string>"
+                                                ],
+                                                "audio_enabled": true,
+                                                "observability_enabled": true,
+                                                "simulation_enabled": true,
+                                                "prompt": "<string>",
+                                                "evaluation_trigger": "always",
+                                                "evaluation_trigger_prompt": "<string>",
+                                                "priority_assignment_prompt": "<string>",
+                                                "vocera_defined_metric_code": "<string>",
+                                                "configuration": {
+                                                    "infra_issues_timeout": "<integer>",
+                                                    "key": "value"
+                                                },
+                                                "kb_file_ids": [
+                                                    "<integer>"
+                                                ],
+                                                "knowledge_base_files": [
+                                                    {
+                                                        "id": "<integer>",
+                                                        "agent": "<integer>",
+                                                        "file_url": "<string>",
+                                                        "file_name": "<string>",
+                                                        "file_type": "<string>",
+                                                        "file_size": "<integer>",
+                                                        "created_at": "<datetime>",
+                                                        "updated_at": "<datetime>"
+                                                    }
+                                                ],
+                                                "metric_cost": "<float>"
+                                            }
+                                        ]
+                                    },
+                                    "MetricListWithOverallScore": {
+                                        "value": [
+                                            {
+                                                "id": "<integer>",
+                                                "name": "<string>",
+                                                "description": "<string>",
+                                                "function_name": "<string>",
+                                                "type": "basic",
+                                                "eval_type": "binary",
+                                                "enum_values": [
+                                                    "<string>"
+                                                ],
+                                                "audio_enabled": true,
+                                                "observability_enabled": true,
+                                                "simulation_enabled": true,
+                                                "prompt": "<string>",
+                                                "evaluation_trigger": "always",
+                                                "evaluation_trigger_prompt": "<string>",
+                                                "priority_assignment_prompt": "<string>",
+                                                "vocera_defined_metric_code": "<string>",
+                                                "configuration": {
+                                                    "infra_issues_timeout": "<integer>",
+                                                    "key": "value"
+                                                },
+                                                "kb_file_ids": [
+                                                    "<integer>"
+                                                ],
+                                                "knowledge_base_files": [
+                                                    {
+                                                        "id": "<integer>",
+                                                        "agent": "<int>",
+                                                        "file_url": "<string>",
+                                                        "file_name": "<string>",
+                                                        "file_type": "<string>",
+                                                        "file_size": "<integer>",
+                                                        "created_at": "<datetime>",
+                                                        "updated_at": "<datetime>"
+                                                    }
+                                                ],
+                                                "metric_cost": "<float>",
+                                                "overall_score": "<integer>",
+                                                "total_score": "<integer>"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "test-framework-v2-metrics-list",
+                        "description": "List quality metrics. Filter by `project_id` or `agent_id` to scope results."
+                    }
+                }
+            },
+            "post": {
+                "operationId": "test-framework-v2-metrics-create",
+                "description": "Create a quality metric. `type` is `llm_judge` or `custom_code`. `eval_type` is one of `binary`, `continuous_qualitative`, `numeric`, `enum`. Set `add_to_rubric=true` to include the metric in the project's call-success rubric.",
+                "summary": "Create a metric",
+                "tags": [
+                    "Metrics"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricEditSerializerV2"
+                            },
+                            "examples": {
+                                "LLMJudgeMetric(simplest—MostCommon)": {
+                                    "value": {
+                                        "project": 1376,
+                                        "name": "Was the caller greeted by name",
+                                        "description": "Score TRUE if the agent addressed the caller by their name within the first 3 turns, FALSE otherwise.",
+                                        "type": "llm_judge",
+                                        "eval_type": "bool",
+                                        "simulation_enabled": true,
+                                        "observability_enabled": true
+                                    },
+                                    "summary": "LLM judge metric (simplest — most common)"
+                                },
+                                "LLMJudge—EnumOutput": {
+                                    "value": {
+                                        "project": 1376,
+                                        "name": "Call resolution outcome",
+                                        "description": "Classify how the call ended: `resolved` (caller's issue was fully addressed), `transferred` (caller was handed off to a human), `dropped` (caller hung up without resolution).",
+                                        "type": "llm_judge",
+                                        "eval_type": "enum",
+                                        "enum_values": [
+                                            "resolved",
+                                            "transferred",
+                                            "dropped"
+                                        ],
+                                        "observability_enabled": true
+                                    },
+                                    "summary": "LLM judge — enum output"
+                                },
+                                "CustomCodeMetric(deterministicCheck)": {
+                                    "value": {
+                                        "project": 1376,
+                                        "name": "Agent asked for order ID before refund",
+                                        "type": "custom_code",
+                                        "eval_type": "bool",
+                                        "custom_code": "def score(transcript, context):\n    text = transcript.lower()\n    return 'order id' in text[:text.find('refund')] if 'refund' in text else True\n",
+                                        "simulation_enabled": true
+                                    },
+                                    "summary": "Custom code metric (deterministic check)"
+                                },
+                                "BinaryLLM-judgeMetric(addedToRubric)": {
+                                    "value": {
+                                        "name": "Agent greeted the customer",
+                                        "description": "Check if the agent greeted the customer at the start of the call.",
+                                        "project": 42,
+                                        "type": "llm_judge",
+                                        "eval_type": "binary",
+                                        "evaluation_trigger": "always",
+                                        "add_to_rubric": true
+                                    },
+                                    "summary": "Binary LLM-judge metric (added to rubric)"
+                                },
+                                "ContinuousLLM-judgeMetric(0–5Rubric)": {
+                                    "value": {
+                                        "name": "Empathy level",
+                                        "description": "Rate how empathetic the agent was on a 0–5 scale.",
+                                        "project": 42,
+                                        "type": "llm_judge",
+                                        "eval_type": "continuous_qualitative",
+                                        "evaluation_trigger": "always"
+                                    },
+                                    "summary": "Continuous LLM-judge metric (0–5 rubric)"
+                                },
+                                "NumericCustom-codeMetric": {
+                                    "value": {
+                                        "name": "Words per minute",
+                                        "description": "Compute the agent's speaking rate.",
+                                        "project": 42,
+                                        "type": "custom_code",
+                                        "eval_type": "numeric",
+                                        "custom_code": "def evaluate(transcript):\n    return {'score': len(transcript.split()) / max(1, transcript_duration_minutes)}",
+                                        "evaluation_trigger": "always"
+                                    },
+                                    "summary": "Numeric custom-code metric"
+                                },
+                                "EnumLLM-judgeMetric": {
+                                    "value": {
+                                        "name": "Call outcome",
+                                        "description": "Classify the call outcome as one of: booked, follow_up, declined.",
+                                        "project": 42,
+                                        "type": "llm_judge",
+                                        "eval_type": "enum",
+                                        "enum_values": [
+                                            "booked",
+                                            "follow_up",
+                                            "declined"
+                                        ],
+                                        "evaluation_trigger": "always"
+                                    },
+                                    "summary": "Enum LLM-judge metric"
+                                }
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricEditSerializerV2"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricEditSerializerV2"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricDetailSerializerV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "test-framework-v2-metrics-create",
+                        "description": "Create a quality metric. `type` is `llm_judge` or `custom_code`. `eval_type` is one of `binary`, `continuous_qualitative`, `numeric`, `enum`. Set `add_to_rubric=true` to include the metric in the project's call-success rubric."
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/{id}/": {
+            "get": {
+                "operationId": "test-framework-v2-metrics-retrieve",
+                "description": "Fetch one metric by id.",
+                "summary": "Retrieve a metric",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "**ID or Slug** - Metric identifier. Can be either:\n- Numeric ID (e.g., `123`)\n- Slug (e.g., `latency_metric`, `customer_satisfaction`)",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Metrics"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricDetailSerializerV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "detail": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "test-framework-v2-metrics-retrieve",
+                        "description": "Fetch one metric by id."
+                    }
+                }
+            },
+            "put": {
+                "operationId": "test-framework-v2-metrics-update",
+                "description": "Update a metric (full)",
+                "summary": "Update a metric (full)",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Metrics"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostMetricEdit"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostMetricEdit"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostMetricEdit"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SchemaPostMetricEdit"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "patch": {
+                "operationId": "test-framework-v2-metrics-partial-update",
+                "description": "Partially update a metric. Pass `add_to_rubric=true` to add the metric to the project's rubric, or `false` to remove it.",
+                "summary": "Update a metric (partial)",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Metrics"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedMetricEditSerializerV2"
+                            },
+                            "examples": {
+                                "UpdatePrompt+CriticalFlag": {
+                                    "value": {
+                                        "description": "Updated rubric",
+                                        "is_critical": true
+                                    },
+                                    "summary": "Update prompt + critical flag"
+                                }
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedMetricEditSerializerV2"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedMetricEditSerializerV2"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricDetailSerializerV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "detail": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "test-framework-v2-metrics-partial-update",
+                        "description": "Partially update a metric. Pass `add_to_rubric=true` to add the metric to the project's rubric, or `false` to remove it."
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "test-framework-v2-metrics-destroy",
+                "description": "⚠ Irreversible. Deletes the metric and detaches it from all agents and evaluators. Dashboard widgets that displayed this metric are also removed.",
+                "summary": "Delete a metric",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No response body"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "detail": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "test-framework-v2-metrics-destroy",
+                        "description": "⚠ Irreversible. Deletes the metric and detaches it from all agents and evaluators. Dashboard widgets that displayed this metric are also removed."
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/{id}/add_to_predefined_metrics/": {
+            "post": {
+                "operationId": "test-framework-v2-metrics-add-to-predefined-metrics-create",
+                "description": "Manage quality metrics for evaluating AI voice agent performance.\n\n`eval_type` values: `binary`, `continuous_qualitative`, `numeric`, `enum`.\n`add_to_rubric` (write-only) controls whether the metric contributes to\nthe project's call-success rubric.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricDetailV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/{id}/apply_optimisation_proposal/": {
+            "post": {
+                "operationId": "test-framework-v2-metrics-apply-optimisation-proposal-create",
+                "description": "Apply a pending optimisation proposal",
+                "summary": "Apply a pending optimisation proposal",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Metric updated; pending proposal cleared."
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/{id}/dismiss_optimisation_proposal/": {
+            "post": {
+                "operationId": "test-framework-v2-metrics-dismiss-optimisation-proposal-create",
+                "description": "Dismiss a pending optimisation proposal",
+                "summary": "Dismiss a pending optimisation proposal",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Proposal cleared."
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/{id}/evaluate_advance_metric/": {
+            "post": {
+                "operationId": "test-framework-v2-metrics-evaluate-advance-metric-create",
+                "description": "Evaluate an advance metric in the background.\n\nReturns a progress_id to poll for results.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricDetailV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/{id}/evaluate_basic_metric/": {
+            "post": {
+                "operationId": "test-framework-v2-metrics-evaluate-basic-metric-create",
+                "description": "Evaluate a basic metric in the background.\n\nReturns a progress_id to poll for results.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricDetailV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/{id}/evaluate_llm_judge_metric/": {
+            "post": {
+                "operationId": "test-framework-v2-metrics-evaluate-llm-judge-metric-create",
+                "description": "Evaluate a metric using LLM Judge (DSPy) in the background.\n\nReturns a progress_id to poll for results.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/EvaluateLlmJudgeMetricRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/EvaluateLlmJudgeMetricRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/EvaluateLlmJudgeMetricRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/EvaluateLlmJudgeMetricResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/{id}/history/": {
+            "get": {
+                "operationId": "test-framework-v2-metrics-history-list",
+                "description": "Metrics history",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric.",
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "page",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "page_size",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedMetricHistoryList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/{id}/history/edit/": {
+            "patch": {
+                "operationId": "test-framework-v2-metrics-history-edit-partial-update",
+                "description": "Metrics history edit",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedMetricEditHistoryRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedMetricEditHistoryRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedMetricEditHistoryRequest"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricHistory"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/{id}/restore/": {
+            "post": {
+                "operationId": "test-framework-v2-metrics-restore-create",
+                "description": "Metrics restore",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricRestoreRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricRestoreRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricRestoreRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricDetailV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/{id}/run_reviews/": {
+            "post": {
+                "operationId": "test-framework-v2-metrics-run-reviews-create",
+                "description": "Metrics run reviews",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RunReviewsRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RunReviewsRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RunReviewsRequest"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Returns progress_id for tracking progress"
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "test-framework-v2-metrics-run-reviews-create",
+                        "description": "Metrics run reviews"
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/{id}/variables/": {
+            "post": {
+                "operationId": "test-framework-v2-metrics-variables-create",
+                "description": "Get all variables and their values for a specific test_set and metric combination.\n\nURL Parameter:\n- pk: The metric_id\n\nRequest Body:\n- test_set_id (required): The ID of the test_set (datapoint)\n- metric_description_variables (required/optional): Array of variable names for description.\n  At least one of metric_description_variables or evaluation_trigger_variables must be provided.\n- evaluation_trigger_variables (required/optional): Array of variable names for trigger.\n  At least one of metric_description_variables or evaluation_trigger_variables must be provided.\n\nThis endpoint retrieves the variables and populates them with values from the test_set (datapoint).",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricDetailV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/basic_list/": {
+            "get": {
+                "operationId": "test-framework-v2-metrics-basic-list-retrieve",
+                "description": "Manage quality metrics for evaluating AI voice agent performance.\n\n`eval_type` values: `binary`, `continuous_qualitative`, `numeric`, `enum`.\n`add_to_rubric` (write-only) controls whether the metric contributes to\nthe project's call-success rubric.",
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricBasicList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/bulk-toggle-settings/": {
+            "post": {
+                "operationId": "test-framework-v2-metrics-bulk-toggle-settings-create",
+                "description": "Manage quality metrics for evaluating AI voice agent performance.\n\n`eval_type` values: `binary`, `continuous_qualitative`, `numeric`, `enum`.\n`add_to_rubric` (write-only) controls whether the metric contributes to\nthe project's call-success rubric.",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricDetailV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/bulk_create/": {
+            "post": {
+                "operationId": "metrics-bulk-create_3",
+                "description": "Create multiple metrics in a single request",
+                "summary": "Create multiple metrics in a single request",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/SchemaPostMetricEdit"
+                                }
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/SchemaPostMetricEdit"
+                                }
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/SchemaPostMetricEdit"
+                                }
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/SchemaPostMetricEdit"
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "metrics-bulk-create",
+                        "description": "Create multiple metrics in a single request"
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/bulk_manage_agents/": {
+            "post": {
+                "operationId": "test-framework-v2-metrics-bulk-manage-agents-create",
+                "description": "Metrics bulk manage agents",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BulkAgentAssignment"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BulkAgentAssignment"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BulkAgentAssignment"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BulkAgentAssignmentResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/delete_metrics/": {
+            "post": {
+                "operationId": "test-framework-v2-metrics-delete-metrics-create",
+                "description": "Manage quality metrics for evaluating AI voice agent performance.\n\n`eval_type` values: `binary`, `continuous_qualitative`, `numeric`, `enum`.\n`add_to_rubric` (write-only) controls whether the metric contributes to\nthe project's call-success rubric.",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricDetailV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/evaluate_metric_progress/": {
+            "get": {
+                "operationId": "test-framework-v2-metrics-evaluate-metric-progress-retrieve",
+                "description": "Poll for metric evaluation progress.\n\nQuery params:\n    progress_id: The progress_id returned from evaluate_basic_metric or evaluate_advance_metric\n\nReturns:\n    State object with status, output, error, etc.",
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricDetailV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/fetch_call_details/": {
+            "get": {
+                "operationId": "test-framework-v2-metrics-fetch-call-details-retrieve",
+                "description": "Metrics fetch call details",
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricDetailV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/generate_clean_description/": {
+            "post": {
+                "operationId": "test-framework-v2-metrics-generate-clean-description-create",
+                "description": "Metrics generate clean description",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricDetailV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "test-framework-v2-metrics-generate-clean-description-create",
+                        "description": "Metrics generate clean description"
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/generate_clean_description_bg/": {
+            "post": {
+                "operationId": "test-framework-v2-metrics-generate-clean-description-bg-create",
+                "description": "Start async clean description generation",
+                "summary": "Start async clean description generation",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CleanMetricDescriptionRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CleanMetricDescriptionRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CleanMetricDescriptionRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GenerateCleanDescriptionBgResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "test-framework-v2-metrics-generate-clean-description-bg-create",
+                        "description": "Start async clean description generation"
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/generate_clean_description_progress/": {
+            "get": {
+                "operationId": "test-framework-v2-metrics-generate-clean-description-progress-re",
+                "description": "Poll async clean description generation",
+                "summary": "Poll async clean description generation",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "progress_id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "progress_id returned from generate_clean_description_bg",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GenerateCleanDescriptionProgressResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "test-framework-v2-metrics-generate-clean-description-progress-re",
+                        "description": "Poll async clean description generation"
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/generate_evaluation_trigger/": {
+            "post": {
+                "operationId": "test-framework-v2-metrics-generate-evaluation-trigger-create",
+                "description": "Metrics generate evaluation trigger",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricDetailV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "test-framework-v2-metrics-generate-evaluation-trigger-create",
+                        "description": "Metrics generate evaluation trigger"
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/generate_metrics/": {
+            "post": {
+                "operationId": "metrics-generate_3",
+                "description": "Generates suggested metrics for an AI agent. Returns a `progress_id` to poll via `generate_metrics_progress`. Results appear in the progress response but are not saved automatically — pass them to the metrics bulk create endpoint to persist. The agent must have a description of at least 100 characters.",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaGenerateMetricsMetricCreate"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaGenerateMetricsMetricCreate"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaGenerateMetricsMetricCreate"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SchemaGenerateMetricsResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "metrics-generate",
+                        "description": "Generates suggested metrics for an AI agent. Returns a `progress_id` to poll via `generate_metrics_progress`. Results appear in the progress response but are not saved automatically — pass them to the metrics bulk create endpoint to persist. The agent must have a description of at least 100 characters."
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/generate_metrics_progress/": {
+            "get": {
+                "operationId": "test-framework-v2-metrics-generate-metrics-progress-retrieve",
+                "description": "Metrics generate metrics progress",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "progress_id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Progress ID returned from the generate_metrics endpoint",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Returns generation state with status and generated metrics"
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "test-framework-v2-metrics-generate-metrics-progress-retrieve",
+                        "description": "Metrics generate metrics progress"
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/preview/": {
+            "post": {
+                "operationId": "test-framework-v2-metrics-preview-create",
+                "description": "Metrics preview",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricPreview"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricPreview"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricPreview"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Returns progress_id for tracking progress"
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "test-framework-v2-metrics-preview-create",
+                        "description": "Metrics preview"
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/preview-progress/": {
+            "get": {
+                "operationId": "metrics-preview-progress_3",
+                "description": "Metrics preview progress",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "progress_id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Progress ID returned from the preview endpoint",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Returns preview state with status and results"
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "metrics-preview-progress",
+                        "description": "Metrics preview progress"
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/run_reviews_progress/": {
+            "get": {
+                "operationId": "metrics-run-reviews-progress_3",
+                "description": "Metrics run reviews progress",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "progress_id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Progress ID returned from the run_reviews endpoint",
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "agent_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Agent ID for permission validation"
+                    },
+                    {
+                        "in": "query",
+                        "name": "project_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Project ID for permission validation"
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Returns progress state with completed/failed counts and metric data when finished"
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "metrics-run-reviews-progress",
+                        "description": "Metrics run reviews progress"
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/save_result/": {
+            "post": {
+                "operationId": "test-framework-v2-metrics-save-result-create",
+                "description": "Metrics save result",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricDetailV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/simplify_prompt/": {
+            "post": {
+                "operationId": "test-framework-v2-metrics-simplify-prompt-create",
+                "description": "Metrics simplify prompt",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SimplifyPromptRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SimplifyPromptRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SimplifyPromptRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SimplifyPromptResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "test-framework-v2-metrics-simplify-prompt-create",
+                        "description": "Metrics simplify prompt"
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/simplify_prompt_progress/": {
+            "get": {
+                "operationId": "test-framework-v2-metrics-simplify-prompt-progress-retrieve",
+                "description": "Metrics simplify prompt progress",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "progress_id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Progress ID returned from simplify_prompt endpoint",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SimplifyPromptProgressResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "test-framework-v2-metrics-simplify-prompt-progress-retrieve",
+                        "description": "Metrics simplify prompt progress"
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/results/": {
+            "get": {
+                "operationId": "test-framework-v2-results-list",
+                "description": "List test results.\n\nTo filter by status, use `results_retrieve(id=result_id)` and inspect `status` directly ('running', 'completed', 'failed') — there is no list-level status filter.\n\n**Result status:** a result marked `failed` indicates infrastructure failures (e.g. connection errors, websocket handshake failures), not metric evaluation failures. `success_runs_count` counts runs that reached terminal state regardless of connection errors. See `results_retrieve().failed_reasons` for the breakdown.\n\n**Scenarios filter note:** filtering by `scenarios` may return duplicate result rows when a result contains multiple runs of the same scenario — deduplicate by `result.id` if needed.\n\nAfter triggering a run, poll `results_retrieve(id=result_id)` until `status` is 'completed' or 'failed'. For outbound runs, each run's `outbound_dial_window_closes_at` shows the deadline by which your agent must dial in.",
+                "parameters": [
+                    {
+                        "name": "page",
+                        "required": false,
+                        "in": "query",
+                        "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "agent_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Filter by agent ID"
+                    },
+                    {
+                        "in": "query",
+                        "name": "project_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Filter by project ID"
+                    },
+                    {
+                        "in": "query",
+                        "name": "search",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter by Result name"
+                    },
+                    {
+                        "in": "query",
+                        "name": "scenarios",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter by scenario IDs — comma-separated string (e.g. '24270,24271'), not a JSON array."
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedResultList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "test-framework-v2-results-list",
+                        "description": "List test results.\n\nTo filter by status, use `results_retrieve(id=result_id)` and inspect `status` directly ('running', 'completed', 'failed') — there is no list-level status filter.\n\n**Result status:** a result marked `failed` indicates infrastructure failures (e.g. connection errors, websocket handshake failures), not metric evaluation failures. `success_runs_count` counts runs that reached terminal state regardless of connection errors. See `results_retrieve().failed_reasons` for the breakdown.\n\n**Scenarios filter note:** filtering by `scenarios` may return duplicate result rows when a result contains multiple runs of the same scenario — deduplicate by `result.id` if needed.\n\nAfter triggering a run, poll `results_retrieve(id=result_id)` until `status` is 'completed' or 'failed'. For outbound runs, each run's `outbound_dial_window_closes_at` shows the deadline by which your agent must dial in."
+                    }
+                }
+            },
+            "post": {
+                "operationId": "test-framework-v2-results-create",
+                "description": "Create a new Results with the canonical binary wire format (eval_type `binary`,",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Result"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Result"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Result"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Result"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/results/{id}/": {
+            "get": {
+                "operationId": "test-framework-v2-results-retrieve",
+                "description": "`success` indicates whether the run passed its quality evaluation. A run with `success=false` either failed to connect (check `error_message`) or failed an evaluation check (check `evaluation`). `success_rate` is the percentage of runs with `success=true`.\n\nThe `runs` field is a dict keyed by run ID string (e.g. `{\"86368\": {...}, \"86367\": {...}}`), not an array — unlike the list endpoint. Each run also has a `call_id` STRING field (the provider's call identifier) — that is a data field, NOT an endpoint ID; do not pass it where `run_id` is expected.",
+                "summary": "Retrieve a test result",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this result.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ResultDetailV2"
+                                },
+                                "examples": {
+                                    "Success": {
+                                        "value": {
+                                            "id": "integer",
+                                            "name": "string",
+                                            "agent": "integer",
+                                            "status": "string",
+                                            "met_expected_outcome_count": "integer",
+                                            "total_expected_outcome_count": "integer",
+                                            "success_rate": "float",
+                                            "run_as_text": "boolean",
+                                            "is_cronjob": "boolean",
+                                            "runs": {
+                                                "run_id": {
+                                                    "id": "integer",
+                                                    "scenario": "integer",
+                                                    "outbound_number": "string",
+                                                    "expected_outcome": {
+                                                        "score": 100,
+                                                        "explanation": [
+                                                            "✅ Positive outcome explanation with checkmark emoji",
+                                                            "❌ Negative outcome explanation with X emoji"
+                                                        ],
+                                                        "outcome_alignments": [
+                                                            {
+                                                                "outcome": "string",
+                                                                "prompt_part": "string",
+                                                                "aligned": "boolean"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "success": "boolean",
+                                                    "evaluation": {
+                                                        "metrics": [
+                                                            {
+                                                                "id": "integer",
+                                                                "name": "string",
+                                                                "type": "binary | continuous_qualitative | numeric | enum",
+                                                                "score": "number",
+                                                                "explanation": "string | array",
+                                                                "function_name": "string (optional)",
+                                                                "extra": {
+                                                                    "categories": [
+                                                                        {
+                                                                            "category": "string",
+                                                                            "deviation": "string (optional)",
+                                                                            "priority": "string (optional)"
+                                                                        }
+                                                                    ],
+                                                                    "percentiles": {
+                                                                        "p50": "number"
+                                                                    }
+                                                                },
+                                                                "enum": "string (for enum type metrics only)"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "timestamp": "datetime",
+                                                    "executed_at": "datetime",
+                                                    "error_message": "string",
+                                                    "status": "string",
+                                                    "duration": "string (MM:SS format)",
+                                                    "scenario_name": "string",
+                                                    "personality_name": "string",
+                                                    "metadata": "object",
+                                                    "inbound_number": "string"
+                                                }
+                                            },
+                                            "overall_evaluation": {
+                                                "success_rate": "number",
+                                                "metric_summary": {
+                                                    "metric_id": {
+                                                        "id": "integer",
+                                                        "name": "string",
+                                                        "type": "string",
+                                                        "score": "number",
+                                                        "explanation": "string (optional)",
+                                                        "function_name": "string",
+                                                        "vocera_defined_metric_code": "string (optional)",
+                                                        "p50": "number (for numeric metrics)"
+                                                    }
+                                                },
+                                                "worst_performing_metrics": {
+                                                    "binary_adherence": [
+                                                        "array of metric_ids"
+                                                    ]
+                                                },
+                                                "numeric_metrics": [
+                                                    {
+                                                        "name": "string",
+                                                        "type": "numeric",
+                                                        "value": "number",
+                                                        "percentiles": {
+                                                            "p50": "number"
+                                                        }
+                                                    }
+                                                ],
+                                                "enum_metrics": [
+                                                    "array of metric_ids"
+                                                ],
+                                                "extra_metrics": [
+                                                    {
+                                                        "name": "string (e.g., 'Expected Outcome', 'Average Ringing Duration')",
+                                                        "type": "string",
+                                                        "value": "number",
+                                                        "percentiles": {
+                                                            "p50": "number (optional)"
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            "total_duration": "string (MM:SS format)",
+                                            "total_runs_count": "integer",
+                                            "completed_runs_count": "integer",
+                                            "success_runs_count": "integer",
+                                            "failed_runs_count": "integer",
+                                            "scenarios": [
+                                                {
+                                                    "id": "integer",
+                                                    "name": "string"
+                                                }
+                                            ],
+                                            "critical_categories": "array",
+                                            "metrics": "array",
+                                            "domain": "string (nullable)",
+                                            "domain_logo": "string (nullable)",
+                                            "runs_by_tags": "object",
+                                            "latency_data": "object",
+                                            "failed_reasons": "array",
+                                            "run_settings": {
+                                                "override_value": 10,
+                                                "frequency": 2,
+                                                "concurrency_limit": 5,
+                                                "personality_ids": [
+                                                    3,
+                                                    7
+                                                ],
+                                                "test_profile_ids": [
+                                                    20
+                                                ],
+                                                "mode": "same_number",
+                                                "livekit_data": {
+                                                    "agent_name": "kit",
+                                                    "config": {},
+                                                    "url": "wss://example"
+                                                }
+                                            },
+                                            "created_at": "datetime",
+                                            "updated_at": "datetime"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "detail": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "test-framework-v2-results-retrieve",
+                        "description": "`success` indicates whether the run passed its quality evaluation. A run with `success=false` either failed to connect (check `error_message`) or failed an evaluation check (check `evaluation`). `success_rate` is the percentage of runs with `success=true`.\n\nThe `runs` field is a dict keyed by run ID string (e.g. `{\"86368\": {...}, \"86367\": {...}}`), not an array — unlike the list endpoint. Each run also has a `call_id` STRING field (the provider's call identifier) — that is a data field, NOT an endpoint ID; do not pass it where `run_id` is expected."
+                    }
+                }
+            },
+            "put": {
+                "operationId": "test-framework-v2-results-update",
+                "description": "Update a Results with the canonical binary wire format (eval_type `binary`,",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this result.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ResultDetailV2"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ResultDetailV2"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ResultDetailV2"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ResultDetailV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "patch": {
+                "operationId": "test-framework-v2-results-partial-update",
+                "description": "Update a Results with the canonical binary wire format (eval_type `binary`,",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this result.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedResultDetailV2"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedResultDetailV2"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedResultDetailV2"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ResultDetailV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "test-framework-v2-results-destroy",
+                "description": "Delete a Results with the canonical binary wire format (eval_type `binary`,",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this result.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No response body"
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/results/{id}/ask_about_failures/": {
+            "post": {
+                "operationId": "test-framework-v2-results-ask-about-failures-create",
+                "description": "Query failed runs chatbot",
+                "summary": "Query failed runs chatbot",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this result.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Results"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AskAboutFailuresRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AskAboutFailuresRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AskAboutFailuresRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Streaming AI-generated analysis of test failures"
+                    },
+                    "400": {
+                        "description": "Invalid request (missing or invalid question)"
+                    },
+                    "404": {
+                        "description": "Result not found"
+                    },
+                    "429": {
+                        "description": "Rate limit exceeded"
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "test-framework-v2-results-ask-about-failures-create",
+                        "description": "Query failed runs chatbot"
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/results/{id}/create_shareable_link_token/": {
+            "post": {
+                "operationId": "create-shareable-link-token_3",
+                "description": "Generate shareable link for result",
+                "summary": "Generate shareable link for result",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this result.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Results"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostCreateShareableLinkToken"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostCreateShareableLinkToken"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostCreateShareableLinkToken"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SchemaCreateShareableLinkTokenResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "create-shareable-link-token",
+                        "description": "Generate shareable link for result"
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/results/{id}/delete_runs/": {
+            "post": {
+                "operationId": "delete-runs_3",
+                "description": "⚠ Irreversible. Removes the specified runs from a result, then triggers re-evaluation so aggregate metrics recompute without them. Maximum 100 run IDs per request.",
+                "summary": "Delete runs from result",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this result.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Results"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostDeleteRuns"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostDeleteRuns"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostDeleteRuns"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No response body"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "detail": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "delete-runs",
+                        "description": "⚠ Irreversible. Removes the specified runs from a result, then triggers re-evaluation so aggregate metrics recompute without them. Maximum 100 run IDs per request."
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/results/{id}/end_calls/": {
+            "post": {
+                "operationId": "end-calls_3",
+                "description": "End all calls in result",
+                "summary": "End all calls in result",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this result.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Results"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No response body"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "detail": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "end-calls",
+                        "description": "End all calls in result"
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/results/{id}/evaluate_metrics/": {
+            "post": {
+                "operationId": "test-framework-v2-results-evaluate-metrics-create",
+                "description": "Results evaluate metrics",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this result.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostReRunResultDetail"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostReRunResultDetail"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostReRunResultDetail"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Result"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "test-framework-v2-results-evaluate-metrics-create",
+                        "description": "Results evaluate metrics"
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/results/{id}/regenerate_ai_summary/": {
+            "post": {
+                "operationId": "test-framework-v2-results-regenerate-ai-summary-create",
+                "description": "Queue a background job that regenerates the structured AI summary (what_happened / why_it_happened / how_to_fix) and recommended next steps for this result, based on its current failure clusters. The new summary appears on the next `results_retrieve` call once the job finishes.",
+                "summary": "Regenerate the AI summary for a result",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this result.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Results"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Regeneration queued; poll results_retrieve to see the new ai_summary / next_steps."
+                    },
+                    "404": {
+                        "description": "Result not found"
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/results/{id}/rerun/": {
+            "post": {
+                "operationId": "test-framework-v2-results-rerun-create",
+                "description": "Results rerun",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this result.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Result"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "test-framework-v2-results-rerun-create",
+                        "description": "Results rerun"
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/results/bulk_delete/": {
+            "post": {
+                "operationId": "bulk-delete-results_3",
+                "description": "⚠ Irreversible. Soft-deletes each result (and its non-deleted runs) with the same side-effects as deleting a single result: outbound phone numbers are released when no queued runs remain, capacity-manager slots are freed, and active_sessions / pending_demand counters are decremented in aggregate. Maximum 100 result IDs per request. Results that are already deleted or that the caller cannot access are silently skipped — the response is 204 even when no results are deleted.",
+                "summary": "Soft-delete multiple results",
+                "tags": [
+                    "Results"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostBulkDeleteResults"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostBulkDeleteResults"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostBulkDeleteResults"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No response body"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/results/bulk_evaluate_metrics/": {
+            "post": {
+                "operationId": "bulk-evaluate-result-metrics_3",
+                "description": "Schedules re-evaluation of the given metrics against every completed/failed, non-deleted run of every selected result. Metrics are validated against each agent's metric scope; balance is checked for the full batch up front before any work is dispatched. Each affected result's status is flipped to RUNNING. Maximum 100 result IDs per request.",
+                "summary": "Re-evaluate metrics across multiple results",
+                "tags": [
+                    "Results"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostBulkEvaluateResultMetrics"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostBulkEvaluateResultMetrics"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostBulkEvaluateResultMetrics"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No response body"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/results/bulk_export_progress/": {
+            "get": {
+                "operationId": "test-framework-v2-results-bulk-export-progress-retrieve",
+                "description": "Results bulk export progress",
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Result"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/results/bulk_export_result_runs/": {
+            "get": {
+                "operationId": "test-framework-v2-results-bulk-export-result-runs-retrieve",
+                "description": "Bulk export results with progress tracking and file URL response.\nAccepts export_type in query params and applies the same filters as the queryset.",
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Result"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/results/export_result_runs/": {
+            "get": {
+                "operationId": "test-framework-v2-results-export-result-runs-retrieve",
+                "description": "Results export result runs",
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Result"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/results/reports/": {
+            "get": {
+                "operationId": "test-framework-v2-results-reports-retrieve",
+                "description": "Results reports",
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Result"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/results/reports/ask-about-failures/": {
+            "post": {
+                "operationId": "test-framework-v2-results-reports-ask-about-failures-create",
+                "description": "Query failed runs chatbot for combined reports",
+                "summary": "Query failed runs chatbot for combined reports",
+                "tags": [
+                    "Results"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AskAboutFailuresReportsRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AskAboutFailuresReportsRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AskAboutFailuresReportsRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Streaming AI-generated analysis of test failures across combined results"
+                    },
+                    "400": {
+                        "description": "Invalid request (missing result_ids or question)"
+                    },
+                    "404": {
+                        "description": "No results found"
+                    },
+                    "429": {
+                        "description": "Rate limit exceeded"
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/results/reports/share/": {
+            "post": {
+                "operationId": "test-framework-v2-results-reports-share-create",
+                "description": "Results reports share",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Result"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Result"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Result"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Result"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/results/result_ids/": {
+            "get": {
+                "operationId": "test-framework-v2-results-result-ids-retrieve",
+                "description": "Results result ids",
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Result"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/runs/": {
+            "get": {
+                "operationId": "test-framework-v2-runs-list",
+                "description": "List Runs with the canonical binary wire format (eval_type `binary`,",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "id__in",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        },
+                        "description": "Multiple values may be separated by commas.",
+                        "explode": false,
+                        "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "id",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "id__contains",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "timestamp__gte",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "timestamp__lte",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "result__agent_id",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "result__agent_id__in",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        },
+                        "description": "Multiple values may be separated by commas.",
+                        "explode": false,
+                        "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "status__in",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "Multiple values may be separated by commas.",
+                        "explode": false,
+                        "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "status",
+                        "schema": {
+                            "type": "string",
+                            "x-spec-enum-id": "623e22fc1eb17833",
+                            "enum": [
+                                "cancelled",
+                                "completed",
+                                "evaluating",
+                                "failed",
+                                "in_progress",
+                                "in_queue",
+                                "pending",
+                                "running",
+                                "scaling_up",
+                                "timeout"
+                            ]
+                        },
+                        "description": "* `running` - Running\n* `completed` - Completed\n* `failed` - Failed\n* `pending` - Pending\n* `in_progress` - In Progress\n* `evaluating` - Evaluating\n* `in_queue` - In Queue\n* `timeout` - Timeout\n* `cancelled` - Cancelled\n* `scaling_up` - Scaling Up"
+                    },
+                    {
+                        "in": "query",
+                        "name": "success",
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "duration__gte",
+                        "schema": {
+                            "type": "number",
+                            "format": "float"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "duration__lte",
+                        "schema": {
+                            "type": "number",
+                            "format": "float"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "call_id__icontains",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "call_id",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "provider_call_id__icontains",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "provider_call_id",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "scenario__id__in",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        },
+                        "description": "Multiple values may be separated by commas.",
+                        "explode": false,
+                        "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "scenario__id",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "personality__id__in",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        },
+                        "description": "Multiple values may be separated by commas.",
+                        "explode": false,
+                        "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "personality__id",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "result__id",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "result__run_as_text",
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "created_at_from",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "created_at_to",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "agent_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Filter runs by agent ID"
+                    },
+                    {
+                        "in": "query",
+                        "name": "assistant_id",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "scenarios",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "tags",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "personalities",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "success_rate",
+                        "schema": {
+                            "type": "number"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "search",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "call_ended_reason",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "call_ended_reason__icontains",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "call_ended_reason__in",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "created_at_range",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "duration_range",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "required": false,
+                        "in": "query",
+                        "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "project_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Filter runs by project ID"
+                    },
+                    {
+                        "in": "query",
+                        "name": "result_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Filter runs by result ID"
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedRunListList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/runs/{id}/": {
+            "get": {
+                "operationId": "test-framework-v2-runs-retrieve",
+                "description": "Retrieve a Runs with the canonical binary wire format (eval_type `binary`, by ID",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this run.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Run"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "put": {
+                "operationId": "test-framework-v2-runs-update",
+                "description": "Update a Runs with the canonical binary wire format (eval_type `binary`,",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this run.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Run"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Run"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Run"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Run"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "patch": {
+                "operationId": "test-framework-v2-runs-partial-update",
+                "description": "Update a Runs with the canonical binary wire format (eval_type `binary`,",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this run.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedRun"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedRun"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedRun"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Run"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "test-framework-v2-runs-destroy",
+                "description": "Delete a Runs with the canonical binary wire format (eval_type `binary`,",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this run.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No response body"
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/runs/{id}/end_call/": {
+            "post": {
+                "operationId": "end-call_3",
+                "description": "End a single call",
+                "summary": "End a single call",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this run.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Runs"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No response body"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "detail": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "end-call",
+                        "description": "End a single call"
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/runs/{id}/get_listen_url/": {
+            "get": {
+                "operationId": "test-framework-v2-runs-get-listen-url-retrieve",
+                "description": "Runs get listen url",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this run.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Run"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/runs/{id}/mark_critical_scenario_wrong/": {
+            "post": {
+                "operationId": "test-framework-v2-runs-mark-critical-scenario-wrong-create",
+                "description": "Runs mark critical scenario wrong",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this run.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Run"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Run"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Run"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Run"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/runs/{id}/mark_expected_outcome_vote/": {
+            "post": {
+                "operationId": "test-framework-v2-runs-mark-expected-outcome-vote-create",
+                "description": "Runs mark expected outcome vote",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this run.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Run"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Run"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Run"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Run"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/runs/{id}/mark_metric_vote/": {
+            "post": {
+                "operationId": "test-framework-v2-runs-mark-metric-vote-create",
+                "description": "Record a thumbs-up or thumbs-down vote on a specific metric evaluation for this run and optionally provide an expected value and free-text feedback. Updates the metric evaluation and marks the run as reviewed.",
+                "summary": "Submit a metric vote for a run",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this run.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Runs"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MarkMetricVote"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MarkMetricVote"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MarkMetricVote"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MarkMetricVoteRunResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "detail": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "test-framework-v2-runs-mark-metric-vote-create",
+                        "description": "Record a thumbs-up or thumbs-down vote on a specific metric evaluation for this run and optionally provide an expected value and free-text feedback. Updates the metric evaluation and marks the run as reviewed."
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/runs/{id}/run_expected_outcome/": {
+            "post": {
+                "operationId": "test-framework-v2-runs-run-expected-outcome-create",
+                "description": "Runs run expected outcome",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this run.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Run"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Run"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Run"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Run"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/runs/{id}/run_expected_outcome_bg/": {
+            "post": {
+                "operationId": "test-framework-v2-runs-run-expected-outcome-bg-create",
+                "description": "Runs run expected outcome bg",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this run.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Run"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Run"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Run"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Run"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/runs/{id}/unmark_critical_scenario_wrong/": {
+            "post": {
+                "operationId": "test-framework-v2-runs-unmark-critical-scenario-wrong-create",
+                "description": "Runs unmark critical scenario wrong",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this run.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Run"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Run"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Run"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Run"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/runs/bulk/": {
+            "get": {
+                "operationId": "test-framework-v2-runs-bulk-retrieve",
+                "description": "Retrieve multiple runs in a single request.\n\n`success: true` indicates the run passed its quality evaluation. A run with `success=false` either failed to connect (check `error_message`) or failed an evaluation check. For detailed outcomes check: `error_message`, `metadata.ended_reason`, and `evaluation.metrics[].result`.",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "run_ids",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "\nComma-separated list of run IDs.\nExample: `1,2,3`\n\nMust be a plain comma-separated string, not a JSON array — passing a JSON array returns a 400 error.\n",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Run"
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "test-framework-v2-runs-bulk-retrieve",
+                        "description": "Retrieve multiple runs in a single request.\n\n`success: true` indicates the run passed its quality evaluation. A run with `success=false` either failed to connect (check `error_message`) or failed an evaluation check. For detailed outcomes check: `error_message`, `metadata.ended_reason`, and `evaluation.metrics[].result`."
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/runs/run_expected_outcome_progress/": {
+            "get": {
+                "operationId": "test-framework-v2-runs-run-expected-outcome-progress-retrieve",
+                "description": "Runs run expected outcome progress",
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Run"
                                 }
                             }
                         },
@@ -48872,15 +54290,6 @@
                             "type": "integer"
                         },
                         "description": "Filter projects by organisation ID"
-                    },
-                    {
-                        "name": "project_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `organization_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -53835,7 +59244,7 @@
                             }
                         ],
                         "readOnly": true,
-                        "description": "Evaluation results for the call.\nExample: \n```json\n{\n    \"metrics\": [\n        {\n            \"id\": 35,\n            \"name\": \"Instruction Follow\",\n            \"type\": \"binary_workflow_adherence\",\n            \"score\": 0,\n            \"explanation\": [\"Agent failed to follow the opening script\", \"Missed key product information\"],\n            \"vocera_defined_metric_code\": \"5dedc41b\",\n            \"function_name\": \"check_critical_deviations\",\n            \"extra\": {\n                \"categories\": [\n                    {\n                        \"category_id\": 5,\n                        \"category\": \"Script Adherence Issue\",\n                        \"deviation\": \"Agent deviated from required script\",\n                        \"priority\": \"critical\"\n                    }\n                ]\n            }\n        },\n        {\n            \"id\": 18,\n            \"name\": \"Customer Satisfaction\",\n            \"type\": \"binary_qualitative\",\n            \"score\": 5,\n            \"explanation\": [\"Customer expressed satisfaction with service\"]\n        }\n    ]\n}\n```"
+                        "description": "Evaluation results for the call.\nExample: \n```json\n{\n    \"metrics\": [\n        {\n            \"id\": 35,\n            \"name\": \"Instruction Follow\",\n            \"type\": \"binary\",\n            \"score\": 0,\n            \"explanation\": [\"Agent failed to follow the opening script\", \"Missed key product information\"],\n            \"vocera_defined_metric_code\": \"5dedc41b\",\n            \"function_name\": \"check_critical_deviations\",\n            \"extra\": {\n                \"categories\": [\n                    {\n                        \"category_id\": 5,\n                        \"category\": \"Script Adherence Issue\",\n                        \"deviation\": \"Agent deviated from required script\",\n                        \"priority\": \"critical\"\n                    }\n                ]\n            }\n        },\n        {\n            \"id\": 18,\n            \"name\": \"Customer Satisfaction\",\n            \"type\": \"binary\",\n            \"score\": 5,\n            \"explanation\": [\"Customer expressed satisfaction with service\"]\n        }\n    ]\n}\n```"
                     },
                     "metadata": {
                         "type": "object",
@@ -55864,7 +61273,7 @@
                             "string",
                             "null"
                         ],
-                        "description": "One of binary_workflow_adherence, binary_qualitative, numeric, continuous_qualitative, enum."
+                        "description": "One of binary, numeric, continuous_qualitative, enum. Legacy values (binary_workflow_adherence, binary_qualitative) are accepted and mapped to binary."
                     },
                     "enum_values": {
                         "type": [
@@ -56667,15 +62076,14 @@
                     },
                     "eval_type": {
                         "enum": [
-                            "binary_workflow_adherence",
-                            "binary_qualitative",
+                            "binary",
                             "continuous_qualitative",
                             "numeric",
                             "enum"
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "1e3e27b342bfd8ec",
-                        "description": "\nType of evaluation\n\n\n* `binary_workflow_adherence` - Binary Workflow Adherence\n* `binary_qualitative` - Binary Qualitative\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum"
+                        "x-spec-enum-id": "b40eac6824409cc2",
+                        "description": "\nType of evaluation\n\n\n* `binary` - Binary\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum"
                     },
                     "enum_values": {
                         "description": "\nList of possible enum values for enum type metrics.\nExample: `[\"satisfied\", \"unsatisfied\"]`\n"
@@ -56736,7 +62144,7 @@
                     "name"
                 ]
             },
-            "MetricDetailV2": {
+            "MetricDetailSerializerV2": {
                 "type": "object",
                 "properties": {
                     "id": {
@@ -56788,15 +62196,14 @@
                     },
                     "eval_type": {
                         "enum": [
-                            "binary_workflow_adherence",
-                            "binary_qualitative",
+                            "binary",
                             "continuous_qualitative",
                             "numeric",
                             "enum"
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "1e3e27b342bfd8ec",
-                        "description": "\nType of evaluation\n\n\n* `binary_workflow_adherence` - Binary Workflow Adherence\n* `binary_qualitative` - Binary Qualitative\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum"
+                        "description": "* `binary` - Binary\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum",
+                        "x-spec-enum-id": "b40eac6824409cc2"
                     },
                     "enum_values": {
                         "description": "\nList of possible enum values for enum type metrics.\nExample: `[\"satisfied\", \"unsatisfied\"]`\n"
@@ -56872,7 +62279,7 @@
                     },
                     "alert_enabled": {
                         "type": "boolean",
-                        "description": "\nEnable alerts for this metric when it fails (value < 5).\nOnly applicable to binary metrics (binary_workflow_adherence and binary_qualitative).\nFor other metric types, use significant_change_alert_status instead.\nExample: `true` or `false`\n        "
+                        "description": "\nEnable alerts for this metric when it fails (value=false).\nOnly applicable to binary metrics (eval_type=binary).\nFor other metric types, use significant_change_alert_status instead.\nExample: `true` or `false`\n        "
                     },
                     "alert_type": {
                         "enum": [
@@ -56989,6 +62396,545 @@
                         ],
                         "readOnly": true,
                         "description": "Unsaved proposal from a metric-optimiser cron run. Shape: {description, evaluation_trigger, type, custom_code, score, baseline_score, cron_job_id, cron_job_name, proposed_at}."
+                    }
+                },
+                "required": [
+                    "eval_type",
+                    "name"
+                ]
+            },
+            "MetricDetailV2": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "slug": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "URL-friendly unique identifier in snake_case format. Example: \"customer_satisfaction_1562\"",
+                        "maxLength": 255
+                    },
+                    "project": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
+                    },
+                    "agents": {
+                        "type": "array",
+                        "items": {
+                            "type": [
+                                "integer",
+                                "null"
+                            ]
+                        }
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "\nName of the metric.\nExample: `\"Customer Satisfaction\"` or `\"Appointment Booking\"`\n        ",
+                        "maxLength": 255
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "\nDescription of what the metric measures.\nExample: `\"Measures how satisfied customers are with the service provided\"`\n        "
+                    },
+                    "type": {
+                        "enum": [
+                            "basic",
+                            "custom_prompt",
+                            "custom_code",
+                            "llm_judge"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "b44700c0a6443b40",
+                        "description": "\nType of metric\n\n\n* `basic` - Basic (Deprecated in favor of LLM Judge)\n* `custom_prompt` - Custom Prompt ( Deprecated in favor of LLM Judge)\n* `custom_code` - Custom Code\n* `llm_judge` - LLM Judge"
+                    },
+                    "eval_type": {
+                        "enum": [
+                            "binary",
+                            "continuous_qualitative",
+                            "numeric",
+                            "enum"
+                        ],
+                        "type": "string",
+                        "description": "* `binary` - Binary\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum",
+                        "x-spec-enum-id": "b40eac6824409cc2"
+                    },
+                    "enum_values": {
+                        "description": "\nList of possible enum values for enum type metrics.\nExample: `[\"satisfied\", \"unsatisfied\"]`\n"
+                    },
+                    "audio_enabled": {
+                        "type": "boolean",
+                        "description": "\nWhether this metric requires audio analysis.\nExample: `true` or `false`\n        "
+                    },
+                    "prompt": {
+                        "type": "string",
+                        "description": "\nEvaluation prompt for the metric.\nExample: `\"Evaluate customer satisfaction based on conversation\"`\n"
+                    },
+                    "evaluation_trigger": {
+                        "enum": [
+                            "always",
+                            "automatic",
+                            "custom"
+                        ],
+                        "type": "string",
+                        "description": "* `always` - Always\n* `automatic` - Automatic\n* `custom` - Custom",
+                        "x-spec-enum-id": "ecd3c02e0e393ef5"
+                    },
+                    "trigger_type": {
+                        "enum": [
+                            "llm_judge",
+                            "custom_code"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "2adad4b8df61914f",
+                        "description": "\nType of trigger evaluation: LLM judge or custom code.\nOnly used when evaluation_trigger is CUSTOM.\nExample: `\"llm_judge\"` or `\"custom_code\"`\n\n\n* `llm_judge` - LLM Judge\n* `custom_code` - Custom Code"
+                    },
+                    "evaluation_trigger_prompt": {
+                        "type": "string",
+                        "description": "\nEvaluation trigger prompt for the metric.\nExample: `\"Evaluate metric only if call ended reason is main-agent-ended-call\"`\n"
+                    },
+                    "evaluation_trigger_custom_code": {
+                        "type": "string",
+                        "description": "\nPython custom code to determine metric relevance. Code should set _result (bool) and _explanation (str).\nExample:\n```python\n_result = True\n_explanation = \"Metric is relevant\"\nif \"call_end_reason\" in data and data[\"call_end_reason\"] == \"customer-hung-up\":\n    _result = False\n    _explanation = \"Customer hung up, metric not applicable\"\n```\n"
+                    },
+                    "priority_assignment_prompt": {
+                        "type": "string",
+                        "description": "\nPriority assignment prompt for the metric.\n"
+                    },
+                    "configuration": {
+                        "description": "\nCustom configuration parameters for specific metrics if metric supports it.\nExample:\n- For Infrastructure issues\n```json\n{\n    \"infra_issues_timeout\": 10\n}\n```\n"
+                    },
+                    "overall_score": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "The overall score for this metric across all test sets"
+                    },
+                    "total_score": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "The total score for this metric"
+                    },
+                    "knowledge_base_files": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "Knowledge base files associated with this metric"
+                    },
+                    "observability_enabled": {
+                        "type": "boolean",
+                        "description": "\nEnable this metric for observability.\nExample: `true` or `false`\n        "
+                    },
+                    "simulation_enabled": {
+                        "type": "boolean",
+                        "description": "\nEnable this metric for simulations.\nExample: `true` or `false`\n        "
+                    },
+                    "sampling_enabled": {
+                        "type": "boolean",
+                        "description": "Enable sampling for this metric using project-level sample rate"
+                    },
+                    "alert_enabled": {
+                        "type": "boolean",
+                        "description": "\nEnable alerts for this metric when it fails (value=false).\nOnly applicable to binary metrics (eval_type=binary).\nFor other metric types, use significant_change_alert_status instead.\nExample: `true` or `false`\n        "
+                    },
+                    "alert_type": {
+                        "enum": [
+                            "disabled",
+                            "normal",
+                            "significant_change"
+                        ],
+                        "type": "string",
+                        "description": "* `disabled` - Alerts Disabled\n* `normal` - Normal Alerts\n* `significant_change` - Significant Change Alerts",
+                        "x-spec-enum-id": "9e2661f1aeca64cf",
+                        "default": "disabled"
+                    },
+                    "alert_filters": {
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Filters to apply before computing alerts (CallLogQueryFilter format)"
+                    },
+                    "slack_workspace": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
+                        "description": "Slack workspace to send alerts to"
+                    },
+                    "slack_channel_id": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "Override channel ID for this metric's alerts",
+                        "maxLength": 255
+                    },
+                    "significant_change_alert_status": {
+                        "enum": [
+                            "enabled",
+                            "disabled"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "6d6f4d361b4ea1fb",
+                        "description": "\nAlert status: enabled or disabled.\n\n\n* `enabled` - Enabled\n* `disabled` - Disabled"
+                    },
+                    "significant_change_alert_direction": {
+                        "enum": [
+                            "",
+                            "increase",
+                            "decrease"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "1e86e60ca5cfba12",
+                        "description": "Alert direction: increase only, decrease only, or both (empty = both).\nExample: `\"increase\"`, `\"decrease\"`, or `\"both\"`\n\n* `` - Both (Increase and Decrease)\n* `increase` - Increase Only\n* `decrease` - Decrease Only"
+                    },
+                    "function_name": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "\nPredefined function name\nExample: `\"get_latency\"` or `\"check_critical_deviations\"`\n",
+                        "maxLength": 255
+                    },
+                    "custom_code": {
+                        "type": "string",
+                        "description": "\nPython custom code for the metric.\nExample:\n```python\n_resul = True\n_explanation = None\nif  \"call_end_reason\" in data and data[\"call_end_reason\"] == \"customer_satisfaction\":\n    _result = True\n    _explanation = \"Customer expressed satisfaction with service\"\n```\n"
+                    },
+                    "vocera_defined_metric_code": {
+                        "type": "string",
+                        "description": "\nVocera defined metric code for the metric.\nExample: `\"7fd534f5\"`\n",
+                        "maxLength": 255
+                    },
+                    "scenarios": {
+                        "writeOnly": true
+                    },
+                    "reviews": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/MetricReviewDetail"
+                        },
+                        "readOnly": true,
+                        "description": "Reviews associated with the metric"
+                    },
+                    "window_size": {
+                        "type": "integer",
+                        "readOnly": true,
+                        "description": "\nWindow size for rolling statistics calculation.\nExample: `50`\n"
+                    },
+                    "std_multiplier": {
+                        "type": "number",
+                        "format": "double",
+                        "readOnly": true,
+                        "description": "\nStandard deviation multiplier for threshold calculation.\nExample: `2.0`\n"
+                    },
+                    "ewma_alpha": {
+                        "type": "number",
+                        "format": "double",
+                        "readOnly": true,
+                        "description": "\nAlpha value for exponentially weighted moving average (EWMA) calculation.\nExample: `0.1`\n"
+                    },
+                    "add_to_new_agents": {
+                        "type": [
+                            "boolean",
+                            "null"
+                        ],
+                        "description": "When enabled, this metric is automatically assigned to new agents created in the project."
+                    },
+                    "pending_optimisation_proposal": {
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "readOnly": true,
+                        "description": "Unsaved proposal from a metric-optimiser cron run. Shape: {description, evaluation_trigger, type, custom_code, score, baseline_score, cron_job_id, cron_job_name, proposed_at}."
+                    }
+                },
+                "required": [
+                    "eval_type",
+                    "name"
+                ]
+            },
+            "MetricEditSerializerV2": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "slug": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "URL-friendly unique identifier in snake_case format",
+                        "maxLength": 255
+                    },
+                    "project": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
+                    },
+                    "agent": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
+                    },
+                    "agents": {
+                        "type": "array",
+                        "items": {
+                            "type": [
+                                "integer",
+                                "null"
+                            ]
+                        }
+                    },
+                    "assistant_id": {
+                        "type": "string",
+                        "writeOnly": true
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "\nName of the metric.\nExample: `\"Customer Satisfaction\"` or `\"Appointment Booking\"`\n        ",
+                        "maxLength": 255
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "\nDescription of what the metric measures.\nExample: `\"Measures how satisfied customers are with the service provided\"`\n        "
+                    },
+                    "type": {
+                        "enum": [
+                            "basic",
+                            "custom_prompt",
+                            "custom_code",
+                            "llm_judge"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "b44700c0a6443b40",
+                        "description": "\nType of metric\n\n\n* `basic` - Basic (Deprecated in favor of LLM Judge)\n* `custom_prompt` - Custom Prompt ( Deprecated in favor of LLM Judge)\n* `custom_code` - Custom Code\n* `llm_judge` - LLM Judge"
+                    },
+                    "eval_type": {
+                        "enum": [
+                            "binary",
+                            "continuous_qualitative",
+                            "numeric",
+                            "enum"
+                        ],
+                        "type": "string",
+                        "description": "* `binary` - Binary\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum",
+                        "x-spec-enum-id": "b40eac6824409cc2"
+                    },
+                    "audio_enabled": {
+                        "type": "boolean",
+                        "readOnly": true,
+                        "description": "\nWhether this metric requires audio analysis.\nExample: `true` or `false`\n        "
+                    },
+                    "observability_enabled": {
+                        "type": "boolean",
+                        "description": "\nEnable this metric for observability.\nExample: `true` or `false`\n        "
+                    },
+                    "simulation_enabled": {
+                        "type": "boolean",
+                        "description": "\nEnable this metric for simulations.\nExample: `true` or `false`\n        "
+                    },
+                    "sampling_enabled": {
+                        "type": "boolean",
+                        "description": "Enable sampling for this metric using project-level sample rate"
+                    },
+                    "prompt": {
+                        "type": "string",
+                        "description": "\nEvaluation prompt for the metric.\nExample: `\"Evaluate customer satisfaction based on conversation\"`\n"
+                    },
+                    "function_name": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "readOnly": true,
+                        "description": "\nPredefined function name\nExample: `\"get_latency\"` or `\"check_critical_deviations\"`\n"
+                    },
+                    "enum_values": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "display_order": {
+                        "type": "integer",
+                        "maximum": 2147483647,
+                        "minimum": -2147483648,
+                        "description": "\nDisplay order for the metric.\nExample: `1`\n"
+                    },
+                    "custom_code": {
+                        "type": "string",
+                        "description": "\nPython custom code for the metric.\nExample:\n```python\n_resul = True\n_explanation = None\nif  \"call_end_reason\" in data and data[\"call_end_reason\"] == \"customer_satisfaction\":\n    _result = True\n    _explanation = \"Customer expressed satisfaction with service\"\n```\n"
+                    },
+                    "evaluation_trigger": {
+                        "enum": [
+                            "always",
+                            "automatic",
+                            "custom"
+                        ],
+                        "type": "string",
+                        "description": "* `always` - Always\n* `automatic` - Automatic\n* `custom` - Custom",
+                        "x-spec-enum-id": "ecd3c02e0e393ef5"
+                    },
+                    "trigger_type": {
+                        "enum": [
+                            "llm_judge",
+                            "custom_code"
+                        ],
+                        "type": "string",
+                        "description": "* `llm_judge` - LLM Judge\n* `custom_code` - Custom Code",
+                        "x-spec-enum-id": "2adad4b8df61914f"
+                    },
+                    "evaluation_trigger_prompt": {
+                        "type": "string",
+                        "description": "\nEvaluation trigger prompt for the metric.\nExample: `\"Evaluate metric only if call ended reason is main-agent-ended-call\"`\n"
+                    },
+                    "evaluation_trigger_custom_code": {
+                        "type": "string",
+                        "description": "\nPython custom code to determine metric relevance. Code should set _result (bool) and _explanation (str).\nExample:\n```python\n_result = True\n_explanation = \"Metric is relevant\"\nif \"call_end_reason\" in data and data[\"call_end_reason\"] == \"customer-hung-up\":\n    _result = False\n    _explanation = \"Customer hung up, metric not applicable\"\n```\n"
+                    },
+                    "vocera_defined_metric_code": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "\nVocera defined metric code for the metric.\nExample: `\"7fd534f5\"`\n"
+                    },
+                    "priority_assignment_prompt": {
+                        "type": "string",
+                        "description": "\nPriority assignment prompt for the metric.\n"
+                    },
+                    "configuration": {
+                        "description": "\nCustom configuration parameters for specific metrics if metric supports it.\nExample:\n- For Infrastructure issues\n```json\n{\n    \"infra_issues_timeout\": 10\n}\n```\n"
+                    },
+                    "scenarios": {
+                        "writeOnly": true
+                    },
+                    "overall_score": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "total_score": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "kb_file_ids": {
+                        "description": "\nList of knowledge base file IDs for the metric.\nExample: `[123, 456]`\n"
+                    },
+                    "knowledge_base_files": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "metric_description_program": {},
+                    "metric_description_variables": {
+                        "type": "array",
+                        "items": {}
+                    },
+                    "evaluation_trigger_program": {},
+                    "evaluation_trigger_variables": {
+                        "type": "array",
+                        "items": {}
+                    },
+                    "alert_enabled": {
+                        "type": "boolean",
+                        "description": "\nEnable alerts for this metric when it fails (value=false).\nOnly applicable to binary metrics (eval_type=binary).\nFor other metric types, use significant_change_alert_status instead.\nExample: `true` or `false`\n        "
+                    },
+                    "alert_type": {
+                        "enum": [
+                            "disabled",
+                            "normal",
+                            "significant_change"
+                        ],
+                        "type": "string",
+                        "description": "* `disabled` - Alerts Disabled\n* `normal` - Normal Alerts\n* `significant_change` - Significant Change Alerts",
+                        "x-spec-enum-id": "9e2661f1aeca64cf",
+                        "default": "disabled"
+                    },
+                    "window_size": {
+                        "type": "integer",
+                        "default": 50
+                    },
+                    "std_multiplier": {
+                        "type": "number",
+                        "format": "double",
+                        "default": 2.0
+                    },
+                    "ewma_alpha": {
+                        "type": "number",
+                        "format": "double",
+                        "default": 0.1
+                    },
+                    "significant_change_alert_status": {
+                        "enum": [
+                            "enabled",
+                            "disabled"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "6d6f4d361b4ea1fb",
+                        "description": "\nAlert status: enabled or disabled.\n\n\n* `enabled` - Enabled\n* `disabled` - Disabled"
+                    },
+                    "significant_change_alert_direction": {
+                        "enum": [
+                            "",
+                            "increase",
+                            "decrease"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "1e86e60ca5cfba12",
+                        "description": "Alert direction: increase only, decrease only, or both (empty = both).\nExample: `\"increase\"`, `\"decrease\"`, or `\"both\"`\n\n* `` - Both (Increase and Decrease)\n* `increase` - Increase Only\n* `decrease` - Decrease Only"
+                    },
+                    "add_to_new_agents": {
+                        "type": [
+                            "boolean",
+                            "null"
+                        ],
+                        "description": "When enabled, this metric is automatically assigned to new agents created in the project."
+                    },
+                    "alert_filters": {
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Filters to apply before computing alerts (CallLogQueryFilter format)"
+                    },
+                    "slack_workspace": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
+                        "description": "Slack workspace to send alerts to"
+                    },
+                    "slack_channel_id": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "Override channel ID for this metric's alerts",
+                        "maxLength": 255
+                    },
+                    "apply_to_all_agents": {
+                        "type": "boolean",
+                        "writeOnly": true,
+                        "default": false,
+                        "description": "For observability_dropoff: when true, copies the dropoff_nodes from configuration to every other agent in the project."
+                    },
+                    "add_to_rubric": {
+                        "type": "boolean",
+                        "writeOnly": true,
+                        "default": false,
+                        "description": "If true, this metric is added to the project's call-success rubric on save (a sensible default rule is chosen by `eval_type`). If false on an existing rubric metric, it's removed from the rubric."
                     }
                 },
                 "required": [
@@ -57338,15 +63284,14 @@
                     },
                     "eval_type": {
                         "enum": [
-                            "binary_workflow_adherence",
-                            "binary_qualitative",
+                            "binary",
                             "continuous_qualitative",
                             "numeric",
                             "enum"
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "1e3e27b342bfd8ec",
-                        "description": "\nType of evaluation\n\n\n* `binary_workflow_adherence` - Binary Workflow Adherence\n* `binary_qualitative` - Binary Qualitative\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum"
+                        "x-spec-enum-id": "b40eac6824409cc2",
+                        "description": "\nType of evaluation\n\n\n* `binary` - Binary\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum"
                     },
                     "enum_values": {
                         "description": "\nList of possible enum values for enum type metrics.\nExample: `[\"satisfied\", \"unsatisfied\"]`\n"
@@ -57369,7 +63314,7 @@
                     },
                     "alert_enabled": {
                         "type": "boolean",
-                        "description": "\nEnable alerts for this metric when it fails (value < 5).\nOnly applicable to binary metrics (binary_workflow_adherence and binary_qualitative).\nFor other metric types, use significant_change_alert_status instead.\nExample: `true` or `false`\n        "
+                        "description": "\nEnable alerts for this metric when it fails (value=false).\nOnly applicable to binary metrics (eval_type=binary).\nFor other metric types, use significant_change_alert_status instead.\nExample: `true` or `false`\n        "
                     },
                     "prompt": {
                         "type": "string",
@@ -57601,15 +63546,14 @@
                     },
                     "eval_type": {
                         "enum": [
-                            "binary_workflow_adherence",
-                            "binary_qualitative",
+                            "binary",
                             "continuous_qualitative",
                             "numeric",
                             "enum"
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "1e3e27b342bfd8ec",
-                        "description": "\nType of evaluation\n\n\n* `binary_workflow_adherence` - Binary Workflow Adherence\n* `binary_qualitative` - Binary Qualitative\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum"
+                        "description": "* `binary` - Binary\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum",
+                        "x-spec-enum-id": "b40eac6824409cc2"
                     },
                     "enum_values": {
                         "description": "\nList of possible enum values for enum type metrics.\nExample: `[\"satisfied\", \"unsatisfied\"]`\n"
@@ -57785,10 +63729,271 @@
                         "description": "Override channel ID for this metric's alerts",
                         "maxLength": 255
                     },
-                    "affects_call_success": {
+                    "uses_llm_judge": {
                         "type": "string",
                         "readOnly": true,
-                        "description": "\nWhether this metric is configured in the project's rubric and therefore contributes\nto overall call success evaluation.\nExample: `true`\n"
+                        "description": "\nWhether this metric produces an LLM-judge narrative: a `custom_code` metric whose\ncode delegates to the LLM judge internally. Computed server-side because the\n`custom_code` body is write-only and not exposed on read.\nExample: `true`\n"
+                    }
+                },
+                "required": [
+                    "eval_type",
+                    "name"
+                ]
+            },
+            "MetricListSerializerV2": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "slug": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "URL-friendly unique identifier in snake_case format. Example: \"customer_satisfaction_1562\"",
+                        "maxLength": 255
+                    },
+                    "project": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
+                    },
+                    "agents": {
+                        "type": "array",
+                        "items": {
+                            "type": [
+                                "integer",
+                                "null"
+                            ]
+                        }
+                    },
+                    "agent_names": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "\nName of the metric.\nExample: `\"Customer Satisfaction\"` or `\"Appointment Booking\"`\n        ",
+                        "maxLength": 255
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "\nDescription of what the metric measures.\nExample: `\"Measures how satisfied customers are with the service provided\"`\n        "
+                    },
+                    "function_name": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "\nPredefined function name\nExample: `\"get_latency\"` or `\"check_critical_deviations\"`\n",
+                        "maxLength": 255
+                    },
+                    "type": {
+                        "enum": [
+                            "basic",
+                            "custom_prompt",
+                            "custom_code",
+                            "llm_judge"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "b44700c0a6443b40",
+                        "description": "\nType of metric\n\n\n* `basic` - Basic (Deprecated in favor of LLM Judge)\n* `custom_prompt` - Custom Prompt ( Deprecated in favor of LLM Judge)\n* `custom_code` - Custom Code\n* `llm_judge` - LLM Judge"
+                    },
+                    "eval_type": {
+                        "enum": [
+                            "binary",
+                            "continuous_qualitative",
+                            "numeric",
+                            "enum"
+                        ],
+                        "type": "string",
+                        "description": "* `binary` - Binary\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum",
+                        "x-spec-enum-id": "b40eac6824409cc2"
+                    },
+                    "enum_values": {
+                        "description": "\nList of possible enum values for enum type metrics.\nExample: `[\"satisfied\", \"unsatisfied\"]`\n"
+                    },
+                    "audio_enabled": {
+                        "type": "boolean",
+                        "description": "\nWhether this metric requires audio analysis.\nExample: `true` or `false`\n        "
+                    },
+                    "observability_enabled": {
+                        "type": "boolean",
+                        "description": "\nEnable this metric for observability.\nExample: `true` or `false`\n        "
+                    },
+                    "simulation_enabled": {
+                        "type": "boolean",
+                        "description": "\nEnable this metric for simulations.\nExample: `true` or `false`\n        "
+                    },
+                    "sampling_enabled": {
+                        "type": "boolean",
+                        "description": "Enable sampling for this metric using project-level sample rate"
+                    },
+                    "prompt": {
+                        "type": "string",
+                        "description": "\nEvaluation prompt for the metric.\nExample: `\"Evaluate customer satisfaction based on conversation\"`\n"
+                    },
+                    "display_order": {
+                        "type": "integer",
+                        "maximum": 2147483647,
+                        "minimum": -2147483648,
+                        "description": "\nDisplay order for the metric.\nExample: `1`\n"
+                    },
+                    "evaluation_trigger": {
+                        "enum": [
+                            "always",
+                            "automatic",
+                            "custom"
+                        ],
+                        "type": "string",
+                        "description": "* `always` - Always\n* `automatic` - Automatic\n* `custom` - Custom",
+                        "x-spec-enum-id": "ecd3c02e0e393ef5"
+                    },
+                    "trigger_type": {
+                        "enum": [
+                            "llm_judge",
+                            "custom_code"
+                        ],
+                        "type": "string",
+                        "description": "* `llm_judge` - LLM Judge\n* `custom_code` - Custom Code",
+                        "x-spec-enum-id": "2adad4b8df61914f"
+                    },
+                    "evaluation_trigger_prompt": {
+                        "type": "string",
+                        "description": "\nEvaluation trigger prompt for the metric.\nExample: `\"Evaluate metric only if call ended reason is main-agent-ended-call\"`\n"
+                    },
+                    "evaluation_trigger_custom_code": {
+                        "type": "string",
+                        "description": "\nPython custom code to determine metric relevance. Code should set _result (bool) and _explanation (str).\nExample:\n```python\n_result = True\n_explanation = \"Metric is relevant\"\nif \"call_end_reason\" in data and data[\"call_end_reason\"] == \"customer-hung-up\":\n    _result = False\n    _explanation = \"Customer hung up, metric not applicable\"\n```\n"
+                    },
+                    "priority_assignment_prompt": {
+                        "type": "string",
+                        "description": "\nPriority assignment prompt for the metric.\n"
+                    },
+                    "vocera_defined_metric_code": {
+                        "type": "string",
+                        "description": "\nVocera defined metric code for the metric.\nExample: `\"7fd534f5\"`\n",
+                        "maxLength": 255
+                    },
+                    "configuration": {
+                        "description": "\nCustom configuration parameters for specific metrics if metric supports it.\nExample:\n- For Infrastructure issues\n```json\n{\n    \"infra_issues_timeout\": 10\n}\n```\n"
+                    },
+                    "overall_score": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "total_score": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "kb_file_ids": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        },
+                        "description": "\nList of knowledge base file IDs for the metric.\nExample: `[123, 456]`\n"
+                    },
+                    "knowledge_base_files": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/KnowledgeBaseFile"
+                        },
+                        "readOnly": true
+                    },
+                    "scenarios": {
+                        "writeOnly": true,
+                        "description": "Either \"all\" or a list of scenario IDs to attach to this metric"
+                    },
+                    "custom_code": {
+                        "type": "string",
+                        "writeOnly": true
+                    },
+                    "metric_cost": {
+                        "type": "number",
+                        "format": "double",
+                        "description": "\nMetric Cost\nExample: `0.10`\n",
+                        "readOnly": true
+                    },
+                    "alert_type": {
+                        "enum": [
+                            "disabled",
+                            "normal",
+                            "significant_change"
+                        ],
+                        "type": "string",
+                        "description": "* `disabled` - Alerts Disabled\n* `normal` - Normal Alerts\n* `significant_change` - Significant Change Alerts",
+                        "x-spec-enum-id": "9e2661f1aeca64cf",
+                        "default": "disabled"
+                    },
+                    "significant_change_alert_status": {
+                        "enum": [
+                            "enabled",
+                            "disabled"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "6d6f4d361b4ea1fb",
+                        "description": "\nAlert status: enabled or disabled.\n\n\n* `enabled` - Enabled\n* `disabled` - Disabled"
+                    },
+                    "significant_change_alert_direction": {
+                        "enum": [
+                            "",
+                            "increase",
+                            "decrease"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "1e86e60ca5cfba12",
+                        "description": "Alert direction: increase only, decrease only, or both (empty = both).\nExample: `\"increase\"`, `\"decrease\"`, or `\"both\"`\n\n* `` - Both (Increase and Decrease)\n* `increase` - Increase Only\n* `decrease` - Decrease Only"
+                    },
+                    "window_size": {
+                        "type": "integer",
+                        "readOnly": true,
+                        "description": "\nWindow size for rolling statistics calculation.\nExample: `50`\n"
+                    },
+                    "std_multiplier": {
+                        "type": "number",
+                        "format": "double",
+                        "readOnly": true,
+                        "description": "\nStandard deviation multiplier for threshold calculation.\nExample: `2.0`\n"
+                    },
+                    "ewma_alpha": {
+                        "type": "number",
+                        "format": "double",
+                        "readOnly": true,
+                        "description": "\nAlpha value for exponentially weighted moving average (EWMA) calculation.\nExample: `0.1`\n"
+                    },
+                    "add_to_new_agents": {
+                        "type": [
+                            "boolean",
+                            "null"
+                        ],
+                        "description": "When enabled, this metric is automatically assigned to new agents created in the project."
+                    },
+                    "alert_filters": {
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Filters to apply before computing alerts (CallLogQueryFilter format)"
+                    },
+                    "slack_workspace": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
+                        "description": "Slack workspace to send alerts to"
+                    },
+                    "slack_channel_id": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "Override channel ID for this metric's alerts",
+                        "maxLength": 255
                     },
                     "uses_llm_judge": {
                         "type": "string",
@@ -57797,6 +64002,7 @@
                     }
                 },
                 "required": [
+                    "eval_type",
                     "name"
                 ]
             },
@@ -57955,15 +64161,14 @@
                     },
                     "eval_type": {
                         "enum": [
-                            "binary_workflow_adherence",
-                            "binary_qualitative",
+                            "binary",
                             "continuous_qualitative",
                             "numeric",
                             "enum"
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "1e3e27b342bfd8ec",
-                        "description": "Evaluation type: binary_workflow_adherence, binary_qualitative, continuous_qualitative, numeric, or enum\n\n* `binary_workflow_adherence` - Binary Workflow Adherence\n* `binary_qualitative` - Binary Qualitative\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum"
+                        "x-spec-enum-id": "b40eac6824409cc2",
+                        "description": "Evaluation type: binary, continuous_qualitative, numeric, or enum. Legacy values (binary_workflow_adherence, binary_qualitative) are accepted and mapped to binary.\n\n* `binary` - Binary\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum"
                     },
                     "evaluation_trigger": {
                         "enum": [
@@ -60115,7 +66320,7 @@
                             }
                         ],
                         "readOnly": true,
-                        "description": "Evaluation results for the call.\nExample: \n```json\n{\n    \"metrics\": [\n        {\n            \"id\": 35,\n            \"name\": \"Instruction Follow\",\n            \"type\": \"binary_workflow_adherence\",\n            \"score\": 0,\n            \"explanation\": [\"Agent failed to follow the opening script\", \"Missed key product information\"],\n            \"vocera_defined_metric_code\": \"5dedc41b\",\n            \"function_name\": \"check_critical_deviations\",\n            \"extra\": {\n                \"categories\": [\n                    {\n                        \"category_id\": 5,\n                        \"category\": \"Script Adherence Issue\",\n                        \"deviation\": \"Agent deviated from required script\",\n                        \"priority\": \"critical\"\n                    }\n                ]\n            }\n        },\n        {\n            \"id\": 18,\n            \"name\": \"Customer Satisfaction\",\n            \"type\": \"binary_qualitative\",\n            \"score\": 5,\n            \"explanation\": [\"Customer expressed satisfaction with service\"]\n        }\n    ]\n}\n```"
+                        "description": "Evaluation results for the call.\nExample: \n```json\n{\n    \"metrics\": [\n        {\n            \"id\": 35,\n            \"name\": \"Instruction Follow\",\n            \"type\": \"binary\",\n            \"score\": 0,\n            \"explanation\": [\"Agent failed to follow the opening script\", \"Missed key product information\"],\n            \"vocera_defined_metric_code\": \"5dedc41b\",\n            \"function_name\": \"check_critical_deviations\",\n            \"extra\": {\n                \"categories\": [\n                    {\n                        \"category_id\": 5,\n                        \"category\": \"Script Adherence Issue\",\n                        \"deviation\": \"Agent deviated from required script\",\n                        \"priority\": \"critical\"\n                    }\n                ]\n            }\n        },\n        {\n            \"id\": 18,\n            \"name\": \"Customer Satisfaction\",\n            \"type\": \"binary\",\n            \"score\": 5,\n            \"explanation\": [\"Customer expressed satisfaction with service\"]\n        }\n    ]\n}\n```"
                     },
                     "metadata": {
                         "type": "object",
@@ -60810,6 +67015,282 @@
                     }
                 }
             },
+            "PatchedMetricEditSerializerV2": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "slug": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "URL-friendly unique identifier in snake_case format",
+                        "maxLength": 255
+                    },
+                    "project": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
+                    },
+                    "agent": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
+                    },
+                    "agents": {
+                        "type": "array",
+                        "items": {
+                            "type": [
+                                "integer",
+                                "null"
+                            ]
+                        }
+                    },
+                    "assistant_id": {
+                        "type": "string",
+                        "writeOnly": true
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "\nName of the metric.\nExample: `\"Customer Satisfaction\"` or `\"Appointment Booking\"`\n        ",
+                        "maxLength": 255
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "\nDescription of what the metric measures.\nExample: `\"Measures how satisfied customers are with the service provided\"`\n        "
+                    },
+                    "type": {
+                        "enum": [
+                            "basic",
+                            "custom_prompt",
+                            "custom_code",
+                            "llm_judge"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "b44700c0a6443b40",
+                        "description": "\nType of metric\n\n\n* `basic` - Basic (Deprecated in favor of LLM Judge)\n* `custom_prompt` - Custom Prompt ( Deprecated in favor of LLM Judge)\n* `custom_code` - Custom Code\n* `llm_judge` - LLM Judge"
+                    },
+                    "eval_type": {
+                        "enum": [
+                            "binary",
+                            "continuous_qualitative",
+                            "numeric",
+                            "enum"
+                        ],
+                        "type": "string",
+                        "description": "* `binary` - Binary\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum",
+                        "x-spec-enum-id": "b40eac6824409cc2"
+                    },
+                    "audio_enabled": {
+                        "type": "boolean",
+                        "readOnly": true,
+                        "description": "\nWhether this metric requires audio analysis.\nExample: `true` or `false`\n        "
+                    },
+                    "observability_enabled": {
+                        "type": "boolean",
+                        "description": "\nEnable this metric for observability.\nExample: `true` or `false`\n        "
+                    },
+                    "simulation_enabled": {
+                        "type": "boolean",
+                        "description": "\nEnable this metric for simulations.\nExample: `true` or `false`\n        "
+                    },
+                    "sampling_enabled": {
+                        "type": "boolean",
+                        "description": "Enable sampling for this metric using project-level sample rate"
+                    },
+                    "prompt": {
+                        "type": "string",
+                        "description": "\nEvaluation prompt for the metric.\nExample: `\"Evaluate customer satisfaction based on conversation\"`\n"
+                    },
+                    "function_name": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "readOnly": true,
+                        "description": "\nPredefined function name\nExample: `\"get_latency\"` or `\"check_critical_deviations\"`\n"
+                    },
+                    "enum_values": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "display_order": {
+                        "type": "integer",
+                        "maximum": 2147483647,
+                        "minimum": -2147483648,
+                        "description": "\nDisplay order for the metric.\nExample: `1`\n"
+                    },
+                    "custom_code": {
+                        "type": "string",
+                        "description": "\nPython custom code for the metric.\nExample:\n```python\n_resul = True\n_explanation = None\nif  \"call_end_reason\" in data and data[\"call_end_reason\"] == \"customer_satisfaction\":\n    _result = True\n    _explanation = \"Customer expressed satisfaction with service\"\n```\n"
+                    },
+                    "evaluation_trigger": {
+                        "enum": [
+                            "always",
+                            "automatic",
+                            "custom"
+                        ],
+                        "type": "string",
+                        "description": "* `always` - Always\n* `automatic` - Automatic\n* `custom` - Custom",
+                        "x-spec-enum-id": "ecd3c02e0e393ef5"
+                    },
+                    "trigger_type": {
+                        "enum": [
+                            "llm_judge",
+                            "custom_code"
+                        ],
+                        "type": "string",
+                        "description": "* `llm_judge` - LLM Judge\n* `custom_code` - Custom Code",
+                        "x-spec-enum-id": "2adad4b8df61914f"
+                    },
+                    "evaluation_trigger_prompt": {
+                        "type": "string",
+                        "description": "\nEvaluation trigger prompt for the metric.\nExample: `\"Evaluate metric only if call ended reason is main-agent-ended-call\"`\n"
+                    },
+                    "evaluation_trigger_custom_code": {
+                        "type": "string",
+                        "description": "\nPython custom code to determine metric relevance. Code should set _result (bool) and _explanation (str).\nExample:\n```python\n_result = True\n_explanation = \"Metric is relevant\"\nif \"call_end_reason\" in data and data[\"call_end_reason\"] == \"customer-hung-up\":\n    _result = False\n    _explanation = \"Customer hung up, metric not applicable\"\n```\n"
+                    },
+                    "vocera_defined_metric_code": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "\nVocera defined metric code for the metric.\nExample: `\"7fd534f5\"`\n"
+                    },
+                    "priority_assignment_prompt": {
+                        "type": "string",
+                        "description": "\nPriority assignment prompt for the metric.\n"
+                    },
+                    "configuration": {
+                        "description": "\nCustom configuration parameters for specific metrics if metric supports it.\nExample:\n- For Infrastructure issues\n```json\n{\n    \"infra_issues_timeout\": 10\n}\n```\n"
+                    },
+                    "scenarios": {
+                        "writeOnly": true
+                    },
+                    "overall_score": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "total_score": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "kb_file_ids": {
+                        "description": "\nList of knowledge base file IDs for the metric.\nExample: `[123, 456]`\n"
+                    },
+                    "knowledge_base_files": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "metric_description_program": {},
+                    "metric_description_variables": {
+                        "type": "array",
+                        "items": {}
+                    },
+                    "evaluation_trigger_program": {},
+                    "evaluation_trigger_variables": {
+                        "type": "array",
+                        "items": {}
+                    },
+                    "alert_enabled": {
+                        "type": "boolean",
+                        "description": "\nEnable alerts for this metric when it fails (value=false).\nOnly applicable to binary metrics (eval_type=binary).\nFor other metric types, use significant_change_alert_status instead.\nExample: `true` or `false`\n        "
+                    },
+                    "alert_type": {
+                        "enum": [
+                            "disabled",
+                            "normal",
+                            "significant_change"
+                        ],
+                        "type": "string",
+                        "description": "* `disabled` - Alerts Disabled\n* `normal` - Normal Alerts\n* `significant_change` - Significant Change Alerts",
+                        "x-spec-enum-id": "9e2661f1aeca64cf",
+                        "default": "disabled"
+                    },
+                    "window_size": {
+                        "type": "integer",
+                        "default": 50
+                    },
+                    "std_multiplier": {
+                        "type": "number",
+                        "format": "double",
+                        "default": 2.0
+                    },
+                    "ewma_alpha": {
+                        "type": "number",
+                        "format": "double",
+                        "default": 0.1
+                    },
+                    "significant_change_alert_status": {
+                        "enum": [
+                            "enabled",
+                            "disabled"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "6d6f4d361b4ea1fb",
+                        "description": "\nAlert status: enabled or disabled.\n\n\n* `enabled` - Enabled\n* `disabled` - Disabled"
+                    },
+                    "significant_change_alert_direction": {
+                        "enum": [
+                            "",
+                            "increase",
+                            "decrease"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "1e86e60ca5cfba12",
+                        "description": "Alert direction: increase only, decrease only, or both (empty = both).\nExample: `\"increase\"`, `\"decrease\"`, or `\"both\"`\n\n* `` - Both (Increase and Decrease)\n* `increase` - Increase Only\n* `decrease` - Decrease Only"
+                    },
+                    "add_to_new_agents": {
+                        "type": [
+                            "boolean",
+                            "null"
+                        ],
+                        "description": "When enabled, this metric is automatically assigned to new agents created in the project."
+                    },
+                    "alert_filters": {
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Filters to apply before computing alerts (CallLogQueryFilter format)"
+                    },
+                    "slack_workspace": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
+                        "description": "Slack workspace to send alerts to"
+                    },
+                    "slack_channel_id": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "Override channel ID for this metric's alerts",
+                        "maxLength": 255
+                    },
+                    "apply_to_all_agents": {
+                        "type": "boolean",
+                        "writeOnly": true,
+                        "default": false,
+                        "description": "For observability_dropoff: when true, copies the dropoff_nodes from configuration to every other agent in the project."
+                    },
+                    "add_to_rubric": {
+                        "type": "boolean",
+                        "writeOnly": true,
+                        "default": false,
+                        "description": "If true, this metric is added to the project's call-success rubric on save (a sensible default rule is chosen by `eval_type`). If false on an existing rubric metric, it's removed from the rubric."
+                    }
+                }
+            },
             "PatchedMetricOptimiserCronJob": {
                 "type": "object",
                 "properties": {
@@ -61384,15 +67865,14 @@
                     },
                     "eval_type": {
                         "enum": [
-                            "binary_workflow_adherence",
-                            "binary_qualitative",
+                            "binary",
                             "continuous_qualitative",
                             "numeric",
                             "enum"
                         ],
                         "type": "string",
-                        "description": "* `binary_workflow_adherence` - Binary Workflow Adherence\n* `binary_qualitative` - Binary Qualitative\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum",
-                        "x-spec-enum-id": "1e3e27b342bfd8ec"
+                        "description": "* `binary` - Binary\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum",
+                        "x-spec-enum-id": "b40eac6824409cc2"
                     },
                     "audio_enabled": {
                         "type": "boolean",
@@ -61673,7 +68153,7 @@
                         "description": "\nIs send emails enabled\nExample: `true` or `false`\n"
                     },
                     "rubric_config": {
-                        "description": "\nProject-level scoring rubric for evaluating call success. Each call log produced under this project is run against the rubric and gets a single pass/fail outcome based on its metric results.\n\nIMPORTANT (read before writing):\n- NEVER blindly overwrite this field. Always first GET the project, read the existing `rubric_config`, then merge in only the rule(s) you intend to add/update, and PATCH the full merged value. Sending a partial value will silently delete every rule you did not include.\n\nStructure:\n- `evaluation_logic`: MUST be `\"and\"`. All rules have to pass for a call to be marked successful. (Other values are not supported by the product currently.)\n- `rules`: List of rules. Use one rule per (metric, condition) — keep each rule simple, with a single condition inside.\n\nEach rule shape:\n```json\n{\n    \"metric_id\": <metric id>,\n    \"conditions\": {\n        \"operator\": \"and\",\n        \"conditions\": [\n            {\"field\": <field>, \"op\": <op>, \"value\": <value>}\n        ]\n    }\n}\n```\n\nWhat `field`, `op`, and `value` to use depends on the metric type. The three supported cases:\n\n1. Numeric / score metrics (qualitative scores, numeric metrics, workflow adherence with a score, etc.):\n   - `field`: `\"score\"`\n   - `op`: one of `\"gt\"`, `\"gte\"`, `\"lt\"`, `\"lte\"`, `\"eq\"`\n   - `value`: a number (qualitative scores are on a 0–5 scale)\n   - Example (score must be at least 4): `{\"field\": \"score\", \"op\": \"gte\", \"value\": 4}`\n\n2. Boolean / binary metrics (eval_type `binary_qualitative`, `binary_workflow_adherence`, or `evaluate_expected_outcome`):\n   - Boolean outcomes are stored as a score: True → `5`, False → `0`.\n   - `field`: `\"score\"`\n   - `op`: `\"eq\"` or `\"neq\"`\n   - `value`: `5` for True, `0` for False\n   - Example (must be True): `{\"field\": \"score\", \"op\": \"eq\", \"value\": 5}`\n   - Example (must be False): `{\"field\": \"score\", \"op\": \"eq\", \"value\": 0}`\n\n3. Enum metrics (eval_type `enum`, or `observability_topics` / `observability_dropoff`):\n   - `field`: `\"enum\"`\n   - `op`: `\"eq\"`, `\"neq\"`, or `\"in\"`\n   - `value`: a single string for `eq`/`neq`, or a list of strings for `in`. Must match one of the metric's defined `enum_values`.\n   - Example: `{\"field\": \"enum\", \"op\": \"eq\", \"value\": \"resolved\"}`\n   - Example (any of): `{\"field\": \"enum\", \"op\": \"in\", \"value\": [\"resolved\", \"partially_resolved\"]}`\n\nFull example:\n```json\n{\n    \"evaluation_logic\": \"and\",\n    \"rules\": [\n        {\n            \"metric_id\": 115164,\n            \"conditions\": {\n                \"operator\": \"and\",\n                \"conditions\": [\n                    {\"op\": \"eq\", \"field\": \"score\", \"value\": 5}\n                ]\n            }\n        },\n        {\n            \"metric_id\": 5512,\n            \"conditions\": {\n                \"operator\": \"and\",\n                \"conditions\": [\n                    {\"op\": \"gte\", \"field\": \"score\", \"value\": 4}\n                ]\n            }\n        },\n        {\n            \"metric_id\": 8821,\n            \"conditions\": {\n                \"operator\": \"and\",\n                \"conditions\": [\n                    {\"op\": \"in\", \"field\": \"enum\", \"value\": [\"resolved\", \"partially_resolved\"]}\n                ]\n            }\n        }\n    ]\n}\n```\n\nNotes:\n- `metric_id` must reference a metric belonging to this project (project-scoped or agent-scoped under this project); unknown ids are rejected.\n- Rules whose metric did not produce a value on a given call are skipped (neither pass nor fail) and do not affect the outcome.\n- Pass an empty object `{}` to clear the rubric.\n"
+                        "description": "\nProject-level scoring rubric for evaluating call success. Each call log produced under this project is run against the rubric and gets a single pass/fail outcome based on its metric results.\n\nIMPORTANT (read before writing):\n- NEVER blindly overwrite this field. Always first GET the project, read the existing `rubric_config`, then merge in only the rule(s) you intend to add/update, and PATCH the full merged value. Sending a partial value will silently delete every rule you did not include.\n\nStructure:\n- `evaluation_logic`: MUST be `\"and\"`. All rules have to pass for a call to be marked successful. (Other values are not supported by the product currently.)\n- `rules`: List of rules. Use one rule per (metric, condition) — keep each rule simple, with a single condition inside.\n\nEach rule shape:\n```json\n{\n    \"metric_id\": <metric id>,\n    \"conditions\": {\n        \"operator\": \"and\",\n        \"conditions\": [\n            {\"field\": <field>, \"op\": <op>, \"value\": <value>}\n        ]\n    }\n}\n```\n\nWhat `field`, `op`, and `value` to use depends on the metric type. The three supported cases:\n\n1. Numeric / score metrics (qualitative scores, numeric metrics, workflow adherence with a score, etc.):\n   - `field`: `\"score\"`\n   - `op`: one of `\"gt\"`, `\"gte\"`, `\"lt\"`, `\"lte\"`, `\"eq\"`\n   - `value`: a number (qualitative scores are on a 0–5 scale)\n   - Example (score must be at least 4): `{\"field\": \"score\", \"op\": \"gte\", \"value\": 4}`\n\n2. Boolean / binary metrics (eval_type `binary`, or `evaluate_expected_outcome`):\n   - `field`: `\"score\"`\n   - `op`: `\"eq\"` or `\"neq\"`\n   - `value`: `true` for pass, `false` for fail\n   - Example (must pass): `{\"field\": \"score\", \"op\": \"eq\", \"value\": true}`\n   - Example (must fail): `{\"field\": \"score\", \"op\": \"eq\", \"value\": false}`\n   - Legacy values `5` (pass) and `0` (fail) are still accepted for back-compat but new rules should use bool.\n\n3. Enum metrics (eval_type `enum`, or `observability_topics` / `observability_dropoff`):\n   - `field`: `\"enum\"`\n   - `op`: `\"eq\"`, `\"neq\"`, or `\"in\"`\n   - `value`: a single string for `eq`/`neq`, or a list of strings for `in`. Must match one of the metric's defined `enum_values`.\n   - Example: `{\"field\": \"enum\", \"op\": \"eq\", \"value\": \"resolved\"}`\n   - Example (any of): `{\"field\": \"enum\", \"op\": \"in\", \"value\": [\"resolved\", \"partially_resolved\"]}`\n\nFull example:\n```json\n{\n    \"evaluation_logic\": \"and\",\n    \"rules\": [\n        {\n            \"metric_id\": 115164,\n            \"conditions\": {\n                \"operator\": \"and\",\n                \"conditions\": [\n                    {\"op\": \"eq\", \"field\": \"score\", \"value\": true}\n                ]\n            }\n        },\n        {\n            \"metric_id\": 5512,\n            \"conditions\": {\n                \"operator\": \"and\",\n                \"conditions\": [\n                    {\"op\": \"gte\", \"field\": \"score\", \"value\": 4}\n                ]\n            }\n        },\n        {\n            \"metric_id\": 8821,\n            \"conditions\": {\n                \"operator\": \"and\",\n                \"conditions\": [\n                    {\"op\": \"in\", \"field\": \"enum\", \"value\": [\"resolved\", \"partially_resolved\"]}\n                ]\n            }\n        }\n    ]\n}\n```\n\nNotes:\n- `metric_id` must reference a metric belonging to this project (project-scoped or agent-scoped under this project); unknown ids are rejected.\n- Rules whose metric did not produce a value on a given call are skipped (neither pass nor fail) and do not affect the outcome.\n- Pass an empty object `{}` to clear the rubric.\n"
                     },
                     "timezone": {
                         "type": "string",
@@ -61987,7 +68467,7 @@
                     "critical_categories": {
                         "type": "string",
                         "readOnly": true,
-                        "description": "\nList of critical categories for this result\nExample:\n```json\n[\n    {\n      \"id\": 2950,\n      \"name\": \"Pronunciation Analysis\",\n      \"eval_type\": \"continuous_qualitative\",\n      \"simulation_enabled\": true,\n      \"observability_enabled\": true\n    },\n    {\n      \"id\": 3284,\n      \"name\": \"Latency\",\n      \"eval_type\": \"numeric\",\n      \"simulation_enabled\": true,\n      \"observability_enabled\": false\n    },\n    {\n      \"id\": 3295,\n      \"name\": \"Detect Silence in Conversation\",\n      \"eval_type\": \"binary_qualitative\",\n      \"simulation_enabled\": true,\n      \"observability_enabled\": true\n    }\n  ]\n```\n"
+                        "description": "\nList of critical categories for this result\nExample:\n```json\n[\n    {\n      \"id\": 2950,\n      \"name\": \"Pronunciation Analysis\",\n      \"eval_type\": \"continuous_qualitative\",\n      \"simulation_enabled\": true,\n      \"observability_enabled\": true\n    },\n    {\n      \"id\": 3284,\n      \"name\": \"Latency\",\n      \"eval_type\": \"numeric\",\n      \"simulation_enabled\": true,\n      \"observability_enabled\": false\n    },\n    {\n      \"id\": 3295,\n      \"name\": \"Detect Silence in Conversation\",\n      \"eval_type\": \"binary\",\n      \"simulation_enabled\": true,\n      \"observability_enabled\": true\n    }\n  ]\n```\n"
                     },
                     "metrics": {
                         "type": "string",
@@ -62822,15 +69302,14 @@
                     },
                     "eval_type": {
                         "enum": [
-                            "binary_workflow_adherence",
-                            "binary_qualitative",
+                            "binary",
                             "continuous_qualitative",
                             "numeric",
                             "enum"
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "1e3e27b342bfd8ec",
-                        "description": "Output shape of the evaluation score\n\n* `binary_workflow_adherence` - Binary Workflow Adherence\n* `binary_qualitative` - Binary Qualitative\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum"
+                        "x-spec-enum-id": "b40eac6824409cc2",
+                        "description": "Output shape of the evaluation score. Accepts canonical (binary, continuous_qualitative, numeric, enum); legacy binary_workflow_adherence and binary_qualitative are accepted and mapped to binary.\n\n* `binary` - Binary\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum"
                     },
                     "enum_values": {
                         "type": "array",
@@ -64652,15 +71131,14 @@
                     },
                     "eval_type": {
                         "enum": [
-                            "binary_workflow_adherence",
-                            "binary_qualitative",
+                            "binary",
                             "continuous_qualitative",
                             "numeric",
                             "enum"
                         ],
                         "type": "string",
-                        "description": "* `binary_workflow_adherence` - Binary Workflow Adherence\n* `binary_qualitative` - Binary Qualitative\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum",
-                        "x-spec-enum-id": "1e3e27b342bfd8ec"
+                        "description": "* `binary` - Binary\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum",
+                        "x-spec-enum-id": "b40eac6824409cc2"
                     },
                     "audio_enabled": {
                         "type": "boolean",
@@ -65090,7 +71568,7 @@
                         "description": "\nIs send emails enabled\nExample: `true` or `false`\n"
                     },
                     "rubric_config": {
-                        "description": "\nProject-level scoring rubric for evaluating call success. Each call log produced under this project is run against the rubric and gets a single pass/fail outcome based on its metric results.\n\nIMPORTANT (read before writing):\n- NEVER blindly overwrite this field. Always first GET the project, read the existing `rubric_config`, then merge in only the rule(s) you intend to add/update, and PATCH the full merged value. Sending a partial value will silently delete every rule you did not include.\n\nStructure:\n- `evaluation_logic`: MUST be `\"and\"`. All rules have to pass for a call to be marked successful. (Other values are not supported by the product currently.)\n- `rules`: List of rules. Use one rule per (metric, condition) — keep each rule simple, with a single condition inside.\n\nEach rule shape:\n```json\n{\n    \"metric_id\": <metric id>,\n    \"conditions\": {\n        \"operator\": \"and\",\n        \"conditions\": [\n            {\"field\": <field>, \"op\": <op>, \"value\": <value>}\n        ]\n    }\n}\n```\n\nWhat `field`, `op`, and `value` to use depends on the metric type. The three supported cases:\n\n1. Numeric / score metrics (qualitative scores, numeric metrics, workflow adherence with a score, etc.):\n   - `field`: `\"score\"`\n   - `op`: one of `\"gt\"`, `\"gte\"`, `\"lt\"`, `\"lte\"`, `\"eq\"`\n   - `value`: a number (qualitative scores are on a 0–5 scale)\n   - Example (score must be at least 4): `{\"field\": \"score\", \"op\": \"gte\", \"value\": 4}`\n\n2. Boolean / binary metrics (eval_type `binary_qualitative`, `binary_workflow_adherence`, or `evaluate_expected_outcome`):\n   - Boolean outcomes are stored as a score: True → `5`, False → `0`.\n   - `field`: `\"score\"`\n   - `op`: `\"eq\"` or `\"neq\"`\n   - `value`: `5` for True, `0` for False\n   - Example (must be True): `{\"field\": \"score\", \"op\": \"eq\", \"value\": 5}`\n   - Example (must be False): `{\"field\": \"score\", \"op\": \"eq\", \"value\": 0}`\n\n3. Enum metrics (eval_type `enum`, or `observability_topics` / `observability_dropoff`):\n   - `field`: `\"enum\"`\n   - `op`: `\"eq\"`, `\"neq\"`, or `\"in\"`\n   - `value`: a single string for `eq`/`neq`, or a list of strings for `in`. Must match one of the metric's defined `enum_values`.\n   - Example: `{\"field\": \"enum\", \"op\": \"eq\", \"value\": \"resolved\"}`\n   - Example (any of): `{\"field\": \"enum\", \"op\": \"in\", \"value\": [\"resolved\", \"partially_resolved\"]}`\n\nFull example:\n```json\n{\n    \"evaluation_logic\": \"and\",\n    \"rules\": [\n        {\n            \"metric_id\": 115164,\n            \"conditions\": {\n                \"operator\": \"and\",\n                \"conditions\": [\n                    {\"op\": \"eq\", \"field\": \"score\", \"value\": 5}\n                ]\n            }\n        },\n        {\n            \"metric_id\": 5512,\n            \"conditions\": {\n                \"operator\": \"and\",\n                \"conditions\": [\n                    {\"op\": \"gte\", \"field\": \"score\", \"value\": 4}\n                ]\n            }\n        },\n        {\n            \"metric_id\": 8821,\n            \"conditions\": {\n                \"operator\": \"and\",\n                \"conditions\": [\n                    {\"op\": \"in\", \"field\": \"enum\", \"value\": [\"resolved\", \"partially_resolved\"]}\n                ]\n            }\n        }\n    ]\n}\n```\n\nNotes:\n- `metric_id` must reference a metric belonging to this project (project-scoped or agent-scoped under this project); unknown ids are rejected.\n- Rules whose metric did not produce a value on a given call are skipped (neither pass nor fail) and do not affect the outcome.\n- Pass an empty object `{}` to clear the rubric.\n"
+                        "description": "\nProject-level scoring rubric for evaluating call success. Each call log produced under this project is run against the rubric and gets a single pass/fail outcome based on its metric results.\n\nIMPORTANT (read before writing):\n- NEVER blindly overwrite this field. Always first GET the project, read the existing `rubric_config`, then merge in only the rule(s) you intend to add/update, and PATCH the full merged value. Sending a partial value will silently delete every rule you did not include.\n\nStructure:\n- `evaluation_logic`: MUST be `\"and\"`. All rules have to pass for a call to be marked successful. (Other values are not supported by the product currently.)\n- `rules`: List of rules. Use one rule per (metric, condition) — keep each rule simple, with a single condition inside.\n\nEach rule shape:\n```json\n{\n    \"metric_id\": <metric id>,\n    \"conditions\": {\n        \"operator\": \"and\",\n        \"conditions\": [\n            {\"field\": <field>, \"op\": <op>, \"value\": <value>}\n        ]\n    }\n}\n```\n\nWhat `field`, `op`, and `value` to use depends on the metric type. The three supported cases:\n\n1. Numeric / score metrics (qualitative scores, numeric metrics, workflow adherence with a score, etc.):\n   - `field`: `\"score\"`\n   - `op`: one of `\"gt\"`, `\"gte\"`, `\"lt\"`, `\"lte\"`, `\"eq\"`\n   - `value`: a number (qualitative scores are on a 0–5 scale)\n   - Example (score must be at least 4): `{\"field\": \"score\", \"op\": \"gte\", \"value\": 4}`\n\n2. Boolean / binary metrics (eval_type `binary`, or `evaluate_expected_outcome`):\n   - `field`: `\"score\"`\n   - `op`: `\"eq\"` or `\"neq\"`\n   - `value`: `true` for pass, `false` for fail\n   - Example (must pass): `{\"field\": \"score\", \"op\": \"eq\", \"value\": true}`\n   - Example (must fail): `{\"field\": \"score\", \"op\": \"eq\", \"value\": false}`\n   - Legacy values `5` (pass) and `0` (fail) are still accepted for back-compat but new rules should use bool.\n\n3. Enum metrics (eval_type `enum`, or `observability_topics` / `observability_dropoff`):\n   - `field`: `\"enum\"`\n   - `op`: `\"eq\"`, `\"neq\"`, or `\"in\"`\n   - `value`: a single string for `eq`/`neq`, or a list of strings for `in`. Must match one of the metric's defined `enum_values`.\n   - Example: `{\"field\": \"enum\", \"op\": \"eq\", \"value\": \"resolved\"}`\n   - Example (any of): `{\"field\": \"enum\", \"op\": \"in\", \"value\": [\"resolved\", \"partially_resolved\"]}`\n\nFull example:\n```json\n{\n    \"evaluation_logic\": \"and\",\n    \"rules\": [\n        {\n            \"metric_id\": 115164,\n            \"conditions\": {\n                \"operator\": \"and\",\n                \"conditions\": [\n                    {\"op\": \"eq\", \"field\": \"score\", \"value\": true}\n                ]\n            }\n        },\n        {\n            \"metric_id\": 5512,\n            \"conditions\": {\n                \"operator\": \"and\",\n                \"conditions\": [\n                    {\"op\": \"gte\", \"field\": \"score\", \"value\": 4}\n                ]\n            }\n        },\n        {\n            \"metric_id\": 8821,\n            \"conditions\": {\n                \"operator\": \"and\",\n                \"conditions\": [\n                    {\"op\": \"in\", \"field\": \"enum\", \"value\": [\"resolved\", \"partially_resolved\"]}\n                ]\n            }\n        }\n    ]\n}\n```\n\nNotes:\n- `metric_id` must reference a metric belonging to this project (project-scoped or agent-scoped under this project); unknown ids are rejected.\n- Rules whose metric did not produce a value on a given call are skipped (neither pass nor fail) and do not affect the outcome.\n- Pass an empty object `{}` to clear the rubric.\n"
                     },
                     "timezone": {
                         "type": "string",
@@ -65696,7 +72174,7 @@
                     "critical_categories": {
                         "type": "string",
                         "readOnly": true,
-                        "description": "\nList of critical categories for this result\nExample:\n```json\n[\n    {\n      \"id\": 2950,\n      \"name\": \"Pronunciation Analysis\",\n      \"eval_type\": \"continuous_qualitative\",\n      \"simulation_enabled\": true,\n      \"observability_enabled\": true\n    },\n    {\n      \"id\": 3284,\n      \"name\": \"Latency\",\n      \"eval_type\": \"numeric\",\n      \"simulation_enabled\": true,\n      \"observability_enabled\": false\n    },\n    {\n      \"id\": 3295,\n      \"name\": \"Detect Silence in Conversation\",\n      \"eval_type\": \"binary_qualitative\",\n      \"simulation_enabled\": true,\n      \"observability_enabled\": true\n    }\n  ]\n```\n"
+                        "description": "\nList of critical categories for this result\nExample:\n```json\n[\n    {\n      \"id\": 2950,\n      \"name\": \"Pronunciation Analysis\",\n      \"eval_type\": \"continuous_qualitative\",\n      \"simulation_enabled\": true,\n      \"observability_enabled\": true\n    },\n    {\n      \"id\": 3284,\n      \"name\": \"Latency\",\n      \"eval_type\": \"numeric\",\n      \"simulation_enabled\": true,\n      \"observability_enabled\": false\n    },\n    {\n      \"id\": 3295,\n      \"name\": \"Detect Silence in Conversation\",\n      \"eval_type\": \"binary\",\n      \"simulation_enabled\": true,\n      \"observability_enabled\": true\n    }\n  ]\n```\n"
                     },
                     "metrics": {
                         "type": "string",
@@ -69061,15 +75539,14 @@
                     },
                     "eval_type": {
                         "enum": [
-                            "binary_workflow_adherence",
-                            "binary_qualitative",
+                            "binary",
                             "continuous_qualitative",
                             "numeric",
                             "enum"
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "1e3e27b342bfd8ec",
-                        "description": "Output shape of the evaluation score\n\n* `binary_workflow_adherence` - Binary Workflow Adherence\n* `binary_qualitative` - Binary Qualitative\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum"
+                        "x-spec-enum-id": "b40eac6824409cc2",
+                        "description": "Output shape of the evaluation score. Accepts canonical (binary, continuous_qualitative, numeric, enum); legacy binary_workflow_adherence and binary_qualitative are accepted and mapped to binary.\n\n* `binary` - Binary\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum"
                     },
                     "enum_values": {
                         "type": "array",

--- a/openapi.json
+++ b/openapi.json
@@ -25,6 +25,42 @@
                 "description": ".well known oauth authorization server"
             }
         },
+        "/a8c8aef15013e2e52ccf6000350258a1eab6cd2a11e62f592c5e19092d7204d7/run/": {
+            "get": {
+                "operationId": "a8c8aef15013e2e52ccf6000350258a1eab6cd2a11e62f592c5e19092d7204d7",
+                "tags": [
+                    "a8c8aef15013e2e52ccf6000350258a1eab6cd2a11e62f592c5e19092d7204d7"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No response body"
+                    }
+                },
+                "description": "A8c8aef15013e2e52ccf6000350258a1eab6cd2a11e62f592c5e19092d7204d7"
+            },
+            "post": {
+                "operationId": "a8c8aef15013e2e52ccf6000350258a1eab6cd2a11e62f592c5e19092d7204d7_2",
+                "tags": [
+                    "a8c8aef15013e2e52ccf6000350258a1eab6cd2a11e62f592c5e19092d7204d7"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No response body"
+                    }
+                },
+                "description": "A8c8aef15013e2e52ccf6000350258a1eab6cd2a11e62f592c5e19092d7204d7"
+            }
+        },
         "/app/otel/validate/": {
             "get": {
                 "operationId": "app-otel-validate-retrieve",
@@ -5842,7 +5878,7 @@
         "/observability/v1/deep-research-insights/generate/": {
             "post": {
                 "operationId": "deep-research-insights-generate-create",
-                "description": "Queue a Deep Research audit; returns the new row in ``pending``.\n\nCost: ``get_deep_research_cost()`` credits per press that actually\nqueues a fresh audit — spam protection for an expensive\nModal-sandboxed agent run. The price is admin-configurable via the\n``DEEP_RESEARCH_GENERATION_COST`` SettingValue. Insufficient\nbalance → HTTP 402 from the global exception handler before any\nwork is queued. A press that only gets an already-in-flight row\nback (double-click while one is still running) is not charged.",
+                "description": "Queue a Deep Research audit; returns the new row in ``pending``.",
                 "tags": [
                     "observability"
                 ],
@@ -5885,10 +5921,10 @@
                 }
             }
         },
-        "/observability/v1/deep-research-insights/pricing/": {
-            "get": {
-                "operationId": "deep-research-insights-pricing-retrieve",
-                "description": "Flat credit cost of a Deep Research ``Generate`` press.\n\nLets the FE label the button with the live price (e.g. \"Generate\n(20 credits)\") instead of hardcoding a number that would drift\nfrom the admin-set ``DEEP_RESEARCH_GENERATION_COST``. Scoped by\n``?project=<id>`` so the standard project-access permission check\napplies; the price itself is global.",
+        "/observability/v1/elevenlabs/observe/": {
+            "post": {
+                "operationId": "elevenlabs-observe-create",
+                "description": "Handle incoming ElevenLabs webhook requests.\n\nThis endpoint processes webhook requests from the ElevenLabs service, validates the request data,\nand creates a call log entry based on the received data. ElevenLabs sends webhooks at the end of the call,\nproviding important information about the interaction.",
                 "tags": [
                     "observability"
                 ],
@@ -5899,14 +5935,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/DeepResearchInsight"
-                                }
-                            }
-                        },
-                        "description": ""
+                        "description": "No response body"
                     }
                 }
             }
@@ -6053,7 +6082,7 @@
         "/observability/v1/metric-failure-mode-insights/bulk_generate/": {
             "post": {
                 "operationId": "metric-failure-mode-insights-bulk-generate-create",
-                "description": "Fan out audits to every eligible metric in the project.\n\nTriggered by the Insights page's \"Generate\" button. Uses the\nsliding ``T-24h`` to ``T`` window (where ``T`` is now), so the\nresult is fresh even between the daily cron firings. Returns\nthe new insight rows so the FE can poll their status.\n\nMetrics with no failing calls in the window get a\n``skipped_no_failures`` marker row (no Celery task queued);\nmetrics already mid-run from a recent cron are returned as-is\ninstead of being re-queued (dedupe inside the kickoff helper).\n\nCost: ``get_insight_generation_cost()`` credits per metric that\nactually produces an insight (i.e. had ≥1 failing call in the 24h\nwindow). Eligible metrics with no failing calls generate nothing\nand are not charged — you pay only for the insight cards you get.\nThe per-metric price is admin-configurable via the\n``INSIGHT_GENERATION_COST`` SettingValue. Insufficient balance →\nHTTP 402 from the global exception handler before any work is\nqueued.",
+                "description": "Fan out audits to every eligible metric in the project.\n\nTriggered by the Insights page's \"Generate\" button. Uses the\nsliding ``T-24h`` to ``T`` window (where ``T`` is now), so the\nresult is fresh even between the daily cron firings. Returns\nthe new insight rows so the FE can poll their status.\n\nMetrics with no failing calls in the window get a\n``skipped_no_failures`` marker row (no Celery task queued);\nmetrics already mid-run from a recent cron are returned as-is\ninstead of being re-queued (dedupe inside the kickoff helper).",
                 "tags": [
                     "observability"
                 ],
@@ -6134,32 +6163,6 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/MetricFailureModeInsightGenerate"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
-        },
-        "/observability/v1/metric-failure-mode-insights/pricing/": {
-            "get": {
-                "operationId": "metric-failure-mode-insights-pricing-retrieve",
-                "description": "Per-metric credit cost of a manual Insights ``Generate`` press.\n\nLets the FE label the button with the live price (e.g. \"Generate\n(10 credits/metric)\") instead of hardcoding a number that would\ndrift from the admin-set ``INSIGHT_GENERATION_COST``. Scoped by\n``?project=<id>`` so the standard project-access permission check\napplies; the price itself is global.",
-                "tags": [
-                    "observability"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/MetricFailureModeInsight"
                                 }
                             }
                         },
@@ -10365,6 +10368,25 @@
                 ],
                 "responses": {
                     "204": {
+                        "description": "No response body"
+                    }
+                }
+            }
+        },
+        "/test_framework/test-outbound-caller/": {
+            "post": {
+                "operationId": "test-framework-test-outbound-caller-create",
+                "description": "API view to test outbound calls.\nThis view allows users to run scenarios associated with a specific agent\nby updating the phone number in the VAPI system.",
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
                         "description": "No response body"
                     }
                 }
@@ -15959,7 +15981,7 @@
                                                 "description": "<string>",
                                                 "function_name": "<string>",
                                                 "type": "basic",
-                                                "eval_type": "binary_workflow_adherence",
+                                                "eval_type": "binary",
                                                 "enum_values": [
                                                     "<string>"
                                                 ],
@@ -16002,7 +16024,7 @@
                                                 "description": "<string>",
                                                 "function_name": "<string>",
                                                 "type": "basic",
-                                                "eval_type": "binary_workflow_adherence",
+                                                "eval_type": "binary",
                                                 "enum_values": [
                                                     "<string>"
                                                 ],
@@ -16043,14 +16065,6 @@
                             }
                         },
                         "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "metrics-list",
-                        "description": "\nmetrics_list: List quality metrics (LLM-judge prompts, custom code, or predefined metrics) used to evaluate AI voice agents. Filter by `agent_id` or `project_id` to scope results.\n\nFiltering behavior:\n- If only agent_id is provided: Returns metrics associated with that agent only\n- If only project_id is provided: Returns metrics associated with that project only\n- If both agent_id and project_id are provided: Returns metrics from both the agent and the project\n- If agents is provided: Returns metrics where any of the specified agents are in the M2M agents field\n- If slug is provided: Returns the metric with that specific slug\n\nPerformance tip: `agent_id` (when a specific agent is in context) or `project_id` will narrow the result. Orgs can accumulate hundreds of metrics so a filter usually helps.\n        "
                     }
                 }
             },
@@ -16156,14 +16170,6 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "metrics-create",
-                        "description": "Create a quality metric for evaluating agent conversations.\n\n**Two supported types on create** (the `BASIC` and `CUSTOM_PROMPT` values are deprecated and rejected on create):\n\n- `llm_judge` — an LLM-as-judge metric. Put the evaluation criterion in `description`. Most common choice for qualitative scoring (politeness, compliance, resolution quality, etc.).\n\n- `custom_code` — Python code that receives the transcript and returns a score. Put the code in `custom_code`. Use for deterministic checks (regex matches, tool-call ordering, structured-field extraction, etc.).\n\n**Scope:** metrics must be created at the project level — pass `project` (project ID). Agent-level metrics are deprecated; if you pass `agent`, the server silently creates a project-level metric and returns a deprecation warning.\n\n**Evaluation control:** `observability_enabled` runs the metric on production calls (via CallLog); `simulation_enabled` runs it on test runs; `sampling_enabled` enables statistical sampling. `eval_type` picks the output shape (`bool`, `int`, `float`, `enum`, `string`); when `eval_type=\"enum\"`, also pass `enum_values`.\n\n**Triggering:** pass `trigger_type` + `evaluation_trigger_prompt` to gate the metric to only fire on specific call patterns (see the metric-triggers guide)."
-                    }
                 }
             }
         },
@@ -16257,7 +16263,7 @@
                                                 "description": "<string>",
                                                 "function_name": "<string>",
                                                 "type": "basic",
-                                                "eval_type": "binary_workflow_adherence",
+                                                "eval_type": "binary",
                                                 "enum_values": [
                                                     "<string>"
                                                 ],
@@ -16300,7 +16306,7 @@
                                                 "description": "<string>",
                                                 "function_name": "<string>",
                                                 "type": "basic",
-                                                "eval_type": "binary_workflow_adherence",
+                                                "eval_type": "binary",
                                                 "enum_values": [
                                                     "<string>"
                                                 ],
@@ -16502,7 +16508,7 @@
             },
             "put": {
                 "operationId": "metrics-external-update",
-                "description": "Fully replace a metric's fields. Prefer `PATCH` (partial_update) unless you specifically need full-replacement semantics. Same field shape as create.",
+                "description": "Update a metric (full)",
                 "summary": "Update a metric (full)",
                 "parameters": [
                     {
@@ -16761,7 +16767,7 @@
         "/test_framework/v1/metrics-external/{id}/apply_optimisation_proposal/": {
             "post": {
                 "operationId": "metrics-external-apply-optimisation-proposal-create",
-                "description": "Copies the fields from `pending_optimisation_proposal` (description, evaluation_trigger, type, custom_code) into the live metric columns and clears the proposal. 400 if no pending proposal exists.",
+                "description": "Apply a pending optimisation proposal",
                 "summary": "Apply a pending optimisation proposal",
                 "parameters": [
                     {
@@ -16792,7 +16798,7 @@
         "/test_framework/v1/metrics-external/{id}/dismiss_optimisation_proposal/": {
             "post": {
                 "operationId": "metrics-external-dismiss-optimisation-proposal-create",
-                "description": "Discards the metric's `pending_optimisation_proposal` without applying. Idempotent — a metric with no pending proposal returns 200.",
+                "description": "Dismiss a pending optimisation proposal",
                 "summary": "Dismiss a pending optimisation proposal",
                 "parameters": [
                     {
@@ -16994,7 +17000,7 @@
         "/test_framework/v1/metrics-external/{id}/history/": {
             "get": {
                 "operationId": "metrics-external-history-list",
-                "description": "Return paginated change history for a metric, including agents snapshot at each point.",
+                "description": "Metrics history",
                 "parameters": [
                     {
                         "in": "path",
@@ -17101,7 +17107,7 @@
         "/test_framework/v1/metrics-external/{id}/restore/": {
             "post": {
                 "operationId": "metrics-external-restore-create",
-                "description": "Restore a metric to a previous historical state, creating a new history record.",
+                "description": "Metrics restore",
                 "parameters": [
                     {
                         "in": "path",
@@ -17158,7 +17164,7 @@
         "/test_framework/v1/metrics-external/{id}/run_reviews/": {
             "post": {
                 "operationId": "metrics-external-run-reviews-create",
-                "description": "Re-evaluate all test sets for this metric with optional overrides. Returns a progress_id to poll for completion.",
+                "description": "Run metric reviews to identify improvement opportunities",
                 "parameters": [
                     {
                         "in": "path",
@@ -17336,7 +17342,7 @@
         "/test_framework/v1/metrics-external/bulk_create/": {
             "post": {
                 "operationId": "metrics-bulk-create",
-                "description": "Atomic bulk creation of project-level metrics. Pass a JSON array of metric objects with the same field shape as `metrics_create`. All entries succeed together or the whole request fails validation.",
+                "description": "Create multiple metrics in a single request",
                 "summary": "Create multiple metrics in a single request",
                 "tags": [
                     "test_framework"
@@ -17413,7 +17419,7 @@
         "/test_framework/v1/metrics-external/bulk_manage_agents/": {
             "post": {
                 "operationId": "metrics-external-bulk-manage-agents-create",
-                "description": "Bulk enable or disable metrics for multiple agents",
+                "description": "Metrics bulk manage agents",
                 "tags": [
                     "test_framework"
                 ],
@@ -17557,7 +17563,7 @@
         "/test_framework/v1/metrics-external/generate_clean_description/": {
             "post": {
                 "operationId": "metrics-external-generate-clean-description-create",
-                "description": "Generate a clean metric description based on agent description and metric description.",
+                "description": "Metrics generate clean description",
                 "tags": [
                     "test_framework"
                 ],
@@ -17603,7 +17609,7 @@
         "/test_framework/v1/metrics-external/generate_clean_description_bg/": {
             "post": {
                 "operationId": "metrics-external-generate-clean-description-bg-create",
-                "description": "Enqueue a background job to generate a clean metric description. Returns a `progress_id`; poll `generate_clean_description_progress` until `status` is `completed` or `failed`.",
+                "description": "Start async clean description generation",
                 "summary": "Start async clean description generation",
                 "tags": [
                     "test_framework"
@@ -17650,7 +17656,7 @@
         "/test_framework/v1/metrics-external/generate_clean_description_progress/": {
             "get": {
                 "operationId": "metrics-external-generate-clean-description-progress-retrieve",
-                "description": "Poll the result of a `generate_clean_description_bg` job. `status` is one of: `queued`, `processing`, `completed`, `failed`. On `completed`, `clean_description` and `thinking` are present.",
+                "description": "Poll async clean description generation",
                 "summary": "Poll async clean description generation",
                 "parameters": [
                     {
@@ -17688,7 +17694,7 @@
         "/test_framework/v1/metrics-external/generate_evaluation_trigger/": {
             "post": {
                 "operationId": "metrics-external-generate-evaluation-trigger-create",
-                "description": "Generate an evaluation trigger based on agent description and metric description.",
+                "description": "Metrics generate evaluation trigger",
                 "tags": [
                     "test_framework"
                 ],
@@ -17797,7 +17803,7 @@
         "/test_framework/v1/metrics-external/generate_metrics_progress/": {
             "get": {
                 "operationId": "metrics-external-generate-metrics-progress-retrieve",
-                "description": "Poll the progress of metric generation. Returns current state including status and generated metrics.",
+                "description": "Metrics generate metrics progress",
                 "parameters": [
                     {
                         "in": "query",
@@ -17827,7 +17833,7 @@
         "/test_framework/v1/metrics-external/preview/": {
             "post": {
                 "operationId": "metrics-external-preview-create",
-                "description": "Preview metric evaluation on call logs or runs before creating it. Supports up to 10 items. Returns progress_id to poll for results.",
+                "description": "Preview metric evaluation against sample transcripts",
                 "tags": [
                     "test_framework"
                 ],
@@ -17866,7 +17872,7 @@
         "/test_framework/v1/metrics-external/preview-progress/": {
             "get": {
                 "operationId": "metrics-preview-progress",
-                "description": "Poll the progress of metric preview. Returns current state with evaluation results.",
+                "description": "Metrics preview progress",
                 "parameters": [
                     {
                         "in": "query",
@@ -17896,7 +17902,7 @@
         "/test_framework/v1/metrics-external/run_reviews_progress/": {
             "get": {
                 "operationId": "metrics-run-reviews-progress",
-                "description": "Poll the progress of metric re-evaluation. Returns current state and full metric data when complete.",
+                "description": "Metrics run reviews progress",
                 "parameters": [
                     {
                         "in": "query",
@@ -17988,7 +17994,7 @@
         "/test_framework/v1/metrics-external/simplify_prompt/": {
             "post": {
                 "operationId": "metrics-external-simplify-prompt-create",
-                "description": "Simplify a verbose metric prompt into a minimal algorithmic version. Returns immediately if metric is already optimized, otherwise returns a progress_id for polling.",
+                "description": "Metrics simplify prompt",
                 "tags": [
                     "test_framework"
                 ],
@@ -18034,7 +18040,7 @@
         "/test_framework/v1/metrics-external/simplify_prompt_progress/": {
             "get": {
                 "operationId": "metrics-external-simplify-prompt-progress-retrieve",
-                "description": "Poll the progress of async prompt simplification.",
+                "description": "Metrics simplify prompt progress",
                 "parameters": [
                     {
                         "in": "query",
@@ -18117,19 +18123,11 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "metrics-retrieve",
-                        "description": "Retrieve a specific metric by ID or slug."
-                    }
                 }
             },
             "put": {
                 "operationId": "metrics-update",
-                "description": "Fully replace a metric's fields. Prefer `PATCH` (partial_update) unless you specifically need full-replacement semantics. Same field shape as create.",
+                "description": "Update a metric (full)",
                 "summary": "Update a metric (full)",
                 "parameters": [
                     {
@@ -18281,14 +18279,6 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "metrics-partial-update",
-                        "description": "Partially update a metric. Same field shape as create — see `metrics_create` for details.\n\n**Note:** `project` and `agent` are read-only once set — you cannot move a metric between projects/agents after creation. To relocate, create a new metric and delete the old one."
-                    }
                 }
             },
             "delete": {
@@ -18332,14 +18322,6 @@
                             }
                         },
                         "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "metrics-destroy",
-                        "description": "⚠ Irreversible. Deletes the metric and detaches it from all agents and evaluators. Dashboard widgets that displayed this metric are also removed."
                     }
                 }
             }
@@ -18404,7 +18386,7 @@
         "/test_framework/v1/metrics/{id}/apply_optimisation_proposal/": {
             "post": {
                 "operationId": "metrics-apply-optimisation-proposal-create",
-                "description": "Copies the fields from `pending_optimisation_proposal` (description, evaluation_trigger, type, custom_code) into the live metric columns and clears the proposal. 400 if no pending proposal exists.",
+                "description": "Apply a pending optimisation proposal",
                 "summary": "Apply a pending optimisation proposal",
                 "parameters": [
                     {
@@ -18435,7 +18417,7 @@
         "/test_framework/v1/metrics/{id}/dismiss_optimisation_proposal/": {
             "post": {
                 "operationId": "metrics-dismiss-optimisation-proposal-create",
-                "description": "Discards the metric's `pending_optimisation_proposal` without applying. Idempotent — a metric with no pending proposal returns 200.",
+                "description": "Dismiss a pending optimisation proposal",
                 "summary": "Dismiss a pending optimisation proposal",
                 "parameters": [
                     {
@@ -18637,7 +18619,7 @@
         "/test_framework/v1/metrics/{id}/history/": {
             "get": {
                 "operationId": "metrics-history-list",
-                "description": "Return paginated change history for a metric, including agents snapshot at each point.",
+                "description": "Metrics history",
                 "parameters": [
                     {
                         "in": "path",
@@ -18744,7 +18726,7 @@
         "/test_framework/v1/metrics/{id}/restore/": {
             "post": {
                 "operationId": "metrics-restore-create",
-                "description": "Restore a metric to a previous historical state, creating a new history record.",
+                "description": "Metrics restore",
                 "parameters": [
                     {
                         "in": "path",
@@ -18801,7 +18783,7 @@
         "/test_framework/v1/metrics/{id}/run_reviews/": {
             "post": {
                 "operationId": "metrics-run-reviews-create",
-                "description": "Re-evaluate all test sets for this metric with optional overrides. Returns a progress_id to poll for completion.",
+                "description": "Run metric reviews to identify improvement opportunities",
                 "parameters": [
                     {
                         "in": "path",
@@ -18843,14 +18825,6 @@
                 "responses": {
                     "200": {
                         "description": "Returns progress_id for tracking progress"
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "metrics-run-reviews-create",
-                        "description": "Re-evaluate all test sets for this metric with optional overrides. Returns a progress_id to poll for completion."
                     }
                 }
             }
@@ -18987,7 +18961,7 @@
         "/test_framework/v1/metrics/bulk_create/": {
             "post": {
                 "operationId": "metrics-bulk-create_2",
-                "description": "Atomic bulk creation of project-level metrics. Pass a JSON array of metric objects with the same field shape as `metrics_create`. All entries succeed together or the whole request fails validation.",
+                "description": "Create multiple metrics in a single request",
                 "summary": "Create multiple metrics in a single request",
                 "tags": [
                     "test_framework"
@@ -19058,21 +19032,13 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "metrics-bulk-create",
-                        "description": "Atomic bulk creation of project-level metrics. Pass a JSON array of metric objects with the same field shape as `metrics_create`. All entries succeed together or the whole request fails validation."
-                    }
                 }
             }
         },
         "/test_framework/v1/metrics/bulk_manage_agents/": {
             "post": {
                 "operationId": "metrics-bulk-manage-agents-create",
-                "description": "Bulk enable or disable metrics for multiple agents",
+                "description": "Metrics bulk manage agents",
                 "tags": [
                     "test_framework"
                 ],
@@ -19216,7 +19182,7 @@
         "/test_framework/v1/metrics/generate_clean_description/": {
             "post": {
                 "operationId": "metrics-generate-clean-description-create",
-                "description": "Generate a clean metric description based on agent description and metric description.",
+                "description": "Metrics generate clean description",
                 "tags": [
                     "test_framework"
                 ],
@@ -19256,21 +19222,13 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "metrics-generate-clean-description-create",
-                        "description": "Generate a clean metric description based on agent description and metric description."
-                    }
                 }
             }
         },
         "/test_framework/v1/metrics/generate_clean_description_bg/": {
             "post": {
                 "operationId": "metrics-generate-clean-description-bg-create",
-                "description": "Enqueue a background job to generate a clean metric description. Returns a `progress_id`; poll `generate_clean_description_progress` until `status` is `completed` or `failed`.",
+                "description": "Start async clean description generation",
                 "summary": "Start async clean description generation",
                 "tags": [
                     "test_framework"
@@ -19311,21 +19269,13 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "metrics-generate-clean-description-bg-create",
-                        "description": "Enqueue a background job to generate a clean metric description. Returns a `progress_id`; poll `generate_clean_description_progress` until `status` is `completed` or `failed`."
-                    }
                 }
             }
         },
         "/test_framework/v1/metrics/generate_clean_description_progress/": {
             "get": {
                 "operationId": "metrics-generate-clean-description-progress-retrieve",
-                "description": "Poll the result of a `generate_clean_description_bg` job. `status` is one of: `queued`, `processing`, `completed`, `failed`. On `completed`, `clean_description` and `thinking` are present.",
+                "description": "Poll async clean description generation",
                 "summary": "Poll async clean description generation",
                 "parameters": [
                     {
@@ -19357,21 +19307,13 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "metrics-generate-clean-description-progress-retrieve",
-                        "description": "Poll the result of a `generate_clean_description_bg` job. `status` is one of: `queued`, `processing`, `completed`, `failed`. On `completed`, `clean_description` and `thinking` are present."
-                    }
                 }
             }
         },
         "/test_framework/v1/metrics/generate_evaluation_trigger/": {
             "post": {
                 "operationId": "metrics-generate-evaluation-trigger-create",
-                "description": "Generate an evaluation trigger based on agent description and metric description.",
+                "description": "Metrics generate evaluation trigger",
                 "tags": [
                     "test_framework"
                 ],
@@ -19410,14 +19352,6 @@
                             }
                         },
                         "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "metrics-generate-evaluation-trigger-create",
-                        "description": "Generate an evaluation trigger based on agent description and metric description."
                     }
                 }
             }
@@ -19482,21 +19416,13 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "metrics-generate",
-                        "description": "Generates suggested metrics for an AI agent. Returns a `progress_id` to poll via `generate_metrics_progress`. Results appear in the progress response but are not saved automatically — pass them to the metrics bulk create endpoint to persist. The agent must have a description of at least 100 characters."
-                    }
                 }
             }
         },
         "/test_framework/v1/metrics/generate_metrics_progress/": {
             "get": {
                 "operationId": "metrics-generate-metrics-progress-retrieve",
-                "description": "Poll the progress of metric generation. Returns current state including status and generated metrics.",
+                "description": "Metrics generate metrics progress",
                 "parameters": [
                     {
                         "in": "query",
@@ -19520,21 +19446,13 @@
                     "200": {
                         "description": "Returns generation state with status and generated metrics"
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "metrics-generate-metrics-progress-retrieve",
-                        "description": "Poll the progress of metric generation. Returns current state including status and generated metrics."
-                    }
                 }
             }
         },
         "/test_framework/v1/metrics/preview/": {
             "post": {
                 "operationId": "metrics-preview-create",
-                "description": "Preview metric evaluation on call logs or runs before creating it. Supports up to 10 items. Returns progress_id to poll for results.",
+                "description": "Preview metric evaluation against sample transcripts",
                 "tags": [
                     "test_framework"
                 ],
@@ -19567,21 +19485,13 @@
                     "200": {
                         "description": "Returns progress_id for tracking progress"
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "metrics-preview-create",
-                        "description": "Preview metric evaluation on call logs or runs before creating it. Supports up to 10 items. Returns progress_id to poll for results."
-                    }
                 }
             }
         },
         "/test_framework/v1/metrics/preview-progress/": {
             "get": {
                 "operationId": "metrics-preview-progress_2",
-                "description": "Poll the progress of metric preview. Returns current state with evaluation results.",
+                "description": "Metrics preview progress",
                 "parameters": [
                     {
                         "in": "query",
@@ -19605,21 +19515,13 @@
                     "200": {
                         "description": "Returns preview state with status and results"
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "metrics-preview-progress",
-                        "description": "Poll the progress of metric preview. Returns current state with evaluation results."
-                    }
                 }
             }
         },
         "/test_framework/v1/metrics/run_reviews_progress/": {
             "get": {
                 "operationId": "metrics-run-reviews-progress_2",
-                "description": "Poll the progress of metric re-evaluation. Returns current state and full metric data when complete.",
+                "description": "Metrics run reviews progress",
                 "parameters": [
                     {
                         "in": "query",
@@ -19658,14 +19560,6 @@
                 "responses": {
                     "200": {
                         "description": "Returns progress state with completed/failed counts and metric data when finished"
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "metrics-run-reviews-progress",
-                        "description": "Poll the progress of metric re-evaluation. Returns current state and full metric data when complete."
                     }
                 }
             }
@@ -19719,7 +19613,7 @@
         "/test_framework/v1/metrics/simplify_prompt/": {
             "post": {
                 "operationId": "metrics-simplify-prompt-create",
-                "description": "Simplify a verbose metric prompt into a minimal algorithmic version. Returns immediately if metric is already optimized, otherwise returns a progress_id for polling.",
+                "description": "Metrics simplify prompt",
                 "tags": [
                     "test_framework"
                 ],
@@ -19759,21 +19653,13 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "metrics-simplify-prompt-create",
-                        "description": "Simplify a verbose metric prompt into a minimal algorithmic version. Returns immediately if metric is already optimized, otherwise returns a progress_id for polling."
-                    }
                 }
             }
         },
         "/test_framework/v1/metrics/simplify_prompt_progress/": {
             "get": {
                 "operationId": "metrics-simplify-prompt-progress-retrieve",
-                "description": "Poll the progress of async prompt simplification.",
+                "description": "Metrics simplify prompt progress",
                 "parameters": [
                     {
                         "in": "query",
@@ -19803,14 +19689,6 @@
                             }
                         },
                         "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "metrics-simplify-prompt-progress-retrieve",
-                        "description": "Poll the progress of async prompt simplification."
                     }
                 }
             }
@@ -23077,40 +22955,6 @@
                 }
             }
         },
-        "/test_framework/v1/results-external/{id}/regenerate_ai_summary/": {
-            "post": {
-                "operationId": "results-external-regenerate-ai-summary-create",
-                "description": "Queue a background job that regenerates the structured AI summary (what_happened / why_it_happened / how_to_fix) and recommended next steps for this result, based on its current failure clusters. The new summary appears on the next `results_retrieve` call once the job finishes.",
-                "summary": "Regenerate the AI summary for a result",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "A unique integer value identifying this result.",
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "Results"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "202": {
-                        "description": "Regeneration queued; poll results_retrieve to see the new ai_summary / next_steps."
-                    },
-                    "404": {
-                        "description": "Result not found"
-                    }
-                }
-            }
-        },
         "/test_framework/v1/results-external/{id}/rerun/": {
             "post": {
                 "operationId": "results-external-rerun-create",
@@ -24211,40 +24055,6 @@
                         "enabled": true,
                         "name": "results-evaluate-metrics-create",
                         "description": "Evaluate metrics against result transcripts"
-                    }
-                }
-            }
-        },
-        "/test_framework/v1/results/{id}/regenerate_ai_summary/": {
-            "post": {
-                "operationId": "results-regenerate-ai-summary-create",
-                "description": "Queue a background job that regenerates the structured AI summary (what_happened / why_it_happened / how_to_fix) and recommended next steps for this result, based on its current failure clusters. The new summary appears on the next `results_retrieve` call once the job finishes.",
-                "summary": "Regenerate the AI summary for a result",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "A unique integer value identifying this result.",
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "Results"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "202": {
-                        "description": "Regeneration queued; poll results_retrieve to see the new ai_summary / next_steps."
-                    },
-                    "404": {
-                        "description": "Result not found"
                     }
                 }
             }
@@ -29503,7 +29313,7 @@
         "/test_framework/v1/scenarios-external/generate-bg/": {
             "post": {
                 "operationId": "scenarios-generate-bg",
-                "description": "Generate scenarios for a given agent in the background. Returns a `progress_id` immediately; poll GET /scenarios/generate-progress/?progress_id={id} until `total_scenarios == completed_scenarios`.\n\n**What happens automatically on generation:**\n- A scenario-specific test profile is created and its `information` is populated using the sectioned shape: `main_agent_variables` (dynamic-variable values that reach the agent under test at call time — e.g. `user_id`, `account_id`) and `testing_agent_variables` (persona/context used by the simulated caller — e.g. `customer_name`, `date_of_birth`). Section values are kept consistent with any generated mock-tool data.\n- 10 project-level evaluation metrics are attached to every generated scenario automatically (e.g. Latency, Pitch, Interruption Score). Scenarios created manually via `scenarios_create` start with no metrics attached.\n\n**Response fields:** `progress_id` (UUID string) for polling; `session_id` is always null.",
+                "description": "Generate scenarios for a given agent in the background. Returns a `progress_id` immediately; poll GET /scenarios/generate-progress/?progress_id={id} until `total_scenarios == completed_scenarios`.\n\n**What happens automatically on generation:**\n- A default test profile is created for the agent if none exists. Each generated scenario will have `test_profile_data` populated with synthetic caller information (name, address, phone, email).\n- 10 project-level evaluation metrics are attached to every generated scenario automatically (e.g. Latency, Pitch, Interruption Score). Scenarios created manually via `scenarios_create` start with no metrics attached.\n\n**Response fields:** `progress_id` (UUID string) for polling; `session_id` is always null.",
                 "tags": [
                     "test_framework"
                 ],
@@ -30036,10 +29846,148 @@
                 }
             }
         },
+        "/test_framework/v1/scenarios-external/run_full_scenario_demo/": {
+            "post": {
+                "operationId": "scenarios-external-run-full-scenario-demo-create",
+                "description": "Complete demo flow for \"try it yourself\" free report feature.\n\nThis endpoint handles:\n1. OTP generation and validation for work email\n2. Agent creation under demo project\n3. Scenario generation\n4. Phone call execution\n5. Email report delivery",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Scenario"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Scenario"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Scenario"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Scenario"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/scenarios-external/run_full_scenario_demo_details/": {
+            "post": {
+                "operationId": "scenarios-external-run-full-scenario-demo-details-create",
+                "description": "Scenarios run full scenario demo details",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Scenario"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Scenario"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Scenario"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Scenario"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/scenarios-external/run_full_scenario_demo_email/": {
+            "post": {
+                "operationId": "scenarios-external-run-full-scenario-demo-email-create",
+                "description": "Scenarios run full scenario demo email",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Scenario"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Scenario"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Scenario"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Scenario"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/test_framework/v1/scenarios-external/run_scenarios/": {
             "post": {
                 "operationId": "scenarios-run-voice",
-                "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing. Requires `telephony.phone_number` configured on the agent (any provider).\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.",
+                "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing.\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others:**\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.",
                 "summary": "Run evaluators over a voice call",
                 "tags": [
                     "Evaluators"
@@ -30298,7 +30246,7 @@
         "/test_framework/v1/scenarios-external/run_scenarios_agora/": {
             "post": {
                 "operationId": "scenarios-run-agora",
-                "description": "AGORA RTC VOICE RUN: Execute evaluators against an agent reachable in an Agora RTC channel. Cekura joins the channel as a participant and converses. The agent must have `agora_data.session_endpoint_url` configured — an endpoint that mints the per-call channel and token; Cekura calls it at run time and never stores the join details.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC",
+                "description": "AGORA RTC VOICE RUN: Execute evaluators against an agent reachable in an Agora RTC channel. Cekura joins the channel as a participant and converses. The agent must have `agora_data.session_endpoint_url` configured — an endpoint that mints the per-call channel and token; Cekura calls it at run time and never stores the join details.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC",
                 "summary": "Run evaluators against an agent in an Agora RTC channel",
                 "tags": [
                     "Evaluators"
@@ -30474,7 +30422,7 @@
         "/test_framework/v1/scenarios-external/run_scenarios_chirp/": {
             "post": {
                 "operationId": "scenarios-run-chirp",
-                "description": "RAW-PCM WEBSOCKET VOICE RUN: Execute evaluators against an agent that exposes a raw-PCM WebSocket endpoint (16 kHz, 16-bit mono, binary frames). The agent must have a websocket endpoint configured (`telephony.websocket_url`); optional Basic Auth lives in `telephony.websocket_auth`. Pass `websocket_url` to override the agent's stored endpoint for this run.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_websocket` — JSON/text WebSocket protocol (per-scenario URLs)\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC",
+                "description": "RAW-PCM WEBSOCKET VOICE RUN: Execute evaluators against an agent that exposes a raw-PCM WebSocket endpoint (16 kHz, 16-bit mono, binary frames). The agent must have a websocket endpoint configured (`telephony.websocket_url`); optional Basic Auth lives in `telephony.websocket_auth`. Pass `websocket_url` to override the agent's stored endpoint for this run.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_websocket` — JSON/text WebSocket protocol (per-scenario URLs)\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC",
                 "summary": "Run evaluators against a raw-PCM WebSocket voice endpoint",
                 "tags": [
                     "Evaluators"
@@ -30650,7 +30598,7 @@
         "/test_framework/v1/scenarios-external/run_scenarios_elevenlabs/": {
             "post": {
                 "operationId": "scenarios-run-elevenlabs",
-                "description": "ELEVENLABS CONVERSATIONAL VOICE RUN: Execute evaluators against an ElevenLabs Conversational AI agent. The agent must have ElevenLabs credentials configured AND `assistant_id` set to the ElevenLabs agent ID.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)",
+                "description": "ELEVENLABS CONVERSATIONAL VOICE RUN: Execute evaluators against an ElevenLabs Conversational AI agent. The agent must have ElevenLabs credentials configured AND `assistant_id` set to the ElevenLabs agent ID.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)",
                 "summary": "Run evaluators against an ElevenLabs Conversational agent",
                 "tags": [
                     "Evaluators"
@@ -31011,7 +30959,7 @@
         "/test_framework/v1/scenarios-external/run_scenarios_livekit_v2/": {
             "post": {
                 "operationId": "scenarios-run-livekit-v2",
-                "description": "LIVEKIT VOICE RUN (project credentials, v2): Execute evaluators against a LiveKit agent using credentials configured at the project (or agent) level. Cekura creates the rooms; you don't pass URLs per-scenario. Requires `livekit_api_key`, `livekit_data.api_secret`, and `livekit_data.url` on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `room_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_websocket` — JSON/text WebSocket runs",
+                "description": "LIVEKIT VOICE RUN (project credentials, v2): Execute evaluators against a LiveKit agent using credentials configured at the project (or agent) level. Cekura creates the rooms; you don't pass URLs per-scenario. Requires `livekit_api_key`, `livekit_data.api_secret`, and `livekit_data.url` on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `room_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_websocket` — JSON/text WebSocket runs",
                 "summary": "Run evaluators against a LiveKit agent (project credentials, v2)",
                 "tags": [
                     "Evaluators"
@@ -31192,7 +31140,7 @@
         "/test_framework/v1/scenarios-external/run_scenarios_pipecat/": {
             "post": {
                 "operationId": "scenarios-run-pipecat-v1",
-                "description": "PIPECAT WEBRTC RUN (manual room URLs, v1): Execute evaluators against an agent running on Pipecat / Daily.co WebRTC. Each scenario entry carries its own `pipecat_room_url` and optional token. For project-credential-based runs (no per-scenario URL), use `scenarios_run_pipecat_v2` instead.\n\n**Run-count:** one run per entry in `scenarios` — this endpoint does not support `frequency` or personality/test-profile multipliers. To run the same scenario multiple times, include it multiple times in the `scenarios` list.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_text` — text / SMS / chat mode\n- `run_scenarios_with_websockets` — agent exposes a plain websocket URL (non-Pipecat)\n\n**Scheduled runs:** WebRTC sessions are not generally scheduled. Use `run_scenarios` or `run_scenarios_text` via CronJob for recurring evaluator runs.",
+                "description": "PIPECAT WEBRTC RUN (manual room URLs, v1): Execute evaluators against an agent running on Pipecat / Daily.co WebRTC. Each scenario entry carries its own `pipecat_room_url` and optional token. For project-credential-based runs (no per-scenario URL), use `scenarios_run_pipecat_v2` instead.\n\n**Run-count:** one run per entry in `scenarios` — this endpoint does not support `frequency` or personality/test-profile multipliers. To run the same scenario multiple times, include it multiple times in the `scenarios` list.\n\n**When to use this vs others:**\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_text` — text / SMS / chat mode\n- `run_scenarios_with_websockets` — agent exposes a plain websocket URL (non-Pipecat)\n\n**Scheduled runs:** WebRTC sessions are not generally scheduled. Use `run_scenarios` or `run_scenarios_text` via CronJob for recurring evaluator runs.",
                 "summary": "Run evaluators against a Pipecat WebRTC deployment (manual room URLs, v1)",
                 "tags": [
                     "Evaluators"
@@ -31372,7 +31320,7 @@
         "/test_framework/v1/scenarios-external/run_scenarios_pipecat_v2/": {
             "post": {
                 "operationId": "scenarios-run-pipecat-v2",
-                "description": "PIPECAT CLOUD VOICE RUN (project credentials, v2): Execute evaluators against an agent deployed on Pipecat Cloud using credentials configured at the project level. Cekura creates the sessions; you don't pass per-scenario room URLs (that's the v1 endpoint). Requires Pipecat Cloud credentials with `pipecat_agent_name` set on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `session_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_pipecat_v1` — manual room URLs per scenario\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
+                "description": "PIPECAT CLOUD VOICE RUN (project credentials, v2): Execute evaluators against an agent deployed on Pipecat Cloud using credentials configured at the project level. Cekura creates the sessions; you don't pass per-scenario room URLs (that's the v1 endpoint). Requires Pipecat Cloud credentials with `pipecat_agent_name` set on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `session_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others:**\n- `scenarios_run_pipecat_v1` — manual room URLs per scenario\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
                 "summary": "Run evaluators against a Pipecat Cloud deployment (project credentials, v2)",
                 "tags": [
                     "Evaluators"
@@ -31553,7 +31501,7 @@
         "/test_framework/v1/scenarios-external/run_scenarios_retell_webrtc/": {
             "post": {
                 "operationId": "scenarios-run-retell-webrtc",
-                "description": "RETELL WEBRTC VOICE RUN: Execute evaluators against a Retell agent over WebRTC (LiveKit infrastructure). The agent must have Retell credentials configured. `retell_agent_id` is optional and defaults to `agent.assistant_id` if not provided.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
+                "description": "RETELL WEBRTC VOICE RUN: Execute evaluators against a Retell agent over WebRTC (LiveKit infrastructure). The agent must have Retell credentials configured. `retell_agent_id` is optional and defaults to `agent.assistant_id` if not provided.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
                 "summary": "Run evaluators against a Retell agent over WebRTC",
                 "tags": [
                     "Evaluators"
@@ -31731,7 +31679,7 @@
         "/test_framework/v1/scenarios-external/run_scenarios_sip/": {
             "post": {
                 "operationId": "scenarios-run-sip",
-                "description": "SIP VOICE RUN (direct SIP): Execute evaluators against an agent over a direct SIP connection (orchestrated by Cekura's SIP voice service). The agent must have a SIP endpoint configured (`telephony.sip_uri` on the v2 agent).\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone calls via Cekura's standard voice path\n- `scenarios_run_vapi_webrtc` / `_retell_webrtc` — provider-managed WebRTC\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
+                "description": "SIP VOICE RUN (direct SIP): Execute evaluators against an agent over a direct SIP connection (orchestrated by Cekura's SIP voice service). The agent must have `sip_endpoint` configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone calls via Cekura's standard voice path\n- `scenarios_run_vapi_webrtc` / `_retell_webrtc` — provider-managed WebRTC\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
                 "summary": "Run evaluators over a direct SIP connection",
                 "tags": [
                     "Evaluators"
@@ -31907,7 +31855,7 @@
         "/test_framework/v1/scenarios-external/run_scenarios_text/": {
             "post": {
                 "operationId": "scenarios-run-text",
-                "description": "TEXT / SMS / CHAT RUN: Execute evaluators against your agent using text-only simulation (SMS, chat, or an agent-hosted websocket). Cheaper than voice — billed at the text-simulation rate. Requires a chat connection (`provider.chat_agent_details`) on the agent, or a websocket URL for `self_hosted` agents.\n\n**Run-count math:** total conversations = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**Concurrency:** use `concurrency_limit` to cap parallel conversations. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Websocket override:** if the agent exposes a plain websocket URL for text, pass it as `websocket_url` — this bypasses the agent's standard text-readiness check. Pass `websocket_headers` (JSON object) to override connection headers for this run — merged over the agent's configured headers, with the per-run values winning.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL (bulk)\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**`self_hosted` agents:** agents with `assistant_provider=\"self_hosted\"` require a websocket URL. Either pre-configure `websocket_url` on the agent, or pass it directly in this request. Without it, the run fails with `[\"Agent does not have a websocket URL\"]`. Passing `websocket_url` here changes the result's `run_type` to `\"WebSocket\"` instead of `\"Text\"`.\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"text\"` instead.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.",
+                "description": "TEXT / SMS / CHAT RUN: Execute evaluators against your agent using text-only simulation (SMS, chat, or an agent-hosted websocket). Cheaper than voice — billed at the text-simulation rate.\n\n**Run-count math:** total conversations = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**Concurrency:** use `concurrency_limit` to cap parallel conversations. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Websocket override:** if the agent exposes a plain websocket URL for text, pass it as `websocket_url` — this bypasses the agent's standard text-readiness check. Pass `websocket_headers` (JSON object) to override connection headers for this run — merged over the agent's configured headers, with the per-run values winning.\n\n**When to use this vs others:**\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL (bulk)\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**`self_hosted` agents:** agents with `assistant_provider=\"self_hosted\"` require a websocket URL. Either pre-configure `websocket_url` on the agent, or pass it directly in this request. Without it, the run fails with `[\"Agent does not have a websocket URL\"]`. Passing `websocket_url` here changes the result's `run_type` to `\"WebSocket\"` instead of `\"Text\"`.\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"text\"` instead.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.",
                 "summary": "Run evaluators in text / SMS / chat mode",
                 "tags": [
                     "Evaluators"
@@ -32106,7 +32054,7 @@
         "/test_framework/v1/scenarios-external/run_scenarios_vapi_webrtc/": {
             "post": {
                 "operationId": "scenarios-run-vapi-webrtc",
-                "description": "VAPI WEBRTC VOICE RUN: Execute evaluators against a VAPI agent over WebRTC. Required: `vapi_assistant_id` (the VAPI assistant). The agent (looked up via `agent_id` or inferred from the first scenario) must have VAPI credentials configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_text` — text/SMS/chat (cheaper)\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
+                "description": "VAPI WEBRTC VOICE RUN: Execute evaluators against a VAPI agent over WebRTC. Required: `vapi_assistant_id` (the VAPI assistant). The agent (looked up via `agent_id` or inferred from the first scenario) must have VAPI credentials configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_text` — text/SMS/chat (cheaper)\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
                 "summary": "Run evaluators against a VAPI WebRTC agent",
                 "tags": [
                     "Evaluators"
@@ -32285,7 +32233,7 @@
         "/test_framework/v1/scenarios-external/run_scenarios_with_websockets/": {
             "post": {
                 "operationId": "scenarios-run-websocket",
-                "description": "WEBSOCKET RUN (per-scenario URLs, bulk): Execute evaluators where each scenario carries its own websocket URL. Useful when you have a fleet of agents or stateful websocket sessions to test in a single batch.\n\n**Run-count:** total conversations = `len(scenarios) × frequency`. (Personality and test-profile multipliers are not supported on this endpoint.)\n\n**`frequency` is required** on this endpoint (no default).\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — single websocket URL or SMS/chat mode (simpler)\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'.\n\n**Known limitation:** `result.run_type` may show 'Text' instead of 'WebSocket' for runs triggered via this endpoint — this is a display issue only and does not affect execution.",
+                "description": "WEBSOCKET RUN (per-scenario URLs, bulk): Execute evaluators where each scenario carries its own websocket URL. Useful when you have a fleet of agents or stateful websocket sessions to test in a single batch.\n\n**Run-count:** total conversations = `len(scenarios) × frequency`. (Personality and test-profile multipliers are not supported on this endpoint.)\n\n**`frequency` is required** on this endpoint (no default).\n\n**When to use this vs others:**\n- `run_scenarios_text` — single websocket URL or SMS/chat mode (simpler)\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'.\n\n**Known limitation:** `result.run_type` may show 'Text' instead of 'WebSocket' for runs triggered via this endpoint — this is a display issue only and does not affect execution.",
                 "summary": "Run evaluators against per-scenario websocket URLs (bulk)",
                 "tags": [
                     "Evaluators"
@@ -34256,7 +34204,7 @@
         "/test_framework/v1/scenarios/generate-bg/": {
             "post": {
                 "operationId": "scenarios-generate-bg_2",
-                "description": "Generate scenarios for a given agent in the background. Returns a `progress_id` immediately; poll GET /scenarios/generate-progress/?progress_id={id} until `total_scenarios == completed_scenarios`.\n\n**What happens automatically on generation:**\n- A scenario-specific test profile is created and its `information` is populated using the sectioned shape: `main_agent_variables` (dynamic-variable values that reach the agent under test at call time — e.g. `user_id`, `account_id`) and `testing_agent_variables` (persona/context used by the simulated caller — e.g. `customer_name`, `date_of_birth`). Section values are kept consistent with any generated mock-tool data.\n- 10 project-level evaluation metrics are attached to every generated scenario automatically (e.g. Latency, Pitch, Interruption Score). Scenarios created manually via `scenarios_create` start with no metrics attached.\n\n**Response fields:** `progress_id` (UUID string) for polling; `session_id` is always null.",
+                "description": "Generate scenarios for a given agent in the background. Returns a `progress_id` immediately; poll GET /scenarios/generate-progress/?progress_id={id} until `total_scenarios == completed_scenarios`.\n\n**What happens automatically on generation:**\n- A default test profile is created for the agent if none exists. Each generated scenario will have `test_profile_data` populated with synthetic caller information (name, address, phone, email).\n- 10 project-level evaluation metrics are attached to every generated scenario automatically (e.g. Latency, Pitch, Interruption Score). Scenarios created manually via `scenarios_create` start with no metrics attached.\n\n**Response fields:** `progress_id` (UUID string) for polling; `session_id` is always null.",
                 "tags": [
                     "test_framework"
                 ],
@@ -34325,7 +34273,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-generate-bg",
-                        "description": "Generate scenarios for a given agent in the background. Returns a `progress_id` immediately; poll GET /scenarios/generate-progress/?progress_id={id} until `total_scenarios == completed_scenarios`.\n\n**What happens automatically on generation:**\n- A scenario-specific test profile is created and its `information` is populated using the sectioned shape: `main_agent_variables` (dynamic-variable values that reach the agent under test at call time — e.g. `user_id`, `account_id`) and `testing_agent_variables` (persona/context used by the simulated caller — e.g. `customer_name`, `date_of_birth`). Section values are kept consistent with any generated mock-tool data.\n- 10 project-level evaluation metrics are attached to every generated scenario automatically (e.g. Latency, Pitch, Interruption Score). Scenarios created manually via `scenarios_create` start with no metrics attached.\n\n**Response fields:** `progress_id` (UUID string) for polling; `session_id` is always null."
+                        "description": "Generate scenarios for a given agent in the background. Returns a `progress_id` immediately; poll GET /scenarios/generate-progress/?progress_id={id} until `total_scenarios == completed_scenarios`.\n\n**What happens automatically on generation:**\n- A default test profile is created for the agent if none exists. Each generated scenario will have `test_profile_data` populated with synthetic caller information (name, address, phone, email).\n- 10 project-level evaluation metrics are attached to every generated scenario automatically (e.g. Latency, Pitch, Interruption Score). Scenarios created manually via `scenarios_create` start with no metrics attached.\n\n**Response fields:** `progress_id` (UUID string) for polling; `session_id` is always null."
                     }
                 }
             }
@@ -34845,10 +34793,148 @@
                 }
             }
         },
+        "/test_framework/v1/scenarios/run_full_scenario_demo/": {
+            "post": {
+                "operationId": "scenarios-run-full-scenario-demo-create",
+                "description": "Complete demo flow for \"try it yourself\" free report feature.\n\nThis endpoint handles:\n1. OTP generation and validation for work email\n2. Agent creation under demo project\n3. Scenario generation\n4. Phone call execution\n5. Email report delivery",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Scenario"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Scenario"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Scenario"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Scenario"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/scenarios/run_full_scenario_demo_details/": {
+            "post": {
+                "operationId": "scenarios-run-full-scenario-demo-details-create",
+                "description": "Scenarios run full scenario demo details",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Scenario"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Scenario"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Scenario"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Scenario"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/scenarios/run_full_scenario_demo_email/": {
+            "post": {
+                "operationId": "scenarios-run-full-scenario-demo-email-create",
+                "description": "Scenarios run full scenario demo email",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Scenario"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Scenario"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Scenario"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Scenario"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/test_framework/v1/scenarios/run_scenarios/": {
             "post": {
                 "operationId": "scenarios-run-voice_2",
-                "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing. Requires `telephony.phone_number` configured on the agent (any provider).\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.",
+                "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing.\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others:**\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.",
                 "summary": "Run evaluators over a voice call",
                 "tags": [
                     "Evaluators"
@@ -35107,7 +35193,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-run-voice",
-                        "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing. Requires `telephony.phone_number` configured on the agent (any provider).\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors."
+                        "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing.\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others:**\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors."
                     }
                 }
             }
@@ -35115,7 +35201,7 @@
         "/test_framework/v1/scenarios/run_scenarios_agora/": {
             "post": {
                 "operationId": "scenarios-run-agora_2",
-                "description": "AGORA RTC VOICE RUN: Execute evaluators against an agent reachable in an Agora RTC channel. Cekura joins the channel as a participant and converses. The agent must have `agora_data.session_endpoint_url` configured — an endpoint that mints the per-call channel and token; Cekura calls it at run time and never stores the join details.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC",
+                "description": "AGORA RTC VOICE RUN: Execute evaluators against an agent reachable in an Agora RTC channel. Cekura joins the channel as a participant and converses. The agent must have `agora_data.session_endpoint_url` configured — an endpoint that mints the per-call channel and token; Cekura calls it at run time and never stores the join details.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC",
                 "summary": "Run evaluators against an agent in an Agora RTC channel",
                 "tags": [
                     "Evaluators"
@@ -35291,7 +35377,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-run-agora",
-                        "description": "AGORA RTC VOICE RUN: Execute evaluators against an agent reachable in an Agora RTC channel. Cekura joins the channel as a participant and converses. The agent must have `agora_data.session_endpoint_url` configured — an endpoint that mints the per-call channel and token; Cekura calls it at run time and never stores the join details.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC"
+                        "description": "AGORA RTC VOICE RUN: Execute evaluators against an agent reachable in an Agora RTC channel. Cekura joins the channel as a participant and converses. The agent must have `agora_data.session_endpoint_url` configured — an endpoint that mints the per-call channel and token; Cekura calls it at run time and never stores the join details.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC"
                     }
                 }
             }
@@ -35299,7 +35385,7 @@
         "/test_framework/v1/scenarios/run_scenarios_chirp/": {
             "post": {
                 "operationId": "scenarios-run-chirp_2",
-                "description": "RAW-PCM WEBSOCKET VOICE RUN: Execute evaluators against an agent that exposes a raw-PCM WebSocket endpoint (16 kHz, 16-bit mono, binary frames). The agent must have a websocket endpoint configured (`telephony.websocket_url`); optional Basic Auth lives in `telephony.websocket_auth`. Pass `websocket_url` to override the agent's stored endpoint for this run.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_websocket` — JSON/text WebSocket protocol (per-scenario URLs)\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC",
+                "description": "RAW-PCM WEBSOCKET VOICE RUN: Execute evaluators against an agent that exposes a raw-PCM WebSocket endpoint (16 kHz, 16-bit mono, binary frames). The agent must have a websocket endpoint configured (`telephony.websocket_url`); optional Basic Auth lives in `telephony.websocket_auth`. Pass `websocket_url` to override the agent's stored endpoint for this run.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_websocket` — JSON/text WebSocket protocol (per-scenario URLs)\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC",
                 "summary": "Run evaluators against a raw-PCM WebSocket voice endpoint",
                 "tags": [
                     "Evaluators"
@@ -35475,7 +35561,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-run-chirp",
-                        "description": "RAW-PCM WEBSOCKET VOICE RUN: Execute evaluators against an agent that exposes a raw-PCM WebSocket endpoint (16 kHz, 16-bit mono, binary frames). The agent must have a websocket endpoint configured (`telephony.websocket_url`); optional Basic Auth lives in `telephony.websocket_auth`. Pass `websocket_url` to override the agent's stored endpoint for this run.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_websocket` — JSON/text WebSocket protocol (per-scenario URLs)\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC"
+                        "description": "RAW-PCM WEBSOCKET VOICE RUN: Execute evaluators against an agent that exposes a raw-PCM WebSocket endpoint (16 kHz, 16-bit mono, binary frames). The agent must have a websocket endpoint configured (`telephony.websocket_url`); optional Basic Auth lives in `telephony.websocket_auth`. Pass `websocket_url` to override the agent's stored endpoint for this run.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_websocket` — JSON/text WebSocket protocol (per-scenario URLs)\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC"
                     }
                 }
             }
@@ -35483,7 +35569,7 @@
         "/test_framework/v1/scenarios/run_scenarios_elevenlabs/": {
             "post": {
                 "operationId": "scenarios-run-elevenlabs_2",
-                "description": "ELEVENLABS CONVERSATIONAL VOICE RUN: Execute evaluators against an ElevenLabs Conversational AI agent. The agent must have ElevenLabs credentials configured AND `assistant_id` set to the ElevenLabs agent ID.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)",
+                "description": "ELEVENLABS CONVERSATIONAL VOICE RUN: Execute evaluators against an ElevenLabs Conversational AI agent. The agent must have ElevenLabs credentials configured AND `assistant_id` set to the ElevenLabs agent ID.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)",
                 "summary": "Run evaluators against an ElevenLabs Conversational agent",
                 "tags": [
                     "Evaluators"
@@ -35660,7 +35746,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-run-elevenlabs",
-                        "description": "ELEVENLABS CONVERSATIONAL VOICE RUN: Execute evaluators against an ElevenLabs Conversational AI agent. The agent must have ElevenLabs credentials configured AND `assistant_id` set to the ElevenLabs agent ID.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)"
+                        "description": "ELEVENLABS CONVERSATIONAL VOICE RUN: Execute evaluators against an ElevenLabs Conversational AI agent. The agent must have ElevenLabs credentials configured AND `assistant_id` set to the ElevenLabs agent ID.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)"
                     }
                 }
             }
@@ -35852,7 +35938,7 @@
         "/test_framework/v1/scenarios/run_scenarios_livekit_v2/": {
             "post": {
                 "operationId": "scenarios-run-livekit-v2_2",
-                "description": "LIVEKIT VOICE RUN (project credentials, v2): Execute evaluators against a LiveKit agent using credentials configured at the project (or agent) level. Cekura creates the rooms; you don't pass URLs per-scenario. Requires `livekit_api_key`, `livekit_data.api_secret`, and `livekit_data.url` on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `room_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_websocket` — JSON/text WebSocket runs",
+                "description": "LIVEKIT VOICE RUN (project credentials, v2): Execute evaluators against a LiveKit agent using credentials configured at the project (or agent) level. Cekura creates the rooms; you don't pass URLs per-scenario. Requires `livekit_api_key`, `livekit_data.api_secret`, and `livekit_data.url` on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `room_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_websocket` — JSON/text WebSocket runs",
                 "summary": "Run evaluators against a LiveKit agent (project credentials, v2)",
                 "tags": [
                     "Evaluators"
@@ -36033,7 +36119,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-run-livekit-v2",
-                        "description": "LIVEKIT VOICE RUN (project credentials, v2): Execute evaluators against a LiveKit agent using credentials configured at the project (or agent) level. Cekura creates the rooms; you don't pass URLs per-scenario. Requires `livekit_api_key`, `livekit_data.api_secret`, and `livekit_data.url` on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `room_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_websocket` — JSON/text WebSocket runs"
+                        "description": "LIVEKIT VOICE RUN (project credentials, v2): Execute evaluators against a LiveKit agent using credentials configured at the project (or agent) level. Cekura creates the rooms; you don't pass URLs per-scenario. Requires `livekit_api_key`, `livekit_data.api_secret`, and `livekit_data.url` on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `room_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_websocket` — JSON/text WebSocket runs"
                     }
                 }
             }
@@ -36041,7 +36127,7 @@
         "/test_framework/v1/scenarios/run_scenarios_pipecat/": {
             "post": {
                 "operationId": "scenarios-run-pipecat-v1_2",
-                "description": "PIPECAT WEBRTC RUN (manual room URLs, v1): Execute evaluators against an agent running on Pipecat / Daily.co WebRTC. Each scenario entry carries its own `pipecat_room_url` and optional token. For project-credential-based runs (no per-scenario URL), use `scenarios_run_pipecat_v2` instead.\n\n**Run-count:** one run per entry in `scenarios` — this endpoint does not support `frequency` or personality/test-profile multipliers. To run the same scenario multiple times, include it multiple times in the `scenarios` list.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_text` — text / SMS / chat mode\n- `run_scenarios_with_websockets` — agent exposes a plain websocket URL (non-Pipecat)\n\n**Scheduled runs:** WebRTC sessions are not generally scheduled. Use `run_scenarios` or `run_scenarios_text` via CronJob for recurring evaluator runs.",
+                "description": "PIPECAT WEBRTC RUN (manual room URLs, v1): Execute evaluators against an agent running on Pipecat / Daily.co WebRTC. Each scenario entry carries its own `pipecat_room_url` and optional token. For project-credential-based runs (no per-scenario URL), use `scenarios_run_pipecat_v2` instead.\n\n**Run-count:** one run per entry in `scenarios` — this endpoint does not support `frequency` or personality/test-profile multipliers. To run the same scenario multiple times, include it multiple times in the `scenarios` list.\n\n**When to use this vs others:**\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_text` — text / SMS / chat mode\n- `run_scenarios_with_websockets` — agent exposes a plain websocket URL (non-Pipecat)\n\n**Scheduled runs:** WebRTC sessions are not generally scheduled. Use `run_scenarios` or `run_scenarios_text` via CronJob for recurring evaluator runs.",
                 "summary": "Run evaluators against a Pipecat WebRTC deployment (manual room URLs, v1)",
                 "tags": [
                     "Evaluators"
@@ -36221,7 +36307,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-run-pipecat-v1",
-                        "description": "PIPECAT WEBRTC RUN (manual room URLs, v1): Execute evaluators against an agent running on Pipecat / Daily.co WebRTC. Each scenario entry carries its own `pipecat_room_url` and optional token. For project-credential-based runs (no per-scenario URL), use `scenarios_run_pipecat_v2` instead.\n\n**Run-count:** one run per entry in `scenarios` — this endpoint does not support `frequency` or personality/test-profile multipliers. To run the same scenario multiple times, include it multiple times in the `scenarios` list.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_text` — text / SMS / chat mode\n- `run_scenarios_with_websockets` — agent exposes a plain websocket URL (non-Pipecat)\n\n**Scheduled runs:** WebRTC sessions are not generally scheduled. Use `run_scenarios` or `run_scenarios_text` via CronJob for recurring evaluator runs."
+                        "description": "PIPECAT WEBRTC RUN (manual room URLs, v1): Execute evaluators against an agent running on Pipecat / Daily.co WebRTC. Each scenario entry carries its own `pipecat_room_url` and optional token. For project-credential-based runs (no per-scenario URL), use `scenarios_run_pipecat_v2` instead.\n\n**Run-count:** one run per entry in `scenarios` — this endpoint does not support `frequency` or personality/test-profile multipliers. To run the same scenario multiple times, include it multiple times in the `scenarios` list.\n\n**When to use this vs others:**\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_text` — text / SMS / chat mode\n- `run_scenarios_with_websockets` — agent exposes a plain websocket URL (non-Pipecat)\n\n**Scheduled runs:** WebRTC sessions are not generally scheduled. Use `run_scenarios` or `run_scenarios_text` via CronJob for recurring evaluator runs."
                     }
                 }
             }
@@ -36229,7 +36315,7 @@
         "/test_framework/v1/scenarios/run_scenarios_pipecat_v2/": {
             "post": {
                 "operationId": "scenarios-run-pipecat-v2_2",
-                "description": "PIPECAT CLOUD VOICE RUN (project credentials, v2): Execute evaluators against an agent deployed on Pipecat Cloud using credentials configured at the project level. Cekura creates the sessions; you don't pass per-scenario room URLs (that's the v1 endpoint). Requires Pipecat Cloud credentials with `pipecat_agent_name` set on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `session_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_pipecat_v1` — manual room URLs per scenario\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
+                "description": "PIPECAT CLOUD VOICE RUN (project credentials, v2): Execute evaluators against an agent deployed on Pipecat Cloud using credentials configured at the project level. Cekura creates the sessions; you don't pass per-scenario room URLs (that's the v1 endpoint). Requires Pipecat Cloud credentials with `pipecat_agent_name` set on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `session_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others:**\n- `scenarios_run_pipecat_v1` — manual room URLs per scenario\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
                 "summary": "Run evaluators against a Pipecat Cloud deployment (project credentials, v2)",
                 "tags": [
                     "Evaluators"
@@ -36410,7 +36496,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-run-pipecat-v2",
-                        "description": "PIPECAT CLOUD VOICE RUN (project credentials, v2): Execute evaluators against an agent deployed on Pipecat Cloud using credentials configured at the project level. Cekura creates the sessions; you don't pass per-scenario room URLs (that's the v1 endpoint). Requires Pipecat Cloud credentials with `pipecat_agent_name` set on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `session_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_pipecat_v1` — manual room URLs per scenario\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)"
+                        "description": "PIPECAT CLOUD VOICE RUN (project credentials, v2): Execute evaluators against an agent deployed on Pipecat Cloud using credentials configured at the project level. Cekura creates the sessions; you don't pass per-scenario room URLs (that's the v1 endpoint). Requires Pipecat Cloud credentials with `pipecat_agent_name` set on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `session_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others:**\n- `scenarios_run_pipecat_v1` — manual room URLs per scenario\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)"
                     }
                 }
             }
@@ -36418,7 +36504,7 @@
         "/test_framework/v1/scenarios/run_scenarios_retell_webrtc/": {
             "post": {
                 "operationId": "scenarios-run-retell-webrtc_2",
-                "description": "RETELL WEBRTC VOICE RUN: Execute evaluators against a Retell agent over WebRTC (LiveKit infrastructure). The agent must have Retell credentials configured. `retell_agent_id` is optional and defaults to `agent.assistant_id` if not provided.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
+                "description": "RETELL WEBRTC VOICE RUN: Execute evaluators against a Retell agent over WebRTC (LiveKit infrastructure). The agent must have Retell credentials configured. `retell_agent_id` is optional and defaults to `agent.assistant_id` if not provided.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
                 "summary": "Run evaluators against a Retell agent over WebRTC",
                 "tags": [
                     "Evaluators"
@@ -36596,7 +36682,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-run-retell-webrtc",
-                        "description": "RETELL WEBRTC VOICE RUN: Execute evaluators against a Retell agent over WebRTC (LiveKit infrastructure). The agent must have Retell credentials configured. `retell_agent_id` is optional and defaults to `agent.assistant_id` if not provided.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)"
+                        "description": "RETELL WEBRTC VOICE RUN: Execute evaluators against a Retell agent over WebRTC (LiveKit infrastructure). The agent must have Retell credentials configured. `retell_agent_id` is optional and defaults to `agent.assistant_id` if not provided.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)"
                     }
                 }
             }
@@ -36604,7 +36690,7 @@
         "/test_framework/v1/scenarios/run_scenarios_sip/": {
             "post": {
                 "operationId": "scenarios-run-sip_2",
-                "description": "SIP VOICE RUN (direct SIP): Execute evaluators against an agent over a direct SIP connection (orchestrated by Cekura's SIP voice service). The agent must have a SIP endpoint configured (`telephony.sip_uri` on the v2 agent).\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone calls via Cekura's standard voice path\n- `scenarios_run_vapi_webrtc` / `_retell_webrtc` — provider-managed WebRTC\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
+                "description": "SIP VOICE RUN (direct SIP): Execute evaluators against an agent over a direct SIP connection (orchestrated by Cekura's SIP voice service). The agent must have `sip_endpoint` configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone calls via Cekura's standard voice path\n- `scenarios_run_vapi_webrtc` / `_retell_webrtc` — provider-managed WebRTC\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
                 "summary": "Run evaluators over a direct SIP connection",
                 "tags": [
                     "Evaluators"
@@ -36780,7 +36866,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-run-sip",
-                        "description": "SIP VOICE RUN (direct SIP): Execute evaluators against an agent over a direct SIP connection (orchestrated by Cekura's SIP voice service). The agent must have a SIP endpoint configured (`telephony.sip_uri` on the v2 agent).\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone calls via Cekura's standard voice path\n- `scenarios_run_vapi_webrtc` / `_retell_webrtc` — provider-managed WebRTC\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)"
+                        "description": "SIP VOICE RUN (direct SIP): Execute evaluators against an agent over a direct SIP connection (orchestrated by Cekura's SIP voice service). The agent must have `sip_endpoint` configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone calls via Cekura's standard voice path\n- `scenarios_run_vapi_webrtc` / `_retell_webrtc` — provider-managed WebRTC\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)"
                     }
                 }
             }
@@ -36788,7 +36874,7 @@
         "/test_framework/v1/scenarios/run_scenarios_text/": {
             "post": {
                 "operationId": "scenarios-run-text_2",
-                "description": "TEXT / SMS / CHAT RUN: Execute evaluators against your agent using text-only simulation (SMS, chat, or an agent-hosted websocket). Cheaper than voice — billed at the text-simulation rate. Requires a chat connection (`provider.chat_agent_details`) on the agent, or a websocket URL for `self_hosted` agents.\n\n**Run-count math:** total conversations = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**Concurrency:** use `concurrency_limit` to cap parallel conversations. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Websocket override:** if the agent exposes a plain websocket URL for text, pass it as `websocket_url` — this bypasses the agent's standard text-readiness check. Pass `websocket_headers` (JSON object) to override connection headers for this run — merged over the agent's configured headers, with the per-run values winning.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL (bulk)\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**`self_hosted` agents:** agents with `assistant_provider=\"self_hosted\"` require a websocket URL. Either pre-configure `websocket_url` on the agent, or pass it directly in this request. Without it, the run fails with `[\"Agent does not have a websocket URL\"]`. Passing `websocket_url` here changes the result's `run_type` to `\"WebSocket\"` instead of `\"Text\"`.\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"text\"` instead.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.",
+                "description": "TEXT / SMS / CHAT RUN: Execute evaluators against your agent using text-only simulation (SMS, chat, or an agent-hosted websocket). Cheaper than voice — billed at the text-simulation rate.\n\n**Run-count math:** total conversations = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**Concurrency:** use `concurrency_limit` to cap parallel conversations. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Websocket override:** if the agent exposes a plain websocket URL for text, pass it as `websocket_url` — this bypasses the agent's standard text-readiness check. Pass `websocket_headers` (JSON object) to override connection headers for this run — merged over the agent's configured headers, with the per-run values winning.\n\n**When to use this vs others:**\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL (bulk)\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**`self_hosted` agents:** agents with `assistant_provider=\"self_hosted\"` require a websocket URL. Either pre-configure `websocket_url` on the agent, or pass it directly in this request. Without it, the run fails with `[\"Agent does not have a websocket URL\"]`. Passing `websocket_url` here changes the result's `run_type` to `\"WebSocket\"` instead of `\"Text\"`.\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"text\"` instead.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.",
                 "summary": "Run evaluators in text / SMS / chat mode",
                 "tags": [
                     "Evaluators"
@@ -36987,7 +37073,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-run-text",
-                        "description": "TEXT / SMS / CHAT RUN: Execute evaluators against your agent using text-only simulation (SMS, chat, or an agent-hosted websocket). Cheaper than voice — billed at the text-simulation rate. Requires a chat connection (`provider.chat_agent_details`) on the agent, or a websocket URL for `self_hosted` agents.\n\n**Run-count math:** total conversations = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**Concurrency:** use `concurrency_limit` to cap parallel conversations. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Websocket override:** if the agent exposes a plain websocket URL for text, pass it as `websocket_url` — this bypasses the agent's standard text-readiness check. Pass `websocket_headers` (JSON object) to override connection headers for this run — merged over the agent's configured headers, with the per-run values winning.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL (bulk)\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**`self_hosted` agents:** agents with `assistant_provider=\"self_hosted\"` require a websocket URL. Either pre-configure `websocket_url` on the agent, or pass it directly in this request. Without it, the run fails with `[\"Agent does not have a websocket URL\"]`. Passing `websocket_url` here changes the result's `run_type` to `\"WebSocket\"` instead of `\"Text\"`.\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"text\"` instead.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors."
+                        "description": "TEXT / SMS / CHAT RUN: Execute evaluators against your agent using text-only simulation (SMS, chat, or an agent-hosted websocket). Cheaper than voice — billed at the text-simulation rate.\n\n**Run-count math:** total conversations = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**Concurrency:** use `concurrency_limit` to cap parallel conversations. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Websocket override:** if the agent exposes a plain websocket URL for text, pass it as `websocket_url` — this bypasses the agent's standard text-readiness check. Pass `websocket_headers` (JSON object) to override connection headers for this run — merged over the agent's configured headers, with the per-run values winning.\n\n**When to use this vs others:**\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL (bulk)\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**`self_hosted` agents:** agents with `assistant_provider=\"self_hosted\"` require a websocket URL. Either pre-configure `websocket_url` on the agent, or pass it directly in this request. Without it, the run fails with `[\"Agent does not have a websocket URL\"]`. Passing `websocket_url` here changes the result's `run_type` to `\"WebSocket\"` instead of `\"Text\"`.\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"text\"` instead.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors."
                     }
                 }
             }
@@ -36995,7 +37081,7 @@
         "/test_framework/v1/scenarios/run_scenarios_vapi_webrtc/": {
             "post": {
                 "operationId": "scenarios-run-vapi-webrtc_2",
-                "description": "VAPI WEBRTC VOICE RUN: Execute evaluators against a VAPI agent over WebRTC. Required: `vapi_assistant_id` (the VAPI assistant). The agent (looked up via `agent_id` or inferred from the first scenario) must have VAPI credentials configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_text` — text/SMS/chat (cheaper)\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
+                "description": "VAPI WEBRTC VOICE RUN: Execute evaluators against a VAPI agent over WebRTC. Required: `vapi_assistant_id` (the VAPI assistant). The agent (looked up via `agent_id` or inferred from the first scenario) must have VAPI credentials configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_text` — text/SMS/chat (cheaper)\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
                 "summary": "Run evaluators against a VAPI WebRTC agent",
                 "tags": [
                     "Evaluators"
@@ -37174,7 +37260,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-run-vapi-webrtc",
-                        "description": "VAPI WEBRTC VOICE RUN: Execute evaluators against a VAPI agent over WebRTC. Required: `vapi_assistant_id` (the VAPI assistant). The agent (looked up via `agent_id` or inferred from the first scenario) must have VAPI credentials configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_text` — text/SMS/chat (cheaper)\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)"
+                        "description": "VAPI WEBRTC VOICE RUN: Execute evaluators against a VAPI agent over WebRTC. Required: `vapi_assistant_id` (the VAPI assistant). The agent (looked up via `agent_id` or inferred from the first scenario) must have VAPI credentials configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_text` — text/SMS/chat (cheaper)\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)"
                     }
                 }
             }
@@ -37182,7 +37268,7 @@
         "/test_framework/v1/scenarios/run_scenarios_with_websockets/": {
             "post": {
                 "operationId": "scenarios-run-websocket_2",
-                "description": "WEBSOCKET RUN (per-scenario URLs, bulk): Execute evaluators where each scenario carries its own websocket URL. Useful when you have a fleet of agents or stateful websocket sessions to test in a single batch.\n\n**Run-count:** total conversations = `len(scenarios) × frequency`. (Personality and test-profile multipliers are not supported on this endpoint.)\n\n**`frequency` is required** on this endpoint (no default).\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — single websocket URL or SMS/chat mode (simpler)\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'.\n\n**Known limitation:** `result.run_type` may show 'Text' instead of 'WebSocket' for runs triggered via this endpoint — this is a display issue only and does not affect execution.",
+                "description": "WEBSOCKET RUN (per-scenario URLs, bulk): Execute evaluators where each scenario carries its own websocket URL. Useful when you have a fleet of agents or stateful websocket sessions to test in a single batch.\n\n**Run-count:** total conversations = `len(scenarios) × frequency`. (Personality and test-profile multipliers are not supported on this endpoint.)\n\n**`frequency` is required** on this endpoint (no default).\n\n**When to use this vs others:**\n- `run_scenarios_text` — single websocket URL or SMS/chat mode (simpler)\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'.\n\n**Known limitation:** `result.run_type` may show 'Text' instead of 'WebSocket' for runs triggered via this endpoint — this is a display issue only and does not affect execution.",
                 "summary": "Run evaluators against per-scenario websocket URLs (bulk)",
                 "tags": [
                     "Evaluators"
@@ -37366,7 +37452,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-run-websocket",
-                        "description": "WEBSOCKET RUN (per-scenario URLs, bulk): Execute evaluators where each scenario carries its own websocket URL. Useful when you have a fleet of agents or stateful websocket sessions to test in a single batch.\n\n**Run-count:** total conversations = `len(scenarios) × frequency`. (Personality and test-profile multipliers are not supported on this endpoint.)\n\n**`frequency` is required** on this endpoint (no default).\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — single websocket URL or SMS/chat mode (simpler)\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'.\n\n**Known limitation:** `result.run_type` may show 'Text' instead of 'WebSocket' for runs triggered via this endpoint — this is a display issue only and does not affect execution."
+                        "description": "WEBSOCKET RUN (per-scenario URLs, bulk): Execute evaluators where each scenario carries its own websocket URL. Useful when you have a fleet of agents or stateful websocket sessions to test in a single batch.\n\n**Run-count:** total conversations = `len(scenarios) × frequency`. (Personality and test-profile multipliers are not supported on this endpoint.)\n\n**`frequency` is required** on this endpoint (no default).\n\n**When to use this vs others:**\n- `run_scenarios_text` — single websocket URL or SMS/chat mode (simpler)\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'.\n\n**Known limitation:** `result.run_type` may show 'Text' instead of 'WebSocket' for runs triggered via this endpoint — this is a display issue only and does not affect execution."
                     }
                 }
             }
@@ -37607,14 +37693,8 @@
                                                 "agent": 123,
                                                 "name": "<string>",
                                                 "information": {
-                                                    "main_agent_variables": {
-                                                        "user_id": "<string>",
-                                                        "account_id": "<string>"
-                                                    },
-                                                    "testing_agent_variables": {
-                                                        "user_name": "<string>",
-                                                        "user_email": "<string>"
-                                                    }
+                                                    "user_name": "<string>",
+                                                    "user_email": "<string>"
                                                 }
                                             }
                                         ],
@@ -37653,14 +37733,8 @@
                                         "agent": 123,
                                         "name": "<string>",
                                         "information": {
-                                            "main_agent_variables": {
-                                                "user_id": "<string>",
-                                                "account_id": "<string>"
-                                            },
-                                            "testing_agent_variables": {
-                                                "user_name": "<string>",
-                                                "user_email": "<string>"
-                                            }
+                                            "user_name": "<string>",
+                                            "user_email": "<string>"
                                         }
                                     },
                                     "summary": "Create Test Profile with Agent"
@@ -37670,14 +37744,8 @@
                                         "project": 456,
                                         "name": "<string>",
                                         "information": {
-                                            "main_agent_variables": {
-                                                "user_id": "<string>",
-                                                "account_id": "<string>"
-                                            },
-                                            "testing_agent_variables": {
-                                                "user_name": "<string>",
-                                                "user_email": "<string>"
-                                            }
+                                            "user_name": "<string>",
+                                            "user_email": "<string>"
                                         }
                                     },
                                     "summary": "Create Test Profile with Project"
@@ -37717,14 +37785,8 @@
                                             "agent": null,
                                             "name": "<string>",
                                             "information": {
-                                                "main_agent_variables": {
-                                                    "user_id": "U-42",
-                                                    "account_id": "ACC-4521"
-                                                },
-                                                "testing_agent_variables": {
-                                                    "user_name": "John Doe",
-                                                    "user_email": "john.doe@example.com"
-                                                }
+                                                "user_name": "John Doe",
+                                                "user_email": "john.doe@example.com"
                                             }
                                         },
                                         "summary": "Create Test Profile Response"
@@ -37810,14 +37872,8 @@
                                                 "agent": 123,
                                                 "name": "<string>",
                                                 "information": {
-                                                    "main_agent_variables": {
-                                                        "user_id": "<string>",
-                                                        "account_id": "<string>"
-                                                    },
-                                                    "testing_agent_variables": {
-                                                        "user_name": "<string>",
-                                                        "user_email": "<string>"
-                                                    }
+                                                    "user_name": "<string>",
+                                                    "user_email": "<string>"
                                                 }
                                             }
                                         ],
@@ -37848,14 +37904,8 @@
                                         "agent": 123,
                                         "name": "<string>",
                                         "information": {
-                                            "main_agent_variables": {
-                                                "user_id": "<string>",
-                                                "account_id": "<string>"
-                                            },
-                                            "testing_agent_variables": {
-                                                "user_name": "<string>",
-                                                "user_email": "<string>"
-                                            }
+                                            "user_name": "<string>",
+                                            "user_email": "<string>"
                                         }
                                     },
                                     "summary": "Create Test Profile with Agent"
@@ -37865,14 +37915,8 @@
                                         "project": 456,
                                         "name": "<string>",
                                         "information": {
-                                            "main_agent_variables": {
-                                                "user_id": "<string>",
-                                                "account_id": "<string>"
-                                            },
-                                            "testing_agent_variables": {
-                                                "user_name": "<string>",
-                                                "user_email": "<string>"
-                                            }
+                                            "user_name": "<string>",
+                                            "user_email": "<string>"
                                         }
                                     },
                                     "summary": "Create Test Profile with Project"
@@ -37912,14 +37956,8 @@
                                             "agent": null,
                                             "name": "<string>",
                                             "information": {
-                                                "main_agent_variables": {
-                                                    "user_id": "U-42",
-                                                    "account_id": "ACC-4521"
-                                                },
-                                                "testing_agent_variables": {
-                                                    "user_name": "John Doe",
-                                                    "user_email": "john.doe@example.com"
-                                                }
+                                                "user_name": "John Doe",
+                                                "user_email": "john.doe@example.com"
                                             }
                                         },
                                         "summary": "Create Test Profile Response"
@@ -37987,14 +38025,8 @@
                                             "agent": 123,
                                             "name": "<string>",
                                             "information": {
-                                                "main_agent_variables": {
-                                                    "user_id": "<string>",
-                                                    "account_id": "<string>"
-                                                },
-                                                "testing_agent_variables": {
-                                                    "user_name": "<string>",
-                                                    "user_email": "<string>"
-                                                }
+                                                "user_name": "<string>",
+                                                "user_email": "<string>"
                                             }
                                         },
                                         "summary": "Get Test Profile"
@@ -38089,14 +38121,8 @@
                                     "value": {
                                         "name": "<string>",
                                         "information": {
-                                            "main_agent_variables": {
-                                                "user_id": "<string>",
-                                                "account_id": "<string>"
-                                            },
-                                            "testing_agent_variables": {
-                                                "user_name": "<string>",
-                                                "user_email": "<string>"
-                                            }
+                                            "user_name": "<string>",
+                                            "user_email": "<string>"
                                         }
                                     },
                                     "summary": "Partial Update Test Profile"
@@ -38134,14 +38160,8 @@
                                             "agent": 123,
                                             "name": "<string>",
                                             "information": {
-                                                "main_agent_variables": {
-                                                    "user_id": "<string>",
-                                                    "account_id": "<string>"
-                                                },
-                                                "testing_agent_variables": {
-                                                    "user_name": "<string>",
-                                                    "user_email": "<string>"
-                                                }
+                                                "user_name": "<string>",
+                                                "user_email": "<string>"
                                             }
                                         },
                                         "summary": "Partial Update Test Profile Response"
@@ -38235,14 +38255,8 @@
                                             "agent": 123,
                                             "name": "<string>",
                                             "information": {
-                                                "main_agent_variables": {
-                                                    "user_id": "<string>",
-                                                    "account_id": "<string>"
-                                                },
-                                                "testing_agent_variables": {
-                                                    "user_name": "<string>",
-                                                    "user_email": "<string>"
-                                                }
+                                                "user_name": "<string>",
+                                                "user_email": "<string>"
                                             }
                                         },
                                         "summary": "Get Test Profile"
@@ -38345,14 +38359,8 @@
                                     "value": {
                                         "name": "<string>",
                                         "information": {
-                                            "main_agent_variables": {
-                                                "user_id": "<string>",
-                                                "account_id": "<string>"
-                                            },
-                                            "testing_agent_variables": {
-                                                "user_name": "<string>",
-                                                "user_email": "<string>"
-                                            }
+                                            "user_name": "<string>",
+                                            "user_email": "<string>"
                                         }
                                     },
                                     "summary": "Partial Update Test Profile"
@@ -38390,14 +38398,8 @@
                                             "agent": 123,
                                             "name": "<string>",
                                             "information": {
-                                                "main_agent_variables": {
-                                                    "user_id": "<string>",
-                                                    "account_id": "<string>"
-                                                },
-                                                "testing_agent_variables": {
-                                                    "user_name": "<string>",
-                                                    "user_email": "<string>"
-                                                }
+                                                "user_name": "<string>",
+                                                "user_email": "<string>"
                                             }
                                         },
                                         "summary": "Partial Update Test Profile Response"
@@ -39034,7 +39036,7 @@
         "/test_framework/v2/aiagents/{id}/": {
             "get": {
                 "operationId": "aiagents-retrieve",
-                "description": "Retrieve an AI voice agent, including its configured connections.\n\n**Configured connection → run endpoint** (call this before running scenarios; a run endpoint only works if its connection is configured on the agent):\n- `telephony.phone_number` → `scenarios-run-voice`\n- `telephony.sip_uri` → `scenarios-run-sip`\n- `telephony.websocket_url` → `scenarios-run-chirp` (raw-PCM voice websocket)\n- `provider.type` vapi / retell / livekit / pipecat / agora (WebRTC) → `scenarios-run-vapi-webrtc` / `-retell-webrtc` / `-livekit-v2` / `-pipecat-v2` / `-agora`\n- `provider.type` elevenlabs → `scenarios-run-elevenlabs`\n- `provider.chat_agent_details` (chat/SMS/WhatsApp) → `scenarios-run-text`",
+                "description": "Retrieve an AI voice agent",
                 "summary": "Retrieve an AI voice agent",
                 "parameters": [
                     {
@@ -39087,7 +39089,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "aiagents-retrieve",
-                        "description": "Retrieve an AI voice agent, including its configured connections.\n\n**Configured connection → run endpoint** (call this before running scenarios; a run endpoint only works if its connection is configured on the agent):\n- `telephony.phone_number` → `scenarios-run-voice`\n- `telephony.sip_uri` → `scenarios-run-sip`\n- `telephony.websocket_url` → `scenarios-run-chirp` (raw-PCM voice websocket)\n- `provider.type` vapi / retell / livekit / pipecat / agora (WebRTC) → `scenarios-run-vapi-webrtc` / `-retell-webrtc` / `-livekit-v2` / `-pipecat-v2` / `-agora`\n- `provider.type` elevenlabs → `scenarios-run-elevenlabs`\n- `provider.chat_agent_details` (chat/SMS/WhatsApp) → `scenarios-run-text`"
+                        "description": "Retrieve an AI voice agent"
                     }
                 }
             },
@@ -40141,6 +40143,2118 @@
                             }
                         },
                         "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/": {
+            "get": {
+                "operationId": "test-framework-v2-metrics-list",
+                "description": "List quality metrics. Filter by `project_id` or `agent_id` to scope results.",
+                "summary": "List quality metrics",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "agent_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "\nFilter by agent ID\nExample: `123`\n"
+                    },
+                    {
+                        "in": "query",
+                        "name": "project_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "\nFilter by project ID\nExample: `456`\n"
+                    },
+                    {
+                        "in": "query",
+                        "name": "assistant_id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "\nFilter by assistant ID\nExample: `asst_1234567890`\n"
+                    },
+                    {
+                        "in": "query",
+                        "name": "agents",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "\nFilter metrics by agent IDs. Supports comma-separated list.\nExample: `1,2,3` to filter metrics associated with any of these agents\n"
+                    },
+                    {
+                        "in": "query",
+                        "name": "slug",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "\nFilter by metric slug\nExample: `latency_metric` or `customer_satisfaction`\n"
+                    },
+                    {
+                        "in": "query",
+                        "name": "filters",
+                        "schema": {
+                            "type": "object"
+                        },
+                        "description": "JSON filter parameter for advanced filtering.\n\nExample:\n```json\n{\"operator\":\"and\",\"conditions\":[{\"field\":\"agents__id\",\"op\":\"in\",\"value\":[1,2,3]}]}\n```\n\nSupported fields: agents__id, eval_type, type, name\nSupported operators: in, eq, contains"
+                    },
+                    {
+                        "in": "query",
+                        "name": "include_scores",
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "description": "\nInclude Overall and Total scores in Metric List\nExample: `true` or `false`\n                "
+                    }
+                ],
+                "tags": [
+                    "Metrics"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/MetricListSerializerV2"
+                                    }
+                                },
+                                "examples": {
+                                    "MetricList": {
+                                        "value": [
+                                            {
+                                                "id": 123,
+                                                "name": "<string>",
+                                                "description": "<string>",
+                                                "function_name": "<string>",
+                                                "type": "basic",
+                                                "eval_type": "binary",
+                                                "enum_values": [
+                                                    "<string>"
+                                                ],
+                                                "audio_enabled": true,
+                                                "observability_enabled": true,
+                                                "simulation_enabled": true,
+                                                "prompt": "<string>",
+                                                "evaluation_trigger": "always",
+                                                "evaluation_trigger_prompt": "<string>",
+                                                "priority_assignment_prompt": "<string>",
+                                                "vocera_defined_metric_code": "<string>",
+                                                "configuration": {
+                                                    "infra_issues_timeout": "<integer>",
+                                                    "key": "value"
+                                                },
+                                                "kb_file_ids": [
+                                                    "<integer>"
+                                                ],
+                                                "knowledge_base_files": [
+                                                    {
+                                                        "id": "<integer>",
+                                                        "agent": "<integer>",
+                                                        "file_url": "<string>",
+                                                        "file_name": "<string>",
+                                                        "file_type": "<string>",
+                                                        "file_size": "<integer>",
+                                                        "created_at": "<datetime>",
+                                                        "updated_at": "<datetime>"
+                                                    }
+                                                ],
+                                                "metric_cost": "<float>"
+                                            }
+                                        ]
+                                    },
+                                    "MetricListWithOverallScore": {
+                                        "value": [
+                                            {
+                                                "id": "<integer>",
+                                                "name": "<string>",
+                                                "description": "<string>",
+                                                "function_name": "<string>",
+                                                "type": "basic",
+                                                "eval_type": "binary",
+                                                "enum_values": [
+                                                    "<string>"
+                                                ],
+                                                "audio_enabled": true,
+                                                "observability_enabled": true,
+                                                "simulation_enabled": true,
+                                                "prompt": "<string>",
+                                                "evaluation_trigger": "always",
+                                                "evaluation_trigger_prompt": "<string>",
+                                                "priority_assignment_prompt": "<string>",
+                                                "vocera_defined_metric_code": "<string>",
+                                                "configuration": {
+                                                    "infra_issues_timeout": "<integer>",
+                                                    "key": "value"
+                                                },
+                                                "kb_file_ids": [
+                                                    "<integer>"
+                                                ],
+                                                "knowledge_base_files": [
+                                                    {
+                                                        "id": "<integer>",
+                                                        "agent": "<int>",
+                                                        "file_url": "<string>",
+                                                        "file_name": "<string>",
+                                                        "file_type": "<string>",
+                                                        "file_size": "<integer>",
+                                                        "created_at": "<datetime>",
+                                                        "updated_at": "<datetime>"
+                                                    }
+                                                ],
+                                                "metric_cost": "<float>",
+                                                "overall_score": "<integer>",
+                                                "total_score": "<integer>"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "test-framework-v2-metrics-list",
+                        "description": "List quality metrics. Filter by `project_id` or `agent_id` to scope results."
+                    }
+                }
+            },
+            "post": {
+                "operationId": "test-framework-v2-metrics-create",
+                "description": "Create a quality metric. `type` is `llm_judge` or `custom_code`. `eval_type` is one of `binary`, `continuous_qualitative`, `numeric`, `enum`. Set `add_to_rubric=true` to include the metric in the project's call-success rubric.",
+                "summary": "Create a metric",
+                "tags": [
+                    "Metrics"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricEditSerializerV2"
+                            },
+                            "examples": {
+                                "LLMJudgeMetric(simplest—MostCommon)": {
+                                    "value": {
+                                        "project": 1376,
+                                        "name": "Was the caller greeted by name",
+                                        "description": "Score TRUE if the agent addressed the caller by their name within the first 3 turns, FALSE otherwise.",
+                                        "type": "llm_judge",
+                                        "eval_type": "bool",
+                                        "simulation_enabled": true,
+                                        "observability_enabled": true
+                                    },
+                                    "summary": "LLM judge metric (simplest — most common)"
+                                },
+                                "LLMJudge—EnumOutput": {
+                                    "value": {
+                                        "project": 1376,
+                                        "name": "Call resolution outcome",
+                                        "description": "Classify how the call ended: `resolved` (caller's issue was fully addressed), `transferred` (caller was handed off to a human), `dropped` (caller hung up without resolution).",
+                                        "type": "llm_judge",
+                                        "eval_type": "enum",
+                                        "enum_values": [
+                                            "resolved",
+                                            "transferred",
+                                            "dropped"
+                                        ],
+                                        "observability_enabled": true
+                                    },
+                                    "summary": "LLM judge — enum output"
+                                },
+                                "CustomCodeMetric(deterministicCheck)": {
+                                    "value": {
+                                        "project": 1376,
+                                        "name": "Agent asked for order ID before refund",
+                                        "type": "custom_code",
+                                        "eval_type": "bool",
+                                        "custom_code": "def score(transcript, context):\n    text = transcript.lower()\n    return 'order id' in text[:text.find('refund')] if 'refund' in text else True\n",
+                                        "simulation_enabled": true
+                                    },
+                                    "summary": "Custom code metric (deterministic check)"
+                                },
+                                "BinaryLLM-judgeMetric(addedToRubric)": {
+                                    "value": {
+                                        "name": "Agent greeted the customer",
+                                        "description": "Check if the agent greeted the customer at the start of the call.",
+                                        "project": 42,
+                                        "type": "llm_judge",
+                                        "eval_type": "binary",
+                                        "evaluation_trigger": "always",
+                                        "add_to_rubric": true
+                                    },
+                                    "summary": "Binary LLM-judge metric (added to rubric)"
+                                },
+                                "ContinuousLLM-judgeMetric(0–5Rubric)": {
+                                    "value": {
+                                        "name": "Empathy level",
+                                        "description": "Rate how empathetic the agent was on a 0–5 scale.",
+                                        "project": 42,
+                                        "type": "llm_judge",
+                                        "eval_type": "continuous_qualitative",
+                                        "evaluation_trigger": "always"
+                                    },
+                                    "summary": "Continuous LLM-judge metric (0–5 rubric)"
+                                },
+                                "NumericCustom-codeMetric": {
+                                    "value": {
+                                        "name": "Words per minute",
+                                        "description": "Compute the agent's speaking rate.",
+                                        "project": 42,
+                                        "type": "custom_code",
+                                        "eval_type": "numeric",
+                                        "custom_code": "def evaluate(transcript):\n    return {'score': len(transcript.split()) / max(1, transcript_duration_minutes)}",
+                                        "evaluation_trigger": "always"
+                                    },
+                                    "summary": "Numeric custom-code metric"
+                                },
+                                "EnumLLM-judgeMetric": {
+                                    "value": {
+                                        "name": "Call outcome",
+                                        "description": "Classify the call outcome as one of: booked, follow_up, declined.",
+                                        "project": 42,
+                                        "type": "llm_judge",
+                                        "eval_type": "enum",
+                                        "enum_values": [
+                                            "booked",
+                                            "follow_up",
+                                            "declined"
+                                        ],
+                                        "evaluation_trigger": "always"
+                                    },
+                                    "summary": "Enum LLM-judge metric"
+                                }
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricEditSerializerV2"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricEditSerializerV2"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricDetailSerializerV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "test-framework-v2-metrics-create",
+                        "description": "Create a quality metric. `type` is `llm_judge` or `custom_code`. `eval_type` is one of `binary`, `continuous_qualitative`, `numeric`, `enum`. Set `add_to_rubric=true` to include the metric in the project's call-success rubric."
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/{id}/": {
+            "get": {
+                "operationId": "test-framework-v2-metrics-retrieve",
+                "description": "Fetch one metric by id.",
+                "summary": "Retrieve a metric",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "**ID or Slug** - Metric identifier. Can be either:\n- Numeric ID (e.g., `123`)\n- Slug (e.g., `latency_metric`, `customer_satisfaction`)",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Metrics"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricDetailSerializerV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "detail": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "test-framework-v2-metrics-retrieve",
+                        "description": "Fetch one metric by id."
+                    }
+                }
+            },
+            "put": {
+                "operationId": "test-framework-v2-metrics-update",
+                "description": "Update a metric (full)",
+                "summary": "Update a metric (full)",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Metrics"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostMetricEdit"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostMetricEdit"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostMetricEdit"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SchemaPostMetricEdit"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "patch": {
+                "operationId": "test-framework-v2-metrics-partial-update",
+                "description": "Partially update a metric. Pass `add_to_rubric=true` to add the metric to the project's rubric, or `false` to remove it.",
+                "summary": "Update a metric (partial)",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Metrics"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedMetricEditSerializerV2"
+                            },
+                            "examples": {
+                                "UpdatePrompt+CriticalFlag": {
+                                    "value": {
+                                        "description": "Updated rubric",
+                                        "is_critical": true
+                                    },
+                                    "summary": "Update prompt + critical flag"
+                                }
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedMetricEditSerializerV2"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedMetricEditSerializerV2"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricDetailSerializerV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "detail": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "test-framework-v2-metrics-partial-update",
+                        "description": "Partially update a metric. Pass `add_to_rubric=true` to add the metric to the project's rubric, or `false` to remove it."
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "test-framework-v2-metrics-destroy",
+                "description": "⚠ Irreversible. Deletes the metric and detaches it from all agents and evaluators. Dashboard widgets that displayed this metric are also removed.",
+                "summary": "Delete a metric",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No response body"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "detail": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "test-framework-v2-metrics-destroy",
+                        "description": "⚠ Irreversible. Deletes the metric and detaches it from all agents and evaluators. Dashboard widgets that displayed this metric are also removed."
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/{id}/add_to_predefined_metrics/": {
+            "post": {
+                "operationId": "test-framework-v2-metrics-add-to-predefined-metrics-create",
+                "description": "Manage quality metrics for evaluating AI voice agent performance.\n\n`eval_type` values: `binary`, `continuous_qualitative`, `numeric`, `enum`.\n`add_to_rubric` (write-only) controls whether the metric contributes to\nthe project's call-success rubric.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricDetailV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/{id}/apply_optimisation_proposal/": {
+            "post": {
+                "operationId": "test-framework-v2-metrics-apply-optimisation-proposal-create",
+                "description": "Apply a pending optimisation proposal",
+                "summary": "Apply a pending optimisation proposal",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Metric updated; pending proposal cleared."
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/{id}/dismiss_optimisation_proposal/": {
+            "post": {
+                "operationId": "test-framework-v2-metrics-dismiss-optimisation-proposal-create",
+                "description": "Dismiss a pending optimisation proposal",
+                "summary": "Dismiss a pending optimisation proposal",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Proposal cleared."
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/{id}/evaluate_advance_metric/": {
+            "post": {
+                "operationId": "test-framework-v2-metrics-evaluate-advance-metric-create",
+                "description": "Evaluate an advance metric in the background.\n\nReturns a progress_id to poll for results.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricDetailV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/{id}/evaluate_basic_metric/": {
+            "post": {
+                "operationId": "test-framework-v2-metrics-evaluate-basic-metric-create",
+                "description": "Evaluate a basic metric in the background.\n\nReturns a progress_id to poll for results.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricDetailV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/{id}/evaluate_llm_judge_metric/": {
+            "post": {
+                "operationId": "test-framework-v2-metrics-evaluate-llm-judge-metric-create",
+                "description": "Evaluate a metric using LLM Judge (DSPy) in the background.\n\nReturns a progress_id to poll for results.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/EvaluateLlmJudgeMetricRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/EvaluateLlmJudgeMetricRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/EvaluateLlmJudgeMetricRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/EvaluateLlmJudgeMetricResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/{id}/history/": {
+            "get": {
+                "operationId": "test-framework-v2-metrics-history-list",
+                "description": "Metrics history",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric.",
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "page",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "page_size",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedMetricHistoryList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/{id}/history/edit/": {
+            "patch": {
+                "operationId": "test-framework-v2-metrics-history-edit-partial-update",
+                "description": "Metrics history edit",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedMetricEditHistoryRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedMetricEditHistoryRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedMetricEditHistoryRequest"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricHistory"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/{id}/restore/": {
+            "post": {
+                "operationId": "test-framework-v2-metrics-restore-create",
+                "description": "Metrics restore",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricRestoreRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricRestoreRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricRestoreRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricDetailV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/{id}/run_reviews/": {
+            "post": {
+                "operationId": "test-framework-v2-metrics-run-reviews-create",
+                "description": "Metrics run reviews",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RunReviewsRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RunReviewsRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RunReviewsRequest"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Returns progress_id for tracking progress"
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "test-framework-v2-metrics-run-reviews-create",
+                        "description": "Metrics run reviews"
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/{id}/variables/": {
+            "post": {
+                "operationId": "test-framework-v2-metrics-variables-create",
+                "description": "Get all variables and their values for a specific test_set and metric combination.\n\nURL Parameter:\n- pk: The metric_id\n\nRequest Body:\n- test_set_id (required): The ID of the test_set (datapoint)\n- metric_description_variables (required/optional): Array of variable names for description.\n  At least one of metric_description_variables or evaluation_trigger_variables must be provided.\n- evaluation_trigger_variables (required/optional): Array of variable names for trigger.\n  At least one of metric_description_variables or evaluation_trigger_variables must be provided.\n\nThis endpoint retrieves the variables and populates them with values from the test_set (datapoint).",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricDetailV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/basic_list/": {
+            "get": {
+                "operationId": "test-framework-v2-metrics-basic-list-retrieve",
+                "description": "Manage quality metrics for evaluating AI voice agent performance.\n\n`eval_type` values: `binary`, `continuous_qualitative`, `numeric`, `enum`.\n`add_to_rubric` (write-only) controls whether the metric contributes to\nthe project's call-success rubric.",
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricBasicList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/bulk-toggle-settings/": {
+            "post": {
+                "operationId": "test-framework-v2-metrics-bulk-toggle-settings-create",
+                "description": "Manage quality metrics for evaluating AI voice agent performance.\n\n`eval_type` values: `binary`, `continuous_qualitative`, `numeric`, `enum`.\n`add_to_rubric` (write-only) controls whether the metric contributes to\nthe project's call-success rubric.",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricDetailV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/bulk_create/": {
+            "post": {
+                "operationId": "metrics-bulk-create_3",
+                "description": "Create multiple metrics in a single request",
+                "summary": "Create multiple metrics in a single request",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/SchemaPostMetricEdit"
+                                }
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/SchemaPostMetricEdit"
+                                }
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/SchemaPostMetricEdit"
+                                }
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/SchemaPostMetricEdit"
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "metrics-bulk-create",
+                        "description": "Create multiple metrics in a single request"
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/bulk_manage_agents/": {
+            "post": {
+                "operationId": "test-framework-v2-metrics-bulk-manage-agents-create",
+                "description": "Metrics bulk manage agents",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BulkAgentAssignment"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BulkAgentAssignment"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BulkAgentAssignment"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BulkAgentAssignmentResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/delete_metrics/": {
+            "post": {
+                "operationId": "test-framework-v2-metrics-delete-metrics-create",
+                "description": "Manage quality metrics for evaluating AI voice agent performance.\n\n`eval_type` values: `binary`, `continuous_qualitative`, `numeric`, `enum`.\n`add_to_rubric` (write-only) controls whether the metric contributes to\nthe project's call-success rubric.",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricDetailV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/evaluate_metric_progress/": {
+            "get": {
+                "operationId": "test-framework-v2-metrics-evaluate-metric-progress-retrieve",
+                "description": "Poll for metric evaluation progress.\n\nQuery params:\n    progress_id: The progress_id returned from evaluate_basic_metric or evaluate_advance_metric\n\nReturns:\n    State object with status, output, error, etc.",
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricDetailV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/fetch_call_details/": {
+            "get": {
+                "operationId": "test-framework-v2-metrics-fetch-call-details-retrieve",
+                "description": "Metrics fetch call details",
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricDetailV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/generate_clean_description/": {
+            "post": {
+                "operationId": "test-framework-v2-metrics-generate-clean-description-create",
+                "description": "Metrics generate clean description",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricDetailV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "test-framework-v2-metrics-generate-clean-description-create",
+                        "description": "Metrics generate clean description"
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/generate_clean_description_bg/": {
+            "post": {
+                "operationId": "test-framework-v2-metrics-generate-clean-description-bg-create",
+                "description": "Start async clean description generation",
+                "summary": "Start async clean description generation",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CleanMetricDescriptionRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CleanMetricDescriptionRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CleanMetricDescriptionRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GenerateCleanDescriptionBgResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "test-framework-v2-metrics-generate-clean-description-bg-create",
+                        "description": "Start async clean description generation"
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/generate_clean_description_progress/": {
+            "get": {
+                "operationId": "test-framework-v2-metrics-generate-clean-description-progress-re",
+                "description": "Poll async clean description generation",
+                "summary": "Poll async clean description generation",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "progress_id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "progress_id returned from generate_clean_description_bg",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GenerateCleanDescriptionProgressResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "test-framework-v2-metrics-generate-clean-description-progress-re",
+                        "description": "Poll async clean description generation"
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/generate_evaluation_trigger/": {
+            "post": {
+                "operationId": "test-framework-v2-metrics-generate-evaluation-trigger-create",
+                "description": "Metrics generate evaluation trigger",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricDetailV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "test-framework-v2-metrics-generate-evaluation-trigger-create",
+                        "description": "Metrics generate evaluation trigger"
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/generate_metrics/": {
+            "post": {
+                "operationId": "metrics-generate_3",
+                "description": "Generates suggested metrics for an AI agent. Returns a `progress_id` to poll via `generate_metrics_progress`. Results appear in the progress response but are not saved automatically — pass them to the metrics bulk create endpoint to persist. The agent must have a description of at least 100 characters.",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaGenerateMetricsMetricCreate"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaGenerateMetricsMetricCreate"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaGenerateMetricsMetricCreate"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SchemaGenerateMetricsResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "metrics-generate",
+                        "description": "Generates suggested metrics for an AI agent. Returns a `progress_id` to poll via `generate_metrics_progress`. Results appear in the progress response but are not saved automatically — pass them to the metrics bulk create endpoint to persist. The agent must have a description of at least 100 characters."
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/generate_metrics_progress/": {
+            "get": {
+                "operationId": "test-framework-v2-metrics-generate-metrics-progress-retrieve",
+                "description": "Metrics generate metrics progress",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "progress_id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Progress ID returned from the generate_metrics endpoint",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Returns generation state with status and generated metrics"
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "test-framework-v2-metrics-generate-metrics-progress-retrieve",
+                        "description": "Metrics generate metrics progress"
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/preview/": {
+            "post": {
+                "operationId": "test-framework-v2-metrics-preview-create",
+                "description": "Metrics preview",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricPreview"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricPreview"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricPreview"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Returns progress_id for tracking progress"
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "test-framework-v2-metrics-preview-create",
+                        "description": "Metrics preview"
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/preview-progress/": {
+            "get": {
+                "operationId": "metrics-preview-progress_3",
+                "description": "Metrics preview progress",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "progress_id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Progress ID returned from the preview endpoint",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Returns preview state with status and results"
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "metrics-preview-progress",
+                        "description": "Metrics preview progress"
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/run_reviews_progress/": {
+            "get": {
+                "operationId": "metrics-run-reviews-progress_3",
+                "description": "Metrics run reviews progress",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "progress_id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Progress ID returned from the run_reviews endpoint",
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "agent_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Agent ID for permission validation"
+                    },
+                    {
+                        "in": "query",
+                        "name": "project_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Project ID for permission validation"
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Returns progress state with completed/failed counts and metric data when finished"
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "metrics-run-reviews-progress",
+                        "description": "Metrics run reviews progress"
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/save_result/": {
+            "post": {
+                "operationId": "test-framework-v2-metrics-save-result-create",
+                "description": "Metrics save result",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricDetailV2"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricDetailV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/simplify_prompt/": {
+            "post": {
+                "operationId": "test-framework-v2-metrics-simplify-prompt-create",
+                "description": "Metrics simplify prompt",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SimplifyPromptRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SimplifyPromptRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SimplifyPromptRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SimplifyPromptResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "test-framework-v2-metrics-simplify-prompt-create",
+                        "description": "Metrics simplify prompt"
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/metrics/simplify_prompt_progress/": {
+            "get": {
+                "operationId": "test-framework-v2-metrics-simplify-prompt-progress-retrieve",
+                "description": "Metrics simplify prompt progress",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "progress_id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Progress ID returned from simplify_prompt endpoint",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SimplifyPromptProgressResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "test-framework-v2-metrics-simplify-prompt-progress-retrieve",
+                        "description": "Metrics simplify prompt progress"
                     }
                 }
             }
@@ -41938,7 +44052,7 @@
         "/test_framework/v2/scenarios/generate-bg/": {
             "post": {
                 "operationId": "scenarios-generate-bg_3",
-                "description": "Generate scenarios for a given agent in the background. Returns a `progress_id` immediately; poll GET /scenarios/generate-progress/?progress_id={id} until `total_scenarios == completed_scenarios`.\n\n**What happens automatically on generation:**\n- A scenario-specific test profile is created and its `information` is populated using the sectioned shape: `main_agent_variables` (dynamic-variable values that reach the agent under test at call time — e.g. `user_id`, `account_id`) and `testing_agent_variables` (persona/context used by the simulated caller — e.g. `customer_name`, `date_of_birth`). Section values are kept consistent with any generated mock-tool data.\n- 10 project-level evaluation metrics are attached to every generated scenario automatically (e.g. Latency, Pitch, Interruption Score). Scenarios created manually via `scenarios_create` start with no metrics attached.\n\n**Response fields:** `progress_id` (UUID string) for polling; `session_id` is always null.",
+                "description": "Generate scenarios for a given agent in the background. Returns a `progress_id` immediately; poll GET /scenarios/generate-progress/?progress_id={id} until `total_scenarios == completed_scenarios`.\n\n**What happens automatically on generation:**\n- A default test profile is created for the agent if none exists. Each generated scenario will have `test_profile_data` populated with synthetic caller information (name, address, phone, email).\n- 10 project-level evaluation metrics are attached to every generated scenario automatically (e.g. Latency, Pitch, Interruption Score). Scenarios created manually via `scenarios_create` start with no metrics attached.\n\n**Response fields:** `progress_id` (UUID string) for polling; `session_id` is always null.",
                 "tags": [
                     "test_framework"
                 ],
@@ -42471,10 +44585,148 @@
                 }
             }
         },
+        "/test_framework/v2/scenarios/run_full_scenario_demo/": {
+            "post": {
+                "operationId": "test-framework-v2-scenarios-run-full-scenario-demo-create",
+                "description": "Complete demo flow for \"try it yourself\" free report feature.\n\nThis endpoint handles:\n1. OTP generation and validation for work email\n2. Agent creation under demo project\n3. Scenario generation\n4. Phone call execution\n5. Email report delivery",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ScenarioSerializerV2"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ScenarioSerializerV2"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ScenarioSerializerV2"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ScenarioSerializerV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/scenarios/run_full_scenario_demo_details/": {
+            "post": {
+                "operationId": "test-framework-v2-scenarios-run-full-scenario-demo-details-creat",
+                "description": "Scenarios run full scenario demo details creat",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ScenarioSerializerV2"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ScenarioSerializerV2"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ScenarioSerializerV2"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ScenarioSerializerV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/scenarios/run_full_scenario_demo_email/": {
+            "post": {
+                "operationId": "test-framework-v2-scenarios-run-full-scenario-demo-email-create",
+                "description": "Scenarios run full scenario demo email",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ScenarioSerializerV2"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ScenarioSerializerV2"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ScenarioSerializerV2"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ScenarioSerializerV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/test_framework/v2/scenarios/run_scenarios/": {
             "post": {
                 "operationId": "scenarios-run-voice_3",
-                "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing. Requires `telephony.phone_number` configured on the agent (any provider).\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.",
+                "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing.\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others:**\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.",
                 "summary": "Run evaluators over a voice call",
                 "tags": [
                     "Evaluators"
@@ -42733,7 +44985,7 @@
         "/test_framework/v2/scenarios/run_scenarios_agora/": {
             "post": {
                 "operationId": "scenarios-run-agora_3",
-                "description": "AGORA RTC VOICE RUN: Execute evaluators against an agent reachable in an Agora RTC channel. Cekura joins the channel as a participant and converses. The agent must have `agora_data.session_endpoint_url` configured — an endpoint that mints the per-call channel and token; Cekura calls it at run time and never stores the join details.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC",
+                "description": "AGORA RTC VOICE RUN: Execute evaluators against an agent reachable in an Agora RTC channel. Cekura joins the channel as a participant and converses. The agent must have `agora_data.session_endpoint_url` configured — an endpoint that mints the per-call channel and token; Cekura calls it at run time and never stores the join details.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC",
                 "summary": "Run evaluators against an agent in an Agora RTC channel",
                 "tags": [
                     "Evaluators"
@@ -42909,7 +45161,7 @@
         "/test_framework/v2/scenarios/run_scenarios_chirp/": {
             "post": {
                 "operationId": "scenarios-run-chirp_3",
-                "description": "RAW-PCM WEBSOCKET VOICE RUN: Execute evaluators against an agent that exposes a raw-PCM WebSocket endpoint (16 kHz, 16-bit mono, binary frames). The agent must have a websocket endpoint configured (`telephony.websocket_url`); optional Basic Auth lives in `telephony.websocket_auth`. Pass `websocket_url` to override the agent's stored endpoint for this run.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_websocket` — JSON/text WebSocket protocol (per-scenario URLs)\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC",
+                "description": "RAW-PCM WEBSOCKET VOICE RUN: Execute evaluators against an agent that exposes a raw-PCM WebSocket endpoint (16 kHz, 16-bit mono, binary frames). The agent must have a websocket endpoint configured (`telephony.websocket_url`); optional Basic Auth lives in `telephony.websocket_auth`. Pass `websocket_url` to override the agent's stored endpoint for this run.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_websocket` — JSON/text WebSocket protocol (per-scenario URLs)\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC",
                 "summary": "Run evaluators against a raw-PCM WebSocket voice endpoint",
                 "tags": [
                     "Evaluators"
@@ -43085,7 +45337,7 @@
         "/test_framework/v2/scenarios/run_scenarios_elevenlabs/": {
             "post": {
                 "operationId": "scenarios-run-elevenlabs_3",
-                "description": "ELEVENLABS CONVERSATIONAL VOICE RUN: Execute evaluators against an ElevenLabs Conversational AI agent. The agent must have ElevenLabs credentials configured AND `assistant_id` set to the ElevenLabs agent ID.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)",
+                "description": "ELEVENLABS CONVERSATIONAL VOICE RUN: Execute evaluators against an ElevenLabs Conversational AI agent. The agent must have ElevenLabs credentials configured AND `assistant_id` set to the ElevenLabs agent ID.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)",
                 "summary": "Run evaluators against an ElevenLabs Conversational agent",
                 "tags": [
                     "Evaluators"
@@ -43446,7 +45698,7 @@
         "/test_framework/v2/scenarios/run_scenarios_livekit_v2/": {
             "post": {
                 "operationId": "scenarios-run-livekit-v2_3",
-                "description": "LIVEKIT VOICE RUN (project credentials, v2): Execute evaluators against a LiveKit agent using credentials configured at the project (or agent) level. Cekura creates the rooms; you don't pass URLs per-scenario. Requires `livekit_api_key`, `livekit_data.api_secret`, and `livekit_data.url` on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `room_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_websocket` — JSON/text WebSocket runs",
+                "description": "LIVEKIT VOICE RUN (project credentials, v2): Execute evaluators against a LiveKit agent using credentials configured at the project (or agent) level. Cekura creates the rooms; you don't pass URLs per-scenario. Requires `livekit_api_key`, `livekit_data.api_secret`, and `livekit_data.url` on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `room_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_websocket` — JSON/text WebSocket runs",
                 "summary": "Run evaluators against a LiveKit agent (project credentials, v2)",
                 "tags": [
                     "Evaluators"
@@ -43627,7 +45879,7 @@
         "/test_framework/v2/scenarios/run_scenarios_pipecat/": {
             "post": {
                 "operationId": "scenarios-run-pipecat-v1_3",
-                "description": "PIPECAT WEBRTC RUN (manual room URLs, v1): Execute evaluators against an agent running on Pipecat / Daily.co WebRTC. Each scenario entry carries its own `pipecat_room_url` and optional token. For project-credential-based runs (no per-scenario URL), use `scenarios_run_pipecat_v2` instead.\n\n**Run-count:** one run per entry in `scenarios` — this endpoint does not support `frequency` or personality/test-profile multipliers. To run the same scenario multiple times, include it multiple times in the `scenarios` list.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_text` — text / SMS / chat mode\n- `run_scenarios_with_websockets` — agent exposes a plain websocket URL (non-Pipecat)\n\n**Scheduled runs:** WebRTC sessions are not generally scheduled. Use `run_scenarios` or `run_scenarios_text` via CronJob for recurring evaluator runs.",
+                "description": "PIPECAT WEBRTC RUN (manual room URLs, v1): Execute evaluators against an agent running on Pipecat / Daily.co WebRTC. Each scenario entry carries its own `pipecat_room_url` and optional token. For project-credential-based runs (no per-scenario URL), use `scenarios_run_pipecat_v2` instead.\n\n**Run-count:** one run per entry in `scenarios` — this endpoint does not support `frequency` or personality/test-profile multipliers. To run the same scenario multiple times, include it multiple times in the `scenarios` list.\n\n**When to use this vs others:**\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_text` — text / SMS / chat mode\n- `run_scenarios_with_websockets` — agent exposes a plain websocket URL (non-Pipecat)\n\n**Scheduled runs:** WebRTC sessions are not generally scheduled. Use `run_scenarios` or `run_scenarios_text` via CronJob for recurring evaluator runs.",
                 "summary": "Run evaluators against a Pipecat WebRTC deployment (manual room URLs, v1)",
                 "tags": [
                     "Evaluators"
@@ -43807,7 +46059,7 @@
         "/test_framework/v2/scenarios/run_scenarios_pipecat_v2/": {
             "post": {
                 "operationId": "scenarios-run-pipecat-v2_3",
-                "description": "PIPECAT CLOUD VOICE RUN (project credentials, v2): Execute evaluators against an agent deployed on Pipecat Cloud using credentials configured at the project level. Cekura creates the sessions; you don't pass per-scenario room URLs (that's the v1 endpoint). Requires Pipecat Cloud credentials with `pipecat_agent_name` set on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `session_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_pipecat_v1` — manual room URLs per scenario\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
+                "description": "PIPECAT CLOUD VOICE RUN (project credentials, v2): Execute evaluators against an agent deployed on Pipecat Cloud using credentials configured at the project level. Cekura creates the sessions; you don't pass per-scenario room URLs (that's the v1 endpoint). Requires Pipecat Cloud credentials with `pipecat_agent_name` set on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `session_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others:**\n- `scenarios_run_pipecat_v1` — manual room URLs per scenario\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
                 "summary": "Run evaluators against a Pipecat Cloud deployment (project credentials, v2)",
                 "tags": [
                     "Evaluators"
@@ -43988,7 +46240,7 @@
         "/test_framework/v2/scenarios/run_scenarios_retell_webrtc/": {
             "post": {
                 "operationId": "scenarios-run-retell-webrtc_3",
-                "description": "RETELL WEBRTC VOICE RUN: Execute evaluators against a Retell agent over WebRTC (LiveKit infrastructure). The agent must have Retell credentials configured. `retell_agent_id` is optional and defaults to `agent.assistant_id` if not provided.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
+                "description": "RETELL WEBRTC VOICE RUN: Execute evaluators against a Retell agent over WebRTC (LiveKit infrastructure). The agent must have Retell credentials configured. `retell_agent_id` is optional and defaults to `agent.assistant_id` if not provided.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
                 "summary": "Run evaluators against a Retell agent over WebRTC",
                 "tags": [
                     "Evaluators"
@@ -44166,7 +46418,7 @@
         "/test_framework/v2/scenarios/run_scenarios_sip/": {
             "post": {
                 "operationId": "scenarios-run-sip_3",
-                "description": "SIP VOICE RUN (direct SIP): Execute evaluators against an agent over a direct SIP connection (orchestrated by Cekura's SIP voice service). The agent must have a SIP endpoint configured (`telephony.sip_uri` on the v2 agent).\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone calls via Cekura's standard voice path\n- `scenarios_run_vapi_webrtc` / `_retell_webrtc` — provider-managed WebRTC\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
+                "description": "SIP VOICE RUN (direct SIP): Execute evaluators against an agent over a direct SIP connection (orchestrated by Cekura's SIP voice service). The agent must have `sip_endpoint` configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone calls via Cekura's standard voice path\n- `scenarios_run_vapi_webrtc` / `_retell_webrtc` — provider-managed WebRTC\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
                 "summary": "Run evaluators over a direct SIP connection",
                 "tags": [
                     "Evaluators"
@@ -44342,7 +46594,7 @@
         "/test_framework/v2/scenarios/run_scenarios_text/": {
             "post": {
                 "operationId": "scenarios-run-text_3",
-                "description": "TEXT / SMS / CHAT RUN: Execute evaluators against your agent using text-only simulation (SMS, chat, or an agent-hosted websocket). Cheaper than voice — billed at the text-simulation rate. Requires a chat connection (`provider.chat_agent_details`) on the agent, or a websocket URL for `self_hosted` agents.\n\n**Run-count math:** total conversations = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**Concurrency:** use `concurrency_limit` to cap parallel conversations. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Websocket override:** if the agent exposes a plain websocket URL for text, pass it as `websocket_url` — this bypasses the agent's standard text-readiness check. Pass `websocket_headers` (JSON object) to override connection headers for this run — merged over the agent's configured headers, with the per-run values winning.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL (bulk)\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**`self_hosted` agents:** agents with `assistant_provider=\"self_hosted\"` require a websocket URL. Either pre-configure `websocket_url` on the agent, or pass it directly in this request. Without it, the run fails with `[\"Agent does not have a websocket URL\"]`. Passing `websocket_url` here changes the result's `run_type` to `\"WebSocket\"` instead of `\"Text\"`.\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"text\"` instead.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.",
+                "description": "TEXT / SMS / CHAT RUN: Execute evaluators against your agent using text-only simulation (SMS, chat, or an agent-hosted websocket). Cheaper than voice — billed at the text-simulation rate.\n\n**Run-count math:** total conversations = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**Concurrency:** use `concurrency_limit` to cap parallel conversations. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Websocket override:** if the agent exposes a plain websocket URL for text, pass it as `websocket_url` — this bypasses the agent's standard text-readiness check. Pass `websocket_headers` (JSON object) to override connection headers for this run — merged over the agent's configured headers, with the per-run values winning.\n\n**When to use this vs others:**\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL (bulk)\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**`self_hosted` agents:** agents with `assistant_provider=\"self_hosted\"` require a websocket URL. Either pre-configure `websocket_url` on the agent, or pass it directly in this request. Without it, the run fails with `[\"Agent does not have a websocket URL\"]`. Passing `websocket_url` here changes the result's `run_type` to `\"WebSocket\"` instead of `\"Text\"`.\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"text\"` instead.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.",
                 "summary": "Run evaluators in text / SMS / chat mode",
                 "tags": [
                     "Evaluators"
@@ -44541,7 +46793,7 @@
         "/test_framework/v2/scenarios/run_scenarios_vapi_webrtc/": {
             "post": {
                 "operationId": "scenarios-run-vapi-webrtc_3",
-                "description": "VAPI WEBRTC VOICE RUN: Execute evaluators against a VAPI agent over WebRTC. Required: `vapi_assistant_id` (the VAPI assistant). The agent (looked up via `agent_id` or inferred from the first scenario) must have VAPI credentials configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_text` — text/SMS/chat (cheaper)\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
+                "description": "VAPI WEBRTC VOICE RUN: Execute evaluators against a VAPI agent over WebRTC. Required: `vapi_assistant_id` (the VAPI assistant). The agent (looked up via `agent_id` or inferred from the first scenario) must have VAPI credentials configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_text` — text/SMS/chat (cheaper)\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
                 "summary": "Run evaluators against a VAPI WebRTC agent",
                 "tags": [
                     "Evaluators"
@@ -44720,7 +46972,7 @@
         "/test_framework/v2/scenarios/run_scenarios_with_websockets/": {
             "post": {
                 "operationId": "scenarios-run-websocket_3",
-                "description": "WEBSOCKET RUN (per-scenario URLs, bulk): Execute evaluators where each scenario carries its own websocket URL. Useful when you have a fleet of agents or stateful websocket sessions to test in a single batch.\n\n**Run-count:** total conversations = `len(scenarios) × frequency`. (Personality and test-profile multipliers are not supported on this endpoint.)\n\n**`frequency` is required** on this endpoint (no default).\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — single websocket URL or SMS/chat mode (simpler)\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'.\n\n**Known limitation:** `result.run_type` may show 'Text' instead of 'WebSocket' for runs triggered via this endpoint — this is a display issue only and does not affect execution.",
+                "description": "WEBSOCKET RUN (per-scenario URLs, bulk): Execute evaluators where each scenario carries its own websocket URL. Useful when you have a fleet of agents or stateful websocket sessions to test in a single batch.\n\n**Run-count:** total conversations = `len(scenarios) × frequency`. (Personality and test-profile multipliers are not supported on this endpoint.)\n\n**`frequency` is required** on this endpoint (no default).\n\n**When to use this vs others:**\n- `run_scenarios_text` — single websocket URL or SMS/chat mode (simpler)\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'.\n\n**Known limitation:** `result.run_type` may show 'Text' instead of 'WebSocket' for runs triggered via this endpoint — this is a display issue only and does not affect execution.",
                 "summary": "Run evaluators against per-scenario websocket URLs (bulk)",
                 "tags": [
                     "Evaluators"
@@ -53050,7 +55302,6 @@
             },
             "CallLogDetail": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -53109,7 +55360,7 @@
                             }
                         ],
                         "readOnly": true,
-                        "description": "Evaluation results for the call.\nExample: \n```json\n{\n    \"metrics\": [\n        {\n            \"id\": 35,\n            \"name\": \"Instruction Follow\",\n            \"type\": \"binary_workflow_adherence\",\n            \"score\": 0,\n            \"explanation\": [\"Agent failed to follow the opening script\", \"Missed key product information\"],\n            \"vocera_defined_metric_code\": \"5dedc41b\",\n            \"function_name\": \"check_critical_deviations\",\n            \"extra\": {\n                \"categories\": [\n                    {\n                        \"category_id\": 5,\n                        \"category\": \"Script Adherence Issue\",\n                        \"deviation\": \"Agent deviated from required script\",\n                        \"priority\": \"critical\"\n                    }\n                ]\n            }\n        },\n        {\n            \"id\": 18,\n            \"name\": \"Customer Satisfaction\",\n            \"type\": \"binary_qualitative\",\n            \"score\": 5,\n            \"explanation\": [\"Customer expressed satisfaction with service\"]\n        }\n    ]\n}\n```"
+                        "description": "Evaluation results for the call.\nExample: \n```json\n{\n    \"metrics\": [\n        {\n            \"id\": 35,\n            \"name\": \"Instruction Follow\",\n            \"type\": \"binary\",\n            \"score\": 0,\n            \"explanation\": [\"Agent failed to follow the opening script\", \"Missed key product information\"],\n            \"vocera_defined_metric_code\": \"5dedc41b\",\n            \"function_name\": \"check_critical_deviations\",\n            \"extra\": {\n                \"categories\": [\n                    {\n                        \"category_id\": 5,\n                        \"category\": \"Script Adherence Issue\",\n                        \"deviation\": \"Agent deviated from required script\",\n                        \"priority\": \"critical\"\n                    }\n                ]\n            }\n        },\n        {\n            \"id\": 18,\n            \"name\": \"Customer Satisfaction\",\n            \"type\": \"binary\",\n            \"score\": 5,\n            \"explanation\": [\"Customer expressed satisfaction with service\"]\n        }\n    ]\n}\n```"
                     },
                     "metadata": {
                         "type": "object",
@@ -53242,7 +55493,6 @@
             },
             "CallLogList": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -54436,7 +56686,6 @@
             },
             "Dashboard": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -54568,7 +56817,6 @@
             },
             "DashboardList": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -55982,15 +58230,14 @@
                     },
                     "eval_type": {
                         "enum": [
-                            "binary_workflow_adherence",
-                            "binary_qualitative",
+                            "binary",
                             "continuous_qualitative",
                             "numeric",
                             "enum"
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "1e3e27b342bfd8ec",
-                        "description": "\nType of evaluation\n\n\n* `binary_workflow_adherence` - Binary Workflow Adherence\n* `binary_qualitative` - Binary Qualitative\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum"
+                        "x-spec-enum-id": "b40eac6824409cc2",
+                        "description": "\nType of evaluation\n\n\n* `binary` - Binary\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum"
                     },
                     "enum_values": {
                         "description": "\nList of possible enum values for enum type metrics.\nExample: `[\"satisfied\", \"unsatisfied\"]`\n"
@@ -56028,15 +58275,14 @@
                     },
                     "eval_type": {
                         "enum": [
-                            "binary_workflow_adherence",
-                            "binary_qualitative",
+                            "binary",
                             "continuous_qualitative",
                             "numeric",
                             "enum"
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "1e3e27b342bfd8ec",
-                        "description": "\nType of evaluation\n\n\n* `binary_workflow_adherence` - Binary Workflow Adherence\n* `binary_qualitative` - Binary Qualitative\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum"
+                        "x-spec-enum-id": "b40eac6824409cc2",
+                        "description": "\nType of evaluation\n\n\n* `binary` - Binary\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum"
                     },
                     "enum_values": {
                         "description": "\nList of possible enum values for enum type metrics.\nExample: `[\"satisfied\", \"unsatisfied\"]`\n"
@@ -56097,7 +58343,7 @@
                     "name"
                 ]
             },
-            "MetricDetailV2": {
+            "MetricDetailSerializerV2": {
                 "type": "object",
                 "properties": {
                     "id": {
@@ -56149,15 +58395,14 @@
                     },
                     "eval_type": {
                         "enum": [
-                            "binary_workflow_adherence",
-                            "binary_qualitative",
+                            "binary",
                             "continuous_qualitative",
                             "numeric",
                             "enum"
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "1e3e27b342bfd8ec",
-                        "description": "\nType of evaluation\n\n\n* `binary_workflow_adherence` - Binary Workflow Adherence\n* `binary_qualitative` - Binary Qualitative\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum"
+                        "description": "* `binary` - Binary\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum",
+                        "x-spec-enum-id": "b40eac6824409cc2"
                     },
                     "enum_values": {
                         "description": "\nList of possible enum values for enum type metrics.\nExample: `[\"satisfied\", \"unsatisfied\"]`\n"
@@ -56350,6 +58595,544 @@
                         ],
                         "readOnly": true,
                         "description": "Unsaved proposal from a metric-optimiser cron run. Shape: {description, evaluation_trigger, type, custom_code, score, baseline_score, cron_job_id, cron_job_name, proposed_at}."
+                    }
+                },
+                "required": [
+                    "eval_type",
+                    "name"
+                ]
+            },
+            "MetricDetailV2": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "slug": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "URL-friendly unique identifier in snake_case format. Example: \"customer_satisfaction_1562\"",
+                        "maxLength": 255
+                    },
+                    "project": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
+                    },
+                    "agents": {
+                        "type": "array",
+                        "items": {
+                            "type": [
+                                "integer",
+                                "null"
+                            ]
+                        }
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "\nName of the metric.\nExample: `\"Customer Satisfaction\"` or `\"Appointment Booking\"`\n        ",
+                        "maxLength": 255
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "\nDescription of what the metric measures.\nExample: `\"Measures how satisfied customers are with the service provided\"`\n        "
+                    },
+                    "type": {
+                        "enum": [
+                            "basic",
+                            "custom_prompt",
+                            "custom_code",
+                            "llm_judge"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "b44700c0a6443b40",
+                        "description": "\nType of metric\n\n\n* `basic` - Basic (Deprecated in favor of LLM Judge)\n* `custom_prompt` - Custom Prompt ( Deprecated in favor of LLM Judge)\n* `custom_code` - Custom Code\n* `llm_judge` - LLM Judge"
+                    },
+                    "eval_type": {
+                        "enum": [
+                            "binary",
+                            "continuous_qualitative",
+                            "numeric",
+                            "enum"
+                        ],
+                        "type": "string",
+                        "description": "* `binary` - Binary\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum",
+                        "x-spec-enum-id": "b40eac6824409cc2"
+                    },
+                    "enum_values": {
+                        "description": "\nList of possible enum values for enum type metrics.\nExample: `[\"satisfied\", \"unsatisfied\"]`\n"
+                    },
+                    "audio_enabled": {
+                        "type": "boolean",
+                        "description": "\nWhether this metric requires audio analysis.\nExample: `true` or `false`\n        "
+                    },
+                    "prompt": {
+                        "type": "string",
+                        "description": "\nEvaluation prompt for the metric.\nExample: `\"Evaluate customer satisfaction based on conversation\"`\n"
+                    },
+                    "evaluation_trigger": {
+                        "enum": [
+                            "always",
+                            "automatic",
+                            "custom"
+                        ],
+                        "type": "string",
+                        "description": "* `always` - Always\n* `automatic` - Automatic\n* `custom` - Custom",
+                        "x-spec-enum-id": "ecd3c02e0e393ef5"
+                    },
+                    "trigger_type": {
+                        "enum": [
+                            "llm_judge",
+                            "custom_code"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "2adad4b8df61914f",
+                        "description": "\nType of trigger evaluation: LLM judge or custom code.\nOnly used when evaluation_trigger is CUSTOM.\nExample: `\"llm_judge\"` or `\"custom_code\"`\n\n\n* `llm_judge` - LLM Judge\n* `custom_code` - Custom Code"
+                    },
+                    "evaluation_trigger_prompt": {
+                        "type": "string",
+                        "description": "\nEvaluation trigger prompt for the metric.\nExample: `\"Evaluate metric only if call ended reason is main-agent-ended-call\"`\n"
+                    },
+                    "evaluation_trigger_custom_code": {
+                        "type": "string",
+                        "description": "\nPython custom code to determine metric relevance. Code should set _result (bool) and _explanation (str).\nExample:\n```python\n_result = True\n_explanation = \"Metric is relevant\"\nif \"call_end_reason\" in data and data[\"call_end_reason\"] == \"customer-hung-up\":\n    _result = False\n    _explanation = \"Customer hung up, metric not applicable\"\n```\n"
+                    },
+                    "priority_assignment_prompt": {
+                        "type": "string",
+                        "description": "\nPriority assignment prompt for the metric.\n"
+                    },
+                    "configuration": {
+                        "description": "\nCustom configuration parameters for specific metrics if metric supports it.\nExample:\n- For Infrastructure issues\n```json\n{\n    \"infra_issues_timeout\": 10\n}\n```\n"
+                    },
+                    "overall_score": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "The overall score for this metric across all test sets"
+                    },
+                    "total_score": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "The total score for this metric"
+                    },
+                    "knowledge_base_files": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "Knowledge base files associated with this metric"
+                    },
+                    "observability_enabled": {
+                        "type": "boolean",
+                        "description": "\nEnable this metric for observability.\nExample: `true` or `false`\n        "
+                    },
+                    "simulation_enabled": {
+                        "type": "boolean",
+                        "description": "\nEnable this metric for simulations.\nExample: `true` or `false`\n        "
+                    },
+                    "sampling_enabled": {
+                        "type": "boolean",
+                        "description": "Enable sampling for this metric using project-level sample rate"
+                    },
+                    "alert_enabled": {
+                        "type": "boolean",
+                        "description": "\nEnable alerts for this metric when it fails (value < 5).\nOnly applicable to binary metrics (binary_workflow_adherence and binary_qualitative).\nFor other metric types, use significant_change_alert_status instead.\nExample: `true` or `false`\n        "
+                    },
+                    "alert_type": {
+                        "enum": [
+                            "disabled",
+                            "normal",
+                            "significant_change"
+                        ],
+                        "type": "string",
+                        "description": "* `disabled` - Alerts Disabled\n* `normal` - Normal Alerts\n* `significant_change` - Significant Change Alerts",
+                        "x-spec-enum-id": "9e2661f1aeca64cf",
+                        "default": "disabled"
+                    },
+                    "alert_filters": {
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Filters to apply before computing alerts (CallLogQueryFilter format)"
+                    },
+                    "slack_workspace": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
+                        "description": "Slack workspace to send alerts to"
+                    },
+                    "slack_channel_id": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "Override channel ID for this metric's alerts",
+                        "maxLength": 255
+                    },
+                    "significant_change_alert_status": {
+                        "enum": [
+                            "enabled",
+                            "disabled"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "6d6f4d361b4ea1fb",
+                        "description": "\nAlert status: enabled or disabled.\n\n\n* `enabled` - Enabled\n* `disabled` - Disabled"
+                    },
+                    "significant_change_alert_direction": {
+                        "enum": [
+                            "",
+                            "increase",
+                            "decrease"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "1e86e60ca5cfba12",
+                        "description": "Alert direction: increase only, decrease only, or both (empty = both).\nExample: `\"increase\"`, `\"decrease\"`, or `\"both\"`\n\n* `` - Both (Increase and Decrease)\n* `increase` - Increase Only\n* `decrease` - Decrease Only"
+                    },
+                    "function_name": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "\nPredefined function name\nExample: `\"get_latency\"` or `\"check_critical_deviations\"`\n",
+                        "maxLength": 255
+                    },
+                    "custom_code": {
+                        "type": "string",
+                        "description": "\nPython custom code for the metric.\nExample:\n```python\n_resul = True\n_explanation = None\nif  \"call_end_reason\" in data and data[\"call_end_reason\"] == \"customer_satisfaction\":\n    _result = True\n    _explanation = \"Customer expressed satisfaction with service\"\n```\n"
+                    },
+                    "vocera_defined_metric_code": {
+                        "type": "string",
+                        "description": "\nVocera defined metric code for the metric.\nExample: `\"7fd534f5\"`\n",
+                        "maxLength": 255
+                    },
+                    "scenarios": {
+                        "writeOnly": true
+                    },
+                    "reviews": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/MetricReviewDetail"
+                        },
+                        "readOnly": true,
+                        "description": "Reviews associated with the metric"
+                    },
+                    "window_size": {
+                        "type": "integer",
+                        "readOnly": true,
+                        "description": "\nWindow size for rolling statistics calculation.\nExample: `50`\n"
+                    },
+                    "std_multiplier": {
+                        "type": "number",
+                        "format": "double",
+                        "readOnly": true,
+                        "description": "\nStandard deviation multiplier for threshold calculation.\nExample: `2.0`\n"
+                    },
+                    "ewma_alpha": {
+                        "type": "number",
+                        "format": "double",
+                        "readOnly": true,
+                        "description": "\nAlpha value for exponentially weighted moving average (EWMA) calculation.\nExample: `0.1`\n"
+                    },
+                    "add_to_new_agents": {
+                        "type": [
+                            "boolean",
+                            "null"
+                        ],
+                        "description": "When enabled, this metric is automatically assigned to new agents created in the project."
+                    },
+                    "pending_optimisation_proposal": {
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "readOnly": true,
+                        "description": "Unsaved proposal from a metric-optimiser cron run. Shape: {description, evaluation_trigger, type, custom_code, score, baseline_score, cron_job_id, cron_job_name, proposed_at}."
+                    }
+                },
+                "required": [
+                    "eval_type",
+                    "name"
+                ]
+            },
+            "MetricEditSerializerV2": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "slug": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "URL-friendly unique identifier in snake_case format",
+                        "maxLength": 255
+                    },
+                    "project": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
+                    },
+                    "agent": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
+                    },
+                    "agents": {
+                        "type": "array",
+                        "items": {
+                            "type": [
+                                "integer",
+                                "null"
+                            ]
+                        }
+                    },
+                    "assistant_id": {
+                        "type": "string",
+                        "writeOnly": true
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "\nName of the metric.\nExample: `\"Customer Satisfaction\"` or `\"Appointment Booking\"`\n        ",
+                        "maxLength": 255
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "\nDescription of what the metric measures.\nExample: `\"Measures how satisfied customers are with the service provided\"`\n        "
+                    },
+                    "type": {
+                        "enum": [
+                            "basic",
+                            "custom_prompt",
+                            "custom_code",
+                            "llm_judge"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "b44700c0a6443b40",
+                        "description": "\nType of metric\n\n\n* `basic` - Basic (Deprecated in favor of LLM Judge)\n* `custom_prompt` - Custom Prompt ( Deprecated in favor of LLM Judge)\n* `custom_code` - Custom Code\n* `llm_judge` - LLM Judge"
+                    },
+                    "eval_type": {
+                        "enum": [
+                            "binary",
+                            "continuous_qualitative",
+                            "numeric",
+                            "enum"
+                        ],
+                        "type": "string",
+                        "description": "* `binary` - Binary\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum",
+                        "x-spec-enum-id": "b40eac6824409cc2"
+                    },
+                    "audio_enabled": {
+                        "type": "boolean",
+                        "readOnly": true,
+                        "description": "\nWhether this metric requires audio analysis.\nExample: `true` or `false`\n        "
+                    },
+                    "observability_enabled": {
+                        "type": "boolean",
+                        "description": "\nEnable this metric for observability.\nExample: `true` or `false`\n        "
+                    },
+                    "simulation_enabled": {
+                        "type": "boolean",
+                        "description": "\nEnable this metric for simulations.\nExample: `true` or `false`\n        "
+                    },
+                    "sampling_enabled": {
+                        "type": "boolean",
+                        "description": "Enable sampling for this metric using project-level sample rate"
+                    },
+                    "prompt": {
+                        "type": "string",
+                        "description": "\nEvaluation prompt for the metric.\nExample: `\"Evaluate customer satisfaction based on conversation\"`\n"
+                    },
+                    "function_name": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "readOnly": true,
+                        "description": "\nPredefined function name\nExample: `\"get_latency\"` or `\"check_critical_deviations\"`\n"
+                    },
+                    "enum_values": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "display_order": {
+                        "type": "integer",
+                        "maximum": 2147483647,
+                        "minimum": -2147483648,
+                        "description": "\nDisplay order for the metric.\nExample: `1`\n"
+                    },
+                    "custom_code": {
+                        "type": "string",
+                        "description": "\nPython custom code for the metric.\nExample:\n```python\n_resul = True\n_explanation = None\nif  \"call_end_reason\" in data and data[\"call_end_reason\"] == \"customer_satisfaction\":\n    _result = True\n    _explanation = \"Customer expressed satisfaction with service\"\n```\n"
+                    },
+                    "evaluation_trigger": {
+                        "enum": [
+                            "always",
+                            "automatic",
+                            "custom"
+                        ],
+                        "type": "string",
+                        "description": "* `always` - Always\n* `automatic` - Automatic\n* `custom` - Custom",
+                        "x-spec-enum-id": "ecd3c02e0e393ef5"
+                    },
+                    "trigger_type": {
+                        "enum": [
+                            "llm_judge",
+                            "custom_code"
+                        ],
+                        "type": "string",
+                        "description": "* `llm_judge` - LLM Judge\n* `custom_code` - Custom Code",
+                        "x-spec-enum-id": "2adad4b8df61914f"
+                    },
+                    "evaluation_trigger_prompt": {
+                        "type": "string",
+                        "description": "\nEvaluation trigger prompt for the metric.\nExample: `\"Evaluate metric only if call ended reason is main-agent-ended-call\"`\n"
+                    },
+                    "evaluation_trigger_custom_code": {
+                        "type": "string",
+                        "description": "\nPython custom code to determine metric relevance. Code should set _result (bool) and _explanation (str).\nExample:\n```python\n_result = True\n_explanation = \"Metric is relevant\"\nif \"call_end_reason\" in data and data[\"call_end_reason\"] == \"customer-hung-up\":\n    _result = False\n    _explanation = \"Customer hung up, metric not applicable\"\n```\n"
+                    },
+                    "vocera_defined_metric_code": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "\nVocera defined metric code for the metric.\nExample: `\"7fd534f5\"`\n"
+                    },
+                    "priority_assignment_prompt": {
+                        "type": "string",
+                        "description": "\nPriority assignment prompt for the metric.\n"
+                    },
+                    "configuration": {
+                        "description": "\nCustom configuration parameters for specific metrics if metric supports it.\nExample:\n- For Infrastructure issues\n```json\n{\n    \"infra_issues_timeout\": 10\n}\n```\n"
+                    },
+                    "scenarios": {
+                        "writeOnly": true
+                    },
+                    "overall_score": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "total_score": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "kb_file_ids": {
+                        "description": "\nList of knowledge base file IDs for the metric.\nExample: `[123, 456]`\n"
+                    },
+                    "knowledge_base_files": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "metric_description_program": {},
+                    "metric_description_variables": {
+                        "type": "array",
+                        "items": {}
+                    },
+                    "evaluation_trigger_program": {},
+                    "evaluation_trigger_variables": {
+                        "type": "array",
+                        "items": {}
+                    },
+                    "alert_enabled": {
+                        "type": "boolean",
+                        "description": "\nEnable alerts for this metric when it fails (value < 5).\nOnly applicable to binary metrics (binary_workflow_adherence and binary_qualitative).\nFor other metric types, use significant_change_alert_status instead.\nExample: `true` or `false`\n        "
+                    },
+                    "alert_type": {
+                        "enum": [
+                            "disabled",
+                            "normal",
+                            "significant_change"
+                        ],
+                        "type": "string",
+                        "description": "* `disabled` - Alerts Disabled\n* `normal` - Normal Alerts\n* `significant_change` - Significant Change Alerts",
+                        "x-spec-enum-id": "9e2661f1aeca64cf",
+                        "default": "disabled"
+                    },
+                    "window_size": {
+                        "type": "integer",
+                        "default": 50
+                    },
+                    "std_multiplier": {
+                        "type": "number",
+                        "format": "double",
+                        "default": 2.0
+                    },
+                    "ewma_alpha": {
+                        "type": "number",
+                        "format": "double",
+                        "default": 0.1
+                    },
+                    "significant_change_alert_status": {
+                        "enum": [
+                            "enabled",
+                            "disabled"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "6d6f4d361b4ea1fb",
+                        "description": "\nAlert status: enabled or disabled.\n\n\n* `enabled` - Enabled\n* `disabled` - Disabled"
+                    },
+                    "significant_change_alert_direction": {
+                        "enum": [
+                            "",
+                            "increase",
+                            "decrease"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "1e86e60ca5cfba12",
+                        "description": "Alert direction: increase only, decrease only, or both (empty = both).\nExample: `\"increase\"`, `\"decrease\"`, or `\"both\"`\n\n* `` - Both (Increase and Decrease)\n* `increase` - Increase Only\n* `decrease` - Decrease Only"
+                    },
+                    "add_to_new_agents": {
+                        "type": [
+                            "boolean",
+                            "null"
+                        ],
+                        "description": "When enabled, this metric is automatically assigned to new agents created in the project."
+                    },
+                    "alert_filters": {
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Filters to apply before computing alerts (CallLogQueryFilter format)"
+                    },
+                    "slack_workspace": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
+                        "description": "Slack workspace to send alerts to"
+                    },
+                    "slack_channel_id": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "Override channel ID for this metric's alerts",
+                        "maxLength": 255
+                    },
+                    "add_to_rubric": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "On write: true adds this metric to the project's call-success rubric (a sensible default rule is chosen by `eval_type`); false removes it. On read: reflects current rubric membership."
+                    },
+                    "apply_to_all_agents": {
+                        "type": "boolean",
+                        "writeOnly": true,
+                        "default": false,
+                        "description": "For observability_dropoff: when true, copies the dropoff_nodes from configuration to every other agent in the project."
                     }
                 },
                 "required": [
@@ -56640,15 +59423,14 @@
                     },
                     "eval_type": {
                         "enum": [
-                            "binary_workflow_adherence",
-                            "binary_qualitative",
+                            "binary",
                             "continuous_qualitative",
                             "numeric",
                             "enum"
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "1e3e27b342bfd8ec",
-                        "description": "\nType of evaluation\n\n\n* `binary_workflow_adherence` - Binary Workflow Adherence\n* `binary_qualitative` - Binary Qualitative\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum"
+                        "x-spec-enum-id": "b40eac6824409cc2",
+                        "description": "\nType of evaluation\n\n\n* `binary` - Binary\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum"
                     },
                     "enum_values": {
                         "description": "\nList of possible enum values for enum type metrics.\nExample: `[\"satisfied\", \"unsatisfied\"]`\n"
@@ -56841,7 +59623,6 @@
             },
             "MetricList": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -56904,15 +59685,14 @@
                     },
                     "eval_type": {
                         "enum": [
-                            "binary_workflow_adherence",
-                            "binary_qualitative",
+                            "binary",
                             "continuous_qualitative",
                             "numeric",
                             "enum"
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "1e3e27b342bfd8ec",
-                        "description": "\nType of evaluation\n\n\n* `binary_workflow_adherence` - Binary Workflow Adherence\n* `binary_qualitative` - Binary Qualitative\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum"
+                        "description": "* `binary` - Binary\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum",
+                        "x-spec-enum-id": "b40eac6824409cc2"
                     },
                     "enum_values": {
                         "description": "\nList of possible enum values for enum type metrics.\nExample: `[\"satisfied\", \"unsatisfied\"]`\n"
@@ -57087,14 +59867,271 @@
                         ],
                         "description": "Override channel ID for this metric's alerts",
                         "maxLength": 255
-                    },
-                    "affects_call_success": {
-                        "type": "string",
-                        "readOnly": true,
-                        "description": "\nWhether this metric is configured in the project's rubric and therefore contributes\nto overall call success evaluation.\nExample: `true`\n"
                     }
                 },
                 "required": [
+                    "eval_type",
+                    "name"
+                ]
+            },
+            "MetricListSerializerV2": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "slug": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "URL-friendly unique identifier in snake_case format. Example: \"customer_satisfaction_1562\"",
+                        "maxLength": 255
+                    },
+                    "project": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
+                    },
+                    "agents": {
+                        "type": "array",
+                        "items": {
+                            "type": [
+                                "integer",
+                                "null"
+                            ]
+                        }
+                    },
+                    "agent_names": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "\nName of the metric.\nExample: `\"Customer Satisfaction\"` or `\"Appointment Booking\"`\n        ",
+                        "maxLength": 255
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "\nDescription of what the metric measures.\nExample: `\"Measures how satisfied customers are with the service provided\"`\n        "
+                    },
+                    "function_name": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "\nPredefined function name\nExample: `\"get_latency\"` or `\"check_critical_deviations\"`\n",
+                        "maxLength": 255
+                    },
+                    "type": {
+                        "enum": [
+                            "basic",
+                            "custom_prompt",
+                            "custom_code",
+                            "llm_judge"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "b44700c0a6443b40",
+                        "description": "\nType of metric\n\n\n* `basic` - Basic (Deprecated in favor of LLM Judge)\n* `custom_prompt` - Custom Prompt ( Deprecated in favor of LLM Judge)\n* `custom_code` - Custom Code\n* `llm_judge` - LLM Judge"
+                    },
+                    "eval_type": {
+                        "enum": [
+                            "binary",
+                            "continuous_qualitative",
+                            "numeric",
+                            "enum"
+                        ],
+                        "type": "string",
+                        "description": "* `binary` - Binary\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum",
+                        "x-spec-enum-id": "b40eac6824409cc2"
+                    },
+                    "enum_values": {
+                        "description": "\nList of possible enum values for enum type metrics.\nExample: `[\"satisfied\", \"unsatisfied\"]`\n"
+                    },
+                    "audio_enabled": {
+                        "type": "boolean",
+                        "description": "\nWhether this metric requires audio analysis.\nExample: `true` or `false`\n        "
+                    },
+                    "observability_enabled": {
+                        "type": "boolean",
+                        "description": "\nEnable this metric for observability.\nExample: `true` or `false`\n        "
+                    },
+                    "simulation_enabled": {
+                        "type": "boolean",
+                        "description": "\nEnable this metric for simulations.\nExample: `true` or `false`\n        "
+                    },
+                    "sampling_enabled": {
+                        "type": "boolean",
+                        "description": "Enable sampling for this metric using project-level sample rate"
+                    },
+                    "prompt": {
+                        "type": "string",
+                        "description": "\nEvaluation prompt for the metric.\nExample: `\"Evaluate customer satisfaction based on conversation\"`\n"
+                    },
+                    "display_order": {
+                        "type": "integer",
+                        "maximum": 2147483647,
+                        "minimum": -2147483648,
+                        "description": "\nDisplay order for the metric.\nExample: `1`\n"
+                    },
+                    "evaluation_trigger": {
+                        "enum": [
+                            "always",
+                            "automatic",
+                            "custom"
+                        ],
+                        "type": "string",
+                        "description": "* `always` - Always\n* `automatic` - Automatic\n* `custom` - Custom",
+                        "x-spec-enum-id": "ecd3c02e0e393ef5"
+                    },
+                    "trigger_type": {
+                        "enum": [
+                            "llm_judge",
+                            "custom_code"
+                        ],
+                        "type": "string",
+                        "description": "* `llm_judge` - LLM Judge\n* `custom_code` - Custom Code",
+                        "x-spec-enum-id": "2adad4b8df61914f"
+                    },
+                    "evaluation_trigger_prompt": {
+                        "type": "string",
+                        "description": "\nEvaluation trigger prompt for the metric.\nExample: `\"Evaluate metric only if call ended reason is main-agent-ended-call\"`\n"
+                    },
+                    "evaluation_trigger_custom_code": {
+                        "type": "string",
+                        "description": "\nPython custom code to determine metric relevance. Code should set _result (bool) and _explanation (str).\nExample:\n```python\n_result = True\n_explanation = \"Metric is relevant\"\nif \"call_end_reason\" in data and data[\"call_end_reason\"] == \"customer-hung-up\":\n    _result = False\n    _explanation = \"Customer hung up, metric not applicable\"\n```\n"
+                    },
+                    "priority_assignment_prompt": {
+                        "type": "string",
+                        "description": "\nPriority assignment prompt for the metric.\n"
+                    },
+                    "vocera_defined_metric_code": {
+                        "type": "string",
+                        "description": "\nVocera defined metric code for the metric.\nExample: `\"7fd534f5\"`\n",
+                        "maxLength": 255
+                    },
+                    "configuration": {
+                        "description": "\nCustom configuration parameters for specific metrics if metric supports it.\nExample:\n- For Infrastructure issues\n```json\n{\n    \"infra_issues_timeout\": 10\n}\n```\n"
+                    },
+                    "overall_score": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "total_score": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "kb_file_ids": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        },
+                        "description": "\nList of knowledge base file IDs for the metric.\nExample: `[123, 456]`\n"
+                    },
+                    "knowledge_base_files": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/KnowledgeBaseFile"
+                        },
+                        "readOnly": true
+                    },
+                    "scenarios": {
+                        "writeOnly": true,
+                        "description": "Either \"all\" or a list of scenario IDs to attach to this metric"
+                    },
+                    "custom_code": {
+                        "type": "string",
+                        "writeOnly": true
+                    },
+                    "metric_cost": {
+                        "type": "number",
+                        "format": "double",
+                        "description": "\nMetric Cost\nExample: `0.10`\n",
+                        "readOnly": true
+                    },
+                    "alert_type": {
+                        "enum": [
+                            "disabled",
+                            "normal",
+                            "significant_change"
+                        ],
+                        "type": "string",
+                        "description": "* `disabled` - Alerts Disabled\n* `normal` - Normal Alerts\n* `significant_change` - Significant Change Alerts",
+                        "x-spec-enum-id": "9e2661f1aeca64cf",
+                        "default": "disabled"
+                    },
+                    "significant_change_alert_status": {
+                        "enum": [
+                            "enabled",
+                            "disabled"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "6d6f4d361b4ea1fb",
+                        "description": "\nAlert status: enabled or disabled.\n\n\n* `enabled` - Enabled\n* `disabled` - Disabled"
+                    },
+                    "significant_change_alert_direction": {
+                        "enum": [
+                            "",
+                            "increase",
+                            "decrease"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "1e86e60ca5cfba12",
+                        "description": "Alert direction: increase only, decrease only, or both (empty = both).\nExample: `\"increase\"`, `\"decrease\"`, or `\"both\"`\n\n* `` - Both (Increase and Decrease)\n* `increase` - Increase Only\n* `decrease` - Decrease Only"
+                    },
+                    "window_size": {
+                        "type": "integer",
+                        "readOnly": true,
+                        "description": "\nWindow size for rolling statistics calculation.\nExample: `50`\n"
+                    },
+                    "std_multiplier": {
+                        "type": "number",
+                        "format": "double",
+                        "readOnly": true,
+                        "description": "\nStandard deviation multiplier for threshold calculation.\nExample: `2.0`\n"
+                    },
+                    "ewma_alpha": {
+                        "type": "number",
+                        "format": "double",
+                        "readOnly": true,
+                        "description": "\nAlpha value for exponentially weighted moving average (EWMA) calculation.\nExample: `0.1`\n"
+                    },
+                    "add_to_new_agents": {
+                        "type": [
+                            "boolean",
+                            "null"
+                        ],
+                        "description": "When enabled, this metric is automatically assigned to new agents created in the project."
+                    },
+                    "alert_filters": {
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Filters to apply before computing alerts (CallLogQueryFilter format)"
+                    },
+                    "slack_workspace": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
+                        "description": "Slack workspace to send alerts to"
+                    },
+                    "slack_channel_id": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "Override channel ID for this metric's alerts",
+                        "maxLength": 255
+                    }
+                },
+                "required": [
+                    "eval_type",
                     "name"
                 ]
             },
@@ -57253,15 +60290,14 @@
                     },
                     "eval_type": {
                         "enum": [
-                            "binary_workflow_adherence",
-                            "binary_qualitative",
+                            "binary",
                             "continuous_qualitative",
                             "numeric",
                             "enum"
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "1e3e27b342bfd8ec",
-                        "description": "Evaluation type: binary_workflow_adherence, binary_qualitative, continuous_qualitative, numeric, or enum\n\n* `binary_workflow_adherence` - Binary Workflow Adherence\n* `binary_qualitative` - Binary Qualitative\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum"
+                        "x-spec-enum-id": "b40eac6824409cc2",
+                        "description": "Evaluation type: binary_workflow_adherence, binary_qualitative, continuous_qualitative, numeric, or enum\n\n* `binary` - Binary\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum"
                     },
                     "evaluation_trigger": {
                         "enum": [
@@ -59543,7 +62579,6 @@
             },
             "PatchedCallLogDetail": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -59602,7 +62637,7 @@
                             }
                         ],
                         "readOnly": true,
-                        "description": "Evaluation results for the call.\nExample: \n```json\n{\n    \"metrics\": [\n        {\n            \"id\": 35,\n            \"name\": \"Instruction Follow\",\n            \"type\": \"binary_workflow_adherence\",\n            \"score\": 0,\n            \"explanation\": [\"Agent failed to follow the opening script\", \"Missed key product information\"],\n            \"vocera_defined_metric_code\": \"5dedc41b\",\n            \"function_name\": \"check_critical_deviations\",\n            \"extra\": {\n                \"categories\": [\n                    {\n                        \"category_id\": 5,\n                        \"category\": \"Script Adherence Issue\",\n                        \"deviation\": \"Agent deviated from required script\",\n                        \"priority\": \"critical\"\n                    }\n                ]\n            }\n        },\n        {\n            \"id\": 18,\n            \"name\": \"Customer Satisfaction\",\n            \"type\": \"binary_qualitative\",\n            \"score\": 5,\n            \"explanation\": [\"Customer expressed satisfaction with service\"]\n        }\n    ]\n}\n```"
+                        "description": "Evaluation results for the call.\nExample: \n```json\n{\n    \"metrics\": [\n        {\n            \"id\": 35,\n            \"name\": \"Instruction Follow\",\n            \"type\": \"binary\",\n            \"score\": 0,\n            \"explanation\": [\"Agent failed to follow the opening script\", \"Missed key product information\"],\n            \"vocera_defined_metric_code\": \"5dedc41b\",\n            \"function_name\": \"check_critical_deviations\",\n            \"extra\": {\n                \"categories\": [\n                    {\n                        \"category_id\": 5,\n                        \"category\": \"Script Adherence Issue\",\n                        \"deviation\": \"Agent deviated from required script\",\n                        \"priority\": \"critical\"\n                    }\n                ]\n            }\n        },\n        {\n            \"id\": 18,\n            \"name\": \"Customer Satisfaction\",\n            \"type\": \"binary\",\n            \"score\": 5,\n            \"explanation\": [\"Customer expressed satisfaction with service\"]\n        }\n    ]\n}\n```"
                     },
                     "metadata": {
                         "type": "object",
@@ -60001,7 +63036,6 @@
             },
             "PatchedDashboard": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -60349,6 +63383,281 @@
                             "string",
                             "null"
                         ]
+                    }
+                }
+            },
+            "PatchedMetricEditSerializerV2": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "slug": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "URL-friendly unique identifier in snake_case format",
+                        "maxLength": 255
+                    },
+                    "project": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
+                    },
+                    "agent": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
+                    },
+                    "agents": {
+                        "type": "array",
+                        "items": {
+                            "type": [
+                                "integer",
+                                "null"
+                            ]
+                        }
+                    },
+                    "assistant_id": {
+                        "type": "string",
+                        "writeOnly": true
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "\nName of the metric.\nExample: `\"Customer Satisfaction\"` or `\"Appointment Booking\"`\n        ",
+                        "maxLength": 255
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "\nDescription of what the metric measures.\nExample: `\"Measures how satisfied customers are with the service provided\"`\n        "
+                    },
+                    "type": {
+                        "enum": [
+                            "basic",
+                            "custom_prompt",
+                            "custom_code",
+                            "llm_judge"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "b44700c0a6443b40",
+                        "description": "\nType of metric\n\n\n* `basic` - Basic (Deprecated in favor of LLM Judge)\n* `custom_prompt` - Custom Prompt ( Deprecated in favor of LLM Judge)\n* `custom_code` - Custom Code\n* `llm_judge` - LLM Judge"
+                    },
+                    "eval_type": {
+                        "enum": [
+                            "binary",
+                            "continuous_qualitative",
+                            "numeric",
+                            "enum"
+                        ],
+                        "type": "string",
+                        "description": "* `binary` - Binary\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum",
+                        "x-spec-enum-id": "b40eac6824409cc2"
+                    },
+                    "audio_enabled": {
+                        "type": "boolean",
+                        "readOnly": true,
+                        "description": "\nWhether this metric requires audio analysis.\nExample: `true` or `false`\n        "
+                    },
+                    "observability_enabled": {
+                        "type": "boolean",
+                        "description": "\nEnable this metric for observability.\nExample: `true` or `false`\n        "
+                    },
+                    "simulation_enabled": {
+                        "type": "boolean",
+                        "description": "\nEnable this metric for simulations.\nExample: `true` or `false`\n        "
+                    },
+                    "sampling_enabled": {
+                        "type": "boolean",
+                        "description": "Enable sampling for this metric using project-level sample rate"
+                    },
+                    "prompt": {
+                        "type": "string",
+                        "description": "\nEvaluation prompt for the metric.\nExample: `\"Evaluate customer satisfaction based on conversation\"`\n"
+                    },
+                    "function_name": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "readOnly": true,
+                        "description": "\nPredefined function name\nExample: `\"get_latency\"` or `\"check_critical_deviations\"`\n"
+                    },
+                    "enum_values": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "display_order": {
+                        "type": "integer",
+                        "maximum": 2147483647,
+                        "minimum": -2147483648,
+                        "description": "\nDisplay order for the metric.\nExample: `1`\n"
+                    },
+                    "custom_code": {
+                        "type": "string",
+                        "description": "\nPython custom code for the metric.\nExample:\n```python\n_resul = True\n_explanation = None\nif  \"call_end_reason\" in data and data[\"call_end_reason\"] == \"customer_satisfaction\":\n    _result = True\n    _explanation = \"Customer expressed satisfaction with service\"\n```\n"
+                    },
+                    "evaluation_trigger": {
+                        "enum": [
+                            "always",
+                            "automatic",
+                            "custom"
+                        ],
+                        "type": "string",
+                        "description": "* `always` - Always\n* `automatic` - Automatic\n* `custom` - Custom",
+                        "x-spec-enum-id": "ecd3c02e0e393ef5"
+                    },
+                    "trigger_type": {
+                        "enum": [
+                            "llm_judge",
+                            "custom_code"
+                        ],
+                        "type": "string",
+                        "description": "* `llm_judge` - LLM Judge\n* `custom_code` - Custom Code",
+                        "x-spec-enum-id": "2adad4b8df61914f"
+                    },
+                    "evaluation_trigger_prompt": {
+                        "type": "string",
+                        "description": "\nEvaluation trigger prompt for the metric.\nExample: `\"Evaluate metric only if call ended reason is main-agent-ended-call\"`\n"
+                    },
+                    "evaluation_trigger_custom_code": {
+                        "type": "string",
+                        "description": "\nPython custom code to determine metric relevance. Code should set _result (bool) and _explanation (str).\nExample:\n```python\n_result = True\n_explanation = \"Metric is relevant\"\nif \"call_end_reason\" in data and data[\"call_end_reason\"] == \"customer-hung-up\":\n    _result = False\n    _explanation = \"Customer hung up, metric not applicable\"\n```\n"
+                    },
+                    "vocera_defined_metric_code": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "\nVocera defined metric code for the metric.\nExample: `\"7fd534f5\"`\n"
+                    },
+                    "priority_assignment_prompt": {
+                        "type": "string",
+                        "description": "\nPriority assignment prompt for the metric.\n"
+                    },
+                    "configuration": {
+                        "description": "\nCustom configuration parameters for specific metrics if metric supports it.\nExample:\n- For Infrastructure issues\n```json\n{\n    \"infra_issues_timeout\": 10\n}\n```\n"
+                    },
+                    "scenarios": {
+                        "writeOnly": true
+                    },
+                    "overall_score": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "total_score": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "kb_file_ids": {
+                        "description": "\nList of knowledge base file IDs for the metric.\nExample: `[123, 456]`\n"
+                    },
+                    "knowledge_base_files": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "metric_description_program": {},
+                    "metric_description_variables": {
+                        "type": "array",
+                        "items": {}
+                    },
+                    "evaluation_trigger_program": {},
+                    "evaluation_trigger_variables": {
+                        "type": "array",
+                        "items": {}
+                    },
+                    "alert_enabled": {
+                        "type": "boolean",
+                        "description": "\nEnable alerts for this metric when it fails (value < 5).\nOnly applicable to binary metrics (binary_workflow_adherence and binary_qualitative).\nFor other metric types, use significant_change_alert_status instead.\nExample: `true` or `false`\n        "
+                    },
+                    "alert_type": {
+                        "enum": [
+                            "disabled",
+                            "normal",
+                            "significant_change"
+                        ],
+                        "type": "string",
+                        "description": "* `disabled` - Alerts Disabled\n* `normal` - Normal Alerts\n* `significant_change` - Significant Change Alerts",
+                        "x-spec-enum-id": "9e2661f1aeca64cf",
+                        "default": "disabled"
+                    },
+                    "window_size": {
+                        "type": "integer",
+                        "default": 50
+                    },
+                    "std_multiplier": {
+                        "type": "number",
+                        "format": "double",
+                        "default": 2.0
+                    },
+                    "ewma_alpha": {
+                        "type": "number",
+                        "format": "double",
+                        "default": 0.1
+                    },
+                    "significant_change_alert_status": {
+                        "enum": [
+                            "enabled",
+                            "disabled"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "6d6f4d361b4ea1fb",
+                        "description": "\nAlert status: enabled or disabled.\n\n\n* `enabled` - Enabled\n* `disabled` - Disabled"
+                    },
+                    "significant_change_alert_direction": {
+                        "enum": [
+                            "",
+                            "increase",
+                            "decrease"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "1e86e60ca5cfba12",
+                        "description": "Alert direction: increase only, decrease only, or both (empty = both).\nExample: `\"increase\"`, `\"decrease\"`, or `\"both\"`\n\n* `` - Both (Increase and Decrease)\n* `increase` - Increase Only\n* `decrease` - Decrease Only"
+                    },
+                    "add_to_new_agents": {
+                        "type": [
+                            "boolean",
+                            "null"
+                        ],
+                        "description": "When enabled, this metric is automatically assigned to new agents created in the project."
+                    },
+                    "alert_filters": {
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Filters to apply before computing alerts (CallLogQueryFilter format)"
+                    },
+                    "slack_workspace": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
+                        "description": "Slack workspace to send alerts to"
+                    },
+                    "slack_channel_id": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "Override channel ID for this metric's alerts",
+                        "maxLength": 255
+                    },
+                    "add_to_rubric": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "On write: true adds this metric to the project's call-success rubric (a sensible default rule is chosen by `eval_type`); false removes it. On read: reflects current rubric membership."
+                    },
+                    "apply_to_all_agents": {
+                        "type": "boolean",
+                        "writeOnly": true,
+                        "default": false,
+                        "description": "For observability_dropoff: when true, copies the dropoff_nodes from configuration to every other agent in the project."
                     }
                 }
             },
@@ -61006,15 +64315,14 @@
                     },
                     "eval_type": {
                         "enum": [
-                            "binary_workflow_adherence",
-                            "binary_qualitative",
+                            "binary",
                             "continuous_qualitative",
                             "numeric",
                             "enum"
                         ],
                         "type": "string",
-                        "description": "* `binary_workflow_adherence` - Binary Workflow Adherence\n* `binary_qualitative` - Binary Qualitative\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum",
-                        "x-spec-enum-id": "1e3e27b342bfd8ec"
+                        "description": "* `binary` - Binary\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum",
+                        "x-spec-enum-id": "b40eac6824409cc2"
                     },
                     "audio_enabled": {
                         "type": "boolean",
@@ -61599,7 +64907,7 @@
                     "critical_categories": {
                         "type": "string",
                         "readOnly": true,
-                        "description": "\nList of critical categories for this result\nExample:\n```json\n[\n    {\n      \"id\": 2950,\n      \"name\": \"Pronunciation Analysis\",\n      \"eval_type\": \"continuous_qualitative\",\n      \"simulation_enabled\": true,\n      \"observability_enabled\": true\n    },\n    {\n      \"id\": 3284,\n      \"name\": \"Latency\",\n      \"eval_type\": \"numeric\",\n      \"simulation_enabled\": true,\n      \"observability_enabled\": false\n    },\n    {\n      \"id\": 3295,\n      \"name\": \"Detect Silence in Conversation\",\n      \"eval_type\": \"binary_qualitative\",\n      \"simulation_enabled\": true,\n      \"observability_enabled\": true\n    }\n  ]\n```\n"
+                        "description": "\nList of critical categories for this result\nExample:\n```json\n[\n    {\n      \"id\": 2950,\n      \"name\": \"Pronunciation Analysis\",\n      \"eval_type\": \"continuous_qualitative\",\n      \"simulation_enabled\": true,\n      \"observability_enabled\": true\n    },\n    {\n      \"id\": 3284,\n      \"name\": \"Latency\",\n      \"eval_type\": \"numeric\",\n      \"simulation_enabled\": true,\n      \"observability_enabled\": false\n    },\n    {\n      \"id\": 3295,\n      \"name\": \"Detect Silence in Conversation\",\n      \"eval_type\": \"binary\",\n      \"simulation_enabled\": true,\n      \"observability_enabled\": true\n    }\n  ]\n```\n"
                     },
                     "metrics": {
                         "type": "string",
@@ -61622,31 +64930,6 @@
                         ],
                         "readOnly": true,
                         "description": "\nFailed reasons of the test runs\nExample:\n```json\n{\n    \"issues\": [\n      {\n        \"rank\": 1,\n        \"run_ids\": [\n          34588\n        ],\n        \"description\": \"The agent did not provide the standard greeting, emergency disclaimer, or ask how they could help.\",\n        \"affected_count\": 1\n      },\n      {\n        \"rank\": 2,\n        \"run_ids\": [\n          34588\n        ],\n        \"description\": \"The agent did not explain the distinction between the primary care and express clinics.\",\n        \"affected_count\": 1\n      }\n    ],\n    \"total_failed_runs\": 1\n  }\n```\n"
-                    },
-                    "ai_summary": {
-                        "oneOf": [
-                            {},
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "readOnly": true,
-                        "description": "\nLLM-generated narrative summary of the result, structured for the Results-page UI.\nExample:\n```json\n{\n    \"what_happened\": \"8 of 10 runs failed, 2 passed. All 8 failures cluster into 3 distinct causes.\",\n    \"why_it_happened\": \"The default test profile isn't seeded in the production backend, so every auth-required workflow exits before PIN/address steps run.\",\n    \"how_to_fix\": \"Seed the test profile in production, tighten the competitor-mention guardrail, and add CA-only store phrasing to the FAQ flow.\",\n    \"generated_from_runs_count\": 10,\n    \"generated_at\": \"2026-05-25T12:00:00Z\"\n}\n```\n"
-                    },
-                    "next_steps": {
-                        "oneOf": [
-                            {},
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "readOnly": true,
-                        "description": "\nLLM-suggested next steps to fix the issues found in this result, ordered by impact.\nExample:\n```json\n[\n    {\"title\": \"Seed test profile in production\", \"description\": \"Unblocks 6 runs; ~5 min.\"},\n    {\"title\": \"Tighten competitor guardrail\", \"description\": \"1 prompt edit; review drift run.\"}\n]\n```\n"
-                    },
-                    "performance_metrics": {
-                        "type": "string",
-                        "readOnly": true,
-                        "description": "Per-rubric-rule performance breakdown. One entry per rule in the project's rubric_config: metric name, aggregated value across the result's runs, and whether that aggregate meets the rule's conditions."
                     },
                     "run_type": {
                         "type": [
@@ -62012,7 +65295,7 @@
                     "information": {
                         "type": "object",
                         "additionalProperties": {},
-                        "description": "Test profile information. Use the sectioned shape — `main_agent_variables` (sent to the agent under test as dynamic variables at call time) and `testing_agent_variables` (persona/context used by the simulated caller, not sent to the agent). Legacy flat dicts (no section keys) are still accepted and delivered to both sides for backward compatibility. Example: {\"main_agent_variables\": {\"user_id\": \"U-42\"}, \"testing_agent_variables\": {\"customer_name\": \"John Doe\"}}."
+                        "description": "Information fields of the test profile"
                     }
                 }
             },
@@ -62222,15 +65505,14 @@
                     },
                     "eval_type": {
                         "enum": [
-                            "binary_workflow_adherence",
-                            "binary_qualitative",
+                            "binary",
                             "continuous_qualitative",
                             "numeric",
                             "enum"
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "1e3e27b342bfd8ec",
-                        "description": "Output shape of the evaluation score\n\n* `binary_workflow_adherence` - Binary Workflow Adherence\n* `binary_qualitative` - Binary Qualitative\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum"
+                        "x-spec-enum-id": "b40eac6824409cc2",
+                        "description": "Output shape of the evaluation score\n\n* `binary` - Binary\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum"
                     },
                     "enum_values": {
                         "type": "array",
@@ -62304,7 +65586,6 @@
             },
             "PatchedSchemaPostScenario": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "agent": {
                         "type": [
@@ -63038,7 +66319,7 @@
                     },
                     "name": {
                         "type": "string",
-                        "description": "Name of the tool - must be less than 64 characters and contain only alphanumerics, underscores, hyphens, and spaces between words (no leading or trailing spaces)",
+                        "description": "Name of the tool - must be less than 64 characters and contain only alphanumerics, underscores, and hyphens",
                         "maxLength": 255
                     },
                     "description": {
@@ -64076,15 +67357,14 @@
                     },
                     "eval_type": {
                         "enum": [
-                            "binary_workflow_adherence",
-                            "binary_qualitative",
+                            "binary",
                             "continuous_qualitative",
                             "numeric",
                             "enum"
                         ],
                         "type": "string",
-                        "description": "* `binary_workflow_adherence` - Binary Workflow Adherence\n* `binary_qualitative` - Binary Qualitative\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum",
-                        "x-spec-enum-id": "1e3e27b342bfd8ec"
+                        "description": "* `binary` - Binary\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum",
+                        "x-spec-enum-id": "b40eac6824409cc2"
                     },
                     "audio_enabled": {
                         "type": "boolean",
@@ -65102,7 +68382,7 @@
                     "critical_categories": {
                         "type": "string",
                         "readOnly": true,
-                        "description": "\nList of critical categories for this result\nExample:\n```json\n[\n    {\n      \"id\": 2950,\n      \"name\": \"Pronunciation Analysis\",\n      \"eval_type\": \"continuous_qualitative\",\n      \"simulation_enabled\": true,\n      \"observability_enabled\": true\n    },\n    {\n      \"id\": 3284,\n      \"name\": \"Latency\",\n      \"eval_type\": \"numeric\",\n      \"simulation_enabled\": true,\n      \"observability_enabled\": false\n    },\n    {\n      \"id\": 3295,\n      \"name\": \"Detect Silence in Conversation\",\n      \"eval_type\": \"binary_qualitative\",\n      \"simulation_enabled\": true,\n      \"observability_enabled\": true\n    }\n  ]\n```\n"
+                        "description": "\nList of critical categories for this result\nExample:\n```json\n[\n    {\n      \"id\": 2950,\n      \"name\": \"Pronunciation Analysis\",\n      \"eval_type\": \"continuous_qualitative\",\n      \"simulation_enabled\": true,\n      \"observability_enabled\": true\n    },\n    {\n      \"id\": 3284,\n      \"name\": \"Latency\",\n      \"eval_type\": \"numeric\",\n      \"simulation_enabled\": true,\n      \"observability_enabled\": false\n    },\n    {\n      \"id\": 3295,\n      \"name\": \"Detect Silence in Conversation\",\n      \"eval_type\": \"binary\",\n      \"simulation_enabled\": true,\n      \"observability_enabled\": true\n    }\n  ]\n```\n"
                     },
                     "metrics": {
                         "type": "string",
@@ -65125,31 +68405,6 @@
                         ],
                         "readOnly": true,
                         "description": "\nFailed reasons of the test runs\nExample:\n```json\n{\n    \"issues\": [\n      {\n        \"rank\": 1,\n        \"run_ids\": [\n          34588\n        ],\n        \"description\": \"The agent did not provide the standard greeting, emergency disclaimer, or ask how they could help.\",\n        \"affected_count\": 1\n      },\n      {\n        \"rank\": 2,\n        \"run_ids\": [\n          34588\n        ],\n        \"description\": \"The agent did not explain the distinction between the primary care and express clinics.\",\n        \"affected_count\": 1\n      }\n    ],\n    \"total_failed_runs\": 1\n  }\n```\n"
-                    },
-                    "ai_summary": {
-                        "oneOf": [
-                            {},
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "readOnly": true,
-                        "description": "\nLLM-generated narrative summary of the result, structured for the Results-page UI.\nExample:\n```json\n{\n    \"what_happened\": \"8 of 10 runs failed, 2 passed. All 8 failures cluster into 3 distinct causes.\",\n    \"why_it_happened\": \"The default test profile isn't seeded in the production backend, so every auth-required workflow exits before PIN/address steps run.\",\n    \"how_to_fix\": \"Seed the test profile in production, tighten the competitor-mention guardrail, and add CA-only store phrasing to the FAQ flow.\",\n    \"generated_from_runs_count\": 10,\n    \"generated_at\": \"2026-05-25T12:00:00Z\"\n}\n```\n"
-                    },
-                    "next_steps": {
-                        "oneOf": [
-                            {},
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "readOnly": true,
-                        "description": "\nLLM-suggested next steps to fix the issues found in this result, ordered by impact.\nExample:\n```json\n[\n    {\"title\": \"Seed test profile in production\", \"description\": \"Unblocks 6 runs; ~5 min.\"},\n    {\"title\": \"Tighten competitor guardrail\", \"description\": \"1 prompt edit; review drift run.\"}\n]\n```\n"
-                    },
-                    "performance_metrics": {
-                        "type": "string",
-                        "readOnly": true,
-                        "description": "Per-rubric-rule performance breakdown. One entry per rule in the project's rubric_config: metric name, aggregated value across the result's runs, and whether that aggregate meets the rule's conditions."
                     },
                     "run_type": {
                         "type": [
@@ -65497,7 +68752,6 @@
             },
             "RunList": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -65922,7 +69176,6 @@
             },
             "Scenario": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -66117,11 +69370,16 @@
                             }
                         ],
                         "readOnly": true,
-                        "description": "\nDetails of the test profile associated with this scenario. `information` uses the\nsectioned shape: `main_agent_variables` are sent to the agent under test as\ndynamic variables at call time; `testing_agent_variables` are persona/context\nused by Cekura's simulated caller. Legacy flat dicts (no section keys) still\nwork — at call time they are delivered to both sides for backward compatibility.\nExample:\n```json\n{\n    \"id\": \"<integer>\",\n    \"agent_id\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"information\": {\n        \"main_agent_variables\": {\n            \"user_id\": \"<string>\",\n            \"account_id\": \"<string>\"\n        },\n        \"testing_agent_variables\": {\n            \"user_name\": \"<string>\",\n            \"user_email\": \"<string>\",\n            \"order_id\": \"<string>\"\n        }\n    }\n}\n```\n"
+                        "description": "\nDetails of the test profile associated with this scenario\nExample:\n```json\n{\n    \"id\": \"<integer>\",\n    \"agent_id\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"information\": {\n        \"user_name\": \"<string>\",\n        \"user_email\": \"<string>\",\n        \"order_id\": \"<string>\",\n    },\n}\n```\n"
                     },
                     "dynamic_variable_values": {
-                        "readOnly": true,
-                        "description": "REMOVED FROM API. Reads return the historical value for legacy rows (`null` for new rows). Writes are no longer accepted — supplying a non-null value yields a 400 error. Put dynamic-variable values in `test_profile_data.information.main_agent_variables` instead: create the test profile via POST /test-profiles/ and attach it via the `test_profile` field on the scenario."
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Generated values for the agent's dynamic variables for this scenario. Keys are variable names; values are the generated values."
                     },
                     "generated_mock_tool_entries": {
                         "readOnly": true,
@@ -66575,7 +69833,7 @@
                                 "type": "null"
                             }
                         ],
-                        "description": "REMOVED FROM API. Historically stored a flat copy of the agent's dynamic-variable values for the scenario. The column is retained read-only for legacy rows; reads still return its historical value, but writes via the API are rejected with a 400. At call time the Run-level helper consults this column ONLY when the attached test_profile is legacy-flat (or absent) — sectioned test profiles are the canonical source and ignore this column. Put dynamic-variable values in `test_profile.information.main_agent_variables` for new scenarios."
+                        "description": "Generated values for the agent's dynamic variables for this scenario. Keys are variable names; values are the generated values."
                     },
                     "phone_number": {
                         "type": [
@@ -66791,7 +70049,6 @@
             },
             "ScenarioList": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -66959,7 +70216,7 @@
                                 "type": "null"
                             }
                         ],
-                        "description": "REMOVED FROM API. Historically stored a flat copy of the agent's dynamic-variable values for the scenario. The column is retained read-only for legacy rows; reads still return its historical value, but writes via the API are rejected with a 400. At call time the Run-level helper consults this column ONLY when the attached test_profile is legacy-flat (or absent) — sectioned test profiles are the canonical source and ignore this column. Put dynamic-variable values in `test_profile.information.main_agent_variables` for new scenarios."
+                        "description": "Generated values for the agent's dynamic variables for this scenario. Keys are variable names; values are the generated values."
                     },
                     "created_at": {
                         "type": "string",
@@ -67011,7 +70268,6 @@
             },
             "ScenarioSerializerV2": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -67209,11 +70465,16 @@
                             }
                         ],
                         "readOnly": true,
-                        "description": "\nDetails of the test profile associated with this scenario. `information` uses the\nsectioned shape: `main_agent_variables` are sent to the agent under test as\ndynamic variables at call time; `testing_agent_variables` are persona/context\nused by Cekura's simulated caller. Legacy flat dicts (no section keys) still\nwork — at call time they are delivered to both sides for backward compatibility.\nExample:\n```json\n{\n    \"id\": \"<integer>\",\n    \"agent_id\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"information\": {\n        \"main_agent_variables\": {\n            \"user_id\": \"<string>\",\n            \"account_id\": \"<string>\"\n        },\n        \"testing_agent_variables\": {\n            \"user_name\": \"<string>\",\n            \"user_email\": \"<string>\",\n            \"order_id\": \"<string>\"\n        }\n    }\n}\n```\n"
+                        "description": "\nDetails of the test profile associated with this scenario\nExample:\n```json\n{\n    \"id\": \"<integer>\",\n    \"agent_id\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"information\": {\n        \"user_name\": \"<string>\",\n        \"user_email\": \"<string>\",\n        \"order_id\": \"<string>\",\n    },\n}\n```\n"
                     },
                     "dynamic_variable_values": {
-                        "readOnly": true,
-                        "description": "REMOVED FROM API. Reads return the historical value for legacy rows (`null` for new rows). Writes are no longer accepted — supplying a non-null value yields a 400 error. Put dynamic-variable values in `test_profile_data.information.main_agent_variables` instead: create the test profile via POST /test-profiles/ and attach it via the `test_profile` field on the scenario."
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Generated values for the agent's dynamic variables for this scenario. Keys are variable names; values are the generated values."
                     },
                     "generated_mock_tool_entries": {
                         "readOnly": true,
@@ -67747,7 +71008,7 @@
                     "information": {
                         "type": "object",
                         "additionalProperties": {},
-                        "description": "Test profile information. Use the sectioned shape — `main_agent_variables` (sent to the agent under test as dynamic variables at call time) and `testing_agent_variables` (persona/context used by the simulated caller, not sent to the agent). Legacy flat dicts (no section keys) are still accepted and delivered to both sides for backward compatibility. Example: {\"main_agent_variables\": {\"user_id\": \"U-42\"}, \"testing_agent_variables\": {\"customer_name\": \"John Doe\"}}."
+                        "description": "Information fields of the test profile"
                     }
                 },
                 "required": [
@@ -68302,15 +71563,14 @@
                     },
                     "eval_type": {
                         "enum": [
-                            "binary_workflow_adherence",
-                            "binary_qualitative",
+                            "binary",
                             "continuous_qualitative",
                             "numeric",
                             "enum"
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "1e3e27b342bfd8ec",
-                        "description": "Output shape of the evaluation score\n\n* `binary_workflow_adherence` - Binary Workflow Adherence\n* `binary_qualitative` - Binary Qualitative\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum"
+                        "x-spec-enum-id": "b40eac6824409cc2",
+                        "description": "Output shape of the evaluation score\n\n* `binary` - Binary\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum"
                     },
                     "enum_values": {
                         "type": "array",
@@ -68456,7 +71716,6 @@
             },
             "SchemaPostRunScenarios": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "agent_id": {
                         "type": "integer",
@@ -68705,7 +71964,6 @@
             },
             "SchemaPostScenario": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "agent": {
                         "type": [
@@ -68865,7 +72123,6 @@
             },
             "SchemaScenario": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -69060,11 +72317,16 @@
                             }
                         ],
                         "readOnly": true,
-                        "description": "\nDetails of the test profile associated with this scenario. `information` uses the\nsectioned shape: `main_agent_variables` are sent to the agent under test as\ndynamic variables at call time; `testing_agent_variables` are persona/context\nused by Cekura's simulated caller. Legacy flat dicts (no section keys) still\nwork — at call time they are delivered to both sides for backward compatibility.\nExample:\n```json\n{\n    \"id\": \"<integer>\",\n    \"agent_id\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"information\": {\n        \"main_agent_variables\": {\n            \"user_id\": \"<string>\",\n            \"account_id\": \"<string>\"\n        },\n        \"testing_agent_variables\": {\n            \"user_name\": \"<string>\",\n            \"user_email\": \"<string>\",\n            \"order_id\": \"<string>\"\n        }\n    }\n}\n```\n"
+                        "description": "\nDetails of the test profile associated with this scenario\nExample:\n```json\n{\n    \"id\": \"<integer>\",\n    \"agent_id\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"information\": {\n        \"user_name\": \"<string>\",\n        \"user_email\": \"<string>\",\n        \"order_id\": \"<string>\",\n    },\n}\n```\n"
                     },
                     "dynamic_variable_values": {
-                        "readOnly": true,
-                        "description": "REMOVED FROM API. Reads return the historical value for legacy rows (`null` for new rows). Writes are no longer accepted — supplying a non-null value yields a 400 error. Put dynamic-variable values in `test_profile_data.information.main_agent_variables` instead: create the test profile via POST /test-profiles/ and attach it via the `test_profile` field on the scenario."
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Generated values for the agent's dynamic variables for this scenario. Keys are variable names; values are the generated values."
                     },
                     "generated_mock_tool_entries": {
                         "readOnly": true,
@@ -70240,7 +73502,7 @@
                     },
                     "name": {
                         "type": "string",
-                        "description": "Name of the tool - must be less than 64 characters and contain only alphanumerics, underscores, hyphens, and spaces between words (no leading or trailing spaces)",
+                        "description": "Name of the tool - must be less than 64 characters and contain only alphanumerics, underscores, and hyphens",
                         "maxLength": 255
                     },
                     "description": {

--- a/openapi.json
+++ b/openapi.json
@@ -2947,14 +2947,6 @@
                         "description": ""
                     }
                 },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "call-logs-list",
-                        "description": "List **production** call logs for an agent or project. Production-only — test/simulation runs triggered via `run_scenarios_*` do NOT create call logs; use `results_list` + `runs_bulk_retrieve` for simulation data instead.\n\nAlways pass `agent_id` or `project_id` to scope results — without one, the response may be very large. **`project_id` is required when using an organization-level API key.**\n\n**Filtering:**\n- `timestamp_from` / `timestamp_to` — ISO 8601 date range filter\n- `call_ids` — comma-separated **CallLog IDs** (integer DB IDs of call logs in this list response), e.g. `\"123,456\"`. Distinct from simulation `run_id`s and from each call log's own `call_id` field (which holds the provider's call identifier string).\n- `filters_v2` — structured JSON filter (same format as dashboard filters). Simple: `{\"field\": \"success\", \"op\": \"eq\", \"value\": true}`. Compound: `{\"operator\": \"and\", \"conditions\": [{...}, {...}]}`. Supported operators: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `contains`, `startswith`, `in`, `isnull`."
-                    }
-                },
                 "deprecated": true
             },
             "post": {
@@ -4418,14 +4410,6 @@
                         "description": ""
                     }
                 },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "call-logs-retrieve",
-                        "description": "Retrieve a production CallLog by its integer **CallLog ID** (path parameter). This is distinct from simulation `run_id` (use `runs_retrieve` for those) and from the call log's own `call_id` string field (the provider's call identifier)."
-                    }
-                },
                 "deprecated": true
             },
             "put": {
@@ -4588,14 +4572,6 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "call-logs-destroy",
-                        "description": "⚠ Irreversible. Deletes the call log along with its transcript and voice recording. By default metric evaluations are also deleted; set `retain_evaluations=true` to keep them and leave the call record un-soft-deleted."
-                    }
                 }
             }
         },
@@ -4743,14 +4719,6 @@
                             }
                         },
                         "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "call-logs-mark-metric-vote-create",
-                        "description": "Record a thumbs-up or thumbs-down vote on a specific metric evaluation for this call log and optionally provide an expected value and free-text feedback. Updates the metric evaluation and marks the call log as reviewed."
                     }
                 }
             }
@@ -5028,14 +4996,6 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "call-logs-create-scenarios",
-                        "description": "Generate test scenarios from real production call logs.\n\nReturns a `progress_id` immediately — the actual scenario creation runs in the background.\nPoll `GET /observability/v1/call-logs/create_scenarios_progress?progress_id=<id>` until\n`completed_scenarios + failed_scenarios >= total_scenarios`. The `scenarios_list` field\n(full Scenario objects) is populated only once processing is complete.\n\n**`call_logs` accepts:** a list of IDs `[1, 2, 3]` or `\"all\"` for every call log on the agent.\n\n**`copy_to_agent`:** optionally copy the generated scenarios to a different agent —\nuseful when your observation agent and your test agent are separate.\n\n**Prerequisite:** call logs must have a transcript (uploaded via `transcript_json`).\nAudio-only logs without a transcript cannot produce scenarios."
-                    }
                 }
             }
         },
@@ -5053,24 +5013,6 @@
                         },
                         "description": "Progress ID returned from create_scenarios endpoint",
                         "required": true
-                    },
-                    {
-                        "name": "agent_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    },
-                    {
-                        "name": "project_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -5258,14 +5200,6 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "call-logs-create-scenarios-progress",
-                        "description": "Call logs create scenarios progress"
-                    }
                 }
             }
         },
@@ -5390,14 +5324,6 @@
                             }
                         },
                         "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "call-logs-evaluate-metrics-create",
-                        "description": "Evaluate one or more metrics against selected call logs. Unlike `rerun_evaluation` (which re-runs all assigned metrics), this endpoint lets you target specific metrics.\n\n**Scope:** provide either `agent_id` or `project_id` to identify which agent's call logs and metrics to use. Metrics must belong to the specified agent or project.\n\n**Credit check:** cost scales with the number of call logs and metrics selected. The request is rejected if your balance is insufficient — check your balance first via `test_framework_billing_info_retrieve`.\n\n**Async:** evaluation runs in the background. The response returns the call logs in their current state. Retrieve each call log individually to see updated metric results once evaluation completes.\n\n**Rate limited.** Respect 429 responses — wait for the `Retry-After` duration."
                     }
                 }
             }
@@ -5672,14 +5598,6 @@
                             }
                         },
                         "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "call-logs-rerun-evaluation-create",
-                        "description": "Trigger metric re-evaluation on one or more existing call logs. Provide either `agent_id` or `assistant_id` (not both) to identify the agent, then specify which call logs to re-evaluate.\n\n**`call_logs` accepts:**\n- A list of call log IDs: `[1, 2, 3]`\n- The string `\"all\"` to re-evaluate every call log for the agent\n\n**Side effect:** for non-reviewed call logs, `success` is reset to `null` before re-evaluation begins. Reviewed call logs retain their human-approved outcome.\n\n**Rate limited.** If the limit is exceeded you will receive a 429 response — wait for the `Retry-After` duration before retrying."
                     }
                 }
             }
@@ -22881,15 +22799,6 @@
                             "type": "string"
                         },
                         "description": "Filter by scenario IDs — comma-separated string (e.g. '24270,24271'), not a JSON array."
-                    },
-                    {
-                        "name": "assistant_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `assistant_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -22910,14 +22819,6 @@
                             }
                         },
                         "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "results-list",
-                        "description": "List test results.\n\nTo filter by status, use `results_retrieve(id=result_id)` and inspect `status` directly ('running', 'completed', 'failed') — there is no list-level status filter.\n\n**Result status:** a result marked `failed` indicates infrastructure failures (e.g. connection errors, websocket handshake failures), not metric evaluation failures. `success_runs_count` counts runs that reached terminal state regardless of connection errors. See `results_retrieve().failed_reasons` for the breakdown.\n\n**Scenarios filter note:** filtering by `scenarios` may return duplicate result rows when a result contains multiple runs of the same scenario — deduplicate by `result.id` if needed.\n\nAfter triggering a run, poll `results_retrieve(id=result_id)` until `status` is 'completed' or 'failed'. For outbound runs, each run's `outbound_dial_window_closes_at` shows the deadline by which your agent must dial in."
                     }
                 },
                 "deprecated": true
@@ -24384,14 +24285,6 @@
                         "description": ""
                     }
                 },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "results-retrieve",
-                        "description": "`success` indicates whether the run passed its quality evaluation. A run with `success=false` either failed to connect (check `error_message`) or failed an evaluation check (check `evaluation`). `success_rate` is the percentage of runs with `success=true`.\n\nThe `runs` field is a dict keyed by run ID string (e.g. `{\"86368\": {...}, \"86367\": {...}}`), not an array — unlike the list endpoint. Each run also has a `call_id` STRING field (the provider's call identifier) — that is a data field, NOT an endpoint ID; do not pass it where `run_id` is expected."
-                    }
-                },
                 "deprecated": true
             },
             "put": {
@@ -24596,14 +24489,6 @@
                     "429": {
                         "description": "Rate limit exceeded"
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "results-ask-about-failures-create",
-                        "description": "Query failed runs chatbot"
-                    }
                 }
             }
         },
@@ -24678,14 +24563,6 @@
                             }
                         },
                         "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "create-shareable-link-token",
-                        "description": "Generate shareable link for result"
                     }
                 }
             }
@@ -24771,14 +24648,6 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "delete-runs",
-                        "description": "⚠ Irreversible. Removes the specified runs from a result, then triggers re-evaluation so aggregate metrics recompute without them. Maximum 100 run IDs per request."
-                    }
                 }
             }
         },
@@ -24824,14 +24693,6 @@
                             }
                         },
                         "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "end-calls",
-                        "description": "End all calls in result"
                     }
                 }
             }
@@ -24889,14 +24750,6 @@
                             }
                         },
                         "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "results-evaluate-metrics-create",
-                        "description": "Evaluate metrics against result transcripts"
                     }
                 }
             }
@@ -24968,14 +24821,6 @@
                             }
                         },
                         "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "results-rerun-create",
-                        "description": "Re-run a test result evaluation"
                     }
                 }
             }
@@ -26972,14 +26817,6 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "end-call",
-                        "description": "End a single call"
-                    }
                 }
             }
         },
@@ -27220,14 +27057,6 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "runs-mark-metric-vote-create",
-                        "description": "Record a thumbs-up or thumbs-down vote on a specific metric evaluation for this run and optionally provide an expected value and free-text feedback. Updates the metric evaluation and marks the run as reviewed."
-                    }
                 }
             }
         },
@@ -27441,33 +27270,6 @@
                         },
                         "description": "\nComma-separated list of run IDs.\nExample: `1,2,3`\n\nMust be a plain comma-separated string, not a JSON array — passing a JSON array returns a 400 error.\n",
                         "required": true
-                    },
-                    {
-                        "name": "agent_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `result_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    },
-                    {
-                        "name": "result_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `result_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    },
-                    {
-                        "name": "project_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `result_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -27491,14 +27293,6 @@
                             }
                         },
                         "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "runs-bulk-retrieve",
-                        "description": "Retrieve multiple runs in a single request.\n\n`success: true` indicates the run passed its quality evaluation. A run with `success=false` either failed to connect (check `error_message`) or failed an evaluation check. For detailed outcomes check: `error_message`, `metadata.ended_reason`, and `evaluation.metrics[].result`."
                     }
                 },
                 "deprecated": true

--- a/openapi.json
+++ b/openapi.json
@@ -1269,6 +1269,15 @@
                         "schema": {
                             "type": "integer"
                         }
+                    },
+                    {
+                        "name": "dashboard_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `dashboard_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -2766,7 +2775,18 @@
                         "name": "alerts-review-retrieve",
                         "description": "Aggregate every alert's fire activity over a rolling window. Returns KPI totals (total fires, unique alerts that fired, top firing alert), a time-bucketed timeline (hourly for 24h, 3-hour for 3d, 6-hour for 7d), and a per-alert breakdown with a sparkline of fires-per-bucket. Use to answer 'what alerts fired this week?' or 'is anything noisy right now?'. Pass `hours` (default 24, capped at 168) to widen the window. The response shape lets you compose a written report in a single call."
                     }
-                }
+                },
+                "parameters": [
+                    {
+                        "name": "project_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    }
+                ]
             }
         },
         "/observability/v1/alerts/summarize_progress/": {
@@ -5029,6 +5049,24 @@
                         },
                         "description": "Progress ID returned from create_scenarios endpoint",
                         "required": true
+                    },
+                    {
+                        "name": "agent_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "project_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -6387,7 +6425,8 @@
         "/observability/v1/metric-failure-mode-insights/{id}/generate-scenario/": {
             "post": {
                 "operationId": "metric-failure-mode-insights-generate-scenario-create",
-                "description": "Queue generation of a test scenario from one failure mode.\n\nReturns a ``progress_id`` the frontend polls via the existing\n``scenarios/generate-progress`` endpoint; the generated scenario\nid lands in that progress state's ``scenarios_list`` when done.",
+                "description": "Turn one failure mode of a metric failure-mode insight into a test scenario that reproduces the issue against a target agent. Choose the failure mode with `failure_mode_index` and the agent with `agent`. Set `redact_transcripts` to strip personal identifiers from the source call transcripts before they are used to draft the scenario. Runs in the background and returns a `progress_id`; poll scenario generation progress to retrieve the generated scenario id.",
+                "summary": "Generate a test scenario from an insight failure mode",
                 "parameters": [
                     {
                         "in": "path",
@@ -6437,6 +6476,14 @@
                             }
                         },
                         "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "metric-failure-mode-insights-generate-scenario-create",
+                        "description": "Turn one failure mode of a metric failure-mode insight into a test scenario that reproduces the issue against a target agent. Choose the failure mode with `failure_mode_index` and the agent with `agent`. Set `redact_transcripts` to strip personal identifiers from the source call transcripts before they are used to draft the scenario. Runs in the background and returns a `progress_id`; poll scenario generation progress to retrieve the generated scenario id."
                     }
                 }
             }
@@ -7967,6 +8014,24 @@
                         },
                         "description": "Progress ID returned from create_scenarios endpoint",
                         "required": true
+                    },
+                    {
+                        "name": "agent_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "project_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -8600,6 +8665,15 @@
                             "type": "string"
                         },
                         "description": "\nFilter by project id\nExample: `123`\n"
+                    },
+                    {
+                        "name": "organization_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `organization_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -9648,7 +9722,18 @@
                         "name": "slack-slack-workspaces-list",
                         "description": "Return every Slack workspace connected to the project, with the bot's default `channel_id`, `team_name`, and verification status. Use to pick a `workspace_id` (and optionally a different `channel_id`) for the `notifications.slack` block on `alerts_create`. Access tokens and bot IDs are not returned."
                     }
-                }
+                },
+                "parameters": [
+                    {
+                        "name": "project_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    }
+                ]
             },
             "post": {
                 "operationId": "slack-slack-workspaces-create",
@@ -10930,7 +11015,18 @@
                         "name": "billing-info-retrieve",
                         "description": "Returns credits remaining, credits used, balance expiry, and subscription status for an organization. When called with an organization-scoped API key, the org is taken from the key. When called with a user session or OAuth bearer, pass `organization_id` as a query parameter — the caller must be an admin of that organization."
                     }
-                }
+                },
+                "parameters": [
+                    {
+                        "name": "organization_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `organization_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    }
+                ]
             }
         },
         "/test_framework/billing/metric-usage/": {
@@ -14144,256 +14240,6 @@
                 }
             }
         },
-        "/test_framework/v1/aiagents/{agent_id}/tools/disable-mock/": {
-            "post": {
-                "operationId": "aiagents-tools-disable-mock-create",
-                "description": "Restore the agent's tools to their original (non-mock) state. For managed providers this PATCHes the provider assistant back to its `original_tool_ids` and deletes the cloned tools. For provider=\"custom\" this only flips `mock_enabled` off; the `mcp_server_url` is preserved so re-enable works.",
-                "summary": "Disable mock tools for an agent",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "agent_id",
-                        "schema": {
-                            "type": "string",
-                            "pattern": "^\\d+$"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "test_framework"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/DisableMockToolsRequest"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/DisableMockToolsRequest"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/DisableMockToolsRequest"
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "deprecated": true,
-                "responses": {
-                    "202": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/DisableMockToolsResponse"
-                                }
-                            }
-                        },
-                        "description": ""
-                    },
-                    "400": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/DisableMockErrorResponse"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
-        },
-        "/test_framework/v1/aiagents/{agent_id}/tools/disable-mock-progress/": {
-            "get": {
-                "operationId": "aiagents-tools-disable-mock-progress-retrieve",
-                "description": "Poll the status of a background disable-mock task.",
-                "summary": "Poll status of a disable-mock task",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "agent_id",
-                        "schema": {
-                            "type": "string",
-                            "pattern": "^\\d+$"
-                        },
-                        "required": true
-                    },
-                    {
-                        "in": "query",
-                        "name": "progress_id",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "test_framework"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "deprecated": true,
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/DisableMockProgressResponse"
-                                }
-                            }
-                        },
-                        "description": ""
-                    },
-                    "400": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/DisableMockProgressErrorResponse"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
-        },
-        "/test_framework/v1/aiagents/{agent_id}/tools/enable-mock/": {
-            "post": {
-                "operationId": "aiagents-tools-enable-mock-create",
-                "description": "Activate mock-tool mode using the data created by `auto-fetch`. For managed providers (vapi/retell/elevenlabs) this clones the provider's tools at the provider and swaps URLs to Cekura-hosted endpoints. For provider=\"custom\" it just registers `mcp_sub_tool_map` so MockMCPView can serve `/mcp/N/` calls. Returns a `progress_id`; poll `enable-mock-progress/` for the resulting `mcp_endpoints`. Run `auto-fetch` first.",
-                "summary": "Enable mock tools for an agent",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "agent_id",
-                        "schema": {
-                            "type": "string",
-                            "pattern": "^\\d+$"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "test_framework"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/EnableMockToolsRequest"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/EnableMockToolsRequest"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/EnableMockToolsRequest"
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "deprecated": true,
-                "responses": {
-                    "202": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/EnableMockToolsResponse"
-                                }
-                            }
-                        },
-                        "description": ""
-                    },
-                    "400": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/EnableMockErrorResponse"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
-        },
-        "/test_framework/v1/aiagents/{agent_id}/tools/enable-mock-progress/": {
-            "get": {
-                "operationId": "aiagents-tools-enable-mock-progress-retrieve",
-                "description": "Poll the status of a background enable-mock task.",
-                "summary": "Poll status of an enable-mock task",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "agent_id",
-                        "schema": {
-                            "type": "string",
-                            "pattern": "^\\d+$"
-                        },
-                        "required": true
-                    },
-                    {
-                        "in": "query",
-                        "name": "progress_id",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "test_framework"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "deprecated": true,
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/EnableMockProgressResponse"
-                                }
-                            }
-                        },
-                        "description": ""
-                    },
-                    "400": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/EnableMockProgressErrorResponse"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
-        },
         "/test_framework/v1/aiagents/{agent_id}/tools/mock-status/": {
             "get": {
                 "operationId": "aiagents-tools-mock-status-retrieve",
@@ -16033,6 +15879,33 @@
                         "schema": {
                             "type": "integer"
                         }
+                    },
+                    {
+                        "name": "agent_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `category_id`, `metric_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "category_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `category_id`, `metric_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "metric_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `category_id`, `metric_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -21975,7 +21848,18 @@
                         "name": "phone-numbers-inbound-list",
                         "description": "Phone numbers inbound"
                     }
-                }
+                },
+                "parameters": [
+                    {
+                        "name": "organization_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `organization_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    }
+                ]
             }
         },
         "/test_framework/v1/phone-numbers/providers/list/": {
@@ -22993,6 +22877,15 @@
                             "type": "string"
                         },
                         "description": "Filter by scenario IDs — comma-separated string (e.g. '24270,24271'), not a JSON array."
+                    },
+                    {
+                        "name": "assistant_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `assistant_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -27535,6 +27428,33 @@
                         },
                         "description": "\nComma-separated list of run IDs.\nExample: `1,2,3`\n\nMust be a plain comma-separated string, not a JSON array — passing a JSON array returns a 400 error.\n",
                         "required": true
+                    },
+                    {
+                        "name": "agent_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `result_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "result_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `result_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "project_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `result_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -27631,7 +27551,18 @@
                         "name": "scenario-improvement-sessions-list",
                         "description": "List scenario-improvement sessions for a project. Each session tracks an AI-assisted refinement run over the project's scenarios. Requires `project_id`."
                     }
-                }
+                },
+                "parameters": [
+                    {
+                        "name": "project_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    }
+                ]
             },
             "post": {
                 "operationId": "scenario-improvement-sessions-create",
@@ -35140,6 +35071,24 @@
                             "type": "string"
                         },
                         "description": "Search folders by name (case-insensitive)"
+                    },
+                    {
+                        "name": "agent_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "assistant_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -35833,7 +35782,36 @@
                         "name": "scenarios-instructions-progress-retrieve",
                         "description": "Scenarios instructions progress"
                     }
-                }
+                },
+                "parameters": [
+                    {
+                        "name": "agent_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "project_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "assistant_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    }
+                ]
             }
         },
         "/test_framework/v1/scenarios/move_folder/": {
@@ -40250,6 +40228,15 @@
                             "type": "string"
                         },
                         "description": "Search agents by name. A numeric value also matches the agent id."
+                    },
+                    {
+                        "name": "organization_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `project_id`, `organization_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -41725,147 +41712,6 @@
                             }
                         },
                         "description": ""
-                    }
-                }
-            }
-        },
-        "/test_framework/v2/aiagents/{id}/toggle-mock-tools/": {
-            "post": {
-                "operationId": "aiagents-toggle-mock-tools-create",
-                "description": "Toggle mock-tool mode on the agent's provider. `enabled=true` replaces the provider tools with Cekura-hosted mocks; `enabled=false` restores the originals (mock data is preserved). Returns a `progress_id`; poll `toggle-mock-tools-progress/`. Run `auto-fetch` first to populate mock tool data before enabling.",
-                "summary": "Enable or disable mock tools on the provider",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "A unique integer value identifying this ai agent.",
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "test_framework"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/AgentToggleMockToolsRequest"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/AgentToggleMockToolsRequest"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/AgentToggleMockToolsRequest"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "202": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/AgentToggleMockToolsResponse"
-                                }
-                            }
-                        },
-                        "description": ""
-                    },
-                    "400": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/AgentToggleMockToolsErrorResponse"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mcp-destructive": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-toggle-mock-tools-create",
-                        "description": "Toggle mock-tool mode on the agent's provider. `enabled=true` replaces the provider tools with Cekura-hosted mocks; `enabled=false` restores the originals (mock data is preserved). Returns a `progress_id`; poll `toggle-mock-tools-progress/`. Run `auto-fetch` first to populate mock tool data before enabling."
-                    }
-                }
-            }
-        },
-        "/test_framework/v2/aiagents/{id}/toggle-mock-tools-progress/": {
-            "get": {
-                "operationId": "aiagents-toggle-mock-tools-progress-retrieve",
-                "description": "Poll the enable/disable task. The progress_id is unique, so we resolve it\nagainst both task namespaces and return whichever holds it.",
-                "summary": "Poll status of a toggle-mock-tools task",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "A unique integer value identifying this ai agent.",
-                        "required": true
-                    },
-                    {
-                        "in": "query",
-                        "name": "progress_id",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "test_framework"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/AgentToggleMockToolsProgressResponse"
-                                }
-                            }
-                        },
-                        "description": ""
-                    },
-                    "400": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/AgentToggleMockToolsProgressErrorResponse"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-toggle-mock-tools-progress-retrieve",
-                        "description": "Poll the enable/disable task. The progress_id is unique, so we resolve it\nagainst both task namespaces and return whichever holds it."
                     }
                 }
             }
@@ -43734,6 +43580,33 @@
                         },
                         "description": "progress_id returned from generate_clean_description_bg",
                         "required": true
+                    },
+                    {
+                        "name": "agent_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "project_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "assistant_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -43904,6 +43777,33 @@
                         },
                         "description": "Progress ID returned from the generate_metrics endpoint",
                         "required": true
+                    },
+                    {
+                        "name": "agent_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "project_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "assistant_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -43989,6 +43889,33 @@
                         },
                         "description": "Progress ID returned from the preview endpoint",
                         "required": true
+                    },
+                    {
+                        "name": "agent_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "project_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "assistant_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -44043,6 +43970,15 @@
                             "type": "integer"
                         },
                         "description": "Project ID for permission validation"
+                    },
+                    {
+                        "name": "assistant_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -44181,6 +44117,33 @@
                         },
                         "description": "Progress ID returned from simplify_prompt endpoint",
                         "required": true
+                    },
+                    {
+                        "name": "agent_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "project_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "assistant_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -44267,6 +44230,15 @@
                             "type": "string"
                         },
                         "description": "Filter by scenario IDs — comma-separated string (e.g. '24270,24271'), not a JSON array."
+                    },
+                    {
+                        "name": "assistant_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `assistant_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -46510,6 +46482,33 @@
                         },
                         "description": "\nComma-separated list of run IDs.\nExample: `1,2,3`\n\nMust be a plain comma-separated string, not a JSON array — passing a JSON array returns a 400 error.\n",
                         "required": true
+                    },
+                    {
+                        "name": "agent_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `result_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "result_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `result_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "project_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `result_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -54290,6 +54289,15 @@
                             "type": "integer"
                         },
                         "description": "Filter projects by organisation ID"
+                    },
+                    {
+                        "name": "project_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `organization_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -57873,101 +57881,6 @@
                     }
                 }
             },
-            "AgentToggleMockToolsErrorResponse": {
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "detail"
-                ]
-            },
-            "AgentToggleMockToolsProgressErrorResponse": {
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "detail"
-                ]
-            },
-            "AgentToggleMockToolsProgressResponse": {
-                "type": "object",
-                "properties": {
-                    "status": {
-                        "enum": [
-                            "in_progress",
-                            "completed",
-                            "failed"
-                        ],
-                        "type": "string",
-                        "description": "* `in_progress` - in_progress\n* `completed` - completed\n* `failed` - failed",
-                        "x-spec-enum-id": "6e9575e5767aaee0"
-                    },
-                    "mock_enabled": {
-                        "type": [
-                            "boolean",
-                            "null"
-                        ]
-                    },
-                    "mcp_endpoints": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/ToggleMockToolsMCPEndpoint"
-                        },
-                        "description": "MCP mock endpoints registered after enabling. Empty for agents without MCP tools or when disabling."
-                    },
-                    "message": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    },
-                    "error": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    }
-                },
-                "required": [
-                    "error",
-                    "message",
-                    "mock_enabled",
-                    "status"
-                ]
-            },
-            "AgentToggleMockToolsRequest": {
-                "type": "object",
-                "properties": {
-                    "enabled": {
-                        "type": "boolean",
-                        "description": "True to enable mock mode, false to disable."
-                    },
-                    "api_key": {
-                        "type": "string",
-                        "description": "Optional API key. If not provided, stored credentials are used."
-                    }
-                },
-                "required": [
-                    "enabled"
-                ]
-            },
-            "AgentToggleMockToolsResponse": {
-                "type": "object",
-                "properties": {
-                    "progress_id": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "progress_id"
-                ]
-            },
             "AgentforceChatConfig": {
                 "type": "object",
                 "description": "Agentforce (Salesforce) chat configuration.",
@@ -60960,87 +60873,6 @@
                     "project_id"
                 ]
             },
-            "DisableMockErrorResponse": {
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "detail"
-                ]
-            },
-            "DisableMockProgressErrorResponse": {
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "detail"
-                ]
-            },
-            "DisableMockProgressResponse": {
-                "type": "object",
-                "properties": {
-                    "status": {
-                        "enum": [
-                            "in_progress",
-                            "completed",
-                            "failed"
-                        ],
-                        "type": "string",
-                        "description": "* `in_progress` - in_progress\n* `completed` - completed\n* `failed` - failed",
-                        "x-spec-enum-id": "6e9575e5767aaee0"
-                    },
-                    "mock_enabled": {
-                        "type": [
-                            "boolean",
-                            "null"
-                        ]
-                    },
-                    "message": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    },
-                    "error": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    }
-                },
-                "required": [
-                    "error",
-                    "message",
-                    "mock_enabled",
-                    "status"
-                ]
-            },
-            "DisableMockToolsRequest": {
-                "type": "object",
-                "properties": {
-                    "api_key": {
-                        "type": "string",
-                        "description": "Optional API key for the provider. If not provided, will use stored credentials."
-                    }
-                }
-            },
-            "DisableMockToolsResponse": {
-                "type": "object",
-                "properties": {
-                    "progress_id": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "progress_id"
-                ]
-            },
             "DisablePersonalitiesRequest": {
                 "type": "object",
                 "properties": {
@@ -61153,94 +60985,6 @@
                 },
                 "required": [
                     "personalities"
-                ]
-            },
-            "EnableMockErrorResponse": {
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "detail"
-                ]
-            },
-            "EnableMockProgressErrorResponse": {
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "detail"
-                ]
-            },
-            "EnableMockProgressResponse": {
-                "type": "object",
-                "properties": {
-                    "status": {
-                        "enum": [
-                            "in_progress",
-                            "completed",
-                            "failed"
-                        ],
-                        "type": "string",
-                        "description": "* `in_progress` - in_progress\n* `completed` - completed\n* `failed` - failed",
-                        "x-spec-enum-id": "6e9575e5767aaee0"
-                    },
-                    "mock_enabled": {
-                        "type": [
-                            "boolean",
-                            "null"
-                        ]
-                    },
-                    "mcp_endpoints": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/MockMCPEndpoint"
-                        },
-                        "description": "MCP mock endpoints registered for this agent (one per MCP-typed tool). Empty for agents without MCP tools."
-                    },
-                    "message": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    },
-                    "error": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    }
-                },
-                "required": [
-                    "error",
-                    "message",
-                    "mock_enabled",
-                    "status"
-                ]
-            },
-            "EnableMockToolsRequest": {
-                "type": "object",
-                "properties": {
-                    "api_key": {
-                        "type": "string",
-                        "description": "Optional API key. If not provided, uses stored credentials."
-                    }
-                }
-            },
-            "EnableMockToolsResponse": {
-                "type": "object",
-                "properties": {
-                    "progress_id": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "progress_id"
                 ]
             },
             "EnablePersonalitiesRequest": {
@@ -64479,28 +64223,6 @@
                 },
                 "required": [
                     "metric"
-                ]
-            },
-            "MockMCPEndpoint": {
-                "type": "object",
-                "properties": {
-                    "mock_index": {
-                        "type": "integer"
-                    },
-                    "url": {
-                        "type": "string"
-                    },
-                    "tool_names": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "required": [
-                    "mock_index",
-                    "tool_names",
-                    "url"
                 ]
             },
             "MockStatusMCPEndpoint": {
@@ -68575,6 +68297,11 @@
                         "readOnly": true,
                         "default": "Scenario Deleted"
                     },
+                    "scenario_type": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "Type of the run's scenario (e.g. instruction, conditional_actions), null if the scenario was deleted"
+                    },
                     "personality": {
                         "type": [
                             "integer",
@@ -72355,6 +72082,11 @@
                         "readOnly": true,
                         "default": "Scenario Deleted"
                     },
+                    "scenario_type": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "Type of the run's scenario (e.g. instruction, conditional_actions), null if the scenario was deleted"
+                    },
                     "personality": {
                         "type": [
                             "integer",
@@ -72891,6 +72623,16 @@
                         },
                         "description": "List of test profile IDs to override for this run. If not provided, uses the scenario's default test profile."
                     },
+                    "mock_tool_names": {
+                        "type": [
+                            "array",
+                            "null"
+                        ],
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Names of mock tools to activate for this run. Omit or pass an empty list to mock every tool configured on the agent."
+                    },
                     "livekit_data": {
                         "allOf": [
                             {
@@ -73008,6 +72750,13 @@
                     },
                     "concurrency_limit": {
                         "type": "integer"
+                    },
+                    "mock_tool_names": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Names of mock tools to activate for this run. Omit or pass an empty list to mock every tool configured on the agent."
                     }
                 },
                 "required": [
@@ -73044,6 +72793,13 @@
                     },
                     "concurrency_limit": {
                         "type": "integer"
+                    },
+                    "mock_tool_names": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Names of mock tools to activate for this run. Omit or pass an empty list to mock every tool configured on the agent."
                     }
                 },
                 "required": [
@@ -73073,6 +72829,16 @@
                         "maximum": 100,
                         "minimum": 1,
                         "description": "Frequency to run"
+                    },
+                    "mock_tool_names": {
+                        "type": [
+                            "array",
+                            "null"
+                        ],
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Names of mock tools to activate for this run. Omit or pass an empty list to mock every tool configured on the agent."
                     }
                 },
                 "required": [
@@ -75755,6 +75521,13 @@
                         "type": "integer",
                         "minimum": 1,
                         "description": "\nCap on the number of evaluator runs executed in parallel. Default: unbounded (subject to your provider's rate limits).\nUse this to avoid hitting provider rate limits on large frequency or folder runs.\nExample: `5`\n"
+                    },
+                    "mock_tool_names": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "\nNames of mock tools to activate for this run. Cekura swaps those tools' URLs to mock endpoints while the\nrun is active and restores the originals when it finishes. Omit or pass an empty list to mock every tool\nconfigured on the agent. Example: `[\"get_appointments\", \"cancel_booking\"]`\n"
                     }
                 }
             },
@@ -75859,6 +75632,13 @@
                         "type": "integer",
                         "minimum": 1,
                         "description": "\nCap on the number of evaluator runs executed in parallel. Default: unbounded (subject to your provider's rate limits).\nUse this to avoid hitting provider rate limits on large frequency or folder runs.\nExample: `5`\n"
+                    },
+                    "mock_tool_names": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "\nNames of mock tools to activate for this run. Cekura swaps those tools' URLs to mock endpoints while the\nrun is active and restores the originals when it finishes. Omit or pass an empty list to mock every tool\nconfigured on the agent. Example: `[\"get_appointments\", \"cancel_booking\"]`\n"
                     },
                     "websocket_url": {
                         "type": "string",
@@ -75968,6 +75748,13 @@
                         "minimum": 1,
                         "description": "\nCap on the number of evaluator runs executed in parallel. Default: unbounded (subject to your provider's rate limits).\nUse this to avoid hitting provider rate limits on large frequency or folder runs.\nExample: `5`\n"
                     },
+                    "mock_tool_names": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "\nNames of mock tools to activate for this run. Cekura swaps those tools' URLs to mock endpoints while the\nrun is active and restores the originals when it finishes. Omit or pass an empty list to mock every tool\nconfigured on the agent. Example: `[\"get_appointments\", \"cancel_booking\"]`\n"
+                    },
                     "elevenlabs_agent_id": {
                         "type": "string",
                         "description": "ElevenLabs agent ID to test against. Overrides the agent's stored assistant_id for this run."
@@ -75996,6 +75783,16 @@
                     "agent": {
                         "type": "integer",
                         "description": "Agent ID to run the scenarios against. If omitted, the agent is derived from the first scenario's configured agent."
+                    },
+                    "mock_tool_names": {
+                        "type": [
+                            "array",
+                            "null"
+                        ],
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Names of mock tools to activate for this run. Omit or pass an empty list to mock every tool configured on the agent."
                     }
                 },
                 "required": [
@@ -76046,6 +75843,16 @@
                             "type": "integer"
                         },
                         "description": "List of test profile IDs to override for this run. If not provided, uses the scenario's default test profile."
+                    },
+                    "mock_tool_names": {
+                        "type": [
+                            "array",
+                            "null"
+                        ],
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Names of mock tools to activate for this run. Omit or pass an empty list to mock every tool configured on the agent."
                     },
                     "personality_id": {
                         "type": [
@@ -76183,6 +75990,13 @@
                         "minimum": 1,
                         "description": "\nCap on the number of evaluator runs executed in parallel. Default: unbounded (subject to your provider's rate limits).\nUse this to avoid hitting provider rate limits on large frequency or folder runs.\nExample: `5`\n"
                     },
+                    "mock_tool_names": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "\nNames of mock tools to activate for this run. Cekura swaps those tools' URLs to mock endpoints while the\nrun is active and restores the originals when it finishes. Omit or pass an empty list to mock every tool\nconfigured on the agent. Example: `[\"get_appointments\", \"cancel_booking\"]`\n"
+                    },
                     "sip_endpoint": {
                         "type": "string",
                         "description": "Override the agent's stored SIP endpoint for this run."
@@ -76275,6 +76089,13 @@
                         "type": "integer",
                         "minimum": 1,
                         "description": "\nCap on the number of evaluator runs executed in parallel. Default: unbounded (subject to your provider's rate limits).\nUse this to avoid hitting provider rate limits on large frequency or folder runs.\nExample: `5`\n"
+                    },
+                    "mock_tool_names": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "\nNames of mock tools to activate for this run. Cekura swaps those tools' URLs to mock endpoints while the\nrun is active and restores the originals when it finishes. Omit or pass an empty list to mock every tool\nconfigured on the agent. Example: `[\"get_appointments\", \"cancel_booking\"]`\n"
                     }
                 }
             },
@@ -77787,28 +77608,6 @@
                 },
                 "required": [
                     "agent"
-                ]
-            },
-            "ToggleMockToolsMCPEndpoint": {
-                "type": "object",
-                "properties": {
-                    "mock_index": {
-                        "type": "integer"
-                    },
-                    "url": {
-                        "type": "string"
-                    },
-                    "tool_names": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "required": [
-                    "mock_index",
-                    "tool_names",
-                    "url"
                 ]
             },
             "TokenRefresh": {

--- a/openapi.json
+++ b/openapi.json
@@ -6622,6 +6622,63 @@
                 }
             }
         },
+        "/observability/v1/metric-failure-mode-insights/{id}/fix-metric/": {
+            "post": {
+                "operationId": "metric-failure-mode-insights-fix-metric-create",
+                "description": "Add a sample of one failure mode's example calls to Labs.\n\nThe metric flagged these calls as failing; the user supplies feedback\nexplaining why and a corrected ``expected_value`` (the label these\ncalls should carry). We sample 2-3 of the mode's example calls and\ncreate a Labs metric review for each — expected value pinned to the\nuser's label, the feedback as the human note — so the metric can be\niterated on against them. When no label is sent we default to a pass.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric failure mode insight.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "observability"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricFailureModeFixMetric"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricFailureModeFixMetric"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricFailureModeFixMetric"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricFailureModeFixMetric"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/observability/v1/metric-failure-mode-insights/{id}/generate-scenario/": {
             "post": {
                 "operationId": "metric-failure-mode-insights-generate-scenario-create",
@@ -13366,6 +13423,7 @@
                         "api_key": []
                     }
                 ],
+                "deprecated": true,
                 "responses": {
                     "200": {
                         "content": {
@@ -13409,19 +13467,12 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-tool-retrieve",
-                        "description": "Return a single tool's full definition, including the input/output pairs that define its mock responses. Use it to inspect what a tool returns before updating it or enabling mock mode."
-                    }
                 }
             },
             "post": {
                 "operationId": "aiagents-tool-create",
                 "description": "Execute tool by matching input and returning corresponding output.\n\nSupports two payload formats:\n1. Flat input (default): {\"param1\": \"value1\", \"param2\": \"value2\"}\n2. VAPI function format: {\"message\": {\"type\": \"tool-calls\", \"toolCallList\": [{\"id\": \"...\", \"arguments\": {...}}]}}",
+                "summary": "Execute a mock tool (provider webhook)",
                 "parameters": [
                     {
                         "in": "path",
@@ -13449,6 +13500,7 @@
                         "api_key": []
                     }
                 ],
+                "deprecated": true,
                 "responses": {
                     "201": {
                         "description": "No response body"
@@ -13536,6 +13588,7 @@
                         "api_key": []
                     }
                 ],
+                "deprecated": true,
                 "responses": {
                     "200": {
                         "content": {
@@ -13580,14 +13633,6 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-tool-partial-update",
-                        "description": "Patch a tool's fields — its `name`, `description`, or `information` (the list of input/output pairs that define its mock responses). Only the fields you send are changed."
-                    }
                 }
             },
             "delete": {
@@ -13621,6 +13666,7 @@
                         "api_key": []
                     }
                 ],
+                "deprecated": true,
                 "responses": {
                     "204": {
                         "description": "No response body"
@@ -13639,14 +13685,6 @@
                             }
                         },
                         "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-tool-destroy",
-                        "description": "⚠ Irreversible. Detaches the named tool from this agent by marking it deleted. The tool definition is not deleted — other agents referencing the same tool_name are unaffected."
                     }
                 }
             }
@@ -13675,6 +13713,7 @@
                         "api_key": []
                     }
                 ],
+                "deprecated": true,
                 "responses": {
                     "200": {
                         "content": {
@@ -13723,14 +13762,6 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-tools-list",
-                        "description": "Return every tool configured on the agent, including mock tools and the input/output pairs that define their mock responses. Use this to see what's set up before enabling or disabling mock mode or updating a specific tool."
-                    }
                 }
             },
             "post": {
@@ -13776,6 +13807,7 @@
                         "api_key": []
                     }
                 ],
+                "deprecated": true,
                 "responses": {
                     "201": {
                         "content": {
@@ -13817,14 +13849,6 @@
                             }
                         },
                         "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-tools-create",
-                        "description": "Register a tool on the agent, including its mock input/output pairs in `information`. For agents on a managed provider, prefer auto-fetch to import tools automatically; use this to add a custom or hand-authored tool."
                     }
                 }
             }
@@ -13892,6 +13916,7 @@
                         "api_key": []
                     }
                 ],
+                "deprecated": true,
                 "responses": {
                     "200": {
                         "content": {
@@ -13920,15 +13945,6 @@
                             }
                         },
                         "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mcp-destructive": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-tools-auto-fetch-create",
-                        "description": "Discover the agent's tools (from a managed provider or a customer-hosted MCP server) and LLM-generate mock input/output data for each. Persists Tool rows and records the provider configuration on the agent. ⚠ Overwrites empty Tool rows; existing rows with mock data are kept. For provider=\"custom\", supply `mcp_server_url`; the URL is SSRF-validated (no private/loopback targets)."
                     }
                 }
             }
@@ -13965,6 +13981,7 @@
                         "api_key": []
                     }
                 ],
+                "deprecated": true,
                 "responses": {
                     "200": {
                         "content": {
@@ -13985,14 +14002,6 @@
                             }
                         },
                         "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-tools-auto-fetch-progress-retrieve",
-                        "description": "Poll the status of a background auto-fetch tools task.\n\nReturns the current state: in_progress, completed (with counts), or failed (with error)."
                     }
                 }
             }
@@ -14040,6 +14049,7 @@
                         "api_key": []
                     }
                 ],
+                "deprecated": true,
                 "responses": {
                     "202": {
                         "content": {
@@ -14060,15 +14070,6 @@
                             }
                         },
                         "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mcp-destructive": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-tools-disable-mock-create",
-                        "description": "Restore the agent's tools to their original (non-mock) state. For managed providers this PATCHes the provider assistant back to its `original_tool_ids` and deletes the cloned tools. For provider=\"custom\" this only flips `mock_enabled` off; the `mcp_server_url` is preserved so re-enable works."
                     }
                 }
             }
@@ -14105,6 +14106,7 @@
                         "api_key": []
                     }
                 ],
+                "deprecated": true,
                 "responses": {
                     "200": {
                         "content": {
@@ -14125,14 +14127,6 @@
                             }
                         },
                         "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-tools-disable-mock-progress-retrieve",
-                        "description": "Poll the status of a background disable-mock task."
                     }
                 }
             }
@@ -14180,6 +14174,7 @@
                         "api_key": []
                     }
                 ],
+                "deprecated": true,
                 "responses": {
                     "202": {
                         "content": {
@@ -14200,15 +14195,6 @@
                             }
                         },
                         "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mcp-destructive": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-tools-enable-mock-create",
-                        "description": "Activate mock-tool mode using the data created by `auto-fetch`. For managed providers (vapi/retell/elevenlabs) this clones the provider's tools at the provider and swaps URLs to Cekura-hosted endpoints. For provider=\"custom\" it just registers `mcp_sub_tool_map` so MockMCPView can serve `/mcp/N/` calls. Returns a `progress_id`; poll `enable-mock-progress/` for the resulting `mcp_endpoints`. Run `auto-fetch` first."
                     }
                 }
             }
@@ -14245,6 +14231,7 @@
                         "api_key": []
                     }
                 ],
+                "deprecated": true,
                 "responses": {
                     "200": {
                         "content": {
@@ -14265,14 +14252,6 @@
                             }
                         },
                         "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-tools-enable-mock-progress-retrieve",
-                        "description": "Poll the status of a background enable-mock task."
                     }
                 }
             }
@@ -14301,6 +14280,7 @@
                         "api_key": []
                     }
                 ],
+                "deprecated": true,
                 "responses": {
                     "200": {
                         "content": {
@@ -14311,14 +14291,6 @@
                             }
                         },
                         "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-tools-mock-status-retrieve",
-                        "description": "Single source of truth for \"what mock-tool runtime URLs do I have, and what are they configured for?\". `mcp_endpoints[]` lists each Cekura-hosted MCP JSON-RPC endpoint with the sub-tools it serves; `tool_endpoints[]` lists standalone (non-MCP) per-tool webhook URLs. URLs are computed from `settings.CEKURA_BASE_URL`, so each environment renders the correct host."
                     }
                 }
             }
@@ -22985,7 +22957,7 @@
                                                             {
                                                                 "id": "integer",
                                                                 "name": "string",
-                                                                "type": "binary_workflow_adherence | binary_qualitative | continuous_qualitative | numeric | enum",
+                                                                "type": "binary | continuous_qualitative | numeric | enum",
                                                                 "score": "number",
                                                                 "explanation": "string | array",
                                                                 "function_name": "string (optional)",
@@ -24075,7 +24047,7 @@
                                                             {
                                                                 "id": "integer",
                                                                 "name": "string",
-                                                                "type": "binary_workflow_adherence | binary_qualitative | continuous_qualitative | numeric | enum",
+                                                                "type": "binary | continuous_qualitative | numeric | enum",
                                                                 "score": "number",
                                                                 "explanation": "string | array",
                                                                 "function_name": "string (optional)",
@@ -39819,7 +39791,7 @@
             },
             "patch": {
                 "operationId": "aiagents-partial-update",
-                "description": "Partially update an agent. Only fields included in the request body are modified.",
+                "description": "Partially update an agent. Only fields included in the request body are modified. Mock tools (create, update, delete) are managed via the `mock_tools` field — pass the full desired list of tools. Knowledge base files are managed via the `knowledge_base_files` field. Dynamic variables are managed via the `dynamic_variables` field.",
                 "summary": "Update an AI voice agent (partial)",
                 "parameters": [
                     {
@@ -39903,7 +39875,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "aiagents-partial-update",
-                        "description": "Partially update an agent. Only fields included in the request body are modified."
+                        "description": "Partially update an agent. Only fields included in the request body are modified. Mock tools (create, update, delete) are managed via the `mock_tools` field — pass the full desired list of tools. Knowledge base files are managed via the `knowledge_base_files` field. Dynamic variables are managed via the `dynamic_variables` field."
                     }
                 }
             },
@@ -40016,6 +39988,14 @@
                         },
                         "description": ""
                     }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "aiagents-auto-fetch-create",
+                        "description": "Re-fetch the full agent configuration from its connected provider (Retell, VAPI, ElevenLabs, Synthflow): system prompt, call settings, phone number, tools with mock data, dynamic variables and knowledge base files. Returns a `progress_id`; poll `auto-fetch-progress/` for staged status."
+                    }
                 }
             }
         },
@@ -40071,6 +40051,14 @@
                             }
                         },
                         "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "aiagents-auto-fetch-progress-retrieve",
+                        "description": "Poll the staged status of a background auto-fetch (whole-agent import)."
                     }
                 }
             }
@@ -40578,7 +40566,7 @@
         "/test_framework/v2/aiagents/{id}/toggle-mock-tools/": {
             "post": {
                 "operationId": "aiagents-toggle-mock-tools-create",
-                "description": "Toggle mock-tool mode on the agent's provider. `enabled=true` replaces the provider tools with Cekura-hosted mocks; `enabled=false` restores the originals (mock data is preserved). Returns a `progress_id`; poll `toggle-mock-tools-progress/`.",
+                "description": "Toggle mock-tool mode on the agent's provider. `enabled=true` replaces the provider tools with Cekura-hosted mocks; `enabled=false` restores the originals (mock data is preserved). Returns a `progress_id`; poll `toggle-mock-tools-progress/`. Run `auto-fetch` first to populate mock tool data before enabling.",
                 "summary": "Enable or disable mock tools on the provider",
                 "parameters": [
                     {
@@ -40640,6 +40628,15 @@
                         },
                         "description": ""
                     }
+                },
+                "x-mcp-expose": true,
+                "x-mcp-destructive": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "aiagents-toggle-mock-tools-create",
+                        "description": "Toggle mock-tool mode on the agent's provider. `enabled=true` replaces the provider tools with Cekura-hosted mocks; `enabled=false` restores the originals (mock data is preserved). Returns a `progress_id`; poll `toggle-mock-tools-progress/`. Run `auto-fetch` first to populate mock tool data before enabling."
+                    }
                 }
             }
         },
@@ -40695,6 +40692,14 @@
                             }
                         },
                         "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "aiagents-toggle-mock-tools-progress-retrieve",
+                        "description": "Poll the enable/disable task. The progress_id is unique, so we resolve it\nagainst both task namespaces and return whichever holds it."
                     }
                 }
             }
@@ -56997,7 +57002,7 @@
                             "string",
                             "null"
                         ],
-                        "description": "One of binary_workflow_adherence, binary_qualitative, numeric, continuous_qualitative, enum."
+                        "description": "One of binary, numeric, continuous_qualitative, enum. Legacy values (binary_workflow_adherence, binary_qualitative) are accepted and mapped to binary."
                     },
                     "enum_values": {
                         "type": [
@@ -57978,7 +57983,7 @@
                     },
                     "alert_enabled": {
                         "type": "boolean",
-                        "description": "\nEnable alerts for this metric when it fails (value < 5).\nOnly applicable to binary metrics (binary_workflow_adherence and binary_qualitative).\nFor other metric types, use significant_change_alert_status instead.\nExample: `true` or `false`\n        "
+                        "description": "\nEnable alerts for this metric when it fails (value=false).\nOnly applicable to binary metrics (eval_type=binary).\nFor other metric types, use significant_change_alert_status instead.\nExample: `true` or `false`\n        "
                     },
                     "alert_type": {
                         "enum": [
@@ -58237,7 +58242,7 @@
                     },
                     "alert_enabled": {
                         "type": "boolean",
-                        "description": "\nEnable alerts for this metric when it fails (value < 5).\nOnly applicable to binary metrics (binary_workflow_adherence and binary_qualitative).\nFor other metric types, use significant_change_alert_status instead.\nExample: `true` or `false`\n        "
+                        "description": "\nEnable alerts for this metric when it fails (value=false).\nOnly applicable to binary metrics (eval_type=binary).\nFor other metric types, use significant_change_alert_status instead.\nExample: `true` or `false`\n        "
                     },
                     "alert_type": {
                         "enum": [
@@ -58546,7 +58551,7 @@
                     },
                     "alert_enabled": {
                         "type": "boolean",
-                        "description": "\nEnable alerts for this metric when it fails (value < 5).\nOnly applicable to binary metrics (binary_workflow_adherence and binary_qualitative).\nFor other metric types, use significant_change_alert_status instead.\nExample: `true` or `false`\n        "
+                        "description": "\nEnable alerts for this metric when it fails (value=false).\nOnly applicable to binary metrics (eval_type=binary).\nFor other metric types, use significant_change_alert_status instead.\nExample: `true` or `false`\n        "
                     },
                     "alert_type": {
                         "enum": [
@@ -58638,6 +58643,34 @@
                 },
                 "required": [
                     "name"
+                ]
+            },
+            "MetricFailureModeFixMetric": {
+                "type": "object",
+                "description": "Request body for ``POST /metric-failure-mode-insights/{id}/fix_metric/``.\n\nSamples a few of one failure mode's example calls and adds them to Labs\nfor the insight's metric, carrying the user's feedback as the note and\n``expected_value`` as the corrected label.",
+                "properties": {
+                    "failure_mode_index": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "Index into the insight's failure_modes list to act on."
+                    },
+                    "feedback": {
+                        "type": "string",
+                        "description": "Human note attached to each sampled call's metric review in Labs."
+                    },
+                    "expected_value": {
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Corrected label to record for each sampled call in Labs: true/false for binary metrics, a 0-5 score for ratings, a number for numeric metrics, or null for N/A. Defaults to a passing value when omitted."
+                    }
+                },
+                "required": [
+                    "failure_mode_index",
+                    "feedback"
                 ]
             },
             "MetricFailureModeInsight": {
@@ -58980,7 +59013,7 @@
                     },
                     "alert_enabled": {
                         "type": "boolean",
-                        "description": "\nEnable alerts for this metric when it fails (value < 5).\nOnly applicable to binary metrics (binary_workflow_adherence and binary_qualitative).\nFor other metric types, use significant_change_alert_status instead.\nExample: `true` or `false`\n        "
+                        "description": "\nEnable alerts for this metric when it fails (value=false).\nOnly applicable to binary metrics (eval_type=binary).\nFor other metric types, use significant_change_alert_status instead.\nExample: `true` or `false`\n        "
                     },
                     "prompt": {
                         "type": "string",
@@ -59834,7 +59867,7 @@
                         ],
                         "type": "string",
                         "x-spec-enum-id": "b40eac6824409cc2",
-                        "description": "Evaluation type: binary_workflow_adherence, binary_qualitative, continuous_qualitative, numeric, or enum\n\n* `binary` - Binary\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum"
+                        "description": "Evaluation type: binary, continuous_qualitative, numeric, or enum. Legacy values (binary_workflow_adherence, binary_qualitative) are accepted and mapped to binary.\n\n* `binary` - Binary\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum"
                     },
                     "evaluation_trigger": {
                         "enum": [
@@ -62820,7 +62853,7 @@
                     },
                     "alert_enabled": {
                         "type": "boolean",
-                        "description": "\nEnable alerts for this metric when it fails (value < 5).\nOnly applicable to binary metrics (binary_workflow_adherence and binary_qualitative).\nFor other metric types, use significant_change_alert_status instead.\nExample: `true` or `false`\n        "
+                        "description": "\nEnable alerts for this metric when it fails (value=false).\nOnly applicable to binary metrics (eval_type=binary).\nFor other metric types, use significant_change_alert_status instead.\nExample: `true` or `false`\n        "
                     },
                     "alert_type": {
                         "enum": [
@@ -63773,7 +63806,7 @@
                         "description": "\nIs send emails enabled\nExample: `true` or `false`\n"
                     },
                     "rubric_config": {
-                        "description": "\nProject-level scoring rubric for evaluating call success. Each call log produced under this project is run against the rubric and gets a single pass/fail outcome based on its metric results.\n\nIMPORTANT (read before writing):\n- NEVER blindly overwrite this field. Always first GET the project, read the existing `rubric_config`, then merge in only the rule(s) you intend to add/update, and PATCH the full merged value. Sending a partial value will silently delete every rule you did not include.\n\nStructure:\n- `evaluation_logic`: MUST be `\"and\"`. All rules have to pass for a call to be marked successful. (Other values are not supported by the product currently.)\n- `rules`: List of rules. Use one rule per (metric, condition) — keep each rule simple, with a single condition inside.\n\nEach rule shape:\n```json\n{\n    \"metric_id\": <metric id>,\n    \"conditions\": {\n        \"operator\": \"and\",\n        \"conditions\": [\n            {\"field\": <field>, \"op\": <op>, \"value\": <value>}\n        ]\n    }\n}\n```\n\nWhat `field`, `op`, and `value` to use depends on the metric type. The three supported cases:\n\n1. Numeric / score metrics (qualitative scores, numeric metrics, workflow adherence with a score, etc.):\n   - `field`: `\"score\"`\n   - `op`: one of `\"gt\"`, `\"gte\"`, `\"lt\"`, `\"lte\"`, `\"eq\"`\n   - `value`: a number (qualitative scores are on a 0–5 scale)\n   - Example (score must be at least 4): `{\"field\": \"score\", \"op\": \"gte\", \"value\": 4}`\n\n2. Boolean / binary metrics (eval_type `binary_qualitative`, `binary_workflow_adherence`, or `evaluate_expected_outcome`):\n   - Boolean outcomes are stored as a score: True → `5`, False → `0`.\n   - `field`: `\"score\"`\n   - `op`: `\"eq\"` or `\"neq\"`\n   - `value`: `5` for True, `0` for False\n   - Example (must be True): `{\"field\": \"score\", \"op\": \"eq\", \"value\": 5}`\n   - Example (must be False): `{\"field\": \"score\", \"op\": \"eq\", \"value\": 0}`\n\n3. Enum metrics (eval_type `enum`, or `observability_topics` / `observability_dropoff`):\n   - `field`: `\"enum\"`\n   - `op`: `\"eq\"`, `\"neq\"`, or `\"in\"`\n   - `value`: a single string for `eq`/`neq`, or a list of strings for `in`. Must match one of the metric's defined `enum_values`.\n   - Example: `{\"field\": \"enum\", \"op\": \"eq\", \"value\": \"resolved\"}`\n   - Example (any of): `{\"field\": \"enum\", \"op\": \"in\", \"value\": [\"resolved\", \"partially_resolved\"]}`\n\nFull example:\n```json\n{\n    \"evaluation_logic\": \"and\",\n    \"rules\": [\n        {\n            \"metric_id\": 115164,\n            \"conditions\": {\n                \"operator\": \"and\",\n                \"conditions\": [\n                    {\"op\": \"eq\", \"field\": \"score\", \"value\": 5}\n                ]\n            }\n        },\n        {\n            \"metric_id\": 5512,\n            \"conditions\": {\n                \"operator\": \"and\",\n                \"conditions\": [\n                    {\"op\": \"gte\", \"field\": \"score\", \"value\": 4}\n                ]\n            }\n        },\n        {\n            \"metric_id\": 8821,\n            \"conditions\": {\n                \"operator\": \"and\",\n                \"conditions\": [\n                    {\"op\": \"in\", \"field\": \"enum\", \"value\": [\"resolved\", \"partially_resolved\"]}\n                ]\n            }\n        }\n    ]\n}\n```\n\nNotes:\n- `metric_id` must reference a metric belonging to this project (project-scoped or agent-scoped under this project); unknown ids are rejected.\n- Rules whose metric did not produce a value on a given call are skipped (neither pass nor fail) and do not affect the outcome.\n- Pass an empty object `{}` to clear the rubric.\n"
+                        "description": "\nProject-level scoring rubric for evaluating call success. Each call log produced under this project is run against the rubric and gets a single pass/fail outcome based on its metric results.\n\nIMPORTANT (read before writing):\n- NEVER blindly overwrite this field. Always first GET the project, read the existing `rubric_config`, then merge in only the rule(s) you intend to add/update, and PATCH the full merged value. Sending a partial value will silently delete every rule you did not include.\n\nStructure:\n- `evaluation_logic`: MUST be `\"and\"`. All rules have to pass for a call to be marked successful. (Other values are not supported by the product currently.)\n- `rules`: List of rules. Use one rule per (metric, condition) — keep each rule simple, with a single condition inside.\n\nEach rule shape:\n```json\n{\n    \"metric_id\": <metric id>,\n    \"conditions\": {\n        \"operator\": \"and\",\n        \"conditions\": [\n            {\"field\": <field>, \"op\": <op>, \"value\": <value>}\n        ]\n    }\n}\n```\n\nWhat `field`, `op`, and `value` to use depends on the metric type. The three supported cases:\n\n1. Numeric / score metrics (qualitative scores, numeric metrics, workflow adherence with a score, etc.):\n   - `field`: `\"score\"`\n   - `op`: one of `\"gt\"`, `\"gte\"`, `\"lt\"`, `\"lte\"`, `\"eq\"`\n   - `value`: a number (qualitative scores are on a 0–5 scale)\n   - Example (score must be at least 4): `{\"field\": \"score\", \"op\": \"gte\", \"value\": 4}`\n\n2. Boolean / binary metrics (eval_type `binary`, or `evaluate_expected_outcome`):\n   - `field`: `\"score\"`\n   - `op`: `\"eq\"` or `\"neq\"`\n   - `value`: `true` for pass, `false` for fail\n   - Example (must pass): `{\"field\": \"score\", \"op\": \"eq\", \"value\": true}`\n   - Example (must fail): `{\"field\": \"score\", \"op\": \"eq\", \"value\": false}`\n   - Legacy values `5` (pass) and `0` (fail) are still accepted for back-compat but new rules should use bool.\n\n3. Enum metrics (eval_type `enum`, or `observability_topics` / `observability_dropoff`):\n   - `field`: `\"enum\"`\n   - `op`: `\"eq\"`, `\"neq\"`, or `\"in\"`\n   - `value`: a single string for `eq`/`neq`, or a list of strings for `in`. Must match one of the metric's defined `enum_values`.\n   - Example: `{\"field\": \"enum\", \"op\": \"eq\", \"value\": \"resolved\"}`\n   - Example (any of): `{\"field\": \"enum\", \"op\": \"in\", \"value\": [\"resolved\", \"partially_resolved\"]}`\n\nFull example:\n```json\n{\n    \"evaluation_logic\": \"and\",\n    \"rules\": [\n        {\n            \"metric_id\": 115164,\n            \"conditions\": {\n                \"operator\": \"and\",\n                \"conditions\": [\n                    {\"op\": \"eq\", \"field\": \"score\", \"value\": true}\n                ]\n            }\n        },\n        {\n            \"metric_id\": 5512,\n            \"conditions\": {\n                \"operator\": \"and\",\n                \"conditions\": [\n                    {\"op\": \"gte\", \"field\": \"score\", \"value\": 4}\n                ]\n            }\n        },\n        {\n            \"metric_id\": 8821,\n            \"conditions\": {\n                \"operator\": \"and\",\n                \"conditions\": [\n                    {\"op\": \"in\", \"field\": \"enum\", \"value\": [\"resolved\", \"partially_resolved\"]}\n                ]\n            }\n        }\n    ]\n}\n```\n\nNotes:\n- `metric_id` must reference a metric belonging to this project (project-scoped or agent-scoped under this project); unknown ids are rejected.\n- Rules whose metric did not produce a value on a given call are skipped (neither pass nor fail) and do not affect the outcome.\n- Pass an empty object `{}` to clear the rubric.\n"
                     },
                     "timezone": {
                         "type": "string",
@@ -64898,7 +64931,7 @@
                         ],
                         "type": "string",
                         "x-spec-enum-id": "b40eac6824409cc2",
-                        "description": "Output shape of the evaluation score\n\n* `binary` - Binary\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum"
+                        "description": "Output shape of the evaluation score. Accepts canonical (binary, continuous_qualitative, numeric, enum); legacy binary_workflow_adherence and binary_qualitative are accepted and mapped to binary.\n\n* `binary` - Binary\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum"
                     },
                     "enum_values": {
                         "type": "array",
@@ -67156,7 +67189,7 @@
                         "description": "\nIs send emails enabled\nExample: `true` or `false`\n"
                     },
                     "rubric_config": {
-                        "description": "\nProject-level scoring rubric for evaluating call success. Each call log produced under this project is run against the rubric and gets a single pass/fail outcome based on its metric results.\n\nIMPORTANT (read before writing):\n- NEVER blindly overwrite this field. Always first GET the project, read the existing `rubric_config`, then merge in only the rule(s) you intend to add/update, and PATCH the full merged value. Sending a partial value will silently delete every rule you did not include.\n\nStructure:\n- `evaluation_logic`: MUST be `\"and\"`. All rules have to pass for a call to be marked successful. (Other values are not supported by the product currently.)\n- `rules`: List of rules. Use one rule per (metric, condition) — keep each rule simple, with a single condition inside.\n\nEach rule shape:\n```json\n{\n    \"metric_id\": <metric id>,\n    \"conditions\": {\n        \"operator\": \"and\",\n        \"conditions\": [\n            {\"field\": <field>, \"op\": <op>, \"value\": <value>}\n        ]\n    }\n}\n```\n\nWhat `field`, `op`, and `value` to use depends on the metric type. The three supported cases:\n\n1. Numeric / score metrics (qualitative scores, numeric metrics, workflow adherence with a score, etc.):\n   - `field`: `\"score\"`\n   - `op`: one of `\"gt\"`, `\"gte\"`, `\"lt\"`, `\"lte\"`, `\"eq\"`\n   - `value`: a number (qualitative scores are on a 0–5 scale)\n   - Example (score must be at least 4): `{\"field\": \"score\", \"op\": \"gte\", \"value\": 4}`\n\n2. Boolean / binary metrics (eval_type `binary_qualitative`, `binary_workflow_adherence`, or `evaluate_expected_outcome`):\n   - Boolean outcomes are stored as a score: True → `5`, False → `0`.\n   - `field`: `\"score\"`\n   - `op`: `\"eq\"` or `\"neq\"`\n   - `value`: `5` for True, `0` for False\n   - Example (must be True): `{\"field\": \"score\", \"op\": \"eq\", \"value\": 5}`\n   - Example (must be False): `{\"field\": \"score\", \"op\": \"eq\", \"value\": 0}`\n\n3. Enum metrics (eval_type `enum`, or `observability_topics` / `observability_dropoff`):\n   - `field`: `\"enum\"`\n   - `op`: `\"eq\"`, `\"neq\"`, or `\"in\"`\n   - `value`: a single string for `eq`/`neq`, or a list of strings for `in`. Must match one of the metric's defined `enum_values`.\n   - Example: `{\"field\": \"enum\", \"op\": \"eq\", \"value\": \"resolved\"}`\n   - Example (any of): `{\"field\": \"enum\", \"op\": \"in\", \"value\": [\"resolved\", \"partially_resolved\"]}`\n\nFull example:\n```json\n{\n    \"evaluation_logic\": \"and\",\n    \"rules\": [\n        {\n            \"metric_id\": 115164,\n            \"conditions\": {\n                \"operator\": \"and\",\n                \"conditions\": [\n                    {\"op\": \"eq\", \"field\": \"score\", \"value\": 5}\n                ]\n            }\n        },\n        {\n            \"metric_id\": 5512,\n            \"conditions\": {\n                \"operator\": \"and\",\n                \"conditions\": [\n                    {\"op\": \"gte\", \"field\": \"score\", \"value\": 4}\n                ]\n            }\n        },\n        {\n            \"metric_id\": 8821,\n            \"conditions\": {\n                \"operator\": \"and\",\n                \"conditions\": [\n                    {\"op\": \"in\", \"field\": \"enum\", \"value\": [\"resolved\", \"partially_resolved\"]}\n                ]\n            }\n        }\n    ]\n}\n```\n\nNotes:\n- `metric_id` must reference a metric belonging to this project (project-scoped or agent-scoped under this project); unknown ids are rejected.\n- Rules whose metric did not produce a value on a given call are skipped (neither pass nor fail) and do not affect the outcome.\n- Pass an empty object `{}` to clear the rubric.\n"
+                        "description": "\nProject-level scoring rubric for evaluating call success. Each call log produced under this project is run against the rubric and gets a single pass/fail outcome based on its metric results.\n\nIMPORTANT (read before writing):\n- NEVER blindly overwrite this field. Always first GET the project, read the existing `rubric_config`, then merge in only the rule(s) you intend to add/update, and PATCH the full merged value. Sending a partial value will silently delete every rule you did not include.\n\nStructure:\n- `evaluation_logic`: MUST be `\"and\"`. All rules have to pass for a call to be marked successful. (Other values are not supported by the product currently.)\n- `rules`: List of rules. Use one rule per (metric, condition) — keep each rule simple, with a single condition inside.\n\nEach rule shape:\n```json\n{\n    \"metric_id\": <metric id>,\n    \"conditions\": {\n        \"operator\": \"and\",\n        \"conditions\": [\n            {\"field\": <field>, \"op\": <op>, \"value\": <value>}\n        ]\n    }\n}\n```\n\nWhat `field`, `op`, and `value` to use depends on the metric type. The three supported cases:\n\n1. Numeric / score metrics (qualitative scores, numeric metrics, workflow adherence with a score, etc.):\n   - `field`: `\"score\"`\n   - `op`: one of `\"gt\"`, `\"gte\"`, `\"lt\"`, `\"lte\"`, `\"eq\"`\n   - `value`: a number (qualitative scores are on a 0–5 scale)\n   - Example (score must be at least 4): `{\"field\": \"score\", \"op\": \"gte\", \"value\": 4}`\n\n2. Boolean / binary metrics (eval_type `binary`, or `evaluate_expected_outcome`):\n   - `field`: `\"score\"`\n   - `op`: `\"eq\"` or `\"neq\"`\n   - `value`: `true` for pass, `false` for fail\n   - Example (must pass): `{\"field\": \"score\", \"op\": \"eq\", \"value\": true}`\n   - Example (must fail): `{\"field\": \"score\", \"op\": \"eq\", \"value\": false}`\n   - Legacy values `5` (pass) and `0` (fail) are still accepted for back-compat but new rules should use bool.\n\n3. Enum metrics (eval_type `enum`, or `observability_topics` / `observability_dropoff`):\n   - `field`: `\"enum\"`\n   - `op`: `\"eq\"`, `\"neq\"`, or `\"in\"`\n   - `value`: a single string for `eq`/`neq`, or a list of strings for `in`. Must match one of the metric's defined `enum_values`.\n   - Example: `{\"field\": \"enum\", \"op\": \"eq\", \"value\": \"resolved\"}`\n   - Example (any of): `{\"field\": \"enum\", \"op\": \"in\", \"value\": [\"resolved\", \"partially_resolved\"]}`\n\nFull example:\n```json\n{\n    \"evaluation_logic\": \"and\",\n    \"rules\": [\n        {\n            \"metric_id\": 115164,\n            \"conditions\": {\n                \"operator\": \"and\",\n                \"conditions\": [\n                    {\"op\": \"eq\", \"field\": \"score\", \"value\": true}\n                ]\n            }\n        },\n        {\n            \"metric_id\": 5512,\n            \"conditions\": {\n                \"operator\": \"and\",\n                \"conditions\": [\n                    {\"op\": \"gte\", \"field\": \"score\", \"value\": 4}\n                ]\n            }\n        },\n        {\n            \"metric_id\": 8821,\n            \"conditions\": {\n                \"operator\": \"and\",\n                \"conditions\": [\n                    {\"op\": \"in\", \"field\": \"enum\", \"value\": [\"resolved\", \"partially_resolved\"]}\n                ]\n            }\n        }\n    ]\n}\n```\n\nNotes:\n- `metric_id` must reference a metric belonging to this project (project-scoped or agent-scoped under this project); unknown ids are rejected.\n- Rules whose metric did not produce a value on a given call are skipped (neither pass nor fail) and do not affect the outcome.\n- Pass an empty object `{}` to clear the rubric.\n"
                     },
                     "timezone": {
                         "type": "string",
@@ -69263,6 +69296,15 @@
                             "integer",
                             "null"
                         ]
+                    },
+                    "generated_mock_tool_entries": {
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Mock tool data generated for this scenario. Format: [{tool_id, tool_name, new_entry: {input, output}}]. Stored for evaluation and debugging purposes."
                     }
                 },
                 "required": [
@@ -70998,7 +71040,7 @@
                         ],
                         "type": "string",
                         "x-spec-enum-id": "b40eac6824409cc2",
-                        "description": "Output shape of the evaluation score\n\n* `binary` - Binary\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum"
+                        "description": "Output shape of the evaluation score. Accepts canonical (binary, continuous_qualitative, numeric, enum); legacy binary_workflow_adherence and binary_qualitative are accepted and mapped to binary.\n\n* `binary` - Binary\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum"
                     },
                     "enum_values": {
                         "type": "array",


### PR DESCRIPTION
- api-reference/test_framework/{create,get,list,update}-metric.mdx now point to /v2/metrics/ paths (canonical eval_type vocabulary).
- documentation/key-concepts/metrics/rubric.mdx + creating-good-metric.mdx drop the affects_call_success narrative and document the rubric membership via the v2 add_to_rubric write field.
- python-metric.mdx + llm-judge-metric.mdx: align example payloads with v2 canonical eval_type values.
- webhook-format.mdx: callout that the webhook keeps emitting legacy type strings for back-compat.
- Regenerate openapi.json from the backend (covers MetricViewSetV2 + AddToRubric write-only field).