### PR TITLE
[Auto] Sync docs for backend PR #9597

### DIFF
--- a/api-reference/app/create-org-skill-source.mdx
+++ b/api-reference/app/create-org-skill-source.mdx
@@ -1,0 +1,6 @@
+---
+title: Create Org Skill Source
+description: "List or create skill sources for the authenticated user's org."
+openapi: post /app/v2/product-chat/org-skills/sources/
+slug: create-org-skill-source
+---

--- a/api-reference/app/create-organization-skill-source-sync.mdx
+++ b/api-reference/app/create-organization-skill-source-sync.mdx
@@ -1,0 +1,6 @@
+---
+title: Create Organization Skill Source Sync
+description: "Re-sync a GitHub source (triggers a new Celery task)."
+openapi: post /app/v2/product-chat/org-skills/sources/{source_id}/sync/
+slug: create-organization-skill-source-sync
+---

--- a/api-reference/app/create-organization-skill-source.mdx
+++ b/api-reference/app/create-organization-skill-source.mdx
@@ -1,0 +1,6 @@
+---
+title: Create Organization Skill Source
+description: "List or create skill sources for the authenticated user's org."
+openapi: post /app/v2/product-chat/org-skills/sources/
+slug: create-organization-skill-source
+---

--- a/api-reference/app/delete-org-skill.mdx
+++ b/api-reference/app/delete-org-skill.mdx
@@ -1,0 +1,6 @@
+---
+title: Delete Org Skill
+description: "Toggle active/inactive or delete a single custom skill."
+openapi: delete /app/v2/product-chat/org-skills/{skill_id}/
+slug: delete-org-skill
+---

--- a/api-reference/app/delete-organization-skill-source-sync.mdx
+++ b/api-reference/app/delete-organization-skill-source-sync.mdx
@@ -1,0 +1,6 @@
+---
+title: Delete Organization Skill Source Sync
+description: "App v2 product chat org skills sources sync"
+openapi: delete /app/v2/product-chat/org-skills/sources/{source_id}/sync/
+slug: delete-organization-skill-source-sync
+---

--- a/api-reference/app/delete-organization-skill-source.mdx
+++ b/api-reference/app/delete-organization-skill-source.mdx
@@ -1,0 +1,6 @@
+---
+title: Delete Organization Skill Source
+description: "Delete a re-sync , or delete a skill source"
+openapi: delete /app/v2/product-chat/org-skills/sources/{source_id}/
+slug: delete-organization-skill-source
+---

--- a/api-reference/app/delete-organization-skill.mdx
+++ b/api-reference/app/delete-organization-skill.mdx
@@ -1,0 +1,6 @@
+---
+title: Delete Organization Skill
+description: "Toggle active/inactive or delete a single custom skill."
+openapi: delete /app/v2/product-chat/org-skills/{skill_id}/
+slug: delete-organization-skill
+---

--- a/api-reference/app/list-org-skills.mdx
+++ b/api-reference/app/list-org-skills.mdx
@@ -1,0 +1,6 @@
+---
+title: List Org Skills
+description: "List all active custom skills for the org. Any member can read."
+openapi: get /app/v2/product-chat/org-skills/
+slug: list-org-skills
+---

--- a/api-reference/app/retrieve-organization-skill-source-sync.mdx
+++ b/api-reference/app/retrieve-organization-skill-source-sync.mdx
@@ -1,0 +1,6 @@
+---
+title: Retrieve Organization Skill Source Sync
+description: "App v2 product chat org skills sources sync"
+openapi: get /app/v2/product-chat/org-skills/sources/{source_id}/sync/
+slug: retrieve-organization-skill-source-sync
+---

--- a/api-reference/app/retrieve-organization-skill-source.mdx
+++ b/api-reference/app/retrieve-organization-skill-source.mdx
@@ -1,0 +1,6 @@
+---
+title: Retrieve Organization Skill Source
+description: "Retrieve a re-sync , or delete a skill source by ID"
+openapi: get /app/v2/product-chat/org-skills/sources/{source_id}/
+slug: retrieve-organization-skill-source
+---

--- a/api-reference/app/retrieve-organization-skill-sources.mdx
+++ b/api-reference/app/retrieve-organization-skill-sources.mdx
@@ -1,0 +1,6 @@
+---
+title: Retrieve Organization Skill Sources
+description: "List or create skill sources for the authenticated user's org."
+openapi: get /app/v2/product-chat/org-skills/sources/
+slug: retrieve-organization-skill-sources
+---

--- a/api-reference/app/retrieve-organization-skills.mdx
+++ b/api-reference/app/retrieve-organization-skills.mdx
@@ -1,0 +1,6 @@
+---
+title: Retrieve Organization Skills
+description: "List all active custom skills for the org. Any member can read."
+openapi: get /app/v2/product-chat/org-skills/
+slug: retrieve-organization-skills
+---

--- a/api-reference/app/update-org-skill-partial.mdx
+++ b/api-reference/app/update-org-skill-partial.mdx
@@ -1,0 +1,6 @@
+---
+title: Update Org Skill Partial
+description: "Toggle active/inactive or delete a single custom skill."
+openapi: patch /app/v2/product-chat/org-skills/{skill_id}/
+slug: update-org-skill-partial
+---

--- a/api-reference/app/update-organization-skill-source.mdx
+++ b/api-reference/app/update-organization-skill-source.mdx
@@ -1,0 +1,6 @@
+---
+title: Update Organization Skill Source
+description: "Re-sync a GitHub source (triggers a new Celery task)."
+openapi: post /app/v2/product-chat/org-skills/sources/{source_id}/
+slug: update-organization-skill-source
+---

--- a/api-reference/app/update-organization-skill.mdx
+++ b/api-reference/app/update-organization-skill.mdx
@@ -1,0 +1,6 @@
+---
+title: Update Organization Skill
+description: "Toggle active/inactive or delete a single custom skill."
+openapi: patch /app/v2/product-chat/org-skills/{skill_id}/
+slug: update-organization-skill
+---

--- a/api-reference/app/upload-organization-skills.mdx
+++ b/api-reference/app/upload-organization-skills.mdx
@@ -1,0 +1,6 @@
+---
+title: Upload Organization Skills
+description: "Upload a single .md file as a skill or command."
+openapi: post /app/v2/product-chat/org-skills/upload/
+slug: upload-organization-skills
+---

--- a/api-reference/notifications/list-notifications.mdx
+++ b/api-reference/notifications/list-notifications.mdx
@@ -1,0 +1,6 @@
+---
+title: List Notifications
+description: "List notifications v1 notifications"
+openapi: get /notifications/v1/notifications/
+slug: list-notifications
+---

--- a/api-reference/notifications/mark-all-notifications-as-read.mdx
+++ b/api-reference/notifications/mark-all-notifications-as-read.mdx
@@ -1,0 +1,6 @@
+---
+title: Mark All Notifications As Read
+description: "Create a new notifications v1 notifications mark all read"
+openapi: post /notifications/v1/notifications/mark_all_read/
+slug: mark-all-notifications-as-read
+---

--- a/api-reference/notifications/mark-notification-as-read.mdx
+++ b/api-reference/notifications/mark-notification-as-read.mdx
@@ -1,0 +1,6 @@
+---
+title: Mark Notification As Read
+description: "Notifications v1 notifications mark read"
+openapi: post /notifications/v1/notifications/{id}/mark_read/
+slug: mark-notification-as-read
+---

--- a/api-reference/notifications/retrieve-notification.mdx
+++ b/api-reference/notifications/retrieve-notification.mdx
@@ -1,0 +1,6 @@
+---
+title: Retrieve Notification
+description: "Retrieve a notifications v1 notification by ID"
+openapi: get /notifications/v1/notifications/{id}/
+slug: retrieve-notification
+---

--- a/api-reference/notifications/retrieve-unread-notification-count.mdx
+++ b/api-reference/notifications/retrieve-unread-notification-count.mdx
@@ -1,0 +1,6 @@
+---
+title: Retrieve Unread Notification Count
+description: "Notifications v1 notifications unread count"
+openapi: get /notifications/v1/notifications/unread_count/
+slug: retrieve-unread-notification-count
+---

--- a/api-reference/notifications/retrieve-vapid-public-key.mdx
+++ b/api-reference/notifications/retrieve-vapid-public-key.mdx
@@ -1,0 +1,6 @@
+---
+title: Retrieve VAPID Public Key
+description: "Notifications v1 push vapid public key"
+openapi: get /notifications/v1/push/vapid_public_key/
+slug: retrieve-vapid-public-key
+---

--- a/api-reference/notifications/subscribe-to-push-notifications.mdx
+++ b/api-reference/notifications/subscribe-to-push-notifications.mdx
@@ -1,0 +1,6 @@
+---
+title: Subscribe To Push Notifications
+description: "Notifications v1 push subscribe"
+openapi: post /notifications/v1/push/subscribe/
+slug: subscribe-to-push-notifications
+---

