### PR TITLE
[Auto] Sync docs for backend PR #9626

### DIFF
--- a/cekura-mcp-server/mcp_tools.json
+++ b/cekura-mcp-server/mcp_tools.json
@@ -100,5 +100,8 @@
   },
   "aiagents_update": {
     "description_suffix": "File uploads not supported via MCP. Use the Cekura dashboard or Python SDK to upload knowledge base files. Updates without file parameters modify agent configuration only."
+  },
+  "aiagents_auto_fetch_create": {
+    "description_suffix": "Async — returns a progress_id. Poll aiagents_auto_fetch_progress_retrieve with the progress_id until completed or failed."
   }
 }

--- a/cekura-mcp-server/mcp_tools.json
+++ b/cekura-mcp-server/mcp_tools.json
@@ -109,5 +109,8 @@
   },
   "aiagents_toggle_mock_tools_create": {
     "description_suffix": "Async — returns a progress_id. Poll aiagents_toggle_mock_tools_progress_retrieve with the progress_id until completed or failed. Run aiagents_auto_fetch_create first to populate mock tool data before enabling."
+  },
+  "aiagents_toggle_mock_tools_progress_retrieve": {
+    "description_suffix": "Poll with the progress_id from aiagents_toggle_mock_tools_create. Status values: queued, in_progress, completed (mock mode applied), failed (with error)."
   }
 }

--- a/cekura-mcp-server/mcp_tools.json
+++ b/cekura-mcp-server/mcp_tools.json
@@ -92,24 +92,6 @@
   "metrics_generate_clean_description_progress_retrieve": {
     "description_suffix": "Poll this endpoint with the progress_id returned from metrics_generate_clean_description_bg_create. Status values: queued, processing, completed, failed. On completed, clean_description and thinking fields contain the result."
   },
-  "aiagents_tools_auto_fetch_create": {
-    "description_suffix": "Async — returns a progress_id. Poll aiagents_tools_auto_fetch_progress_retrieve with the progress_id until completed or failed."
-  },
-  "aiagents_tools_auto_fetch_progress_retrieve": {
-    "description_suffix": "Poll with the progress_id from aiagents_tools_auto_fetch_create. Status values: in_progress, completed (with discovered tool counts), failed (with error)."
-  },
-  "aiagents_tools_disable_mock_create": {
-    "description_suffix": "Async — returns a progress_id. Poll aiagents_tools_disable_mock_progress_retrieve with the progress_id until completed or failed."
-  },
-  "aiagents_tools_disable_mock_progress_retrieve": {
-    "description_suffix": "Poll with the progress_id from aiagents_tools_disable_mock_create. Status values: in_progress, completed, failed (with error)."
-  },
-  "aiagents_tools_enable_mock_create": {
-    "description_suffix": "Async — returns a progress_id. Poll aiagents_tools_enable_mock_progress_retrieve with the progress_id until completed (yields mcp_endpoints array) or failed."
-  },
-  "aiagents_tools_enable_mock_progress_retrieve": {
-    "description_suffix": "Poll with the progress_id from aiagents_tools_enable_mock_create. Status values: in_progress, completed (with mcp_endpoints[]), failed (with error). The mcp_endpoints array is populated only after completion."
-  },
   "aiagents_destroy": {
     "description_suffix": "Deletes the agent and all associated resources (scenarios, runs, results, call logs). Cannot be undone."
   },

--- a/cekura-mcp-server/mcp_tools.json
+++ b/cekura-mcp-server/mcp_tools.json
@@ -103,5 +103,8 @@
   },
   "aiagents_auto_fetch_create": {
     "description_suffix": "Async — returns a progress_id. Poll aiagents_auto_fetch_progress_retrieve with the progress_id until completed or failed."
+  },
+  "aiagents_auto_fetch_progress_retrieve": {
+    "description_suffix": "Poll with the progress_id from aiagents_auto_fetch_create. Status values: queued, in_progress, completed (with staged configuration), failed (with error)."
   }
 }

--- a/cekura-mcp-server/mcp_tools.json
+++ b/cekura-mcp-server/mcp_tools.json
@@ -106,5 +106,8 @@
   },
   "aiagents_auto_fetch_progress_retrieve": {
     "description_suffix": "Poll with the progress_id from aiagents_auto_fetch_create. Status values: queued, in_progress, completed (with staged configuration), failed (with error)."
+  },
+  "aiagents_toggle_mock_tools_create": {
+    "description_suffix": "Async — returns a progress_id. Poll aiagents_toggle_mock_tools_progress_retrieve with the progress_id until completed or failed. Run aiagents_auto_fetch_create first to populate mock tool data before enabling."
   }
 }

