### PR TITLE
[Auto] Sync docs for backend PR #9393

### DIFF
--- a/api-reference/observability/generate-metric-failure-mode-scenario.mdx
+++ b/api-reference/observability/generate-metric-failure-mode-scenario.mdx
@@ -1,0 +1,6 @@
+---
+title: Generate Metric Failure Mode Scenario
+description: "Queue generation of a test scenario from one failure mode."
+openapi: post /observability/v1/metric-failure-mode-insights/{id}/generate-scenario/
+slug: generate-metric-failure-mode-scenario
+---

--- a/api-reference/observability/retrieve-metric-failure-mode-agents.mdx
+++ b/api-reference/observability/retrieve-metric-failure-mode-agents.mdx
@@ -1,0 +1,6 @@
+---
+title: Retrieve Metric Failure Mode Agents
+description: "List the agents implicated by a failure mode's example calls."
+openapi: get /observability/v1/metric-failure-mode-insights/{id}/failure-mode-agents/
+slug: retrieve-metric-failure-mode-agents
+---

--- a/documentation/key-concepts/evaluators/mock-tools.mdx
+++ b/documentation/key-concepts/evaluators/mock-tools.mdx
@@ -244,11 +244,34 @@ To handle variable inputs reliably:
 - **Pin dynamic values in your evaluator instructions.** If a parameter like a date or appointment slot is completely open-ended, use [Test Profiles](/documentation/key-concepts/evaluators/test-profile) to fix the value: set `{{test_profile.appointment_date}}` in your evaluator scenario, and mock only for that pinned value. This makes both the mock matching and the evaluator assertion deterministic.
 - **Check the tool name matches exactly.** Any casing or underscore mismatch between the tool name in your mock config and the name in your provider (Retell LLM/Flow, VAPI, ElevenLabs) will silently prevent the mock from firing, regardless of the input.
 
+## Mock Tool Response Fields
+
+When you retrieve an agent, the response includes these mock tool fields:
+
+- **`mock_tools_enabled`**: Boolean indicating whether mock mode is currently enabled on the provider
+- **`mock_tools_provider`**: The provider where mock mode is configured (e.g., `vapi`, `retell`, `elevenlabs`)
+- **`mock_tools[]`**: Array of mock tool configurations, each including:
+  - **`mock_data`**: The input-output mappings for this tool
+  - **`served_via`**: Runtime routing information — how the mock tool is accessed:
+    - **`type: "direct"`**: Tool has its own dedicated URL at `served_via.url`
+    - **`type: "mcp"`**: Tool is grouped under a shared MCP endpoint at `served_via.url`, identified by `mock_index`
+
+### MCP Routing
+
+Mock tools can be served two ways:
+
+1. **Direct routing** (`served_via.type='direct'`): Each tool gets a unique URL. This is the default for providers that expect per-tool webhook URLs (VAPI, Retell, ElevenLabs). Use `served_via.url` directly when configuring your provider.
+
+2. **MCP routing** (`served_via.type='mcp'`): Multiple tools share a single endpoint, with each tool identified by its `mock_index`. This groups related tools under one URL to simplify configuration and reduce webhook sprawl. The MCP endpoint dispatches to the correct tool based on the `mock_index` path parameter.
+
+MCP routing is useful when you have many mock tools and want to minimize the number of webhook URLs you configure on your provider. Direct routing gives you per-tool URLs for maximum flexibility.
+
 ## API Reference
 
 For programmatic access to mock tools — they are managed directly on the agent:
 
-- [Get Agent](/api-reference/test_framework/get-agent) — read the agent's `mock_tools` (each entry includes its mock data and runtime access URL)
+- [Get Agent](/api-reference/test_framework/get-agent) — read the agent's `mock_tools`, `mock_tools_enabled`, and `mock_tools_provider` fields (each tool includes its mock data and `served_via` routing info)
 - [Update Agent](/api-reference/test_framework/update-agent-partial) — create, update, or delete mock tools via the `mock_tools` field
-- [Auto-Fetch Agent from Provider](/api-reference/test_framework/auto-fetch-agent) — re-fetch the agent's full configuration (including tools + mock data) from its provider
-- [Toggle Mock Tools](/api-reference/test_framework/toggle-mock-tools) — enable or disable mock mode on the provider
+- [Auto-Fetch Agent from Provider](/api-reference/test_framework/auto-fetch-agent) — re-fetch the agent's full configuration (including tools + mock data) from its provider; monitor progress with the auto-fetch progress endpoint
+- [Auto-Fetch Progress](/api-reference/test_framework/auto-fetch-progress) — poll this per-agent endpoint to track the status of an auto-fetch operation
+- [Toggle Mock Tools](/api-reference/test_framework/toggle-mock-tools) — enable or disable mock mode on the provider (updates `mock_tools_enabled` and applies changes to the provider's configuration)

--- a/mint.json
+++ b/mint.json
@@ -486,7 +486,10 @@
             "api-reference/observability/delete-deep-research-insight",
             "api-reference/observability/dismiss-deep-research-insight-mode",
             "api-reference/observability/generate-deep-research-insights",
-            "api-reference/observability/get-metric-failure-mode-insights-available-dates"
+            "api-reference/observability/get-metric-failure-mode-insights-available-dates",
+            "api-reference/observability/retrieve-deep-research-insights-pricing",
+            "api-reference/observability/retrieve-metric-failure-mode-agents",
+            "api-reference/observability/generate-metric-failure-mode-scenario"
           ]
         }
       ]

--- a/openapi.json
+++ b/openapi.json
@@ -6024,6 +6024,100 @@
                 }
             }
         },