--- a/api-reference/notifications/unsubscribe-from-push-notifications.mdx
+++ b/api-reference/notifications/unsubscribe-from-push-notifications.mdx
@@ -1,0 +1,6 @@
+---
+title: Unsubscribe From Push Notifications
+description: "Notifications v1 push unsubscribe"
+openapi: post /notifications/v1/push/unsubscribe/
+slug: unsubscribe-from-push-notifications
+---

--- a/api-reference/observability/generate-metric-failure-mode-scenario.mdx
+++ b/api-reference/observability/generate-metric-failure-mode-scenario.mdx
@@ -1,0 +1,6 @@
+---
+title: Generate Metric Failure Mode Scenario
+description: "Queue generation of a test scenario from one failure mode."
+openapi: post /observability/v1/metric-failure-mode-insights/{id}/generate-scenario/
+slug: generate-metric-failure-mode-scenario
+---

--- a/api-reference/observability/retrieve-metric-failure-mode-agents.mdx
+++ b/api-reference/observability/retrieve-metric-failure-mode-agents.mdx
@@ -1,0 +1,6 @@
+---
+title: Retrieve Metric Failure Mode Agents
+description: "List the agents implicated by a failure mode's example calls."
+openapi: get /observability/v1/metric-failure-mode-insights/{id}/failure-mode-agents/
+slug: retrieve-metric-failure-mode-agents
+---

--- a/mint.json
+++ b/mint.json
@@ -487,7 +487,11 @@
             "api-reference/observability/dismiss-deep-research-insight-mode",
             "api-reference/observability/generate-deep-research-insights",
             "api-reference/observability/get-metric-failure-mode-insights-available-dates",
-            "api-reference/observability/retrieve-deep-research-insights-pricing"
+            "api-reference/observability/retrieve-deep-research-insights-pricing",
+            "api-reference/app/list-org-skills",
+            "api-reference/app/delete-org-skill",
+            "api-reference/app/update-org-skill-partial",
+            "api-reference/app/create-org-skill-source"
           ]
         }
       ]

--- a/mint.json
+++ b/mint.json
@@ -488,10 +488,28 @@
             "api-reference/observability/generate-deep-research-insights",
             "api-reference/observability/get-metric-failure-mode-insights-available-dates",
             "api-reference/observability/retrieve-deep-research-insights-pricing",
-            "api-reference/app/list-org-skills",
-            "api-reference/app/delete-org-skill",
-            "api-reference/app/update-org-skill-partial",
-            "api-reference/app/create-org-skill-source"
+            "api-reference/app/retrieve-organization-skills",
+            "api-reference/app/delete-organization-skill",
+            "api-reference/app/update-organization-skill",
+            "api-reference/app/create-organization-skill-source",
+            "api-reference/app/retrieve-organization-skill-sources",
+            "api-reference/app/delete-organization-skill-source",
+            "api-reference/app/update-organization-skill-source",
+            "api-reference/app/retrieve-organization-skill-source",
+            "api-reference/app/delete-organization-skill-source-sync",
+            "api-reference/app/create-organization-skill-source-sync",
+            "api-reference/app/retrieve-organization-skill-source-sync",
+            "api-reference/app/upload-organization-skills",
+            "api-reference/notifications/list-notifications",
+            "api-reference/notifications/retrieve-notification",
+            "api-reference/notifications/mark-notification-as-read",
+            "api-reference/notifications/mark-all-notifications-as-read",
+            "api-reference/notifications/retrieve-unread-notification-count",
+            "api-reference/notifications/subscribe-to-push-notifications",
+            "api-reference/notifications/unsubscribe-from-push-notifications",
+            "api-reference/notifications/retrieve-vapid-public-key",
+            "api-reference/observability/retrieve-metric-failure-mode-agents",
+            "api-reference/observability/generate-metric-failure-mode-scenario"
           ]
         }
       ]

--- a/openapi.json
+++ b/openapi.json
@@ -423,6 +423,302 @@
                 }
             }
         },
+        "/app/v2/product-chat/org-skills/": {
+            "get": {
+                "operationId": "app-v2-product-chat-org-skills-retrieve",
+                "description": "List all active custom skills for the org. Any member can read.",
+                "tags": [
+                    "app"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No response body"
+                    }
+                }
+            }
+        },
+        "/app/v2/product-chat/org-skills/{skill_id}/": {
+            "patch": {
+                "operationId": "app-v2-product-chat-org-skills-partial-update",
+                "description": "Toggle active/inactive or delete a single custom skill.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "skill_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "app"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No response body"
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "app-v2-product-chat-org-skills-destroy",
+                "description": "Toggle active/inactive or delete a single custom skill.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "skill_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "app"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No response body"
+                    }
+                }
+            }
+        },
+        "/app/v2/product-chat/org-skills/sources/": {
+            "get": {
+                "operationId": "app-v2-product-chat-org-skills-sources-retrieve",
+                "description": "List or create skill sources for the authenticated user's org.\n\nPOST accepts either:\n  - multipart/form-data with source_type=zip and file=<.zip|.tar.gz>\n  - application/json with source_type=github and github_url=<url>",
+                "tags": [
+                    "app"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No response body"
+                    }
+                }
+            },
+            "post": {
+                "operationId": "app-v2-product-chat-org-skills-sources-create",
+                "description": "List or create skill sources for the authenticated user's org.\n\nPOST accepts either:\n  - multipart/form-data with source_type=zip and file=<.zip|.tar.gz>\n  - application/json with source_type=github and github_url=<url>",
+                "tags": [
+                    "app"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No response body"
+                    }
+                }
+            }
+        },
+        "/app/v2/product-chat/org-skills/sources/{source_id}/": {
+            "get": {
+                "operationId": "app-v2-product-chat-org-skills-sources-retrieve_2",
+                "description": "Retrieve a re-sync , or delete a skill source by ID",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "source_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "app"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No response body"
+                    }
+                }
+            },
+            "post": {
+                "operationId": "app-v2-product-chat-org-skills-sources-create_2",
+                "description": "Re-sync a GitHub source (triggers a new Celery task).",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "source_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "app"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No response body"
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "app-v2-product-chat-org-skills-sources-destroy",
+                "description": "Delete a re-sync , or delete a skill source",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "source_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "app"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No response body"
+                    }
+                }
+            }
+        },
+        "/app/v2/product-chat/org-skills/sources/{source_id}/sync/": {
+            "get": {
+                "operationId": "app-v2-product-chat-org-skills-sources-sync-retrieve",
+                "description": "App v2 product chat org skills sources sync",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "source_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "app"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No response body"
+                    }
+                }
+            },
+            "post": {
+                "operationId": "app-v2-product-chat-org-skills-sources-sync-create",
+                "description": "Re-sync a GitHub source (triggers a new Celery task).",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "source_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "app"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No response body"
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "app-v2-product-chat-org-skills-sources-sync-destroy",
+                "description": "App v2 product chat org skills sources sync",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "source_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "app"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No response body"
+                    }
+                }
+            }
+        },
+        "/app/v2/product-chat/org-skills/upload/": {
+            "post": {
+                "operationId": "app-v2-product-chat-org-skills-upload-create",
+                "description": "Upload a single .md file as a skill or command.\n\nAccepts multipart/form-data with a single \"file\" field.\nThe file is scanned immediately (synchronously) — fast because it's\na single file, no git clone or zip extraction required.",
+                "tags": [
+                    "app"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No response body"
+                    }
+                }
+            }
+        },
         "/dashboards/dashboards/": {
             "get": {
                 "operationId": "dashboards-list",
@@ -1672,6 +1968,271 @@
                     }
                 },
                 "description": "Enums"
+            }
+        },
+        "/notifications/v1/notifications/": {
+            "get": {
+                "operationId": "notifications-v1-notifications-list",
+                "parameters": [
+                    {
+                        "name": "page",
+                        "required": false,
+                        "in": "query",
+                        "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "tags": [
+                    "notifications"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedNotificationList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "description": "List notifications v1 notifications"
+            }
+        },
+        "/notifications/v1/notifications/{id}/": {
+            "get": {
+                "operationId": "notifications-v1-notifications-retrieve",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "notifications"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Notification"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "description": "Retrieve a notifications v1 notification by ID"
+            }
+        },
+        "/notifications/v1/notifications/{id}/mark_read/": {
+            "post": {
+                "operationId": "notifications-v1-notifications-mark-read-create",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "notifications"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Notification"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Notification"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Notification"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Notification"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "description": "Notifications v1 notifications mark read"
+            }
+        },
+        "/notifications/v1/notifications/mark_all_read/": {
+            "post": {
+                "operationId": "notifications-v1-notifications-mark-all-read-create",
+                "tags": [
+                    "notifications"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Notification"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Notification"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Notification"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Notification"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "description": "Create a new notifications v1 notifications mark all read"
+            }
+        },
+        "/notifications/v1/notifications/unread_count/": {
+            "get": {
+                "operationId": "notifications-v1-notifications-unread-count-retrieve",
+                "tags": [
+                    "notifications"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Notification"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "description": "Notifications v1 notifications unread count"
+            }
+        },
+        "/notifications/v1/push/subscribe/": {
+            "post": {
+                "operationId": "notifications-v1-push-subscribe-create",
+                "tags": [
+                    "notifications"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No response body"
+                    }
+                },
+                "description": "Notifications v1 push subscribe"
+            }
+        },
+        "/notifications/v1/push/unsubscribe/": {
+            "post": {
+                "operationId": "notifications-v1-push-unsubscribe-create",
+                "tags": [
+                    "notifications"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No response body"
+                    }
+                },
+                "description": "Notifications v1 push unsubscribe"
+            }
+        },
+        "/notifications/v1/push/vapid_public_key/": {
+            "get": {
+                "operationId": "notifications-v1-push-vapid-public-key-retrieve",
+                "tags": [
+                    "notifications"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No response body"
+                    }
+                },
+                "description": "Notifications v1 push vapid public key"
             }
         },
         "/observability/v1/alerts/": {
@@ -6024,6 +6585,100 @@
                 }
             }
         },