--- a/openapi.json
+++ b/openapi.json
@@ -56835,6 +56835,11 @@
                         "type": "string",
                         "readOnly": true,
                         "description": "\nWhether this metric is configured in the project's rubric and therefore contributes\nto overall call success evaluation.\nExample: `true`\n"
+                    },
+                    "uses_llm_judge": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "\nWhether this metric produces an LLM-judge narrative: a `custom_code` metric whose\ncode delegates to the LLM judge internally. Computed server-side because the\n`custom_code` body is write-only and not exposed on read.\nExample: `true`\n"
                     }
                 },
                 "required": [
@@ -61272,6 +61277,15 @@
                         "description": "Test Profile",
                         "readOnly": true
                     },
+                    "generated_mock_tool_entries": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                        },
+                        "readOnly": true,
+                        "description": "Expected mock tool calls for this run's evaluator. Each entry has shape {tool_id, tool_name, new_entry: {input, output}}."
+                    },
                     "provider_call_details": {
                         "readOnly": true,
                         "description": "\nDetails of the call from the provider\n"
@@ -65008,6 +65022,15 @@
                         ],
                         "description": "Test Profile",
                         "readOnly": true
+                    },
+                    "generated_mock_tool_entries": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                        },
+                        "readOnly": true,
+                        "description": "Expected mock tool calls for this run's evaluator. Each entry has shape {tool_id, tool_name, new_entry: {input, output}}."
                     },
                     "provider_call_details": {
                         "readOnly": true,

--- a/openapi.json
+++ b/openapi.json
@@ -13409,14 +13409,6 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-tool-retrieve",
-                        "description": "Return a single tool's full definition, including the input/output pairs that define its mock responses. Use it to inspect what a tool returns before updating it or enabling mock mode."
-                    }
                 }
             },
             "post": {
@@ -13580,14 +13572,6 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-tool-partial-update",
-                        "description": "Patch a tool's fields — its `name`, `description`, or `information` (the list of input/output pairs that define its mock responses). Only the fields you send are changed."
-                    }
                 }
             },
             "delete": {
@@ -13639,14 +13623,6 @@
                             }
                         },
                         "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-tool-destroy",
-                        "description": "⚠ Irreversible. Detaches the named tool from this agent by marking it deleted. The tool definition is not deleted — other agents referencing the same tool_name are unaffected."
                     }
                 }
             }
@@ -13722,14 +13698,6 @@
                             }
                         },
                         "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-tools-list",
-                        "description": "Return every tool configured on the agent, including mock tools and the input/output pairs that define their mock responses. Use this to see what's set up before enabling or disabling mock mode or updating a specific tool."
                     }
                 }
             },
@@ -13817,14 +13785,6 @@
                             }
                         },
                         "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-tools-create",
-                        "description": "Register a tool on the agent, including its mock input/output pairs in `information`. For agents on a managed provider, prefer auto-fetch to import tools automatically; use this to add a custom or hand-authored tool."
                     }
                 }
             }
@@ -13921,15 +13881,6 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mcp-destructive": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-tools-auto-fetch-create",
-                        "description": "Discover the agent's tools (from a managed provider or a customer-hosted MCP server) and LLM-generate mock input/output data for each. Persists Tool rows and records the provider configuration on the agent. ⚠ Overwrites empty Tool rows; existing rows with mock data are kept. For provider=\"custom\", supply `mcp_server_url`; the URL is SSRF-validated (no private/loopback targets)."
-                    }
                 }
             }
         },
@@ -13985,14 +13936,6 @@
                             }
                         },
                         "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-tools-auto-fetch-progress-retrieve",
-                        "description": "Poll the status of a background auto-fetch tools task.\n\nReturns the current state: in_progress, completed (with counts), or failed (with error)."
                     }
                 }
             }
@@ -14061,15 +14004,6 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mcp-destructive": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-tools-disable-mock-create",
-                        "description": "Restore the agent's tools to their original (non-mock) state. For managed providers this PATCHes the provider assistant back to its `original_tool_ids` and deletes the cloned tools. For provider=\"custom\" this only flips `mock_enabled` off; the `mcp_server_url` is preserved so re-enable works."
-                    }
                 }
             }
         },
@@ -14125,14 +14059,6 @@
                             }
                         },
                         "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-tools-disable-mock-progress-retrieve",