+        "/observability/v1/metric-failure-mode-insights/{id}/failure-mode-agents/": {
+            "get": {
+                "operationId": "metric-failure-mode-insights-failure-mode-agents-retrieve",
+                "description": "List the agents implicated by a failure mode's example calls.\n\nThe frontend uses this to decide which agent(s) to create a\nscenario for: it resolves each example call's agent and, when a\nfailure mode spans several agents, posts ``generate-scenario``\nonce per agent. Falls back to the project's agents when no example\ncall resolves to an agent.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric failure mode insight.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "observability"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricFailureModeInsight"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/observability/v1/metric-failure-mode-insights/{id}/generate-scenario/": {
+            "post": {
+                "operationId": "metric-failure-mode-insights-generate-scenario-create",
+                "description": "Queue generation of a test scenario from one failure mode.\n\nReturns a ``progress_id`` the frontend polls via the existing\n``scenarios/generate-progress`` endpoint; the generated scenario\nid lands in that progress state's ``scenarios_list`` when done.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric failure mode insight.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "observability"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricFailureModeInsightGenerateScenario"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricFailureModeInsightGenerateScenario"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricFailureModeInsightGenerateScenario"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricFailureModeInsightGenerateScenario"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/observability/v1/metric-failure-mode-insights/available_dates/": {
             "get": {
                 "operationId": "metric-failure-mode-insights-available-dates-retrieve",
@@ -8164,7 +8258,7 @@
         "/subscriptions/packs/add_developer_pack/": {
             "post": {
                 "operationId": "subscriptions-packs-add-developer-pack-create",
-                "description": "Add developer pack to organization after verifying phone number.\nRequires phone number to be verified in Supabase.\nThrottled to 1 request per 30 seconds per user.",
+                "description": "Add developer pack to organization.\nPhone verification is not required here — it is only enforced\nfor the developer trial pack (add_developer_trial_pack).\nThrottled to 1 request per 30 seconds per user.",
                 "tags": [
                     "subscriptions"
                 ],
@@ -22409,7 +22503,7 @@
         "/test_framework/v1/results-external/{id}/": {
             "get": {
                 "operationId": "results-external-retrieve",
-                "description": "The `success` and `success_rate` fields indicate the run reached a terminal state, not that it passed its expected outcome. A run with an `error_message` (e.g. failed connection) still reports `success=true`. For actual pass/fail outcomes check: `runs[].evaluation.metrics[].result`, `runs[].expected_outcome`, and `runs[].error_message`.\n\nThe `runs` field is a dict keyed by run ID string (e.g. `{\"86368\": {...}, \"86367\": {...}}`), not an array — unlike the list endpoint. Each run also has a `call_id` STRING field (the provider's call identifier) — that is a data field, NOT an endpoint ID; do not pass it where `run_id` is expected.",
+                "description": "`success` indicates whether the run passed its quality evaluation. A run with `success=false` either failed to connect (check `error_message`) or failed an evaluation check (check `evaluation`). `success_rate` is the percentage of runs with `success=true`.\n\nThe `runs` field is a dict keyed by run ID string (e.g. `{\"86368\": {...}, \"86367\": {...}}`), not an array — unlike the list endpoint. Each run also has a `call_id` STRING field (the provider's call identifier) — that is a data field, NOT an endpoint ID; do not pass it where `run_id` is expected.",
                 "summary": "Retrieve a test result",
                 "parameters": [
                     {
@@ -23499,7 +23593,7 @@
         "/test_framework/v1/results/{id}/": {
             "get": {
                 "operationId": "results-retrieve",
-                "description": "The `success` and `success_rate` fields indicate the run reached a terminal state, not that it passed its expected outcome. A run with an `error_message` (e.g. failed connection) still reports `success=true`. For actual pass/fail outcomes check: `runs[].evaluation.metrics[].result`, `runs[].expected_outcome`, and `runs[].error_message`.\n\nThe `runs` field is a dict keyed by run ID string (e.g. `{\"86368\": {...}, \"86367\": {...}}`), not an array — unlike the list endpoint. Each run also has a `call_id` STRING field (the provider's call identifier) — that is a data field, NOT an endpoint ID; do not pass it where `run_id` is expected.",
+                "description": "`success` indicates whether the run passed its quality evaluation. A run with `success=false` either failed to connect (check `error_message`) or failed an evaluation check (check `evaluation`). `success_rate` is the percentage of runs with `success=true`.\n\nThe `runs` field is a dict keyed by run ID string (e.g. `{\"86368\": {...}, \"86367\": {...}}`), not an array — unlike the list endpoint. Each run also has a `call_id` STRING field (the provider's call identifier) — that is a data field, NOT an endpoint ID; do not pass it where `run_id` is expected.",
                 "summary": "Retrieve a test result",
                 "parameters": [
                     {
@@ -23704,7 +23798,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "results-retrieve",
-                        "description": "The `success` and `success_rate` fields indicate the run reached a terminal state, not that it passed its expected outcome. A run with an `error_message` (e.g. failed connection) still reports `success=true`. For actual pass/fail outcomes check: `runs[].evaluation.metrics[].result`, `runs[].expected_outcome`, and `runs[].error_message`.\n\nThe `runs` field is a dict keyed by run ID string (e.g. `{\"86368\": {...}, \"86367\": {...}}`), not an array — unlike the list endpoint. Each run also has a `call_id` STRING field (the provider's call identifier) — that is a data field, NOT an endpoint ID; do not pass it where `run_id` is expected."
+                        "description": "`success` indicates whether the run passed its quality evaluation. A run with `success=false` either failed to connect (check `error_message`) or failed an evaluation check (check `evaluation`). `success_rate` is the percentage of runs with `success=true`.\n\nThe `runs` field is a dict keyed by run ID string (e.g. `{\"86368\": {...}, \"86367\": {...}}`), not an array — unlike the list endpoint. Each run also has a `call_id` STRING field (the provider's call identifier) — that is a data field, NOT an endpoint ID; do not pass it where `run_id` is expected."
                     }
                 }
             },
@@ -25988,7 +26082,7 @@
         "/test_framework/v1/runs-external/bulk/": {
             "get": {
                 "operationId": "runs-external-bulk-retrieve",
-                "description": "Retrieve multiple runs in a single request.\n\n`success: true` indicates the run reached a terminal state, not that it passed. A run with `error_message` (e.g. websocket handshake failure) still reports `success=true` and `evaluation_status='success'`. For actual outcomes check: `error_message`, `metadata.ended_reason`, and `evaluation.metrics[].result`.",
+                "description": "Retrieve multiple runs in a single request.\n\n`success: true` indicates the run passed its quality evaluation. A run with `success=false` either failed to connect (check `error_message`) or failed an evaluation check. For detailed outcomes check: `error_message`, `metadata.ended_reason`, and `evaluation.metrics[].result`.",
                 "parameters": [
                     {
                         "in": "query",
@@ -26906,7 +27000,7 @@
         "/test_framework/v1/runs/bulk/": {
             "get": {
                 "operationId": "runs-bulk-retrieve",
-                "description": "Retrieve multiple runs in a single request.\n\n`success: true` indicates the run reached a terminal state, not that it passed. A run with `error_message` (e.g. websocket handshake failure) still reports `success=true` and `evaluation_status='success'`. For actual outcomes check: `error_message`, `metadata.ended_reason`, and `evaluation.metrics[].result`.",
+                "description": "Retrieve multiple runs in a single request.\n\n`success: true` indicates the run passed its quality evaluation. A run with `success=false` either failed to connect (check `error_message`) or failed an evaluation check. For detailed outcomes check: `error_message`, `metadata.ended_reason`, and `evaluation.metrics[].result`.",
                 "parameters": [
                     {
                         "in": "query",
@@ -26946,7 +27040,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "runs-bulk-retrieve",
-                        "description": "Retrieve multiple runs in a single request.\n\n`success: true` indicates the run reached a terminal state, not that it passed. A run with `error_message` (e.g. websocket handshake failure) still reports `success=true` and `evaluation_status='success'`. For actual outcomes check: `error_message`, `metadata.ended_reason`, and `evaluation.metrics[].result`."
+                        "description": "Retrieve multiple runs in a single request.\n\n`success: true` indicates the run passed its quality evaluation. A run with `success=false` either failed to connect (check `error_message`) or failed an evaluation check. For detailed outcomes check: `error_message`, `metadata.ended_reason`, and `evaluation.metrics[].result`."
                     }
                 }
             }
@@ -30039,7 +30133,7 @@
         "/test_framework/v1/scenarios-external/run_scenarios/": {
             "post": {
                 "operationId": "scenarios-run-voice",
-                "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing.\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others:**\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.",
+                "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing. Requires `telephony.phone_number` configured on the agent (any provider).\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.",
                 "summary": "Run evaluators over a voice call",
                 "tags": [
                     "Evaluators"
@@ -30298,7 +30392,7 @@
         "/test_framework/v1/scenarios-external/run_scenarios_agora/": {
             "post": {
                 "operationId": "scenarios-run-agora",
-                "description": "AGORA RTC VOICE RUN: Execute evaluators against an agent reachable in an Agora RTC channel. Cekura joins the channel as a participant and converses. The agent must have `agora_data.session_endpoint_url` configured — an endpoint that mints the per-call channel and token; Cekura calls it at run time and never stores the join details.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC",
+                "description": "AGORA RTC VOICE RUN: Execute evaluators against an agent reachable in an Agora RTC channel. Cekura joins the channel as a participant and converses. The agent must have `agora_data.session_endpoint_url` configured — an endpoint that mints the per-call channel and token; Cekura calls it at run time and never stores the join details.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC",
                 "summary": "Run evaluators against an agent in an Agora RTC channel",
                 "tags": [
                     "Evaluators"
@@ -30474,7 +30568,7 @@
         "/test_framework/v1/scenarios-external/run_scenarios_chirp/": {
             "post": {
                 "operationId": "scenarios-run-chirp",
-                "description": "RAW-PCM WEBSOCKET VOICE RUN: Execute evaluators against an agent that exposes a raw-PCM WebSocket endpoint (16 kHz, 16-bit mono, binary frames). The agent must have a websocket endpoint configured (`telephony.websocket_url`); optional Basic Auth lives in `telephony.websocket_auth`. Pass `websocket_url` to override the agent's stored endpoint for this run.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_websocket` — JSON/text WebSocket protocol (per-scenario URLs)\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC",
+                "description": "RAW-PCM WEBSOCKET VOICE RUN: Execute evaluators against an agent that exposes a raw-PCM WebSocket endpoint (16 kHz, 16-bit mono, binary frames). The agent must have a websocket endpoint configured (`telephony.websocket_url`); optional Basic Auth lives in `telephony.websocket_auth`. Pass `websocket_url` to override the agent's stored endpoint for this run.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_websocket` — JSON/text WebSocket protocol (per-scenario URLs)\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC",
                 "summary": "Run evaluators against a raw-PCM WebSocket voice endpoint",
                 "tags": [
                     "Evaluators"
@@ -30650,7 +30744,7 @@
         "/test_framework/v1/scenarios-external/run_scenarios_elevenlabs/": {
             "post": {
                 "operationId": "scenarios-run-elevenlabs",
-                "description": "ELEVENLABS CONVERSATIONAL VOICE RUN: Execute evaluators against an ElevenLabs Conversational AI agent. The agent must have ElevenLabs credentials configured AND `assistant_id` set to the ElevenLabs agent ID.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)",
+                "description": "ELEVENLABS CONVERSATIONAL VOICE RUN: Execute evaluators against an ElevenLabs Conversational AI agent. The agent must have ElevenLabs credentials configured AND `assistant_id` set to the ElevenLabs agent ID.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)",
                 "summary": "Run evaluators against an ElevenLabs Conversational agent",
                 "tags": [
                     "Evaluators"
@@ -31011,7 +31105,7 @@
         "/test_framework/v1/scenarios-external/run_scenarios_livekit_v2/": {
             "post": {
                 "operationId": "scenarios-run-livekit-v2",
-                "description": "LIVEKIT VOICE RUN (project credentials, v2): Execute evaluators against a LiveKit agent using credentials configured at the project (or agent) level. Cekura creates the rooms; you don't pass URLs per-scenario. Requires `livekit_api_key`, `livekit_data.api_secret`, and `livekit_data.url` on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `room_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_websocket` — JSON/text WebSocket runs",
+                "description": "LIVEKIT VOICE RUN (project credentials, v2): Execute evaluators against a LiveKit agent using credentials configured at the project (or agent) level. Cekura creates the rooms; you don't pass URLs per-scenario. Requires `livekit_api_key`, `livekit_data.api_secret`, and `livekit_data.url` on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `room_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_websocket` — JSON/text WebSocket runs",
                 "summary": "Run evaluators against a LiveKit agent (project credentials, v2)",
                 "tags": [
                     "Evaluators"
@@ -31192,7 +31286,7 @@
         "/test_framework/v1/scenarios-external/run_scenarios_pipecat/": {
             "post": {
                 "operationId": "scenarios-run-pipecat-v1",
-                "description": "PIPECAT WEBRTC RUN (manual room URLs, v1): Execute evaluators against an agent running on Pipecat / Daily.co WebRTC. Each scenario entry carries its own `pipecat_room_url` and optional token. For project-credential-based runs (no per-scenario URL), use `scenarios_run_pipecat_v2` instead.\n\n**Run-count:** one run per entry in `scenarios` — this endpoint does not support `frequency` or personality/test-profile multipliers. To run the same scenario multiple times, include it multiple times in the `scenarios` list.\n\n**When to use this vs others:**\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_text` — text / SMS / chat mode\n- `run_scenarios_with_websockets` — agent exposes a plain websocket URL (non-Pipecat)\n\n**Scheduled runs:** WebRTC sessions are not generally scheduled. Use `run_scenarios` or `run_scenarios_text` via CronJob for recurring evaluator runs.",
+                "description": "PIPECAT WEBRTC RUN (manual room URLs, v1): Execute evaluators against an agent running on Pipecat / Daily.co WebRTC. Each scenario entry carries its own `pipecat_room_url` and optional token. For project-credential-based runs (no per-scenario URL), use `scenarios_run_pipecat_v2` instead.\n\n**Run-count:** one run per entry in `scenarios` — this endpoint does not support `frequency` or personality/test-profile multipliers. To run the same scenario multiple times, include it multiple times in the `scenarios` list.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_text` — text / SMS / chat mode\n- `run_scenarios_with_websockets` — agent exposes a plain websocket URL (non-Pipecat)\n\n**Scheduled runs:** WebRTC sessions are not generally scheduled. Use `run_scenarios` or `run_scenarios_text` via CronJob for recurring evaluator runs.",
                 "summary": "Run evaluators against a Pipecat WebRTC deployment (manual room URLs, v1)",
                 "tags": [
                     "Evaluators"
@@ -31372,7 +31466,7 @@
         "/test_framework/v1/scenarios-external/run_scenarios_pipecat_v2/": {
             "post": {
                 "operationId": "scenarios-run-pipecat-v2",
-                "description": "PIPECAT CLOUD VOICE RUN (project credentials, v2): Execute evaluators against an agent deployed on Pipecat Cloud using credentials configured at the project level. Cekura creates the sessions; you don't pass per-scenario room URLs (that's the v1 endpoint). Requires Pipecat Cloud credentials with `pipecat_agent_name` set on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `session_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others:**\n- `scenarios_run_pipecat_v1` — manual room URLs per scenario\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
+                "description": "PIPECAT CLOUD VOICE RUN (project credentials, v2): Execute evaluators against an agent deployed on Pipecat Cloud using credentials configured at the project level. Cekura creates the sessions; you don't pass per-scenario room URLs (that's the v1 endpoint). Requires Pipecat Cloud credentials with `pipecat_agent_name` set on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `session_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_pipecat_v1` — manual room URLs per scenario\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
                 "summary": "Run evaluators against a Pipecat Cloud deployment (project credentials, v2)",
                 "tags": [
                     "Evaluators"
@@ -31553,7 +31647,7 @@
         "/test_framework/v1/scenarios-external/run_scenarios_retell_webrtc/": {
             "post": {
                 "operationId": "scenarios-run-retell-webrtc",
-                "description": "RETELL WEBRTC VOICE RUN: Execute evaluators against a Retell agent over WebRTC (LiveKit infrastructure). The agent must have Retell credentials configured. `retell_agent_id` is optional and defaults to `agent.assistant_id` if not provided.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
+                "description": "RETELL WEBRTC VOICE RUN: Execute evaluators against a Retell agent over WebRTC (LiveKit infrastructure). The agent must have Retell credentials configured. `retell_agent_id` is optional and defaults to `agent.assistant_id` if not provided.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
                 "summary": "Run evaluators against a Retell agent over WebRTC",
                 "tags": [
                     "Evaluators"
@@ -31731,7 +31825,7 @@
         "/test_framework/v1/scenarios-external/run_scenarios_sip/": {
             "post": {
                 "operationId": "scenarios-run-sip",
-                "description": "SIP VOICE RUN (direct SIP): Execute evaluators against an agent over a direct SIP connection (orchestrated by Cekura's SIP voice service). The agent must have `sip_endpoint` configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone calls via Cekura's standard voice path\n- `scenarios_run_vapi_webrtc` / `_retell_webrtc` — provider-managed WebRTC\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
+                "description": "SIP VOICE RUN (direct SIP): Execute evaluators against an agent over a direct SIP connection (orchestrated by Cekura's SIP voice service). The agent must have a SIP endpoint configured (`telephony.sip_uri` on the v2 agent).\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone calls via Cekura's standard voice path\n- `scenarios_run_vapi_webrtc` / `_retell_webrtc` — provider-managed WebRTC\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
                 "summary": "Run evaluators over a direct SIP connection",
                 "tags": [
                     "Evaluators"
@@ -31907,7 +32001,7 @@
         "/test_framework/v1/scenarios-external/run_scenarios_text/": {
             "post": {
                 "operationId": "scenarios-run-text",
-                "description": "TEXT / SMS / CHAT RUN: Execute evaluators against your agent using text-only simulation (SMS, chat, or an agent-hosted websocket). Cheaper than voice — billed at the text-simulation rate.\n\n**Run-count math:** total conversations = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**Concurrency:** use `concurrency_limit` to cap parallel conversations. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Websocket override:** if the agent exposes a plain websocket URL for text, pass it as `websocket_url` — this bypasses the agent's standard text-readiness check. Pass `websocket_headers` (JSON object) to override connection headers for this run — merged over the agent's configured headers, with the per-run values winning.\n\n**When to use this vs others:**\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL (bulk)\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**`self_hosted` agents:** agents with `assistant_provider=\"self_hosted\"` require a websocket URL. Either pre-configure `websocket_url` on the agent, or pass it directly in this request. Without it, the run fails with `[\"Agent does not have a websocket URL\"]`. Passing `websocket_url` here changes the result's `run_type` to `\"WebSocket\"` instead of `\"Text\"`.\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"text\"` instead.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.",
+                "description": "TEXT / SMS / CHAT RUN: Execute evaluators against your agent using text-only simulation (SMS, chat, or an agent-hosted websocket). Cheaper than voice — billed at the text-simulation rate. Requires a chat connection (`provider.chat_agent_details`) on the agent, or a websocket URL for `self_hosted` agents.\n\n**Run-count math:** total conversations = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**Concurrency:** use `concurrency_limit` to cap parallel conversations. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Websocket override:** if the agent exposes a plain websocket URL for text, pass it as `websocket_url` — this bypasses the agent's standard text-readiness check. Pass `websocket_headers` (JSON object) to override connection headers for this run — merged over the agent's configured headers, with the per-run values winning.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL (bulk)\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**`self_hosted` agents:** agents with `assistant_provider=\"self_hosted\"` require a websocket URL. Either pre-configure `websocket_url` on the agent, or pass it directly in this request. Without it, the run fails with `[\"Agent does not have a websocket URL\"]`. Passing `websocket_url` here changes the result's `run_type` to `\"WebSocket\"` instead of `\"Text\"`.\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"text\"` instead.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.",
                 "summary": "Run evaluators in text / SMS / chat mode",
                 "tags": [
                     "Evaluators"
@@ -32106,7 +32200,7 @@
         "/test_framework/v1/scenarios-external/run_scenarios_vapi_webrtc/": {
             "post": {
                 "operationId": "scenarios-run-vapi-webrtc",
-                "description": "VAPI WEBRTC VOICE RUN: Execute evaluators against a VAPI agent over WebRTC. Required: `vapi_assistant_id` (the VAPI assistant). The agent (looked up via `agent_id` or inferred from the first scenario) must have VAPI credentials configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_text` — text/SMS/chat (cheaper)\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
+                "description": "VAPI WEBRTC VOICE RUN: Execute evaluators against a VAPI agent over WebRTC. Required: `vapi_assistant_id` (the VAPI assistant). The agent (looked up via `agent_id` or inferred from the first scenario) must have VAPI credentials configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_text` — text/SMS/chat (cheaper)\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
                 "summary": "Run evaluators against a VAPI WebRTC agent",
                 "tags": [
                     "Evaluators"
@@ -32285,7 +32379,7 @@
         "/test_framework/v1/scenarios-external/run_scenarios_with_websockets/": {
             "post": {
                 "operationId": "scenarios-run-websocket",
-                "description": "WEBSOCKET RUN (per-scenario URLs, bulk): Execute evaluators where each scenario carries its own websocket URL. Useful when you have a fleet of agents or stateful websocket sessions to test in a single batch.\n\n**Run-count:** total conversations = `len(scenarios) × frequency`. (Personality and test-profile multipliers are not supported on this endpoint.)\n\n**`frequency` is required** on this endpoint (no default).\n\n**When to use this vs others:**\n- `run_scenarios_text` — single websocket URL or SMS/chat mode (simpler)\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'.\n\n**Known limitation:** `result.run_type` may show 'Text' instead of 'WebSocket' for runs triggered via this endpoint — this is a display issue only and does not affect execution.",
+                "description": "WEBSOCKET RUN (per-scenario URLs, bulk): Execute evaluators where each scenario carries its own websocket URL. Useful when you have a fleet of agents or stateful websocket sessions to test in a single batch.\n\n**Run-count:** total conversations = `len(scenarios) × frequency`. (Personality and test-profile multipliers are not supported on this endpoint.)\n\n**`frequency` is required** on this endpoint (no default).\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — single websocket URL or SMS/chat mode (simpler)\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'.\n\n**Known limitation:** `result.run_type` may show 'Text' instead of 'WebSocket' for runs triggered via this endpoint — this is a display issue only and does not affect execution.",
                 "summary": "Run evaluators against per-scenario websocket URLs (bulk)",
                 "tags": [
                     "Evaluators"
@@ -34848,7 +34942,7 @@
         "/test_framework/v1/scenarios/run_scenarios/": {
             "post": {
                 "operationId": "scenarios-run-voice_2",
-                "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing.\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others:**\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.",
+                "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing. Requires `telephony.phone_number` configured on the agent (any provider).\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.",
                 "summary": "Run evaluators over a voice call",
                 "tags": [
                     "Evaluators"
@@ -35107,7 +35201,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-run-voice",
-                        "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing.\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others:**\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors."
+                        "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing. Requires `telephony.phone_number` configured on the agent (any provider).\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors."
                     }
                 }
             }
@@ -35115,7 +35209,7 @@
         "/test_framework/v1/scenarios/run_scenarios_agora/": {
             "post": {
                 "operationId": "scenarios-run-agora_2",
-                "description": "AGORA RTC VOICE RUN: Execute evaluators against an agent reachable in an Agora RTC channel. Cekura joins the channel as a participant and converses. The agent must have `agora_data.session_endpoint_url` configured — an endpoint that mints the per-call channel and token; Cekura calls it at run time and never stores the join details.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC",
+                "description": "AGORA RTC VOICE RUN: Execute evaluators against an agent reachable in an Agora RTC channel. Cekura joins the channel as a participant and converses. The agent must have `agora_data.session_endpoint_url` configured — an endpoint that mints the per-call channel and token; Cekura calls it at run time and never stores the join details.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC",
                 "summary": "Run evaluators against an agent in an Agora RTC channel",
                 "tags": [
                     "Evaluators"
@@ -35291,7 +35385,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-run-agora",
-                        "description": "AGORA RTC VOICE RUN: Execute evaluators against an agent reachable in an Agora RTC channel. Cekura joins the channel as a participant and converses. The agent must have `agora_data.session_endpoint_url` configured — an endpoint that mints the per-call channel and token; Cekura calls it at run time and never stores the join details.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC"
+                        "description": "AGORA RTC VOICE RUN: Execute evaluators against an agent reachable in an Agora RTC channel. Cekura joins the channel as a participant and converses. The agent must have `agora_data.session_endpoint_url` configured — an endpoint that mints the per-call channel and token; Cekura calls it at run time and never stores the join details.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC"
                     }
                 }
             }
@@ -35299,7 +35393,7 @@
         "/test_framework/v1/scenarios/run_scenarios_chirp/": {
             "post": {
                 "operationId": "scenarios-run-chirp_2",
-                "description": "RAW-PCM WEBSOCKET VOICE RUN: Execute evaluators against an agent that exposes a raw-PCM WebSocket endpoint (16 kHz, 16-bit mono, binary frames). The agent must have a websocket endpoint configured (`telephony.websocket_url`); optional Basic Auth lives in `telephony.websocket_auth`. Pass `websocket_url` to override the agent's stored endpoint for this run.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_websocket` — JSON/text WebSocket protocol (per-scenario URLs)\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC",
+                "description": "RAW-PCM WEBSOCKET VOICE RUN: Execute evaluators against an agent that exposes a raw-PCM WebSocket endpoint (16 kHz, 16-bit mono, binary frames). The agent must have a websocket endpoint configured (`telephony.websocket_url`); optional Basic Auth lives in `telephony.websocket_auth`. Pass `websocket_url` to override the agent's stored endpoint for this run.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_websocket` — JSON/text WebSocket protocol (per-scenario URLs)\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC",
                 "summary": "Run evaluators against a raw-PCM WebSocket voice endpoint",
                 "tags": [
                     "Evaluators"
@@ -35475,7 +35569,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-run-chirp",
-                        "description": "RAW-PCM WEBSOCKET VOICE RUN: Execute evaluators against an agent that exposes a raw-PCM WebSocket endpoint (16 kHz, 16-bit mono, binary frames). The agent must have a websocket endpoint configured (`telephony.websocket_url`); optional Basic Auth lives in `telephony.websocket_auth`. Pass `websocket_url` to override the agent's stored endpoint for this run.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_websocket` — JSON/text WebSocket protocol (per-scenario URLs)\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC"
+                        "description": "RAW-PCM WEBSOCKET VOICE RUN: Execute evaluators against an agent that exposes a raw-PCM WebSocket endpoint (16 kHz, 16-bit mono, binary frames). The agent must have a websocket endpoint configured (`telephony.websocket_url`); optional Basic Auth lives in `telephony.websocket_auth`. Pass `websocket_url` to override the agent's stored endpoint for this run.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_websocket` — JSON/text WebSocket protocol (per-scenario URLs)\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC"
                     }
                 }
             }
@@ -35483,7 +35577,7 @@
         "/test_framework/v1/scenarios/run_scenarios_elevenlabs/": {
             "post": {
                 "operationId": "scenarios-run-elevenlabs_2",
-                "description": "ELEVENLABS CONVERSATIONAL VOICE RUN: Execute evaluators against an ElevenLabs Conversational AI agent. The agent must have ElevenLabs credentials configured AND `assistant_id` set to the ElevenLabs agent ID.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)",
+                "description": "ELEVENLABS CONVERSATIONAL VOICE RUN: Execute evaluators against an ElevenLabs Conversational AI agent. The agent must have ElevenLabs credentials configured AND `assistant_id` set to the ElevenLabs agent ID.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)",
                 "summary": "Run evaluators against an ElevenLabs Conversational agent",
                 "tags": [
                     "Evaluators"
@@ -35660,7 +35754,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-run-elevenlabs",
-                        "description": "ELEVENLABS CONVERSATIONAL VOICE RUN: Execute evaluators against an ElevenLabs Conversational AI agent. The agent must have ElevenLabs credentials configured AND `assistant_id` set to the ElevenLabs agent ID.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)"
+                        "description": "ELEVENLABS CONVERSATIONAL VOICE RUN: Execute evaluators against an ElevenLabs Conversational AI agent. The agent must have ElevenLabs credentials configured AND `assistant_id` set to the ElevenLabs agent ID.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)"
                     }
                 }
             }
@@ -35852,7 +35946,7 @@
         "/test_framework/v1/scenarios/run_scenarios_livekit_v2/": {
             "post": {
                 "operationId": "scenarios-run-livekit-v2_2",
-                "description": "LIVEKIT VOICE RUN (project credentials, v2): Execute evaluators against a LiveKit agent using credentials configured at the project (or agent) level. Cekura creates the rooms; you don't pass URLs per-scenario. Requires `livekit_api_key`, `livekit_data.api_secret`, and `livekit_data.url` on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `room_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_websocket` — JSON/text WebSocket runs",
+                "description": "LIVEKIT VOICE RUN (project credentials, v2): Execute evaluators against a LiveKit agent using credentials configured at the project (or agent) level. Cekura creates the rooms; you don't pass URLs per-scenario. Requires `livekit_api_key`, `livekit_data.api_secret`, and `livekit_data.url` on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `room_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_websocket` — JSON/text WebSocket runs",
                 "summary": "Run evaluators against a LiveKit agent (project credentials, v2)",
                 "tags": [
                     "Evaluators"
@@ -36033,7 +36127,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-run-livekit-v2",
-                        "description": "LIVEKIT VOICE RUN (project credentials, v2): Execute evaluators against a LiveKit agent using credentials configured at the project (or agent) level. Cekura creates the rooms; you don't pass URLs per-scenario. Requires `livekit_api_key`, `livekit_data.api_secret`, and `livekit_data.url` on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `room_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_websocket` — JSON/text WebSocket runs"
+                        "description": "LIVEKIT VOICE RUN (project credentials, v2): Execute evaluators against a LiveKit agent using credentials configured at the project (or agent) level. Cekura creates the rooms; you don't pass URLs per-scenario. Requires `livekit_api_key`, `livekit_data.api_secret`, and `livekit_data.url` on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `room_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_websocket` — JSON/text WebSocket runs"
                     }
                 }
             }
@@ -36041,7 +36135,7 @@
         "/test_framework/v1/scenarios/run_scenarios_pipecat/": {
             "post": {
                 "operationId": "scenarios-run-pipecat-v1_2",
-                "description": "PIPECAT WEBRTC RUN (manual room URLs, v1): Execute evaluators against an agent running on Pipecat / Daily.co WebRTC. Each scenario entry carries its own `pipecat_room_url` and optional token. For project-credential-based runs (no per-scenario URL), use `scenarios_run_pipecat_v2` instead.\n\n**Run-count:** one run per entry in `scenarios` — this endpoint does not support `frequency` or personality/test-profile multipliers. To run the same scenario multiple times, include it multiple times in the `scenarios` list.\n\n**When to use this vs others:**\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_text` — text / SMS / chat mode\n- `run_scenarios_with_websockets` — agent exposes a plain websocket URL (non-Pipecat)\n\n**Scheduled runs:** WebRTC sessions are not generally scheduled. Use `run_scenarios` or `run_scenarios_text` via CronJob for recurring evaluator runs.",
+                "description": "PIPECAT WEBRTC RUN (manual room URLs, v1): Execute evaluators against an agent running on Pipecat / Daily.co WebRTC. Each scenario entry carries its own `pipecat_room_url` and optional token. For project-credential-based runs (no per-scenario URL), use `scenarios_run_pipecat_v2` instead.\n\n**Run-count:** one run per entry in `scenarios` — this endpoint does not support `frequency` or personality/test-profile multipliers. To run the same scenario multiple times, include it multiple times in the `scenarios` list.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_text` — text / SMS / chat mode\n- `run_scenarios_with_websockets` — agent exposes a plain websocket URL (non-Pipecat)\n\n**Scheduled runs:** WebRTC sessions are not generally scheduled. Use `run_scenarios` or `run_scenarios_text` via CronJob for recurring evaluator runs.",
                 "summary": "Run evaluators against a Pipecat WebRTC deployment (manual room URLs, v1)",
                 "tags": [
                     "Evaluators"
@@ -36221,7 +36315,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-run-pipecat-v1",
-                        "description": "PIPECAT WEBRTC RUN (manual room URLs, v1): Execute evaluators against an agent running on Pipecat / Daily.co WebRTC. Each scenario entry carries its own `pipecat_room_url` and optional token. For project-credential-based runs (no per-scenario URL), use `scenarios_run_pipecat_v2` instead.\n\n**Run-count:** one run per entry in `scenarios` — this endpoint does not support `frequency` or personality/test-profile multipliers. To run the same scenario multiple times, include it multiple times in the `scenarios` list.\n\n**When to use this vs others:**\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_text` — text / SMS / chat mode\n- `run_scenarios_with_websockets` — agent exposes a plain websocket URL (non-Pipecat)\n\n**Scheduled runs:** WebRTC sessions are not generally scheduled. Use `run_scenarios` or `run_scenarios_text` via CronJob for recurring evaluator runs."
+                        "description": "PIPECAT WEBRTC RUN (manual room URLs, v1): Execute evaluators against an agent running on Pipecat / Daily.co WebRTC. Each scenario entry carries its own `pipecat_room_url` and optional token. For project-credential-based runs (no per-scenario URL), use `scenarios_run_pipecat_v2` instead.\n\n**Run-count:** one run per entry in `scenarios` — this endpoint does not support `frequency` or personality/test-profile multipliers. To run the same scenario multiple times, include it multiple times in the `scenarios` list.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_text` — text / SMS / chat mode\n- `run_scenarios_with_websockets` — agent exposes a plain websocket URL (non-Pipecat)\n\n**Scheduled runs:** WebRTC sessions are not generally scheduled. Use `run_scenarios` or `run_scenarios_text` via CronJob for recurring evaluator runs."
                     }
                 }
             }
@@ -36229,7 +36323,7 @@
         "/test_framework/v1/scenarios/run_scenarios_pipecat_v2/": {
             "post": {
                 "operationId": "scenarios-run-pipecat-v2_2",
-                "description": "PIPECAT CLOUD VOICE RUN (project credentials, v2): Execute evaluators against an agent deployed on Pipecat Cloud using credentials configured at the project level. Cekura creates the sessions; you don't pass per-scenario room URLs (that's the v1 endpoint). Requires Pipecat Cloud credentials with `pipecat_agent_name` set on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `session_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others:**\n- `scenarios_run_pipecat_v1` — manual room URLs per scenario\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
+                "description": "PIPECAT CLOUD VOICE RUN (project credentials, v2): Execute evaluators against an agent deployed on Pipecat Cloud using credentials configured at the project level. Cekura creates the sessions; you don't pass per-scenario room URLs (that's the v1 endpoint). Requires Pipecat Cloud credentials with `pipecat_agent_name` set on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `session_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_pipecat_v1` — manual room URLs per scenario\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
                 "summary": "Run evaluators against a Pipecat Cloud deployment (project credentials, v2)",
                 "tags": [
                     "Evaluators"
@@ -36410,7 +36504,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-run-pipecat-v2",
-                        "description": "PIPECAT CLOUD VOICE RUN (project credentials, v2): Execute evaluators against an agent deployed on Pipecat Cloud using credentials configured at the project level. Cekura creates the sessions; you don't pass per-scenario room URLs (that's the v1 endpoint). Requires Pipecat Cloud credentials with `pipecat_agent_name` set on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `session_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others:**\n- `scenarios_run_pipecat_v1` — manual room URLs per scenario\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)"
+                        "description": "PIPECAT CLOUD VOICE RUN (project credentials, v2): Execute evaluators against an agent deployed on Pipecat Cloud using credentials configured at the project level. Cekura creates the sessions; you don't pass per-scenario room URLs (that's the v1 endpoint). Requires Pipecat Cloud credentials with `pipecat_agent_name` set on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `session_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_pipecat_v1` — manual room URLs per scenario\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)"
                     }
                 }
             }
@@ -36418,7 +36512,7 @@
         "/test_framework/v1/scenarios/run_scenarios_retell_webrtc/": {
             "post": {
                 "operationId": "scenarios-run-retell-webrtc_2",
-                "description": "RETELL WEBRTC VOICE RUN: Execute evaluators against a Retell agent over WebRTC (LiveKit infrastructure). The agent must have Retell credentials configured. `retell_agent_id` is optional and defaults to `agent.assistant_id` if not provided.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
+                "description": "RETELL WEBRTC VOICE RUN: Execute evaluators against a Retell agent over WebRTC (LiveKit infrastructure). The agent must have Retell credentials configured. `retell_agent_id` is optional and defaults to `agent.assistant_id` if not provided.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
                 "summary": "Run evaluators against a Retell agent over WebRTC",
                 "tags": [
                     "Evaluators"
@@ -36596,7 +36690,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-run-retell-webrtc",
-                        "description": "RETELL WEBRTC VOICE RUN: Execute evaluators against a Retell agent over WebRTC (LiveKit infrastructure). The agent must have Retell credentials configured. `retell_agent_id` is optional and defaults to `agent.assistant_id` if not provided.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)"
+                        "description": "RETELL WEBRTC VOICE RUN: Execute evaluators against a Retell agent over WebRTC (LiveKit infrastructure). The agent must have Retell credentials configured. `retell_agent_id` is optional and defaults to `agent.assistant_id` if not provided.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)"
                     }
                 }
             }
@@ -36604,7 +36698,7 @@
         "/test_framework/v1/scenarios/run_scenarios_sip/": {
             "post": {
                 "operationId": "scenarios-run-sip_2",
-                "description": "SIP VOICE RUN (direct SIP): Execute evaluators against an agent over a direct SIP connection (orchestrated by Cekura's SIP voice service). The agent must have `sip_endpoint` configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone calls via Cekura's standard voice path\n- `scenarios_run_vapi_webrtc` / `_retell_webrtc` — provider-managed WebRTC\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
+                "description": "SIP VOICE RUN (direct SIP): Execute evaluators against an agent over a direct SIP connection (orchestrated by Cekura's SIP voice service). The agent must have a SIP endpoint configured (`telephony.sip_uri` on the v2 agent).\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone calls via Cekura's standard voice path\n- `scenarios_run_vapi_webrtc` / `_retell_webrtc` — provider-managed WebRTC\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
                 "summary": "Run evaluators over a direct SIP connection",
                 "tags": [
                     "Evaluators"
@@ -36780,7 +36874,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-run-sip",
-                        "description": "SIP VOICE RUN (direct SIP): Execute evaluators against an agent over a direct SIP connection (orchestrated by Cekura's SIP voice service). The agent must have `sip_endpoint` configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone calls via Cekura's standard voice path\n- `scenarios_run_vapi_webrtc` / `_retell_webrtc` — provider-managed WebRTC\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)"
+                        "description": "SIP VOICE RUN (direct SIP): Execute evaluators against an agent over a direct SIP connection (orchestrated by Cekura's SIP voice service). The agent must have a SIP endpoint configured (`telephony.sip_uri` on the v2 agent).\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone calls via Cekura's standard voice path\n- `scenarios_run_vapi_webrtc` / `_retell_webrtc` — provider-managed WebRTC\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)"
                     }
                 }
             }
@@ -36788,7 +36882,7 @@
         "/test_framework/v1/scenarios/run_scenarios_text/": {
             "post": {
                 "operationId": "scenarios-run-text_2",
-                "description": "TEXT / SMS / CHAT RUN: Execute evaluators against your agent using text-only simulation (SMS, chat, or an agent-hosted websocket). Cheaper than voice — billed at the text-simulation rate.\n\n**Run-count math:** total conversations = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**Concurrency:** use `concurrency_limit` to cap parallel conversations. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Websocket override:** if the agent exposes a plain websocket URL for text, pass it as `websocket_url` — this bypasses the agent's standard text-readiness check. Pass `websocket_headers` (JSON object) to override connection headers for this run — merged over the agent's configured headers, with the per-run values winning.\n\n**When to use this vs others:**\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL (bulk)\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**`self_hosted` agents:** agents with `assistant_provider=\"self_hosted\"` require a websocket URL. Either pre-configure `websocket_url` on the agent, or pass it directly in this request. Without it, the run fails with `[\"Agent does not have a websocket URL\"]`. Passing `websocket_url` here changes the result's `run_type` to `\"WebSocket\"` instead of `\"Text\"`.\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"text\"` instead.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.",
+                "description": "TEXT / SMS / CHAT RUN: Execute evaluators against your agent using text-only simulation (SMS, chat, or an agent-hosted websocket). Cheaper than voice — billed at the text-simulation rate. Requires a chat connection (`provider.chat_agent_details`) on the agent, or a websocket URL for `self_hosted` agents.\n\n**Run-count math:** total conversations = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**Concurrency:** use `concurrency_limit` to cap parallel conversations. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Websocket override:** if the agent exposes a plain websocket URL for text, pass it as `websocket_url` — this bypasses the agent's standard text-readiness check. Pass `websocket_headers` (JSON object) to override connection headers for this run — merged over the agent's configured headers, with the per-run values winning.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL (bulk)\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**`self_hosted` agents:** agents with `assistant_provider=\"self_hosted\"` require a websocket URL. Either pre-configure `websocket_url` on the agent, or pass it directly in this request. Without it, the run fails with `[\"Agent does not have a websocket URL\"]`. Passing `websocket_url` here changes the result's `run_type` to `\"WebSocket\"` instead of `\"Text\"`.\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"text\"` instead.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.",
                 "summary": "Run evaluators in text / SMS / chat mode",
                 "tags": [
                     "Evaluators"
@@ -36987,7 +37081,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-run-text",
-                        "description": "TEXT / SMS / CHAT RUN: Execute evaluators against your agent using text-only simulation (SMS, chat, or an agent-hosted websocket). Cheaper than voice — billed at the text-simulation rate.\n\n**Run-count math:** total conversations = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**Concurrency:** use `concurrency_limit` to cap parallel conversations. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Websocket override:** if the agent exposes a plain websocket URL for text, pass it as `websocket_url` — this bypasses the agent's standard text-readiness check. Pass `websocket_headers` (JSON object) to override connection headers for this run — merged over the agent's configured headers, with the per-run values winning.\n\n**When to use this vs others:**\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL (bulk)\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**`self_hosted` agents:** agents with `assistant_provider=\"self_hosted\"` require a websocket URL. Either pre-configure `websocket_url` on the agent, or pass it directly in this request. Without it, the run fails with `[\"Agent does not have a websocket URL\"]`. Passing `websocket_url` here changes the result's `run_type` to `\"WebSocket\"` instead of `\"Text\"`.\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"text\"` instead.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors."
+                        "description": "TEXT / SMS / CHAT RUN: Execute evaluators against your agent using text-only simulation (SMS, chat, or an agent-hosted websocket). Cheaper than voice — billed at the text-simulation rate. Requires a chat connection (`provider.chat_agent_details`) on the agent, or a websocket URL for `self_hosted` agents.\n\n**Run-count math:** total conversations = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**Concurrency:** use `concurrency_limit` to cap parallel conversations. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Websocket override:** if the agent exposes a plain websocket URL for text, pass it as `websocket_url` — this bypasses the agent's standard text-readiness check. Pass `websocket_headers` (JSON object) to override connection headers for this run — merged over the agent's configured headers, with the per-run values winning.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL (bulk)\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**`self_hosted` agents:** agents with `assistant_provider=\"self_hosted\"` require a websocket URL. Either pre-configure `websocket_url` on the agent, or pass it directly in this request. Without it, the run fails with `[\"Agent does not have a websocket URL\"]`. Passing `websocket_url` here changes the result's `run_type` to `\"WebSocket\"` instead of `\"Text\"`.\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"text\"` instead.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors."
                     }
                 }
             }
@@ -36995,7 +37089,7 @@
         "/test_framework/v1/scenarios/run_scenarios_vapi_webrtc/": {
             "post": {
                 "operationId": "scenarios-run-vapi-webrtc_2",
-                "description": "VAPI WEBRTC VOICE RUN: Execute evaluators against a VAPI agent over WebRTC. Required: `vapi_assistant_id` (the VAPI assistant). The agent (looked up via `agent_id` or inferred from the first scenario) must have VAPI credentials configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_text` — text/SMS/chat (cheaper)\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
+                "description": "VAPI WEBRTC VOICE RUN: Execute evaluators against a VAPI agent over WebRTC. Required: `vapi_assistant_id` (the VAPI assistant). The agent (looked up via `agent_id` or inferred from the first scenario) must have VAPI credentials configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_text` — text/SMS/chat (cheaper)\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
                 "summary": "Run evaluators against a VAPI WebRTC agent",
                 "tags": [
                     "Evaluators"
@@ -37174,7 +37268,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-run-vapi-webrtc",
-                        "description": "VAPI WEBRTC VOICE RUN: Execute evaluators against a VAPI agent over WebRTC. Required: `vapi_assistant_id` (the VAPI assistant). The agent (looked up via `agent_id` or inferred from the first scenario) must have VAPI credentials configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_text` — text/SMS/chat (cheaper)\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)"
+                        "description": "VAPI WEBRTC VOICE RUN: Execute evaluators against a VAPI agent over WebRTC. Required: `vapi_assistant_id` (the VAPI assistant). The agent (looked up via `agent_id` or inferred from the first scenario) must have VAPI credentials configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_text` — text/SMS/chat (cheaper)\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)"
                     }
                 }
             }
@@ -37182,7 +37276,7 @@
         "/test_framework/v1/scenarios/run_scenarios_with_websockets/": {
             "post": {
                 "operationId": "scenarios-run-websocket_2",
-                "description": "WEBSOCKET RUN (per-scenario URLs, bulk): Execute evaluators where each scenario carries its own websocket URL. Useful when you have a fleet of agents or stateful websocket sessions to test in a single batch.\n\n**Run-count:** total conversations = `len(scenarios) × frequency`. (Personality and test-profile multipliers are not supported on this endpoint.)\n\n**`frequency` is required** on this endpoint (no default).\n\n**When to use this vs others:**\n- `run_scenarios_text` — single websocket URL or SMS/chat mode (simpler)\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'.\n\n**Known limitation:** `result.run_type` may show 'Text' instead of 'WebSocket' for runs triggered via this endpoint — this is a display issue only and does not affect execution.",
+                "description": "WEBSOCKET RUN (per-scenario URLs, bulk): Execute evaluators where each scenario carries its own websocket URL. Useful when you have a fleet of agents or stateful websocket sessions to test in a single batch.\n\n**Run-count:** total conversations = `len(scenarios) × frequency`. (Personality and test-profile multipliers are not supported on this endpoint.)\n\n**`frequency` is required** on this endpoint (no default).\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — single websocket URL or SMS/chat mode (simpler)\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'.\n\n**Known limitation:** `result.run_type` may show 'Text' instead of 'WebSocket' for runs triggered via this endpoint — this is a display issue only and does not affect execution.",
                 "summary": "Run evaluators against per-scenario websocket URLs (bulk)",
                 "tags": [
                     "Evaluators"
@@ -37366,7 +37460,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-run-websocket",
-                        "description": "WEBSOCKET RUN (per-scenario URLs, bulk): Execute evaluators where each scenario carries its own websocket URL. Useful when you have a fleet of agents or stateful websocket sessions to test in a single batch.\n\n**Run-count:** total conversations = `len(scenarios) × frequency`. (Personality and test-profile multipliers are not supported on this endpoint.)\n\n**`frequency` is required** on this endpoint (no default).\n\n**When to use this vs others:**\n- `run_scenarios_text` — single websocket URL or SMS/chat mode (simpler)\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'.\n\n**Known limitation:** `result.run_type` may show 'Text' instead of 'WebSocket' for runs triggered via this endpoint — this is a display issue only and does not affect execution."
+                        "description": "WEBSOCKET RUN (per-scenario URLs, bulk): Execute evaluators where each scenario carries its own websocket URL. Useful when you have a fleet of agents or stateful websocket sessions to test in a single batch.\n\n**Run-count:** total conversations = `len(scenarios) × frequency`. (Personality and test-profile multipliers are not supported on this endpoint.)\n\n**`frequency` is required** on this endpoint (no default).\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — single websocket URL or SMS/chat mode (simpler)\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'.\n\n**Known limitation:** `result.run_type` may show 'Text' instead of 'WebSocket' for runs triggered via this endpoint — this is a display issue only and does not affect execution."
                     }
                 }
             }
@@ -39153,7 +39247,7 @@
         "/test_framework/v2/aiagents/{id}/": {
             "get": {
                 "operationId": "aiagents-retrieve",
-                "description": "Retrieve an AI voice agent",
+                "description": "Retrieve an AI voice agent, including its configured connections.\n\n**Configured connection → run endpoint** (call this before running scenarios; a run endpoint only works if its connection is configured on the agent):\n- `telephony.phone_number` → `scenarios-run-voice`\n- `telephony.sip_uri` → `scenarios-run-sip`\n- `telephony.websocket_url` → `scenarios-run-chirp` (raw-PCM voice websocket)\n- `provider.type` vapi / retell / livekit / pipecat / agora (WebRTC) → `scenarios-run-vapi-webrtc` / `-retell-webrtc` / `-livekit-v2` / `-pipecat-v2` / `-agora`\n- `provider.type` elevenlabs → `scenarios-run-elevenlabs`\n- `provider.chat_agent_details` (chat/SMS/WhatsApp) → `scenarios-run-text`",
                 "summary": "Retrieve an AI voice agent",
                 "parameters": [
                     {
@@ -39206,7 +39300,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "aiagents-retrieve",
-                        "description": "Retrieve an AI voice agent"
+                        "description": "Retrieve an AI voice agent, including its configured connections.\n\n**Configured connection → run endpoint** (call this before running scenarios; a run endpoint only works if its connection is configured on the agent):\n- `telephony.phone_number` → `scenarios-run-voice`\n- `telephony.sip_uri` → `scenarios-run-sip`\n- `telephony.websocket_url` → `scenarios-run-chirp` (raw-PCM voice websocket)\n- `provider.type` vapi / retell / livekit / pipecat / agora (WebRTC) → `scenarios-run-vapi-webrtc` / `-retell-webrtc` / `-livekit-v2` / `-pipecat-v2` / `-agora`\n- `provider.type` elevenlabs → `scenarios-run-elevenlabs`\n- `provider.chat_agent_details` (chat/SMS/WhatsApp) → `scenarios-run-text`"
                     }
                 }
             },
@@ -42766,7 +42860,7 @@
         "/test_framework/v2/scenarios/run_scenarios/": {
             "post": {
                 "operationId": "scenarios-run-voice_3",
-                "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing.\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others:**\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.",
+                "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing. Requires `telephony.phone_number` configured on the agent (any provider).\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.",
                 "summary": "Run evaluators over a voice call",
                 "tags": [
                     "Evaluators"
@@ -43025,7 +43119,7 @@
         "/test_framework/v2/scenarios/run_scenarios_agora/": {
             "post": {
                 "operationId": "scenarios-run-agora_3",
-                "description": "AGORA RTC VOICE RUN: Execute evaluators against an agent reachable in an Agora RTC channel. Cekura joins the channel as a participant and converses. The agent must have `agora_data.session_endpoint_url` configured — an endpoint that mints the per-call channel and token; Cekura calls it at run time and never stores the join details.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC",
+                "description": "AGORA RTC VOICE RUN: Execute evaluators against an agent reachable in an Agora RTC channel. Cekura joins the channel as a participant and converses. The agent must have `agora_data.session_endpoint_url` configured — an endpoint that mints the per-call channel and token; Cekura calls it at run time and never stores the join details.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC",
                 "summary": "Run evaluators against an agent in an Agora RTC channel",
                 "tags": [
                     "Evaluators"
@@ -43201,7 +43295,7 @@
         "/test_framework/v2/scenarios/run_scenarios_chirp/": {
             "post": {
                 "operationId": "scenarios-run-chirp_3",
-                "description": "RAW-PCM WEBSOCKET VOICE RUN: Execute evaluators against an agent that exposes a raw-PCM WebSocket endpoint (16 kHz, 16-bit mono, binary frames). The agent must have a websocket endpoint configured (`telephony.websocket_url`); optional Basic Auth lives in `telephony.websocket_auth`. Pass `websocket_url` to override the agent's stored endpoint for this run.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_websocket` — JSON/text WebSocket protocol (per-scenario URLs)\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC",
+                "description": "RAW-PCM WEBSOCKET VOICE RUN: Execute evaluators against an agent that exposes a raw-PCM WebSocket endpoint (16 kHz, 16-bit mono, binary frames). The agent must have a websocket endpoint configured (`telephony.websocket_url`); optional Basic Auth lives in `telephony.websocket_auth`. Pass `websocket_url` to override the agent's stored endpoint for this run.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_websocket` — JSON/text WebSocket protocol (per-scenario URLs)\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud WebRTC",
                 "summary": "Run evaluators against a raw-PCM WebSocket voice endpoint",
                 "tags": [
                     "Evaluators"
@@ -43377,7 +43471,7 @@
         "/test_framework/v2/scenarios/run_scenarios_elevenlabs/": {
             "post": {
                 "operationId": "scenarios-run-elevenlabs_3",
-                "description": "ELEVENLABS CONVERSATIONAL VOICE RUN: Execute evaluators against an ElevenLabs Conversational AI agent. The agent must have ElevenLabs credentials configured AND `assistant_id` set to the ElevenLabs agent ID.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)",
+                "description": "ELEVENLABS CONVERSATIONAL VOICE RUN: Execute evaluators against an ElevenLabs Conversational AI agent. The agent must have ElevenLabs credentials configured AND `assistant_id` set to the ElevenLabs agent ID.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)",
                 "summary": "Run evaluators against an ElevenLabs Conversational agent",
                 "tags": [
                     "Evaluators"
@@ -43738,7 +43832,7 @@
         "/test_framework/v2/scenarios/run_scenarios_livekit_v2/": {
             "post": {
                 "operationId": "scenarios-run-livekit-v2_3",
-                "description": "LIVEKIT VOICE RUN (project credentials, v2): Execute evaluators against a LiveKit agent using credentials configured at the project (or agent) level. Cekura creates the rooms; you don't pass URLs per-scenario. Requires `livekit_api_key`, `livekit_data.api_secret`, and `livekit_data.url` on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `room_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_websocket` — JSON/text WebSocket runs",
+                "description": "LIVEKIT VOICE RUN (project credentials, v2): Execute evaluators against a LiveKit agent using credentials configured at the project (or agent) level. Cekura creates the rooms; you don't pass URLs per-scenario. Requires `livekit_api_key`, `livekit_data.api_secret`, and `livekit_data.url` on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `room_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_websocket` — JSON/text WebSocket runs",
                 "summary": "Run evaluators against a LiveKit agent (project credentials, v2)",
                 "tags": [
                     "Evaluators"
@@ -43919,7 +44013,7 @@
         "/test_framework/v2/scenarios/run_scenarios_pipecat/": {
             "post": {
                 "operationId": "scenarios-run-pipecat-v1_3",
-                "description": "PIPECAT WEBRTC RUN (manual room URLs, v1): Execute evaluators against an agent running on Pipecat / Daily.co WebRTC. Each scenario entry carries its own `pipecat_room_url` and optional token. For project-credential-based runs (no per-scenario URL), use `scenarios_run_pipecat_v2` instead.\n\n**Run-count:** one run per entry in `scenarios` — this endpoint does not support `frequency` or personality/test-profile multipliers. To run the same scenario multiple times, include it multiple times in the `scenarios` list.\n\n**When to use this vs others:**\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_text` — text / SMS / chat mode\n- `run_scenarios_with_websockets` — agent exposes a plain websocket URL (non-Pipecat)\n\n**Scheduled runs:** WebRTC sessions are not generally scheduled. Use `run_scenarios` or `run_scenarios_text` via CronJob for recurring evaluator runs.",
+                "description": "PIPECAT WEBRTC RUN (manual room URLs, v1): Execute evaluators against an agent running on Pipecat / Daily.co WebRTC. Each scenario entry carries its own `pipecat_room_url` and optional token. For project-credential-based runs (no per-scenario URL), use `scenarios_run_pipecat_v2` instead.\n\n**Run-count:** one run per entry in `scenarios` — this endpoint does not support `frequency` or personality/test-profile multipliers. To run the same scenario multiple times, include it multiple times in the `scenarios` list.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_text` — text / SMS / chat mode\n- `run_scenarios_with_websockets` — agent exposes a plain websocket URL (non-Pipecat)\n\n**Scheduled runs:** WebRTC sessions are not generally scheduled. Use `run_scenarios` or `run_scenarios_text` via CronJob for recurring evaluator runs.",
                 "summary": "Run evaluators against a Pipecat WebRTC deployment (manual room URLs, v1)",
                 "tags": [
                     "Evaluators"
@@ -44099,7 +44193,7 @@
         "/test_framework/v2/scenarios/run_scenarios_pipecat_v2/": {
             "post": {
                 "operationId": "scenarios-run-pipecat-v2_3",
-                "description": "PIPECAT CLOUD VOICE RUN (project credentials, v2): Execute evaluators against an agent deployed on Pipecat Cloud using credentials configured at the project level. Cekura creates the sessions; you don't pass per-scenario room URLs (that's the v1 endpoint). Requires Pipecat Cloud credentials with `pipecat_agent_name` set on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `session_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others:**\n- `scenarios_run_pipecat_v1` — manual room URLs per scenario\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
+                "description": "PIPECAT CLOUD VOICE RUN (project credentials, v2): Execute evaluators against an agent deployed on Pipecat Cloud using credentials configured at the project level. Cekura creates the sessions; you don't pass per-scenario room URLs (that's the v1 endpoint). Requires Pipecat Cloud credentials with `pipecat_agent_name` set on the agent or project.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**Per-request `session_config` override** is allowed; merges over agent defaults.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_pipecat_v1` — manual room URLs per scenario\n- `scenarios_run_voice` — phone / SIP voice run\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
                 "summary": "Run evaluators against a Pipecat Cloud deployment (project credentials, v2)",
                 "tags": [
                     "Evaluators"
@@ -44280,7 +44374,7 @@
         "/test_framework/v2/scenarios/run_scenarios_retell_webrtc/": {
             "post": {
                 "operationId": "scenarios-run-retell-webrtc_3",
-                "description": "RETELL WEBRTC VOICE RUN: Execute evaluators against a Retell agent over WebRTC (LiveKit infrastructure). The agent must have Retell credentials configured. `retell_agent_id` is optional and defaults to `agent.assistant_id` if not provided.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
+                "description": "RETELL WEBRTC VOICE RUN: Execute evaluators against a Retell agent over WebRTC (LiveKit infrastructure). The agent must have Retell credentials configured. `retell_agent_id` is optional and defaults to `agent.assistant_id` if not provided.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_vapi_webrtc` — VAPI agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
                 "summary": "Run evaluators against a Retell agent over WebRTC",
                 "tags": [
                     "Evaluators"
@@ -44458,7 +44552,7 @@
         "/test_framework/v2/scenarios/run_scenarios_sip/": {
             "post": {
                 "operationId": "scenarios-run-sip_3",
-                "description": "SIP VOICE RUN (direct SIP): Execute evaluators against an agent over a direct SIP connection (orchestrated by Cekura's SIP voice service). The agent must have `sip_endpoint` configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone calls via Cekura's standard voice path\n- `scenarios_run_vapi_webrtc` / `_retell_webrtc` — provider-managed WebRTC\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
+                "description": "SIP VOICE RUN (direct SIP): Execute evaluators against an agent over a direct SIP connection (orchestrated by Cekura's SIP voice service). The agent must have a SIP endpoint configured (`telephony.sip_uri` on the v2 agent).\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone calls via Cekura's standard voice path\n- `scenarios_run_vapi_webrtc` / `_retell_webrtc` — provider-managed WebRTC\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
                 "summary": "Run evaluators over a direct SIP connection",
                 "tags": [
                     "Evaluators"
@@ -44634,7 +44728,7 @@
         "/test_framework/v2/scenarios/run_scenarios_text/": {
             "post": {
                 "operationId": "scenarios-run-text_3",
-                "description": "TEXT / SMS / CHAT RUN: Execute evaluators against your agent using text-only simulation (SMS, chat, or an agent-hosted websocket). Cheaper than voice — billed at the text-simulation rate.\n\n**Run-count math:** total conversations = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**Concurrency:** use `concurrency_limit` to cap parallel conversations. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Websocket override:** if the agent exposes a plain websocket URL for text, pass it as `websocket_url` — this bypasses the agent's standard text-readiness check. Pass `websocket_headers` (JSON object) to override connection headers for this run — merged over the agent's configured headers, with the per-run values winning.\n\n**When to use this vs others:**\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL (bulk)\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**`self_hosted` agents:** agents with `assistant_provider=\"self_hosted\"` require a websocket URL. Either pre-configure `websocket_url` on the agent, or pass it directly in this request. Without it, the run fails with `[\"Agent does not have a websocket URL\"]`. Passing `websocket_url` here changes the result's `run_type` to `\"WebSocket\"` instead of `\"Text\"`.\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"text\"` instead.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.",
+                "description": "TEXT / SMS / CHAT RUN: Execute evaluators against your agent using text-only simulation (SMS, chat, or an agent-hosted websocket). Cheaper than voice — billed at the text-simulation rate. Requires a chat connection (`provider.chat_agent_details`) on the agent, or a websocket URL for `self_hosted` agents.\n\n**Run-count math:** total conversations = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**Concurrency:** use `concurrency_limit` to cap parallel conversations. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Websocket override:** if the agent exposes a plain websocket URL for text, pass it as `websocket_url` — this bypasses the agent's standard text-readiness check. Pass `websocket_headers` (JSON object) to override connection headers for this run — merged over the agent's configured headers, with the per-run values winning.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL (bulk)\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**`self_hosted` agents:** agents with `assistant_provider=\"self_hosted\"` require a websocket URL. Either pre-configure `websocket_url` on the agent, or pass it directly in this request. Without it, the run fails with `[\"Agent does not have a websocket URL\"]`. Passing `websocket_url` here changes the result's `run_type` to `\"WebSocket\"` instead of `\"Text\"`.\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"text\"` instead.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.",
                 "summary": "Run evaluators in text / SMS / chat mode",
                 "tags": [
                     "Evaluators"
@@ -44833,7 +44927,7 @@
         "/test_framework/v2/scenarios/run_scenarios_vapi_webrtc/": {
             "post": {
                 "operationId": "scenarios-run-vapi-webrtc_3",
-                "description": "VAPI WEBRTC VOICE RUN: Execute evaluators against a VAPI agent over WebRTC. Required: `vapi_assistant_id` (the VAPI assistant). The agent (looked up via `agent_id` or inferred from the first scenario) must have VAPI credentials configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others:**\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_text` — text/SMS/chat (cheaper)\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
+                "description": "VAPI WEBRTC VOICE RUN: Execute evaluators against a VAPI agent over WebRTC. Required: `vapi_assistant_id` (the VAPI assistant). The agent (looked up via `agent_id` or inferred from the first scenario) must have VAPI credentials configured.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone / SIP voice run (no provider WebRTC needed)\n- `scenarios_run_text` — text/SMS/chat (cheaper)\n- `scenarios_run_retell_webrtc` — Retell agents over WebRTC\n- `scenarios_run_elevenlabs` — ElevenLabs Conversational agents\n- `scenarios_run_pipecat_v2` — Pipecat Cloud (project credentials, v2)\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
                 "summary": "Run evaluators against a VAPI WebRTC agent",
                 "tags": [
                     "Evaluators"
@@ -45012,7 +45106,7 @@
         "/test_framework/v2/scenarios/run_scenarios_with_websockets/": {
             "post": {
                 "operationId": "scenarios-run-websocket_3",
-                "description": "WEBSOCKET RUN (per-scenario URLs, bulk): Execute evaluators where each scenario carries its own websocket URL. Useful when you have a fleet of agents or stateful websocket sessions to test in a single batch.\n\n**Run-count:** total conversations = `len(scenarios) × frequency`. (Personality and test-profile multipliers are not supported on this endpoint.)\n\n**`frequency` is required** on this endpoint (no default).\n\n**When to use this vs others:**\n- `run_scenarios_text` — single websocket URL or SMS/chat mode (simpler)\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'.\n\n**Known limitation:** `result.run_type` may show 'Text' instead of 'WebSocket' for runs triggered via this endpoint — this is a display issue only and does not affect execution.",
+                "description": "WEBSOCKET RUN (per-scenario URLs, bulk): Execute evaluators where each scenario carries its own websocket URL. Useful when you have a fleet of agents or stateful websocket sessions to test in a single batch.\n\n**Run-count:** total conversations = `len(scenarios) × frequency`. (Personality and test-profile multipliers are not supported on this endpoint.)\n\n**`frequency` is required** on this endpoint (no default).\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — single websocket URL or SMS/chat mode (simpler)\n- `run_scenarios` — real voice / phone / SIP call\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'.\n\n**Known limitation:** `result.run_type` may show 'Text' instead of 'WebSocket' for runs triggered via this endpoint — this is a display issue only and does not affect execution.",
                 "summary": "Run evaluators against per-scenario websocket URLs (bulk)",
                 "tags": [
                     "Evaluators"
@@ -51251,13 +51345,14 @@
                             "cisco",
                             "genesys",
                             "agora",
+                            "amazon_connect",
                             "telnyx",
                             ""
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "eaf4e8ebc9a5bda2",
+                        "x-spec-enum-id": "2b38755f8404d645",
                         "default": "",
-                        "description": "\nService provider for speech-to-text transcription\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `synthflow` - Synthflow\n* `elevenlabs` - Elevenlabs\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `koreai` - Kore\n* `custom` - Custom\n* `cisco` - Cisco\n* `genesys` - Genesys\n* `agora` - Agora\n* `telnyx` - Telnyx"
+                        "description": "\nService provider for speech-to-text transcription\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `synthflow` - Synthflow\n* `elevenlabs` - Elevenlabs\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `koreai` - Kore\n* `custom` - Custom\n* `cisco` - Cisco\n* `genesys` - Genesys\n* `agora` - Agora\n* `amazon_connect` - Amazon Connect\n* `telnyx` - Telnyx"
                     },
                     "assistant_provider": {
                         "enum": [
@@ -52307,13 +52402,14 @@
                             "agora",
                             "koreai",
                             "genesys",
+                            "amazon_connect",
                             "telnyx",
                             "custom",
                             ""
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "acf2b20623442583",
-                        "description": "Voice/inbound platform provider type. Valid values: vapi, retell, elevenlabs, bland, livekit, cisco, synthflow, koreai, genesys, self_hosted, pipecat, custom. Use 'custom' (or omit) for chat-only agents with no voice provider — the chat channel goes in chat_agent_details.type. For a raw-PCM websocket voice agent you host yourself, use type='custom' and put the endpoint in telephony.websocket_url. Text-only channels (sms, whatsapp, agentforce, amazon_connect) belong in chat_agent_details.type, not here.\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `elevenlabs` - Elevenlabs\n* `self_hosted` - Self Hosted\n* `cisco` - Cisco\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `synthflow` - Synthflow\n* `agora` - Agora\n* `koreai` - Koreai\n* `genesys` - Genesys\n* `telnyx` - Telnyx\n* `custom` - Custom (chat-only, no voice provider)"
+                        "x-spec-enum-id": "4bbea9038bd498ab",
+                        "description": "Voice/inbound platform provider type. Valid values: vapi, retell, elevenlabs, bland, livekit, cisco, synthflow, koreai, genesys, amazon_connect, self_hosted, pipecat, custom. Use 'custom' (or omit) for chat-only agents with no voice provider — the chat channel goes in chat_agent_details.type. For a raw-PCM websocket voice agent you host yourself, use type='custom' and put the endpoint in telephony.websocket_url. Text-only channels (sms, whatsapp, agentforce) belong in chat_agent_details.type, not here.\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `elevenlabs` - Elevenlabs\n* `self_hosted` - Self Hosted\n* `cisco` - Cisco\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `synthflow` - Synthflow\n* `agora` - Agora\n* `koreai` - Koreai\n* `genesys` - Genesys\n* `amazon_connect` - Amazon Connect\n* `telnyx` - Telnyx\n* `custom` - Custom (chat-only, no voice provider)"
                     },
                     "agent_id": {
                         "type": [
@@ -52857,11 +52953,6 @@
                         "type": "string",
                         "description": "Chat-widget UUID from the Amazon Connect console."
                     },
-                    "security_token": {
-                        "type": "string",
-                        "writeOnly": true,
-                        "description": "x-amz-security-token for authenticated widgets (write-only — never returned)."
-                    },
                     "snippet_id": {
                         "type": "string",
                         "description": "Base64-encoded KMS snippet from your Amazon Connect chat widget."
@@ -52880,6 +52971,28 @@
                     "snippet_id",
                     "widget_id"
                 ]
+            },
+            "AmazonConnectConfig": {
+                "type": "object",
+                "description": "Amazon Connect provider configuration.",
+                "properties": {
+                    "widget_id": {
+                        "type": "string",
+                        "description": "Chat widget UUID from the Amazon Connect console."
+                    },
+                    "snippet_id": {
+                        "type": "string",
+                        "description": "Base64-encoded KMS snippet from your Amazon Connect chat widget."
+                    },
+                    "connect_host": {
+                        "type": "string",
+                        "description": "Amazon Connect instance host, e.g. acme.my.connect.aws."
+                    },
+                    "region": {
+                        "type": "string",
+                        "description": "AWS region for the Connect instance. Defaults to us-east-1."
+                    }
+                }
             },
             "AskAboutFailuresReportsRequest": {
                 "type": "object",
@@ -53723,6 +53836,7 @@
             },
             "CallLogDetail": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -53914,6 +54028,7 @@
             },
             "CallLogList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -55107,6 +55222,7 @@
             },
             "Dashboard": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -55238,6 +55354,7 @@
             },
             "DashboardList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -57151,6 +57268,25 @@
                     "project"
                 ]
             },
+            "MetricFailureModeInsightGenerateScenario": {
+                "type": "object",
+                "description": "Request body for\n``POST /metric-failure-mode-insights/<id>/generate-scenario/``.\n\nTurns one failure mode of an insight into a test scenario for the\ngiven agent. The agent is resolved on the frontend from the failure\nmode's example calls (see the ``failure-mode-agents`` action), so when\na failure mode spans several agents the UI posts once per agent.",
+                "properties": {
+                    "failure_mode_index": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "Zero-based index of the failure mode within the insight's failure_modes list."
+                    },
+                    "agent": {
+                        "type": "integer",
+                        "description": "ID of the agent the generated scenario should target."
+                    }
+                },
+                "required": [
+                    "agent",
+                    "failure_mode_index"
+                ]
+            },
             "MetricHistory": {
                 "type": "object",
                 "properties": {
@@ -57469,6 +57605,7 @@
             },
             "MetricList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -60033,6 +60170,7 @@
             },
             "PatchedCallLogDetail": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -60490,6 +60628,7 @@
             },
             "PatchedDashboard": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -61787,7 +61926,7 @@
                     "vapi_api_key": {
                         "type": "string",
                         "writeOnly": true,
-                        "description": "\nVAPI API key\nExample: `\"vapi_api_key_123\"`\n"
+                        "description": "\nVAPI Private API Key. Used for all VAPI operations (calls, chat, and testing).\nExample: `\"vapi_api_key_123\"`\n"
                     },
                     "vapi_api_key_configured": {
                         "type": "string",
@@ -62961,6 +63100,7 @@
             },
             "PatchedSchemaPostScenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "agent": {
                         "type": [
@@ -63255,13 +63395,14 @@
                             "cisco",
                             "genesys",
                             "agora",
+                            "amazon_connect",
                             "telnyx",
                             ""
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "eaf4e8ebc9a5bda2",
+                        "x-spec-enum-id": "2b38755f8404d645",
                         "default": "",
-                        "description": "\nService provider for speech-to-text transcription\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `synthflow` - Synthflow\n* `elevenlabs` - Elevenlabs\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `koreai` - Kore\n* `custom` - Custom\n* `cisco` - Cisco\n* `genesys` - Genesys\n* `agora` - Agora\n* `telnyx` - Telnyx"
+                        "description": "\nService provider for speech-to-text transcription\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `synthflow` - Synthflow\n* `elevenlabs` - Elevenlabs\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `koreai` - Kore\n* `custom` - Custom\n* `cisco` - Cisco\n* `genesys` - Genesys\n* `agora` - Agora\n* `amazon_connect` - Amazon Connect\n* `telnyx` - Telnyx"
                     },
                     "assistant_provider": {
                         "enum": [
@@ -65174,7 +65315,7 @@
                     "vapi_api_key": {
                         "type": "string",
                         "writeOnly": true,
-                        "description": "\nVAPI API key\nExample: `\"vapi_api_key_123\"`\n"
+                        "description": "\nVAPI Private API Key. Used for all VAPI operations (calls, chat, and testing).\nExample: `\"vapi_api_key_123\"`\n"
                     },
                     "vapi_api_key_configured": {
                         "type": "string",
@@ -65446,6 +65587,9 @@
                     },
                     {
                         "$ref": "#/components/schemas/SelfHostedConfig"
+                    },
+                    {
+                        "$ref": "#/components/schemas/AmazonConnectConfig"
                     }
                 ]
             },
@@ -66153,6 +66297,7 @@
             },
             "RunList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -66577,6 +66722,7 @@
             },
             "Scenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -67445,6 +67591,7 @@
             },
             "ScenarioList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -67664,6 +67811,7 @@
             },
             "ScenarioSerializerV2": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -68030,13 +68178,14 @@
                             "agora",
                             "koreai",
                             "genesys",
+                            "amazon_connect",
                             "telnyx",
                             "custom",
                             ""
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "acf2b20623442583",
-                        "description": "Voice/inbound platform provider type. Valid values: vapi, retell, elevenlabs, bland, livekit, cisco, synthflow, koreai, genesys, self_hosted, pipecat, custom. Use 'custom' (or omit) for chat-only agents with no voice provider — the chat channel goes in chat_agent_details.type. For a raw-PCM websocket voice agent you host yourself, use type='custom' and put the endpoint in telephony.websocket_url. Text-only channels (sms, whatsapp, agentforce, amazon_connect) belong in chat_agent_details.type, not here.\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `elevenlabs` - Elevenlabs\n* `self_hosted` - Self Hosted\n* `cisco` - Cisco\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `synthflow` - Synthflow\n* `agora` - Agora\n* `koreai` - Koreai\n* `genesys` - Genesys\n* `telnyx` - Telnyx\n* `custom` - Custom (chat-only, no voice provider)"
+                        "x-spec-enum-id": "4bbea9038bd498ab",
+                        "description": "Voice/inbound platform provider type. Valid values: vapi, retell, elevenlabs, bland, livekit, cisco, synthflow, koreai, genesys, amazon_connect, self_hosted, pipecat, custom. Use 'custom' (or omit) for chat-only agents with no voice provider — the chat channel goes in chat_agent_details.type. For a raw-PCM websocket voice agent you host yourself, use type='custom' and put the endpoint in telephony.websocket_url. Text-only channels (sms, whatsapp, agentforce) belong in chat_agent_details.type, not here.\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `elevenlabs` - Elevenlabs\n* `self_hosted` - Self Hosted\n* `cisco` - Cisco\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `synthflow` - Synthflow\n* `agora` - Agora\n* `koreai` - Koreai\n* `genesys` - Genesys\n* `amazon_connect` - Amazon Connect\n* `telnyx` - Telnyx\n* `custom` - Custom (chat-only, no voice provider)"
                     },
                     "agent_id": {
                         "type": [
@@ -69140,6 +69289,7 @@
             },
             "SchemaPostRunScenarios": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "agent_id": {
                         "type": "integer",
@@ -69388,6 +69538,7 @@
             },
             "SchemaPostScenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "agent": {
                         "type": [
@@ -69547,6 +69698,7 @@
             },
             "SchemaScenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -69961,13 +70113,14 @@
                             "cisco",
                             "genesys",
                             "agora",
+                            "amazon_connect",
                             "telnyx",
                             ""
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "eaf4e8ebc9a5bda2",
+                        "x-spec-enum-id": "2b38755f8404d645",
                         "default": "",
-                        "description": "\nService provider for speech-to-text transcription\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `synthflow` - Synthflow\n* `elevenlabs` - Elevenlabs\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `koreai` - Kore\n* `custom` - Custom\n* `cisco` - Cisco\n* `genesys` - Genesys\n* `agora` - Agora\n* `telnyx` - Telnyx"
+                        "description": "\nService provider for speech-to-text transcription\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `synthflow` - Synthflow\n* `elevenlabs` - Elevenlabs\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `koreai` - Kore\n* `custom` - Custom\n* `cisco` - Cisco\n* `genesys` - Genesys\n* `agora` - Agora\n* `amazon_connect` - Amazon Connect\n* `telnyx` - Telnyx"
                     },
                     "assistant_provider": {
                         "enum": [
@@ -71218,7 +71371,7 @@
                 "properties": {
                     "public_key": {
                         "type": "string",
-                        "description": "VAPI public key for WebRTC sessions."
+                        "description": "VAPI Public Key for WebRTC sessions only. Not required for telephony or chat testing."
                     },
                     "trigger_url": {
                         "type": "string",


### PR DESCRIPTION
Auto-generated docs sync for backend PR [#9393](https://github.com/cekura-ai/vocera.backend/pull/9393).

Reviewers: @dileep-chagam, @rahul-cekura

## Summary

**Spec/overlay:** 2 exposed operations had description changes (results-retrieve, runs-bulk-retrieve). No overlay additions needed — no transport-quirk signals fired. 2 unexposed observability endpoints flagged for potential exposure consideration.

**Conceptual docs:** Updated mock-tools.mdx to document new v2 agent API capabilities: added section documenting mock_tools_enabled/mock_tools_provider response fields and MCP routing (served_via.type with mock_index); updated API Reference section to clarify new v2 endpoints (auto-fetch, toggle-mock-tools) and per-agent progress polling.

## Changes

- `openapi.json` — regenerate_from_backend
- `documentation/key-concepts/evaluators/mock-tools.mdx` — update

## Exposure suggestions (@mcp_expose candidates)

- **`metric_failure_mode_insights_failure_mode_agents_retrieve`** (GET `/observability/v1/metric-failure-mode-insights/{id}/failure-mode-agents/`)
  - Lists agents implicated by a failure mode — user-facing read operation co-located with other metric-failure-mode-insights CRUD endpoints. Similar observability resources (alerts, call-logs) are already exposed. Consider adding @mcp_expose() in a follow-up PR.
- **`metric_failure_mode_insights_generate_scenario_create`** (POST `/observability/v1/metric-failure-mode-insights/{id}/generate-scenario/`)
  - Generates test scenarios from failure modes — similar to the already-exposed call-logs-create-scenarios operation. User-facing action co-located with other metric-failure-mode-insights endpoints. Consider adding @mcp_expose() in a follow-up PR.

---
*Auto-generated from backend PR #9393.*

<!-- mcp-sync:file-hashes -->
```json
{
  "documentation/key-concepts/evaluators/mock-tools.mdx": "2be71d858c1a1d0df0e1029698c9f0f7b7d4842d0f70cfdfd19be45cc4bb8170"
}
```
<!-- /mcp-sync:file-hashes -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cekura-ai/docs/pull/696" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->