+        "/observability/v1/metric-failure-mode-insights/{id}/failure-mode-agents/": {
+            "get": {
+                "operationId": "metric-failure-mode-insights-failure-mode-agents-retrieve",
+                "description": "List the agents implicated by a failure mode's example calls.\n\nThe frontend uses this to decide which agent(s) to create a\nscenario for: it resolves each example call's agent and, when a\nfailure mode spans several agents, posts ``generate-scenario``\nonce per agent. Falls back to the project's agents when no example\ncall resolves to an agent.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric failure mode insight.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "observability"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricFailureModeInsight"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/observability/v1/metric-failure-mode-insights/{id}/generate-scenario/": {
+            "post": {
+                "operationId": "metric-failure-mode-insights-generate-scenario-create",
+                "description": "Queue generation of a test scenario from one failure mode.\n\nReturns a ``progress_id`` the frontend polls via the existing\n``scenarios/generate-progress`` endpoint; the generated scenario\nid lands in that progress state's ``scenarios_list`` when done.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric failure mode insight.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "observability"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricFailureModeInsightGenerateScenario"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricFailureModeInsightGenerateScenario"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricFailureModeInsightGenerateScenario"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricFailureModeInsightGenerateScenario"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/observability/v1/metric-failure-mode-insights/available_dates/": {
             "get": {
                 "operationId": "metric-failure-mode-insights-available-dates-retrieve",
@@ -8164,7 +8819,7 @@
         "/subscriptions/packs/add_developer_pack/": {
             "post": {
                 "operationId": "subscriptions-packs-add-developer-pack-create",
-                "description": "Add developer pack to organization after verifying phone number.\nRequires phone number to be verified in Supabase.\nThrottled to 1 request per 30 seconds per user.",
+                "description": "Add developer pack to organization.\nPhone verification is not required here — it is only enforced\nfor the developer trial pack (add_developer_trial_pack).\nThrottled to 1 request per 30 seconds per user.",
                 "tags": [
                     "subscriptions"
                 ],
@@ -22409,7 +23064,7 @@
         "/test_framework/v1/results-external/{id}/": {
             "get": {
                 "operationId": "results-external-retrieve",
-                "description": "The `success` and `success_rate` fields indicate the run reached a terminal state, not that it passed its expected outcome. A run with an `error_message` (e.g. failed connection) still reports `success=true`. For actual pass/fail outcomes check: `runs[].evaluation.metrics[].result`, `runs[].expected_outcome`, and `runs[].error_message`.\n\nThe `runs` field is a dict keyed by run ID string (e.g. `{\"86368\": {...}, \"86367\": {...}}`), not an array — unlike the list endpoint. Each run also has a `call_id` STRING field (the provider's call identifier) — that is a data field, NOT an endpoint ID; do not pass it where `run_id` is expected.",
+                "description": "`success` indicates whether the run passed its quality evaluation. A run with `success=false` either failed to connect (check `error_message`) or failed an evaluation check (check `evaluation`). `success_rate` is the percentage of runs with `success=true`.\n\nThe `runs` field is a dict keyed by run ID string (e.g. `{\"86368\": {...}, \"86367\": {...}}`), not an array — unlike the list endpoint. Each run also has a `call_id` STRING field (the provider's call identifier) — that is a data field, NOT an endpoint ID; do not pass it where `run_id` is expected.",
                 "summary": "Retrieve a test result",
                 "parameters": [
                     {
@@ -22818,7 +23473,7 @@
         "/test_framework/v1/results-external/{id}/create_shareable_link_token/": {
             "post": {
                 "operationId": "create-shareable-link-token",
-                "description": "Generates a secure, time-limited shareable link that allows users to view test results without authentication. This feature requires an active subscription with whitelabel_reports enabled and provides both standard and custom branded URLs based on organization settings.",
+                "description": "Generates a secure, time-limited shareable link that allows users to view test results without authentication. Requires an active subscription.",
                 "summary": "Generate shareable link for result",
                 "parameters": [
                     {
@@ -23499,7 +24154,7 @@
         "/test_framework/v1/results/{id}/": {
             "get": {
                 "operationId": "results-retrieve",
-                "description": "The `success` and `success_rate` fields indicate the run reached a terminal state, not that it passed its expected outcome. A run with an `error_message` (e.g. failed connection) still reports `success=true`. For actual pass/fail outcomes check: `runs[].evaluation.metrics[].result`, `runs[].expected_outcome`, and `runs[].error_message`.\n\nThe `runs` field is a dict keyed by run ID string (e.g. `{\"86368\": {...}, \"86367\": {...}}`), not an array — unlike the list endpoint. Each run also has a `call_id` STRING field (the provider's call identifier) — that is a data field, NOT an endpoint ID; do not pass it where `run_id` is expected.",
+                "description": "`success` indicates whether the run passed its quality evaluation. A run with `success=false` either failed to connect (check `error_message`) or failed an evaluation check (check `evaluation`). `success_rate` is the percentage of runs with `success=true`.\n\nThe `runs` field is a dict keyed by run ID string (e.g. `{\"86368\": {...}, \"86367\": {...}}`), not an array — unlike the list endpoint. Each run also has a `call_id` STRING field (the provider's call identifier) — that is a data field, NOT an endpoint ID; do not pass it where `run_id` is expected.",
                 "summary": "Retrieve a test result",
                 "parameters": [
                     {
@@ -23704,7 +24359,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "results-retrieve",
-                        "description": "The `success` and `success_rate` fields indicate the run reached a terminal state, not that it passed its expected outcome. A run with an `error_message` (e.g. failed connection) still reports `success=true`. For actual pass/fail outcomes check: `runs[].evaluation.metrics[].result`, `runs[].expected_outcome`, and `runs[].error_message`.\n\nThe `runs` field is a dict keyed by run ID string (e.g. `{\"86368\": {...}, \"86367\": {...}}`), not an array — unlike the list endpoint. Each run also has a `call_id` STRING field (the provider's call identifier) — that is a data field, NOT an endpoint ID; do not pass it where `run_id` is expected."
+                        "description": "`success` indicates whether the run passed its quality evaluation. A run with `success=false` either failed to connect (check `error_message`) or failed an evaluation check (check `evaluation`). `success_rate` is the percentage of runs with `success=true`.\n\nThe `runs` field is a dict keyed by run ID string (e.g. `{\"86368\": {...}, \"86367\": {...}}`), not an array — unlike the list endpoint. Each run also has a `call_id` STRING field (the provider's call identifier) — that is a data field, NOT an endpoint ID; do not pass it where `run_id` is expected."
                     }
                 }
             },
@@ -23924,7 +24579,7 @@
         "/test_framework/v1/results/{id}/create_shareable_link_token/": {
             "post": {
                 "operationId": "create-shareable-link-token_2",
-                "description": "Generates a secure, time-limited shareable link that allows users to view test results without authentication. This feature requires an active subscription with whitelabel_reports enabled and provides both standard and custom branded URLs based on organization settings.",
+                "description": "Generates a secure, time-limited shareable link that allows users to view test results without authentication. Requires an active subscription.",
                 "summary": "Generate shareable link for result",
                 "parameters": [
                     {
@@ -23999,7 +24654,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "create-shareable-link-token",
-                        "description": "Generates a secure, time-limited shareable link that allows users to view test results without authentication. This feature requires an active subscription with whitelabel_reports enabled and provides both standard and custom branded URLs based on organization settings."
+                        "description": "Generates a secure, time-limited shareable link that allows users to view test results without authentication. Requires an active subscription."
                     }
                 }
             }
@@ -25988,7 +26643,7 @@
         "/test_framework/v1/runs-external/bulk/": {
             "get": {
                 "operationId": "runs-external-bulk-retrieve",
-                "description": "Retrieve multiple runs in a single request.\n\n`success: true` indicates the run reached a terminal state, not that it passed. A run with `error_message` (e.g. websocket handshake failure) still reports `success=true` and `evaluation_status='success'`. For actual outcomes check: `error_message`, `metadata.ended_reason`, and `evaluation.metrics[].result`.",
+                "description": "Retrieve multiple runs in a single request.\n\n`success: true` indicates the run passed its quality evaluation. A run with `success=false` either failed to connect (check `error_message`) or failed an evaluation check. For detailed outcomes check: `error_message`, `metadata.ended_reason`, and `evaluation.metrics[].result`.",
                 "parameters": [
                     {
                         "in": "query",
@@ -26906,7 +27561,7 @@
         "/test_framework/v1/runs/bulk/": {
             "get": {
                 "operationId": "runs-bulk-retrieve",
-                "description": "Retrieve multiple runs in a single request.\n\n`success: true` indicates the run reached a terminal state, not that it passed. A run with `error_message` (e.g. websocket handshake failure) still reports `success=true` and `evaluation_status='success'`. For actual outcomes check: `error_message`, `metadata.ended_reason`, and `evaluation.metrics[].result`.",
+                "description": "Retrieve multiple runs in a single request.\n\n`success: true` indicates the run passed its quality evaluation. A run with `success=false` either failed to connect (check `error_message`) or failed an evaluation check. For detailed outcomes check: `error_message`, `metadata.ended_reason`, and `evaluation.metrics[].result`.",
                 "parameters": [
                     {
                         "in": "query",
@@ -26946,7 +27601,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "runs-bulk-retrieve",
-                        "description": "Retrieve multiple runs in a single request.\n\n`success: true` indicates the run reached a terminal state, not that it passed. A run with `error_message` (e.g. websocket handshake failure) still reports `success=true` and `evaluation_status='success'`. For actual outcomes check: `error_message`, `metadata.ended_reason`, and `evaluation.metrics[].result`."
+                        "description": "Retrieve multiple runs in a single request.\n\n`success: true` indicates the run passed its quality evaluation. A run with `success=false` either failed to connect (check `error_message`) or failed an evaluation check. For detailed outcomes check: `error_message`, `metadata.ended_reason`, and `evaluation.metrics[].result`."
                     }
                 }
             }
@@ -39627,7 +40282,7 @@
         "/test_framework/v2/aiagents/{id}/disable_personalities/": {
             "post": {
                 "operationId": "aiagents-disable-personalities-create",
-                "description": "Disable personalities for the agent's project. Pass `personalities` as a list of personality IDs, or the string \"all\". Returns the project's personalities.",
+                "description": "Disable personalities for the agent's project. Pass `personalities` as a list of personality IDs, or the string \"all\".",
                 "summary": "Disable personalities for an agent's project",
                 "parameters": [
                     {
@@ -39638,24 +40293,6 @@
                         },
                         "description": "A unique integer value identifying this ai agent.",
                         "required": true
-                    },
-                    {
-                        "name": "page",
-                        "required": false,
-                        "in": "query",
-                        "description": "A page number within the paginated result set.",
-                        "schema": {
-                            "type": "integer"
-                        }
-                    },
-                    {
-                        "name": "page_size",
-                        "required": false,
-                        "in": "query",
-                        "description": "Number of results to return per page.",
-                        "schema": {
-                            "type": "integer"
-                        }
                     }
                 ],
                 "tags": [
@@ -39665,17 +40302,17 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/AIAgentV2"
+                                "$ref": "#/components/schemas/EnableDisablePersonalities"
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/AIAgentV2"
+                                "$ref": "#/components/schemas/EnableDisablePersonalities"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/AIAgentV2"
+                                "$ref": "#/components/schemas/EnableDisablePersonalities"
                             }
                         }
                     },
@@ -39691,7 +40328,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/PaginatedPersonalityList"
+                                    "$ref": "#/components/schemas/DisablePersonalitiesResponse"
                                 }
                             }
                         },
@@ -39721,7 +40358,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "aiagents-disable-personalities-create",
-                        "description": "Disable personalities for the agent's project. Pass `personalities` as a list of personality IDs, or the string \"all\". Returns the project's personalities."
+                        "description": "Disable personalities for the agent's project. Pass `personalities` as a list of personality IDs, or the string \"all\"."
                     }
                 }
             }
@@ -39850,17 +40487,17 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/AIAgentV2"
+                                "$ref": "#/components/schemas/EnableDisablePersonalities"
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/AIAgentV2"
+                                "$ref": "#/components/schemas/EnableDisablePersonalities"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/AIAgentV2"
+                                "$ref": "#/components/schemas/EnableDisablePersonalities"
                             }
                         }
                     },
@@ -46311,61 +46948,6 @@
                 },
                 "description": "Retrieve an user membership by ID"
             },
-            "put": {
-                "operationId": "user-memberships-update",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "A unique integer value identifying this membership.",
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "user"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/UserMembership"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/UserMembership"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/UserMembership"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/UserMembership"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Update an user membership"
-            },
             "patch": {
                 "operationId": "user-memberships-partial-update",
                 "parameters": [
@@ -49688,1364 +50270,6 @@
                 },
                 "description": "Projects members"
             }
-        },
-        "/webpage/domain/": {
-            "get": {
-                "operationId": "webpage-domain-list",
-                "tags": [
-                    "webpage"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/CustomDomainList"
-                                    }
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "List webpage domain"
-            },
-            "post": {
-                "operationId": "webpage-domain-create",
-                "description": "Create a new custom domain",
-                "tags": [
-                    "webpage"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomDomainDetail"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomDomainDetail"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomDomainDetail"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/CustomDomainDetail"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
-        },
-        "/webpage/domain/{organization}/": {
-            "get": {
-                "operationId": "webpage-domain-retrieve",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "organization",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "webpage"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/CustomDomainDetail"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Retrieve a webpage domain by ID"
-            },
-            "put": {
-                "operationId": "webpage-domain-update",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "organization",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "webpage"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomDomainDetail"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomDomainDetail"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomDomainDetail"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/CustomDomainDetail"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Update a webpage domain"
-            },
-            "patch": {
-                "operationId": "webpage-domain-partial-update",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "organization",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "webpage"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchedCustomDomainDetail"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchedCustomDomainDetail"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchedCustomDomainDetail"
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/CustomDomainDetail"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Update a webpage domain"
-            },
-            "delete": {
-                "operationId": "webpage-domain-destroy",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "organization",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "webpage"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No response body"
-                    }
-                },
-                "description": "Delete a webpage domain"
-            }
-        },
-        "/webpage/domain/{organization}/verify/": {
-            "get": {
-                "operationId": "webpage-domain-verify-retrieve",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "organization",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "webpage"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/CustomDomainDetail"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Webpage domain verify"
-            }
-        },
-        "/webpage/page/": {
-            "post": {
-                "operationId": "webpage-page-create",
-                "description": "POST method to create/update a webpage\nExpected request data:\n{\n    \"domain\": \"example.com\", # Can be full URL like https://www.example.com\n    \"html_content\": \"<html>...</html>\"\n}",
-                "tags": [
-                    "webpage"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomDomainDetail"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomDomainDetail"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomDomainDetail"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/CustomDomainDetail"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
-        },
-        "/webpage/page/{organization}/": {
-            "get": {
-                "operationId": "webpage-page-retrieve",
-                "description": "GET method to retrieve a webpage's HTML content\npk should be the organization id",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "organization",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "webpage"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/CustomDomainDetail"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            },
-            "delete": {
-                "operationId": "webpage-page-destroy",
-                "description": "DELETE method to remove a webpage\npk should be the organization id",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "organization",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "webpage"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No response body"
-                    }
-                }
-            }
-        },
-        "/workflows/edges/": {
-            "get": {
-                "operationId": "workflows-edges-list",
-                "tags": [
-                    "workflows"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Edge"
-                                    }
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "List workflows edges"
-            },
-            "post": {
-                "operationId": "workflows-edges-create",
-                "tags": [
-                    "workflows"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Edge"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Edge"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Edge"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Edge"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Create a new workflows edge"
-            }
-        },
-        "/workflows/edges/{id}/": {
-            "get": {
-                "operationId": "workflows-edges-retrieve",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "workflows"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Edge"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Retrieve a workflows edge by ID"
-            },
-            "put": {
-                "operationId": "workflows-edges-update",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "workflows"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Edge"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Edge"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Edge"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Edge"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Update a workflows edge"
-            },
-            "patch": {
-                "operationId": "workflows-edges-partial-update",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "workflows"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchedEdge"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchedEdge"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchedEdge"
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Edge"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Update a workflows edge"
-            },
-            "delete": {
-                "operationId": "workflows-edges-destroy",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "workflows"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No response body"
-                    }
-                },
-                "description": "Delete a workflows edge"
-            }
-        },
-        "/workflows/node-metrics/": {
-            "get": {
-                "operationId": "workflows-node-metrics-list",
-                "tags": [
-                    "workflows"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/NodeMetric"
-                                    }
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "List workflows node metrics"
-            },
-            "post": {
-                "operationId": "workflows-node-metrics-create",
-                "tags": [
-                    "workflows"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/NodeMetricCreate"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/NodeMetricCreate"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/NodeMetricCreate"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/NodeMetricCreate"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Create a new workflows node metric"
-            }
-        },
-        "/workflows/node-metrics/{id}/": {
-            "get": {
-                "operationId": "workflows-node-metrics-retrieve",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "workflows"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/NodeMetric"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Retrieve a workflows node metric by ID"
-            },
-            "put": {
-                "operationId": "workflows-node-metrics-update",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "workflows"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/NodeMetric"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/NodeMetric"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/NodeMetric"
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/NodeMetric"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Update a workflows node metric"
-            },
-            "patch": {
-                "operationId": "workflows-node-metrics-partial-update",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "workflows"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchedNodeMetric"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchedNodeMetric"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchedNodeMetric"
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/NodeMetric"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Update a workflows node metric"
-            },
-            "delete": {
-                "operationId": "workflows-node-metrics-destroy",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "workflows"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No response body"
-                    }
-                },
-                "description": "Delete a workflows node metric"
-            }
-        },
-        "/workflows/nodes/": {
-            "get": {
-                "operationId": "workflows-nodes-list",
-                "tags": [
-                    "workflows"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Node"
-                                    }
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "List workflows nodes"
-            },
-            "post": {
-                "operationId": "workflows-nodes-create",
-                "tags": [
-                    "workflows"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/NodeCreate"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/NodeCreate"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/NodeCreate"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/NodeCreate"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Create a new workflows node"
-            }
-        },
-        "/workflows/nodes/{id}/": {
-            "get": {
-                "operationId": "workflows-nodes-retrieve",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "workflows"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Node"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Retrieve a workflows node by ID"
-            },
-            "put": {
-                "operationId": "workflows-nodes-update",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "workflows"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Node"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Node"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Node"
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Node"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Update a workflows node"
-            },
-            "patch": {
-                "operationId": "workflows-nodes-partial-update",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "workflows"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchedNode"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchedNode"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchedNode"
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Node"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Update a workflows node"
-            },
-            "delete": {
-                "operationId": "workflows-nodes-destroy",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "workflows"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No response body"
-                    }
-                },
-                "description": "Delete a workflows node"
-            }
-        },
-        "/workflows/workflows/": {
-            "get": {
-                "operationId": "workflows-workflows-list",
-                "tags": [
-                    "workflows"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Workflow"
-                                    }
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "List workflows workflows"
-            },
-            "post": {
-                "operationId": "workflows-workflows-create",
-                "tags": [
-                    "workflows"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Workflow"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Workflow"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Workflow"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Workflow"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Create a new workflows workflow"
-            }
-        },
-        "/workflows/workflows/{id}/": {
-            "get": {
-                "operationId": "workflows-workflows-retrieve",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "workflows"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkflowDetail"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Retrieve a workflows workflow by ID"
-            },
-            "put": {
-                "operationId": "workflows-workflows-update",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "workflows"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Workflow"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Workflow"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Workflow"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Workflow"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Update a workflows workflow"
-            },
-            "patch": {
-                "operationId": "workflows-workflows-partial-update",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "workflows"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchedWorkflow"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchedWorkflow"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchedWorkflow"
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Workflow"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Update a workflows workflow"
-            },
-            "delete": {
-                "operationId": "workflows-workflows-destroy",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "workflows"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No response body"
-                    }
-                },
-                "description": "Delete a workflows workflow"
-            }
         }
     },
     "components": {
@@ -51251,13 +50475,14 @@
                             "cisco",
                             "genesys",
                             "agora",
+                            "amazon_connect",
                             "telnyx",
                             ""
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "eaf4e8ebc9a5bda2",
+                        "x-spec-enum-id": "2b38755f8404d645",
                         "default": "",
-                        "description": "\nService provider for speech-to-text transcription\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `synthflow` - Synthflow\n* `elevenlabs` - Elevenlabs\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `koreai` - Kore\n* `custom` - Custom\n* `cisco` - Cisco\n* `genesys` - Genesys\n* `agora` - Agora\n* `telnyx` - Telnyx"
+                        "description": "\nService provider for speech-to-text transcription\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `synthflow` - Synthflow\n* `elevenlabs` - Elevenlabs\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `koreai` - Kore\n* `custom` - Custom\n* `cisco` - Cisco\n* `genesys` - Genesys\n* `agora` - Agora\n* `amazon_connect` - Amazon Connect\n* `telnyx` - Telnyx"
                     },
                     "assistant_provider": {
                         "enum": [
@@ -51556,7 +50781,12 @@
                     },
                     "webhook_secret": {
                         "type": "string",
-                        "description": "Secret sent in X-CEKURA-SECRET header. Applies when agent webhook_url is set."
+                        "writeOnly": true,
+                        "description": "Secret sent in X-CEKURA-SECRET header. Applies when agent webhook_url is set. Write-only — never returned in API responses. Use `webhook_secret_configured` to check whether one is set."
+                    },
+                    "webhook_secret_configured": {
+                        "type": "string",
+                        "readOnly": true
                     }
                 },
                 "required": [
@@ -51969,7 +51199,12 @@
                     },
                     "webhook_secret": {
                         "type": "string",
-                        "description": "Secret sent in X-CEKURA-SECRET header. Applies when agent webhook_url is set."
+                        "writeOnly": true,
+                        "description": "Secret sent in X-CEKURA-SECRET header. Applies when agent webhook_url is set. Write-only — never returned in API responses. Use `webhook_secret_configured` to check whether one is set."
+                    },
+                    "webhook_secret_configured": {
+                        "type": "string",
+                        "readOnly": true
                     },
                     "mock_tools": {
                         "type": "array",
@@ -52307,13 +51542,14 @@
                             "agora",
                             "koreai",
                             "genesys",
+                            "amazon_connect",
                             "telnyx",
                             "custom",
                             ""
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "acf2b20623442583",
-                        "description": "Voice/inbound platform provider type. Valid values: vapi, retell, elevenlabs, bland, livekit, cisco, synthflow, koreai, genesys, self_hosted, pipecat, custom. Use 'custom' (or omit) for chat-only agents with no voice provider — the chat channel goes in chat_agent_details.type. For a raw-PCM websocket voice agent you host yourself, use type='custom' and put the endpoint in telephony.websocket_url. Text-only channels (sms, whatsapp, agentforce, amazon_connect) belong in chat_agent_details.type, not here.\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `elevenlabs` - Elevenlabs\n* `self_hosted` - Self Hosted\n* `cisco` - Cisco\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `synthflow` - Synthflow\n* `agora` - Agora\n* `koreai` - Koreai\n* `genesys` - Genesys\n* `telnyx` - Telnyx\n* `custom` - Custom (chat-only, no voice provider)"
+                        "x-spec-enum-id": "4bbea9038bd498ab",
+                        "description": "Voice/inbound platform provider type. Valid values: vapi, retell, elevenlabs, bland, livekit, cisco, synthflow, koreai, genesys, amazon_connect, self_hosted, pipecat, custom. Use 'custom' (or omit) for chat-only agents with no voice provider — the chat channel goes in chat_agent_details.type. For a raw-PCM websocket voice agent you host yourself, use type='custom' and put the endpoint in telephony.websocket_url. Text-only channels (sms, whatsapp, agentforce) belong in chat_agent_details.type, not here.\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `elevenlabs` - Elevenlabs\n* `self_hosted` - Self Hosted\n* `cisco` - Cisco\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `synthflow` - Synthflow\n* `agora` - Agora\n* `koreai` - Koreai\n* `genesys` - Genesys\n* `amazon_connect` - Amazon Connect\n* `telnyx` - Telnyx\n* `custom` - Custom (chat-only, no voice provider)"
                     },
                     "agent_id": {
                         "type": [
@@ -52857,11 +52093,6 @@
                         "type": "string",
                         "description": "Chat-widget UUID from the Amazon Connect console."
                     },
-                    "security_token": {
-                        "type": "string",
-                        "writeOnly": true,
-                        "description": "x-amz-security-token for authenticated widgets (write-only — never returned)."
-                    },
                     "snippet_id": {
                         "type": "string",
                         "description": "Base64-encoded KMS snippet from your Amazon Connect chat widget."
@@ -52880,6 +52111,28 @@
                     "snippet_id",
                     "widget_id"
                 ]
+            },
+            "AmazonConnectConfig": {
+                "type": "object",
+                "description": "Amazon Connect provider configuration.",
+                "properties": {
+                    "widget_id": {
+                        "type": "string",
+                        "description": "Chat widget UUID from the Amazon Connect console."
+                    },
+                    "snippet_id": {
+                        "type": "string",
+                        "description": "Base64-encoded KMS snippet from your Amazon Connect chat widget."
+                    },
+                    "connect_host": {
+                        "type": "string",
+                        "description": "Amazon Connect instance host, e.g. acme.my.connect.aws."
+                    },
+                    "region": {
+                        "type": "string",
+                        "description": "AWS region for the Connect instance. Defaults to us-east-1."
+                    }
+                }
             },
             "AskAboutFailuresReportsRequest": {
                 "type": "object",
@@ -53723,6 +52976,7 @@
             },
             "CallLogDetail": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -53914,6 +53168,7 @@
             },
             "CallLogList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -54028,12 +53283,8 @@
                         "description": "Full text transcript of the call.\nExample: \n```text\n[00:01] Testing Agent: Hello. \n[00:02] Main Agent: Hello, how can I help you today?\n[00:03] Testing Agent: Well, I mean, sure. What time exactly are we talking about here\n[00:04] Main Agent: 6 PM.\n[00:05] Testing Agent: Great. I'll book that for you. Just a sec.\n[00:06] Main Agent: Okay.\n```\n"
                     },
                     "transcript_object": {
-                        "oneOf": [
-                            {},
-                            {
-                                "type": "null"
-                            }
-                        ],
+                        "type": "string",
+                        "readOnly": true,
                         "description": "Structured transcript data with timestamps.\nExample: \n```json\n[\n    {\n        \"role\": \"Testing Agent\",\n        \"content\": \"Hello\",\n        \"start_time\": 1.2,\n        \"end_time\": 1.8\n    },\n    {\n        \"role\": \"Main Agent\",\n        \"content\": \"Hello, how can I help you today?\",\n        \"start_time\": 1.8,\n        \"end_time\": 2.5\n    }\n]`"
                     },
                     "evaluation": {
@@ -55026,70 +54277,6 @@
                     "crontab_expression"
                 ]
             },
-            "CustomDomainDetail": {
-                "type": "object",
-                "description": "",
-                "properties": {
-                    "organization": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
-                    "domain": {
-                        "type": "string",
-                        "maxLength": 255
-                    },
-                    "verification_token": {
-                        "type": "string",
-                        "readOnly": true
-                    },
-                    "verified": {
-                        "type": "boolean",
-                        "readOnly": true
-                    },
-                    "domain_logo": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "format": "uri"
-                    }
-                },
-                "required": [
-                    "domain"
-                ]
-            },
-            "CustomDomainList": {
-                "type": "object",
-                "description": "",
-                "properties": {
-                    "organization": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
-                    "domain": {
-                        "type": "string",
-                        "maxLength": 255
-                    },
-                    "verified": {
-                        "type": "boolean",
-                        "readOnly": true
-                    },
-                    "verification_token": {
-                        "type": "string",
-                        "readOnly": true
-                    },
-                    "domain_logo": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "format": "uri"
-                    }
-                },
-                "required": [
-                    "domain"
-                ]
-            },
             "CustomTokenObtainPair": {
                 "type": "object",
                 "properties": {
@@ -55107,6 +54294,7 @@
             },
             "Dashboard": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -55238,6 +54426,7 @@
             },
             "DashboardList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -55627,6 +54816,17 @@
                     "personalities"
                 ]
             },
