### PR TITLE
docs(metrics): document the custom-code evaluation trigger contract

### DIFF
--- a/documentation/key-concepts/metrics/llm-judge-metric.mdx
+++ b/documentation/key-concepts/metrics/llm-judge-metric.mdx
@@ -64,7 +64,7 @@ Check if the Main Agent ended the call only after all steps in
 Define when the metric should run under the **Evaluation Trigger** section.
 
 - **Always:** Runs on every call (default).
-- **Custom:** Use logic to run metrics only in specific scenarios. You can write a trigger prompt in natural language or use Python code to define when the metric should run (e.g., `return True` only if the agent is attempting to book an appointment).
+- **Custom:** Use logic to run metrics only in specific scenarios. You can write a trigger prompt in natural language, or write Python code that decides when the metric should run. Trigger code receives the same [`data`](/documentation/key-concepts/metrics/python-metric#evaluation-trigger-custom-code) dictionary as a Python metric and sets `_result` (a bool — `True` to run, `False` to skip) and `_explanation`. See [Evaluation Trigger (Custom Code)](/documentation/key-concepts/metrics/python-metric#evaluation-trigger-custom-code) for the contract and an example.
 
 ### Testing Your Metrics
 

--- a/documentation/key-concepts/metrics/python-metric.mdx
+++ b/documentation/key-concepts/metrics/python-metric.mdx
@@ -315,12 +315,13 @@ When writing your custom code, you have access to different variables depending 
     cekura_transcript = data.get("cekura_transcript_json", [])
     # Structure:
     # [
-    #   {"role": "Main Agent", "content": "Hello", "timestamp": 1.0},
-    #   {"role": "Testing Agent", "content": "Hi there", "timestamp": 5.5}
+    #   {"role": "assistant", "content": "Hello", "timestamp": 1.0},
+    #   {"role": "user", "content": "Hi there", "timestamp": 5.5}
     # ]
 
-    # Provides alternative transcript format with simplified structure
-    # Each entry contains role (assistant/user), content, and timestamp in seconds
+    # Provides alternative transcript format with simplified structure.
+    # Note: this format uses "assistant"/"user" roles, unlike transcript_json
+    # which uses "Main Agent"/"Testing Agent".
     ```
   </Accordion>
   <Accordion title="test_profile" href="#test-profile">
@@ -461,6 +462,35 @@ if "premium plan" in transcript:
 else:
     _result = False
     _explanation = "Agent did not mention the Premium Plan in the conversation"
+```
+
+### Evaluation Trigger (Custom Code)
+
+A metric's **Evaluation Trigger** decides *whether* the metric runs on a given call (distinct from the metric body, which decides the score). When the trigger is set to **Custom** with **Custom Code**, you write a short Python snippet that runs in the same secure Python environment as a Python metric: it receives the same [`data`](#available-data-variables) dictionary and must set `_result` and `_explanation`.
+
+- `_result` — a **boolean**: `True` to run the metric on this call, `False` to skip it.
+- `_explanation` — a string explaining the decision.
+
+<Warning>
+A trigger is **not** a function — there is no `return`. Set `_result` and `_explanation` as variables, exactly like a Python metric. The transcript is in `data["transcript_json"]` (there is no `messages` variable), and each turn's `role` is `"Main Agent"` or `"Testing Agent"` — not `"agent"`, `"assistant"`, or `"user"`.
+</Warning>
+
+**Example** — only run the metric when the Main Agent spoke more than 5 times:
+
+```python
+main_messages = [m for m in data["transcript_json"] if m["role"] == "Main Agent"]
+_result = len(main_messages) > 5
+_explanation = f"Main Agent spoke {len(main_messages)} times"
+```
+
+**Example** — skip the metric when the customer hung up:
+
+```python
+_result = True
+_explanation = "Metric is relevant"
+if data.get("call_end_reason") == "customer-hung-up":
+    _result = False
+    _explanation = "Customer hung up, metric not applicable"
 ```
 
 ### Latency Threshold Example


### PR DESCRIPTION
## Problem

A user asked the Cekura product-chat agent how to write the custom code for a metric **evaluation trigger** (run a metric only if the Main Agent spoke >5 times). The agent answered from memory and got it wrong on three counts: it referenced a `messages` variable, used `role == "agent"`, and used `return`.

Tracing it back, the docs themselves were a contributing cause. The **only** place a Python evaluation trigger was documented — `llm-judge-metric.mdx` — told users to write `return True`, which contradicts the real contract (`evaluation_trigger_custom_code` must set `_result`/`_explanation`, per `openapi.json`). There was no page describing what trigger code receives or the correct transcript role labels.

## Fix

- **`llm-judge-metric.mdx`** — replace the incorrect `return True` example with the real contract and link to the new reference section.
- **`python-metric.mdx`** — add an **"Evaluation Trigger (Custom Code)"** section: the code receives the same `data` dict, must set `_result` (bool) / `_explanation`, has no `return`/`messages`, and reads the transcript from `data["transcript_json"]` where roles are `"Main Agent"` / `"Testing Agent"`. Includes the exact snippet that answers the user's question.
- **`python-metric.mdx`** — fix the `cekura_transcript_json` example, which inconsistently showed `"Main Agent"`/`"Testing Agent"` in one place and `assistant`/`user` in another; that field uses `assistant`/`user`, now noted explicitly.

Ground truth confirmed against `openapi.json` (`evaluation_trigger_custom_code`) and backend `metric_functions.py` (filters on `"Main Agent"`/`"Testing Agent"`).

## Verification

Docs-only `.mdx` change. `<Warning>` component already used elsewhere in the file. No internal implementation details added (repo is public).

🤖 Generated with [Claude Code](https://claude.com/claude-code)