### PR TITLE
docs(mcp): sync skills list (9 → 11 skills)

### DIFF
--- a/mcp/skills.mdx
+++ b/mcp/skills.mdx
@@ -14,7 +14,7 @@ Cekura skills give your AI coding agent the playbook for designing evaluators, c
 
 ## What you get
 
-Nine skills, scoped to specific Cekura workflows:
+Eleven skills, scoped to specific Cekura workflows:
 
 | Skill | Activates on |
 |---|---|
@@ -26,6 +26,8 @@ Nine skills, scoped to specific Cekura workflows:
 | `cekura-metric-improvement` | "Improve a metric / fix metric accuracy" |
 | `cekura-predefined-metrics` | "What predefined metrics are available / which built-in metrics should I use" |
 | `cekura-eval-design` | "Design test scenarios for my voice agent" |
+| `cekura-generate-scenarios` | "Create scenarios from failed prod calls / turn call logs into tests" |
+| `cekura-infra-test-suite` | "Create CI/CD tests for my voice pipeline / test my STT-LLM-TTS infra" |
 | `cekura-fixing-prod-issues` | "Fix a production call bug / reproduce and test a fix before raising a PR" |
 
 <Note>
@@ -34,7 +36,7 @@ Nine skills, scoped to specific Cekura workflows:
 
 ## Install
 
-**Claude Code users — install the marketplace plugin.** It bundles all 9 skills, 14 slash commands, the MCP server config, and a failure-detection hook in a single install. Other agents (Cursor, Codex, Windsurf, etc.) use `npx skills add` to get the skills only.
+**Claude Code users — install the marketplace plugin.** It bundles all 11 skills, 14 slash commands, the MCP server config, and a failure-detection hook in a single install. Other agents (Cursor, Codex, Windsurf, etc.) use `npx skills add` to get the skills only.
 
 <Tabs>
   <Tab title="Claude Code (recommended)">


### PR DESCRIPTION
## What

Updates [docs.cekura.ai/mcp/skills](https://docs.cekura.ai/mcp/skills) to reflect the current `cekura-skills` plugin (now at v0.7.1). The page listed **9 skills**; the plugin ships **11**.

## Changes
- Add two new skills to the **What you get** table:
  - `cekura-generate-scenarios` — create scenarios from failed prod calls / turn call logs into tests
  - `cekura-infra-test-suite` — create CI/CD tests for a voice pipeline (STT/LLM/TTS infra)
- Bump skill count `Nine → Eleven` in the table intro and `9 → 11` in the marketplace-bundle blurb.

## Unchanged
- Slash commands remain **14** (same set) — no edit needed there.

Source of truth: `cekura-ai/cekura-skills` @ `origin/main` (`cekura/skills/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cekura-ai/docs/pull/705" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->