+            "DisablePersonalitiesResponse": {
+                "type": "object",
+                "properties": {
+                    "message": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "message"
+                ]
+            },
             "DiscordServer": {
                 "type": "object",
                 "properties": {
@@ -55673,36 +54873,6 @@
                     }
                 }
             },
-            "Edge": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
-                    "source_node": {
-                        "type": "integer"
-                    },
-                    "target_node": {
-                        "type": "integer"
-                    },
-                    "value": {},
-                    "created_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    },
-                    "updated_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    }
-                },
-                "required": [
-                    "source_node",
-                    "target_node"
-                ]
-            },
             "ElevenLabsConfig": {
                 "type": "object",
                 "description": "ElevenLabs provider configuration.",
@@ -55717,6 +54887,24 @@
                     }
                 },
                 "title": "ElevenLabs"
+            },
+            "EnableDisablePersonalities": {
+                "type": "object",
+                "properties": {
+                    "personalities": {
+                        "description": "List of personality IDs to enable/disable, or the string 'all'."
+                    },
+                    "language": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "Language filter. Only used when personalities='all'."
+                    }
+                },
+                "required": [
+                    "personalities"
+                ]
             },
             "EnableMockErrorResponse": {
                 "type": "object",
@@ -56592,48 +55780,6 @@
                     }
                 }
             },