-                        "description": "Poll the status of a background disable-mock task."
                     }
                 }
             }
@@ -14201,15 +14127,6 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mcp-destructive": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-tools-enable-mock-create",
-                        "description": "Activate mock-tool mode using the data created by `auto-fetch`. For managed providers (vapi/retell/elevenlabs) this clones the provider's tools at the provider and swaps URLs to Cekura-hosted endpoints. For provider=\"custom\" it just registers `mcp_sub_tool_map` so MockMCPView can serve `/mcp/N/` calls. Returns a `progress_id`; poll `enable-mock-progress/` for the resulting `mcp_endpoints`. Run `auto-fetch` first."
-                    }
                 }
             }
         },
@@ -14266,14 +14183,6 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-tools-enable-mock-progress-retrieve",
-                        "description": "Poll the status of a background enable-mock task."
-                    }
                 }
             }
         },
@@ -14311,14 +14220,6 @@
                             }
                         },
                         "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-tools-mock-status-retrieve",
-                        "description": "Single source of truth for \"what mock-tool runtime URLs do I have, and what are they configured for?\". `mcp_endpoints[]` lists each Cekura-hosted MCP JSON-RPC endpoint with the sub-tools it serves; `tool_endpoints[]` lists standalone (non-MCP) per-tool webhook URLs. URLs are computed from `settings.CEKURA_BASE_URL`, so each environment renders the correct host."
                     }
                 }
             }
@@ -39963,7 +39864,7 @@
             },
             "patch": {
                 "operationId": "aiagents-partial-update",
-                "description": "Partially update an agent. Only fields included in the request body are modified.",
+                "description": "Partially update an agent. Only fields included in the request body are modified. Mock tools (create, update, delete) are managed via the `mock_tools` field — pass the full desired list; to enable/disable mock mode use `POST toggle-mock-tools/`; to re-fetch from the provider use `POST auto-fetch/`. Knowledge base files are managed via the `knowledge_base_files` field — pass file objects with `id` to keep existing files or add new ones by uploading first. Dynamic variables are managed via the `dynamic_variables` field — pass the full list of variable definitions with `name` and `description`.",
                 "summary": "Update an AI voice agent (partial)",
                 "parameters": [
                     {
@@ -40047,7 +39948,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "aiagents-partial-update",
-                        "description": "Partially update an agent. Only fields included in the request body are modified."
+                        "description": "Partially update an agent. Only fields included in the request body are modified. Mock tools (create, update, delete) are managed via the `mock_tools` field — pass the full desired list; to enable/disable mock mode use `POST toggle-mock-tools/`; to re-fetch from the provider use `POST auto-fetch/`. Knowledge base files are managed via the `knowledge_base_files` field — pass file objects with `id` to keep existing files or add new ones by uploading first. Dynamic variables are managed via the `dynamic_variables` field — pass the full list of variable definitions with `name` and `description`."
                     }
                 }
             },
@@ -52976,6 +52877,7 @@
             },
             "CallLogDetail": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -53167,6 +53069,7 @@
             },
             "CallLogList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -54292,6 +54195,7 @@
             },
             "Dashboard": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -54423,6 +54327,7 @@
             },
             "DashboardList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -56646,6 +56551,7 @@
             },
             "MetricList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -59114,6 +59020,7 @@
             },
             "PatchedCallLogDetail": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -59542,6 +59449,7 @@
             },
             "PatchedDashboard": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -61920,6 +61828,7 @@
             },
             "PatchedSchemaPostScenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "agent": {
                         "type": [
@@ -65099,6 +65008,7 @@
             },
             "RunList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -65526,6 +65436,7 @@
             },
             "Scenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -66394,6 +66305,7 @@
             },
             "ScenarioList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -66613,6 +66525,7 @@
             },
             "ScenarioSerializerV2": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -68085,6 +67998,7 @@
             },
             "SchemaPostRunScenarios": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "agent_id": {
                         "type": "integer",
@@ -68333,6 +68247,7 @@
             },
             "SchemaPostScenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "agent": {
                         "type": [
@@ -68492,6 +68407,7 @@
             },
             "SchemaScenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",

