### PR TITLE
Push image to new account ECR (us-west-2) in parallel

### DIFF
--- a/.github/workflows/deploy-mcp-server-new.yml
+++ b/.github/workflows/deploy-mcp-server-new.yml
@@ -1,0 +1,83 @@
+name: Build and deploy MCP server (new account)
+
+# Targets the new AWS account (cet-prd-cekura-workload-prod, us-west-2).
+# Build + push only for now — deploy will be wired in once the new ECS
+# task definition is ready in the new account.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'openapi.json'
+      - 'cekura-mcp-server/**'
+      - 'mint.json'
+      - 'scripts/**'
+      - '.github/workflows/deploy-mcp-server-new.yml'
+  workflow_dispatch:
+
+env:
+  AWS_REGION: us-west-2
+  ECR_REPOSITORY: cekura/mcp-server
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      image-tag: ${{ steps.construct-tag.outputs.image-tag }}
+      registry: ${{ steps.login-ecr.outputs.registry }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          version: latest
+
+      - name: Configure AWS credentials (new account)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN_PROD_NEW }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Sync API descriptions from OpenAPI spec to MDX pages
+        run: python3 scripts/sync_descriptions.py --write
+
+      - name: Generate structured llms.txt
+        run: python3 scripts/generate_llms_txt.py --write
+
+      - name: Construct Docker image tag
+        id: construct-tag
+        run: |
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          BRANCH_NAME=${GITHUB_REF_NAME//\//-}
+          IMAGE_TAG="${BRANCH_NAME}-${SHORT_SHA}"
+          echo "image-tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+      - name: Build and push image to ECR
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./cekura-mcp-server/Dockerfile
+          push: true
+          tags: ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ steps.construct-tag.outputs.image-tag }}
+          cache-from: |
+            type=gha,scope=mcp-server-new-${{ github.ref_name }}
+            type=gha,scope=mcp-server-new-main
+          cache-to: type=gha,mode=max,scope=mcp-server-new-${{ github.ref_name }}
+
+  # TODO: deploy + notify — added once new ECS cluster + service ready.


### PR DESCRIPTION
## Summary
Adds a parallel workflow that pushes the same image to the new account ECR (`212351099297.dkr.ecr.us-west-2.amazonaws.com`) on the same triggers as the existing deploy workflow. Existing workflow is untouched and continues to publish + deploy against old prod.

Deploy / migrations / notify jobs are intentionally left as TODOs — they'll be added once the new account's ECS cluster + task definitions are provisioned.

## Context
Part of the AWS account migration to `cet-org-shared-services` / `cet-prd-cekura-workload-prod` (SnapSoft). Other repos doing the same: `vocera.backend` (#9675), `vocera.webrtc`, `cekura.patronus`, `docs` (cekura-mcp-server).

Requires repo variable `AWS_ROLE_ARN_PROD_NEW = arn:aws:iam::212351099297:role/cet-org-oidc-github-actions-iam-role` to be set before the workflow can run.