-            "Metric": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
-                    "name": {
-                        "type": "string",
-                        "description": "\nName of the metric.\nExample: `\"Customer Satisfaction\"` or `\"Appointment Booking\"`\n        ",
-                        "maxLength": 255
-                    },
-                    "description": {
-                        "type": "string",
-                        "description": "\nDescription of what the metric measures.\nExample: `\"Measures how satisfied customers are with the service provided\"`\n        "
-                    },
-                    "eval_type": {
-                        "enum": [
-                            "binary_workflow_adherence",
-                            "binary_qualitative",
-                            "continuous_qualitative",
-                            "numeric",
-                            "enum"
-                        ],
-                        "type": "string",
-                        "x-spec-enum-id": "1e3e27b342bfd8ec",
-                        "description": "\nType of evaluation\n\n\n* `binary_workflow_adherence` - Binary Workflow Adherence\n* `binary_qualitative` - Binary Qualitative\n* `continuous_qualitative` - Continuous Qualitative\n* `numeric` - Numeric\n* `enum` - Enum"
-                    },
-                    "enum_values": {
-                        "description": "\nList of possible enum values for enum type metrics.\nExample: `[\"satisfied\", \"unsatisfied\"]`\n"
-                    },
-                    "display_order": {
-                        "type": "integer",
-                        "maximum": 2147483647,
-                        "minimum": -2147483648,
-                        "description": "\nDisplay order for the metric.\nExample: `1`\n"
-                    }
-                },
-                "required": [
-                    "name"
-                ]
-            },
             "MetricBasicList": {
                 "type": "object",
                 "properties": {
@@ -57014,6 +56160,11 @@
                         "type": "string",
                         "readOnly": true
                     },
+                    "is_triage": {
+                        "type": "boolean",
+                        "description": "Derived live from the metric's current `triage_enabled` + rubric\nmembership (not persisted) — the FE renders the triage section only\nwhen this is true.",
+                        "readOnly": true
+                    },
                     "window_start": {
                         "type": "string",
                         "format": "date-time",
@@ -57139,16 +56290,37 @@
                         "description": "Deprecated — audits now always use the last 24 hours."
                     },
                     "max_calls": {
-                        "type": "integer",
-                        "maximum": 50,
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
+                        "maximum": 500,
                         "minimum": 1,
-                        "default": 20,
-                        "description": "Upper bound on failing calls fed to the agent. If the 24h window has more than this, a random sample is taken."
+                        "description": "Upper-bound ceiling on failing calls fed to the agent. Omit to audit every failing call in the 24h window up to 500. If the window exceeds the cap a random sample is taken."
                     }
                 },
                 "required": [
                     "metric_name",
                     "project"
+                ]
+            },
+            "MetricFailureModeInsightGenerateScenario": {
+                "type": "object",
+                "description": "Request body for\n``POST /metric-failure-mode-insights/<id>/generate-scenario/``.\n\nTurns one failure mode of an insight into a test scenario for the\ngiven agent. The agent is resolved on the frontend from the failure\nmode's example calls (see the ``failure-mode-agents`` action), so when\na failure mode spans several agents the UI posts once per agent.",
+                "properties": {
+                    "failure_mode_index": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "Zero-based index of the failure mode within the insight's failure_modes list."
+                    },
+                    "agent": {
+                        "type": "integer",
+                        "description": "ID of the agent the generated scenario should target."
+                    }
+                },
+                "required": [
+                    "agent",
+                    "failure_mode_index"
                 ]
             },
             "MetricHistory": {
@@ -57469,6 +56641,7 @@
             },
             "MetricList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -58325,180 +57498,62 @@
                     "project_id"
                 ]
             },