--- a/openapi.json
+++ b/openapi.json
@@ -39864,7 +39864,7 @@
             },
             "patch": {
                 "operationId": "aiagents-partial-update",
-                "description": "Partially update an agent. Only fields included in the request body are modified. Mock tools (create, update, delete) are managed via the `mock_tools` field — pass the full desired list; to enable/disable mock mode use `POST toggle-mock-tools/`; to re-fetch from the provider use `POST auto-fetch/`. Knowledge base files are managed via the `knowledge_base_files` field — pass file objects with `id` to keep existing files or add new ones by uploading first. Dynamic variables are managed via the `dynamic_variables` field — pass the full list of variable definitions with `name` and `description`.",
+                "description": "Partially update an agent. Only fields included in the request body are modified. Mock tools (create, update, delete) are managed via the `mock_tools` field — pass the full desired list of tools. Knowledge base files are managed via the `knowledge_base_files` field. Dynamic variables are managed via the `dynamic_variables` field.",
                 "summary": "Update an AI voice agent (partial)",
                 "parameters": [
                     {
@@ -39948,7 +39948,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "aiagents-partial-update",
-                        "description": "Partially update an agent. Only fields included in the request body are modified. Mock tools (create, update, delete) are managed via the `mock_tools` field — pass the full desired list; to enable/disable mock mode use `POST toggle-mock-tools/`; to re-fetch from the provider use `POST auto-fetch/`. Knowledge base files are managed via the `knowledge_base_files` field — pass file objects with `id` to keep existing files or add new ones by uploading first. Dynamic variables are managed via the `dynamic_variables` field — pass the full list of variable definitions with `name` and `description`."
+                        "description": "Partially update an agent. Only fields included in the request body are modified. Mock tools (create, update, delete) are managed via the `mock_tools` field — pass the full desired list of tools. Knowledge base files are managed via the `knowledge_base_files` field. Dynamic variables are managed via the `dynamic_variables` field."
                     }
                 }
             },
@@ -40061,6 +40061,14 @@
                         },
                         "description": ""
                     }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "aiagents-auto-fetch-create",
+                        "description": "Re-fetch the full agent configuration from its connected provider (Retell, VAPI, ElevenLabs, Synthflow): system prompt, call settings, phone number, tools with mock data, dynamic variables and knowledge base files. Returns a `progress_id`; poll `auto-fetch-progress/` for staged status."
+                    }
                 }
             }
         },
@@ -40116,6 +40124,14 @@
                             }
                         },
                         "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "aiagents-auto-fetch-progress-retrieve",
+                        "description": "Poll the staged status of a background auto-fetch (whole-agent import)."
                     }
                 }
             }
@@ -40623,7 +40639,7 @@
         "/test_framework/v2/aiagents/{id}/toggle-mock-tools/": {
             "post": {
                 "operationId": "aiagents-toggle-mock-tools-create",
-                "description": "Toggle mock-tool mode on the agent's provider. `enabled=true` replaces the provider tools with Cekura-hosted mocks; `enabled=false` restores the originals (mock data is preserved). Returns a `progress_id`; poll `toggle-mock-tools-progress/`.",
+                "description": "Toggle mock-tool mode on the agent's provider. `enabled=true` replaces the provider tools with Cekura-hosted mocks; `enabled=false` restores the originals (mock data is preserved). Returns a `progress_id`; poll `toggle-mock-tools-progress/`. Run `auto-fetch` first to populate mock tool data before enabling.",
                 "summary": "Enable or disable mock tools on the provider",
                 "parameters": [
                     {
@@ -40685,6 +40701,15 @@
                         },
                         "description": ""
                     }
+                },
+                "x-mcp-expose": true,
+                "x-mcp-destructive": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "aiagents-toggle-mock-tools-create",
+                        "description": "Toggle mock-tool mode on the agent's provider. `enabled=true` replaces the provider tools with Cekura-hosted mocks; `enabled=false` restores the originals (mock data is preserved). Returns a `progress_id`; poll `toggle-mock-tools-progress/`. Run `auto-fetch` first to populate mock tool data before enabling."
+                    }
                 }
             }
         },
@@ -40740,6 +40765,14 @@
                             }
                         },
                         "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "aiagents-toggle-mock-tools-progress-retrieve",
+                        "description": "Poll the enable/disable task. The progress_id is unique, so we resolve it\nagainst both task namespaces and return whichever holds it."
                     }
                 }
             }