-            "Node": {
+            "Notification": {
                 "type": "object",
                 "properties": {
                     "id": {
                         "type": "integer",
                         "readOnly": true
                     },
-                    "workflow": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
-                    "is_root": {
-                        "type": "boolean"
-                    },
-                    "metrics": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/NodeMetric"
-                        },
-                        "readOnly": true
-                    },
-                    "created_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    },
-                    "updated_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    }
-                }
-            },
-            "NodeCreate": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
-                    "workflow": {
-                        "type": "integer"
-                    },
-                    "is_root": {
-                        "type": "boolean"
-                    },
-                    "metric": {
-                        "type": "integer",
-                        "writeOnly": true
-                    },
-                    "metrics": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/NodeMetric"
-                        },
-                        "readOnly": true
-                    },
-                    "created_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    },
-                    "updated_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    }
-                },
-                "required": [
-                    "metric",
-                    "workflow"
-                ]
-            },
-            "NodeInline": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
-                    "workflow": {
-                        "type": "integer"
-                    },
-                    "is_root": {
-                        "type": "boolean"
-                    },
-                    "main_metric": {
+                    "event_type": {
                         "type": "string",
                         "readOnly": true
                     },
-                    "created_at": {
+                    "title": {
                         "type": "string",
-                        "format": "date-time",
                         "readOnly": true
                     },
-                    "updated_at": {
+                    "body": {
                         "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    }
-                },
-                "required": [
-                    "workflow"
-                ]
-            },
-            "NodeMetric": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "integer",
                         "readOnly": true
                     },
-                    "node": {
-                        "type": "integer",
+                    "deep_link": {
+                        "type": "string",
                         "readOnly": true
                     },
-                    "metric": {
-                        "type": "integer",
+                    "payload": {
                         "readOnly": true
                     },
-                    "metric_data": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Metric"
-                            }
+                    "severity": {
+                        "enum": [
+                            "info",
+                            "success",
+                            "warning",
+                            "error"
                         ],
+                        "type": "string",
+                        "description": "* `info` - Info\n* `success` - Success\n* `warning` - Warning\n* `error` - Error",
+                        "x-spec-enum-id": "0307c5efa9f93e91",
                         "readOnly": true
                     },
-                    "is_main": {
-                        "type": "boolean"
+                    "is_read": {
+                        "type": "boolean",
+                        "readOnly": true
                     },
-                    "created_at": {
-                        "type": "string",
+                    "read_at": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
                         "format": "date-time",
                         "readOnly": true
                     },
-                    "updated_at": {
+                    "created_at": {
                         "type": "string",
                         "format": "date-time",
                         "readOnly": true
                     }
                 }
-            },
-            "NodeMetricCreate": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
-                    "node": {
-                        "type": "integer"
-                    },
-                    "metric": {
-                        "type": "integer"
-                    },
-                    "is_main": {
-                        "type": "boolean"
-                    },
-                    "created_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    },
-                    "updated_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    }
-                },
-                "required": [
-                    "metric",
-                    "node"
-                ]
             },
             "Organization": {
                 "type": "object",
@@ -58686,15 +57741,6 @@
                     "syntflow_api_key_configured": {
                         "type": "string",
                         "readOnly": true
-                    },
-                    "webhook_url": {
-                        "type": "string",
-                        "format": "uri",
-                        "maxLength": 200
-                    },
-                    "webhook_secret": {
-                        "type": "string",
-                        "maxLength": 255
                     },
                     "members": {
                         "type": "array",
@@ -59658,6 +58704,37 @@
                     }
                 }
             },
+            "PaginatedNotificationList": {
+                "type": "object",
+                "required": [
+                    "count",
+                    "results"
+                ],
+                "properties": {
+                    "count": {
+                        "type": "integer",
+                        "example": 123
+                    },
+                    "next": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?page=4"
+                    },
+                    "previous": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?page=2"
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Notification"
+                        }
+                    }
+                }
+            },
             "PaginatedPersonalityList": {
                 "type": "object",
                 "required": [
@@ -60033,6 +59110,7 @@
             },
             "PatchedCallLogDetail": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -60459,37 +59537,9 @@
                     }
                 }
             },
-            "PatchedCustomDomainDetail": {
-                "type": "object",
-                "description": "",
-                "properties": {
-                    "organization": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
-                    "domain": {
-                        "type": "string",
-                        "maxLength": 255
-                    },
-                    "verification_token": {
-                        "type": "string",
-                        "readOnly": true
-                    },
-                    "verified": {
-                        "type": "boolean",
-                        "readOnly": true
-                    },
-                    "domain_logo": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "format": "uri"
-                    }
-                }
-            },
             "PatchedDashboard": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -60645,32 +59695,6 @@
                     },
                     "is_verified": {
                         "type": "boolean",
-                        "readOnly": true
-                    }
-                }
-            },
-            "PatchedEdge": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
-                    "source_node": {
-                        "type": "integer"
-                    },
-                    "target_node": {
-                        "type": "integer"
-                    },
-                    "value": {},
-                    "created_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    },
-                    "updated_at": {
-                        "type": "string",
-                        "format": "date-time",
                         "readOnly": true
                     }
                 }
@@ -60994,77 +60018,6 @@
                     }
                 }
             },
-            "PatchedNode": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
-                    "workflow": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
-                    "is_root": {
-                        "type": "boolean"
-                    },
-                    "metrics": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/NodeMetric"
-                        },
-                        "readOnly": true
-                    },
-                    "created_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    },
-                    "updated_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    }
-                }
-            },
-            "PatchedNodeMetric": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
-                    "node": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
-                    "metric": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
-                    "metric_data": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Metric"
-                            }
-                        ],
-                        "readOnly": true
-                    },
-                    "is_main": {
-                        "type": "boolean"
-                    },
-                    "created_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    },
-                    "updated_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    }
-                }
-            },
             "PatchedOrganization": {
                 "type": "object",
                 "properties": {
@@ -61251,15 +60204,6 @@
                     "syntflow_api_key_configured": {
                         "type": "string",
                         "readOnly": true
-                    },
-                    "webhook_url": {
-                        "type": "string",
-                        "format": "uri",
-                        "maxLength": 200
-                    },
-                    "webhook_secret": {
-                        "type": "string",
-                        "maxLength": 255
                     },
                     "members": {
                         "type": "array",
@@ -61647,7 +60591,12 @@
                     },
                     "webhook_secret": {
                         "type": "string",
-                        "description": "\nWebhook secret\nExample: `\"your-webhook-secret\"`\n"
+                        "writeOnly": true,
+                        "description": "\nWebhook secret. Sent in `X-CEKURA-SECRET` header when invoking `webhook_url`.\nWrite-only — never returned in API responses. Use `webhook_secret_configured`\nto check whether one is set.\nExample: `\"your-webhook-secret\"`\n"
+                    },
+                    "webhook_secret_configured": {
+                        "type": "string",
+                        "readOnly": true
                     },
                     "evaluate_relevant_metrics_enabled": {
                         "type": "boolean",
@@ -62196,7 +61145,10 @@
                         "default": "Scenario Deleted"
                     },
                     "personality": {
-                        "type": "integer",
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
                         "readOnly": true,
                         "description": "Personality this run belongs to"
                     },
@@ -62628,7 +61580,12 @@
                     },
                     "webhook_secret": {
                         "type": "string",
-                        "description": "Secret sent in X-CEKURA-SECRET header. Applies when agent webhook_url is set."
+                        "writeOnly": true,
+                        "description": "Secret sent in X-CEKURA-SECRET header. Applies when agent webhook_url is set. Write-only — never returned in API responses. Use `webhook_secret_configured` to check whether one is set."
+                    },
+                    "webhook_secret_configured": {
+                        "type": "string",
+                        "readOnly": true
                     },
                     "mock_tools": {
                         "type": "array",
@@ -62961,6 +61918,7 @@
             },
             "PatchedSchemaPostScenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "agent": {
                         "type": [
@@ -63255,13 +62213,14 @@
                             "cisco",
                             "genesys",
                             "agora",
+                            "amazon_connect",
                             "telnyx",
                             ""
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "eaf4e8ebc9a5bda2",
+                        "x-spec-enum-id": "2b38755f8404d645",
                         "default": "",
-                        "description": "\nService provider for speech-to-text transcription\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `synthflow` - Synthflow\n* `elevenlabs` - Elevenlabs\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `koreai` - Kore\n* `custom` - Custom\n* `cisco` - Cisco\n* `genesys` - Genesys\n* `agora` - Agora\n* `telnyx` - Telnyx"
+                        "description": "\nService provider for speech-to-text transcription\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `synthflow` - Synthflow\n* `elevenlabs` - Elevenlabs\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `koreai` - Kore\n* `custom` - Custom\n* `cisco` - Cisco\n* `genesys` - Genesys\n* `agora` - Agora\n* `amazon_connect` - Amazon Connect\n* `telnyx` - Telnyx"
                     },
                     "assistant_provider": {
                         "enum": [
@@ -63560,7 +62519,12 @@
                     },
                     "webhook_secret": {
                         "type": "string",
-                        "description": "Secret sent in X-CEKURA-SECRET header. Applies when agent webhook_url is set."
+                        "writeOnly": true,
+                        "description": "Secret sent in X-CEKURA-SECRET header. Applies when agent webhook_url is set. Write-only — never returned in API responses. Use `webhook_secret_configured` to check whether one is set."
+                    },
+                    "webhook_secret_configured": {
+                        "type": "string",
+                        "readOnly": true
                     }
                 }
             },
@@ -64198,32 +63162,6 @@
                     }
                 }
             },