### PR DESCRIPTION
Auto-generated docs sync for backend PR [#9626](https://github.com/cekura-ai/vocera.backend/pull/9626).

Reviewers: @dileep-chagam, @rahul-cekura

## Summary

**Spec/overlay:** Mock tool management consolidated from nested tool endpoints to agent-level endpoints. 4 operations newly exposed (aiagents_auto_fetch_create, aiagents_auto_fetch_progress_retrieve, aiagents_toggle_mock_tools_create, aiagents_toggle_mock_tools_progress_retrieve). 12 operations retracted (all legacy /v1/aiagents/{agent_id}/tools/ endpoints). 6 orphaned overlays removed. 4 overlays added for async_progress_pairing signals. 1 exposed operation modified (aiagents_partial_update description). 16 SDK/CLI followups emitted (4 adds, 12 removes).

**Conceptual docs:** No conceptual docs edits needed. This PR removes MCP exposure from deprecated v1 mock tool endpoints and adds MCP exposure to v2 auto-fetch and toggle-mock-tools endpoints. It also clarifies the v2 PATCH description to document mock_tools field usage. These are MCP-exposure and API-spec documentation changes, not behavior changes. The v1 endpoints still function (just not via MCP), and v2 is already the canonical version. Conceptual docs should describe workflows and concepts (not enumerate specific endpoint versions or MCP tool availability), so no misrepresentation of end-to-end behavior exists. The updated PATCH description now lives in the OpenAPI spec itself, which is the authoritative source for API contracts.

## Changes

- `openapi.json` — regenerate_from_backend
- `cekura-mcp-server/mcp_tools.json` — patch_json
- `cekura-mcp-server/mcp_tools.json` — patch_json

## SDK / CLI parity follow-ups

- `aiagents_auto_fetch_create` (POST `/test_framework/v2/aiagents/{id}/auto-fetch/`) — add
- `aiagents_auto_fetch_progress_retrieve` (GET `/test_framework/v2/aiagents/{id}/auto-fetch-progress/`) — add
- `aiagents_toggle_mock_tools_create` (POST `/test_framework/v2/aiagents/{id}/toggle-mock-tools/`) — add
- `aiagents_toggle_mock_tools_progress_retrieve` (GET `/test_framework/v2/aiagents/{id}/toggle-mock-tools-progress/`) — add
- `aiagents_tools_list` (GET `/test_framework/v1/aiagents/{agent_id}/tools/`) — remove
- `aiagents_tools_create` (POST `/test_framework/v1/aiagents/{agent_id}/tools/`) — remove
- `aiagents_tools_auto_fetch_create` (POST `/test_framework/v1/aiagents/{agent_id}/tools/auto-fetch/`) — remove
- `aiagents_tools_auto_fetch_progress_retrieve` (GET `/test_framework/v1/aiagents/{agent_id}/tools/auto-fetch-progress/`) — remove
- `aiagents_tools_enable_mock_create` (POST `/test_framework/v1/aiagents/{agent_id}/tools/enable-mock/`) — remove
- `aiagents_tools_enable_mock_progress_retrieve` (GET `/test_framework/v1/aiagents/{agent_id}/tools/enable-mock-progress/`) — remove
- `aiagents_tools_disable_mock_create` (POST `/test_framework/v1/aiagents/{agent_id}/tools/disable-mock/`) — remove
- `aiagents_tools_disable_mock_progress_retrieve` (GET `/test_framework/v1/aiagents/{agent_id}/tools/disable-mock-progress/`) — remove
- `aiagents_tools_mock_status_retrieve` (GET `/test_framework/v1/aiagents/{agent_id}/tools/mock-status/`) — remove
- `aiagents_tool_retrieve` (GET `/test_framework/v1/aiagents/{agent_id}/tool/{tool_name}/`) — remove
- `aiagents_tool_partial_update` (PATCH `/test_framework/v1/aiagents/{agent_id}/tool/{tool_name}/`) — remove
- `aiagents_tool_destroy` (DELETE `/test_framework/v1/aiagents/{agent_id}/tool/{tool_name}/`) — remove

## Applied with notes

- mcp_tools.json: existing overlay at /aiagents_auto_fetch_create differs from proposed; left existing in place (D2 precedence)
- mcp_tools.json: existing overlay at /aiagents_auto_fetch_progress_retrieve differs from proposed; left existing in place (D2 precedence)
- mcp_tools.json: existing overlay at /aiagents_toggle_mock_tools_create differs from proposed; left existing in place (D2 precedence)
- mcp_tools.json: existing overlay at /aiagents_toggle_mock_tools_progress_retrieve differs from proposed; left existing in place (D2 precedence)

---
*Auto-generated from backend PR #9626.*

<!-- mcp-sync:file-hashes -->
```json
{}
```
<!-- /mcp-sync:file-hashes -->