-            "PatchedWorkflow": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
-                    "agent": {
-                        "type": "integer"
-                    },
-                    "name": {
-                        "type": "string",
-                        "maxLength": 255
-                    },
-                    "created_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    },
-                    "updated_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    }
-                }
-            },
             "PaymentHistory": {
                 "type": "object",
                 "properties": {
@@ -64559,10 +63497,6 @@
                 "properties": {
                     "id": {
                         "type": "integer",
-                        "readOnly": true
-                    },
-                    "metadata": {
-                        "type": "string",
                         "readOnly": true
                     },
                     "number": {
@@ -65034,7 +63968,12 @@
                     },
                     "webhook_secret": {
                         "type": "string",
-                        "description": "\nWebhook secret\nExample: `\"your-webhook-secret\"`\n"
+                        "writeOnly": true,
+                        "description": "\nWebhook secret. Sent in `X-CEKURA-SECRET` header when invoking `webhook_url`.\nWrite-only — never returned in API responses. Use `webhook_secret_configured`\nto check whether one is set.\nExample: `\"your-webhook-secret\"`\n"
+                    },
+                    "webhook_secret_configured": {
+                        "type": "string",
+                        "readOnly": true
                     },
                     "evaluate_relevant_metrics_enabled": {
                         "type": "boolean",
@@ -65446,6 +64385,9 @@
                     },
                     {
                         "$ref": "#/components/schemas/SelfHostedConfig"
+                    },
+                    {
+                        "$ref": "#/components/schemas/AmazonConnectConfig"
                     }
                 ]
             },
@@ -65940,7 +64882,10 @@
                         "default": "Scenario Deleted"
                     },
                     "personality": {
-                        "type": "integer",
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
                         "readOnly": true,
                         "description": "Personality this run belongs to"
                     },
@@ -66153,6 +65098,7 @@
             },
             "RunList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -66180,7 +65126,10 @@
                         "default": "Scenario Deleted"
                     },
                     "personality": {
-                        "type": "integer",
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
                         "readOnly": true
                     },
                     "personality_name": {
@@ -66577,6 +65526,7 @@
             },
             "Scenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -67445,6 +66395,7 @@
             },
             "ScenarioList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -67664,6 +66615,7 @@
             },
             "ScenarioSerializerV2": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -68030,13 +66982,14 @@
                             "agora",
                             "koreai",
                             "genesys",
+                            "amazon_connect",
                             "telnyx",
                             "custom",
                             ""
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "acf2b20623442583",
-                        "description": "Voice/inbound platform provider type. Valid values: vapi, retell, elevenlabs, bland, livekit, cisco, synthflow, koreai, genesys, self_hosted, pipecat, custom. Use 'custom' (or omit) for chat-only agents with no voice provider — the chat channel goes in chat_agent_details.type. For a raw-PCM websocket voice agent you host yourself, use type='custom' and put the endpoint in telephony.websocket_url. Text-only channels (sms, whatsapp, agentforce, amazon_connect) belong in chat_agent_details.type, not here.\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `elevenlabs` - Elevenlabs\n* `self_hosted` - Self Hosted\n* `cisco` - Cisco\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `synthflow` - Synthflow\n* `agora` - Agora\n* `koreai` - Koreai\n* `genesys` - Genesys\n* `telnyx` - Telnyx\n* `custom` - Custom (chat-only, no voice provider)"
+                        "x-spec-enum-id": "4bbea9038bd498ab",
+                        "description": "Voice/inbound platform provider type. Valid values: vapi, retell, elevenlabs, bland, livekit, cisco, synthflow, koreai, genesys, amazon_connect, self_hosted, pipecat, custom. Use 'custom' (or omit) for chat-only agents with no voice provider — the chat channel goes in chat_agent_details.type. For a raw-PCM websocket voice agent you host yourself, use type='custom' and put the endpoint in telephony.websocket_url. Text-only channels (sms, whatsapp, agentforce) belong in chat_agent_details.type, not here.\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `elevenlabs` - Elevenlabs\n* `self_hosted` - Self Hosted\n* `cisco` - Cisco\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `synthflow` - Synthflow\n* `agora` - Agora\n* `koreai` - Koreai\n* `genesys` - Genesys\n* `amazon_connect` - Amazon Connect\n* `telnyx` - Telnyx\n* `custom` - Custom (chat-only, no voice provider)"
                     },
                     "agent_id": {
                         "type": [
@@ -68153,19 +67106,9 @@
                     "shareable_link": {
                         "type": "string",
                         "description": "Complete URL for the shareable link that can be distributed to external users"
-                    },
-                    "custom_link": {
-                        "type": "string",
-                        "description": "Customized branded URL for the shareable link with organization-specific branding"
-                    },
-                    "custom_domain": {
-                        "type": "boolean",
-                        "description": "Whether the organization has whitelabel custom domain enabled for branded links"
                     }
                 },
                 "required": [
-                    "custom_domain",
-                    "custom_link",
                     "shareable_link",
                     "token"
                 ]
@@ -68530,7 +67473,12 @@
                     },
                     "webhook_secret": {
                         "type": "string",
-                        "description": "Secret sent in X-CEKURA-SECRET header. Applies when agent webhook_url is set."
+                        "writeOnly": true,
+                        "description": "Secret sent in X-CEKURA-SECRET header. Applies when agent webhook_url is set. Write-only — never returned in API responses. Use `webhook_secret_configured` to check whether one is set."
+                    },
+                    "webhook_secret_configured": {
+                        "type": "string",
+                        "readOnly": true
                     },
                     "mock_tools": {
                         "type": "array",
@@ -69140,6 +68088,7 @@
             },
             "SchemaPostRunScenarios": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "agent_id": {
                         "type": "integer",
@@ -69388,6 +68337,7 @@
             },
             "SchemaPostScenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "agent": {
                         "type": [
@@ -69547,6 +68497,7 @@
             },
             "SchemaScenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -69961,13 +68912,14 @@
                             "cisco",
                             "genesys",
                             "agora",
+                            "amazon_connect",
                             "telnyx",
                             ""
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "eaf4e8ebc9a5bda2",
+                        "x-spec-enum-id": "2b38755f8404d645",
                         "default": "",
-                        "description": "\nService provider for speech-to-text transcription\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `synthflow` - Synthflow\n* `elevenlabs` - Elevenlabs\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `koreai` - Kore\n* `custom` - Custom\n* `cisco` - Cisco\n* `genesys` - Genesys\n* `agora` - Agora\n* `telnyx` - Telnyx"
+                        "description": "\nService provider for speech-to-text transcription\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `synthflow` - Synthflow\n* `elevenlabs` - Elevenlabs\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `koreai` - Kore\n* `custom` - Custom\n* `cisco` - Cisco\n* `genesys` - Genesys\n* `agora` - Agora\n* `amazon_connect` - Amazon Connect\n* `telnyx` - Telnyx"
                     },
                     "assistant_provider": {
                         "enum": [
@@ -70266,7 +69218,12 @@
                     },
                     "webhook_secret": {
                         "type": "string",
-                        "description": "Secret sent in X-CEKURA-SECRET header. Applies when agent webhook_url is set."
+                        "writeOnly": true,
+                        "description": "Secret sent in X-CEKURA-SECRET header. Applies when agent webhook_url is set. Write-only — never returned in API responses. Use `webhook_secret_configured` to check whether one is set."
+                    },
+                    "webhook_secret_configured": {
+                        "type": "string",
+                        "readOnly": true
                     }
                 },
                 "required": [
@@ -71682,77 +70639,6 @@
                     "metadata",
                     "time_period",
                     "widget_id"
-                ]
-            },
-            "Workflow": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
-                    "agent": {
-                        "type": "integer"
-                    },
-                    "name": {
-                        "type": "string",
-                        "maxLength": 255
-                    },
-                    "created_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    },
-                    "updated_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    }
-                },
-                "required": [
-                    "agent",
-                    "name"
-                ]
-            },
-            "WorkflowDetail": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
-                    "agent": {
-                        "type": "integer"
-                    },
-                    "name": {
-                        "type": "string",
-                        "maxLength": 255
-                    },
-                    "nodes": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/NodeInline"
-                        },
-                        "readOnly": true
-                    },
-                    "edges": {
-                        "type": "string",
-                        "readOnly": true
-                    },
-                    "created_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    },
-                    "updated_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    }
-                },
-                "required": [
-                    "agent",
-                    "name"
                 ]
             }
         },


### PR DESCRIPTION
Auto-generated docs sync for backend PR [#9597](https://github.com/cekura-ai/vocera.backend/pull/9597).

Reviewers: @dileep-chagam, @rahul-cekura

## Summary

**Spec/overlay:** 5 MCP-exposed operations updated. aiagents_enable_personalities_create and aiagents_disable_personalities_create now use dedicated EnableDisablePersonalities request schema (previously AIAgentV2). disable endpoint also returns DisablePersonalitiesResponse instead of PaginatedPersonalityList. 3 operations had description clarifications: create_shareable_link_token_2 simplified subscription requirements text; results_retrieve and runs_bulk_retrieve clarified success field semantics (now correctly indicates quality evaluation pass/fail, not just terminal state). No transport-quirk signals fired; no overlay changes needed. Spec regeneration only.

**Conceptual docs:** No edits — PR adds input validation to enable/disable personalities endpoints. These are low-level API operations not covered in conceptual docs. The OpenAPI spec now properly documents the request schema (EnableDisablePersonalitiesSerializer with validated `personalities` and optional `language` fields), which the API-reference workflow handles separately. No user-visible behavior change for correctly-formed requests.

## Changes

- `openapi.json` — regenerate_from_backend

---
*Auto-generated from backend PR #9597.*

<!-- mcp-sync:file-hashes -->
```json
{}
```
<!-- /mcp-sync:file-hashes -->