### PR TITLE
[Auto] Sync docs for backend PR #9699

### DIFF
--- a/api-reference/observability/fix-metric-failure-mode-insight.mdx
+++ b/api-reference/observability/fix-metric-failure-mode-insight.mdx
@@ -1,0 +1,6 @@
+---
+title: Fix Metric Failure Mode Insight
+description: "Add a sample of one failure mode's example calls to Labs."
+openapi: post /observability/v1/metric-failure-mode-insights/{id}/fix-metric/
+slug: fix-metric-failure-mode-insight
+---

--- a/api-reference/test_framework/edit-agent-history-v1.mdx
+++ b/api-reference/test_framework/edit-agent-history-v1.mdx
@@ -1,0 +1,6 @@
+---
+title: Edit Agent History (v1)
+description: "Aiagents v1 history edit"
+openapi: patch /test_framework/v1/aiagents/{id}/history/edit/
+slug: edit-agent-history-v1
+---

--- a/api-reference/test_framework/edit-agent-history-v2.mdx
+++ b/api-reference/test_framework/edit-agent-history-v2.mdx
@@ -1,0 +1,6 @@
+---
+title: Edit Agent History (v2)
+description: "Aiagents history edit"
+openapi: patch /test_framework/v2/aiagents/{id}/history/edit/
+slug: edit-agent-history-v2
+---

--- a/api-reference/test_framework/edit-external-agent-history.mdx
+++ b/api-reference/test_framework/edit-external-agent-history.mdx
@@ -1,0 +1,6 @@
+---
+title: Edit External Agent History
+description: "Aiagents history edit"
+openapi: patch /test_framework/v1/aiagents-external/{id}/history/edit/
+slug: edit-external-agent-history
+---

--- a/api-reference/test_framework/list-agent-history-v1.mdx
+++ b/api-reference/test_framework/list-agent-history-v1.mdx
@@ -1,0 +1,6 @@
+---
+title: List Agent History (v1)
+description: "Paginated version history for an agent: name/language/description plus the mock"
+openapi: get /test_framework/v1/aiagents/{id}/history/
+slug: list-agent-history-v1
+---

--- a/api-reference/test_framework/list-agent-history-v2.mdx
+++ b/api-reference/test_framework/list-agent-history-v2.mdx
@@ -1,0 +1,6 @@
+---
+title: List Agent History (v2)
+description: "Paginated version history for an agent: name/language/description plus the mock"
+openapi: get /test_framework/v2/aiagents/{id}/history/
+slug: list-agent-history-v2
+---

--- a/api-reference/test_framework/list-external-agent-history.mdx
+++ b/api-reference/test_framework/list-external-agent-history.mdx
@@ -1,0 +1,6 @@
+---
+title: List External Agent History
+description: "Paginated version history for an agent: name/language/description plus the mock"
+openapi: get /test_framework/v1/aiagents-external/{id}/history/
+slug: list-external-agent-history
+---

--- a/api-reference/test_framework/restore-agent-v1.mdx
+++ b/api-reference/test_framework/restore-agent-v1.mdx
@@ -1,0 +1,6 @@
+---
+title: Restore Agent (v1)
+description: "Restore an agent to a previous version, creating a new version for the restore."
+openapi: post /test_framework/v1/aiagents/{id}/restore/
+slug: restore-agent-v1
+---

--- a/api-reference/test_framework/restore-agent-v2.mdx
+++ b/api-reference/test_framework/restore-agent-v2.mdx
@@ -1,0 +1,6 @@
+---
+title: Restore Agent (v2)
+description: "Restore an agent to a previous version, creating a new version for the restore."
+openapi: post /test_framework/v2/aiagents/{id}/restore/
+slug: restore-agent-v2
+---

--- a/api-reference/test_framework/restore-external-agent.mdx
+++ b/api-reference/test_framework/restore-external-agent.mdx
@@ -1,0 +1,6 @@
+---
+title: Restore External Agent
+description: "Restore an agent to a previous version, creating a new version for the restore."
+openapi: post /test_framework/v1/aiagents-external/{id}/restore/
+slug: restore-external-agent
+---

--- a/documentation/integrations/custom-integration.mdx
+++ b/documentation/integrations/custom-integration.mdx
@@ -82,6 +82,7 @@ Each call in the `calls` array should include:
 | `metadata` | object | No | Optional metadata as key-value pairs for additional call information |
 | `endedReason` | string | No | Reason call ended (default: "unknown", e.g., "assistant-ended-call", "customer-hungup") |
 | `run_id` | string | Conditionally required | Cekura Run ID for this call. Required on each call when `agent_id` is omitted at the top level. Intended for SIP integrations where run IDs are pre-known from SIP headers. |
+| `trace_id` | string | No | OpenTelemetry trace ID (32-char hex string) for this call. When provided, the trace ID is propagated to the matched run for correlation with distributed traces. Example: '4bf92f3577b34da6a3ce929d0e0e4736' |
 
 <Tip>
 **Passing a recording URL:** The custom integration payload does not have a dedicated `voice_recording_url` field. To include a recording URL (or any other custom call context), add it to the `metadata` object:

--- a/documentation/integrations/custom-integration.mdx
+++ b/documentation/integrations/custom-integration.mdx
@@ -82,7 +82,7 @@ Each call in the `calls` array should include:
 | `metadata` | object | No | Optional metadata as key-value pairs for additional call information |
 | `endedReason` | string | No | Reason call ended (default: "unknown", e.g., "assistant-ended-call", "customer-hungup") |
 | `run_id` | string | Conditionally required | Cekura Run ID for this call. Required on each call when `agent_id` is omitted at the top level. Intended for SIP integrations where run IDs are pre-known from SIP headers. |
-| `trace_id` | string | No | OpenTelemetry trace ID (32-char hex string) for this call. When provided, the trace ID is propagated to the matched run for correlation with distributed traces. Example: '4bf92f3577b34da6a3ce929d0e0e4736' |
+| `trace_id` | string | No | OpenTelemetry trace ID (32-character lowercase hex string) for this call. Propagated to the matched run for correlation with distributed traces. |
 
 <Tip>
 **Passing a recording URL:** The custom integration payload does not have a dedicated `voice_recording_url` field. To include a recording URL (or any other custom call context), add it to the `metadata` object:
@@ -238,6 +238,7 @@ For successful webhook integration, ensure:
 6. **Agent ID**: Use the correct agent ID from your Cekura dashboard. If you have a Cekura Run ID available ahead of time (e.g. from SIP headers), you can omit `agent_id` and include `run_id` on each call object instead — Cekura will match transcripts directly to the existing runs
 7. **Unique Call IDs**: Each call should have a unique identifier (max 255 chars)
 8. **Metadata**: Use the `metadata` field to pass additional key-value pairs for call information
+9. **Trace ID**: Optionally include a `trace_id` (32-character hex string) to correlate calls with your distributed tracing system. The trace ID will be propagated to the matched run in Cekura
 
 ## Troubleshooting
 
@@ -271,6 +272,7 @@ If your webhook integration isn't working as expected:
 - Verify the `agent_id` is an integer, not a string (required unless each call includes a `run_id`)
 - Check that phone numbers follow the correct format (+ followed by digits, max 15 chars)
 - Ensure `messages` is an array with dictionaries containing role and content fields
+- If including `trace_id`, ensure it is a 32-character lowercase hex string
 
 ## Next Steps
 

--- a/mint.json
+++ b/mint.json
@@ -254,7 +254,16 @@
             "api-reference/test_framework/auto-fetch-agent",
             "api-reference/test_framework/poll-import-progress",
             "api-reference/test_framework/toggle-mock-tools",
-            "api-reference/test_framework/poll-toggle-mock-tools-progress"
+            "api-reference/test_framework/poll-toggle-mock-tools-progress",
+            "api-reference/test_framework/list-external-agent-history",
+            "api-reference/test_framework/edit-external-agent-history",
+            "api-reference/test_framework/restore-external-agent",
+            "api-reference/test_framework/list-agent-history-v1",
+            "api-reference/test_framework/edit-agent-history-v1",
+            "api-reference/test_framework/restore-agent-v1",
+            "api-reference/test_framework/list-agent-history-v2",
+            "api-reference/test_framework/edit-agent-history-v2",
+            "api-reference/test_framework/restore-agent-v2"
           ]
         },
         {

--- a/mint.json
+++ b/mint.json
@@ -487,7 +487,8 @@
             "api-reference/observability/dismiss-deep-research-insight-mode",
             "api-reference/observability/generate-deep-research-insights",
             "api-reference/observability/get-metric-failure-mode-insights-available-dates",
-            "api-reference/observability/retrieve-deep-research-insights-pricing"
+            "api-reference/observability/retrieve-deep-research-insights-pricing",
+            "api-reference/observability/fix-metric-failure-mode-insight"
           ]
         }
       ]

--- a/openapi.json
+++ b/openapi.json
@@ -12755,6 +12755,113 @@
                 }
             }
         },
+        "/test_framework/v1/aiagents-external/{id}/history/": {
+            "get": {
+                "operationId": "aiagents-external-history-list",
+                "description": "Paginated version history for an agent: name/language/description plus the mock\ntools, dynamic variables, and knowledge base files active at each version.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this ai agent.",
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "page",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "page_size",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedAIAgentHistoryList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/aiagents-external/{id}/history/edit/": {
+            "patch": {
+                "operationId": "aiagents-external-history-edit-partial-update",
+                "description": "Aiagents history edit",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this ai agent.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedAIAgentEditHistoryRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedAIAgentEditHistoryRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedAIAgentEditHistoryRequest"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AIAgentHistory"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/test_framework/v1/aiagents-external/{id}/knowledge_base/": {
             "get": {
                 "operationId": "aiagents-external-knowledge-base-list",
@@ -12854,6 +12961,63 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/AIAgent"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/aiagents-external/{id}/restore/": {
+            "post": {
+                "operationId": "aiagents-external-restore-create",
+                "description": "Restore an agent to a previous version, creating a new version for the restore.\n\nRestores the versioned concrete fields (name, language, description) and the related\ncollections: tools and dynamic variables are reverted in place to their\nlinked versions (ids preserved) and any not in the version are soft-deleted; knowledge\nbase files referenced by the version are reactivated and the rest soft-deleted.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this ai agent.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AIAgentRestoreRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AIAgentRestoreRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AIAgentRestoreRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AIAgentV2"
                                 }
                             }
                         },
@@ -13189,7 +13353,7 @@
             },
             "delete": {
                 "operationId": "dynamic-variables-destroy",
-                "description": "Permanently deletes a single dynamic variable definition. ⚠ Irreversible.",
+                "description": "Soft-deletes a single dynamic variable definition by ID.",
                 "summary": "Delete a dynamic variable definition",
                 "parameters": [
                     {
@@ -13423,6 +13587,7 @@
                         "api_key": []
                     }
                 ],
+                "deprecated": true,
                 "responses": {
                     "200": {
                         "content": {
@@ -13471,6 +13636,7 @@
             "post": {
                 "operationId": "aiagents-tool-create",
                 "description": "Execute tool by matching input and returning corresponding output.\n\nSupports two payload formats:\n1. Flat input (default): {\"param1\": \"value1\", \"param2\": \"value2\"}\n2. VAPI function format: {\"message\": {\"type\": \"tool-calls\", \"toolCallList\": [{\"id\": \"...\", \"arguments\": {...}}]}}",
+                "summary": "Execute a mock tool (provider webhook)",
                 "parameters": [
                     {
                         "in": "path",
@@ -13498,6 +13664,7 @@
                         "api_key": []
                     }
                 ],
+                "deprecated": true,
                 "responses": {
                     "201": {
                         "description": "No response body"
@@ -13585,6 +13752,7 @@
                         "api_key": []
                     }
                 ],
+                "deprecated": true,
                 "responses": {
                     "200": {
                         "content": {
@@ -13633,7 +13801,7 @@
             },
             "delete": {
                 "operationId": "aiagents-tool-destroy",
-                "description": "⚠ Irreversible. Detaches the named tool from this agent by marking it deleted. The tool definition is not deleted — other agents referencing the same tool_name are unaffected.",
+                "description": "Detaches the named tool from this agent by marking it deleted. The tool definition is not deleted — other agents referencing the same tool_name are unaffected.",
                 "summary": "Remove a tool from an agent",
                 "parameters": [
                     {
@@ -13662,6 +13830,7 @@
                         "api_key": []
                     }
                 ],
+                "deprecated": true,
                 "responses": {
                     "204": {
                         "description": "No response body"
@@ -13708,6 +13877,7 @@
                         "api_key": []
                     }
                 ],
+                "deprecated": true,
                 "responses": {
                     "200": {
                         "content": {
@@ -13801,6 +13971,7 @@
                         "api_key": []
                     }
                 ],
+                "deprecated": true,
                 "responses": {
                     "201": {
                         "content": {
@@ -13909,6 +14080,7 @@
                         "api_key": []
                     }
                 ],
+                "deprecated": true,
                 "responses": {
                     "200": {
                         "content": {
@@ -13973,6 +14145,7 @@
                         "api_key": []
                     }
                 ],
+                "deprecated": true,
                 "responses": {
                     "200": {
                         "content": {
@@ -14040,6 +14213,7 @@
                         "api_key": []
                     }
                 ],
+                "deprecated": true,
                 "responses": {
                     "202": {
                         "content": {
@@ -14096,6 +14270,7 @@
                         "api_key": []
                     }
                 ],
+                "deprecated": true,
                 "responses": {
                     "200": {
                         "content": {
@@ -14163,6 +14338,7 @@
                         "api_key": []
                     }
                 ],
+                "deprecated": true,
                 "responses": {
                     "202": {
                         "content": {
@@ -14219,6 +14395,7 @@
                         "api_key": []
                     }
                 ],
+                "deprecated": true,
                 "responses": {
                     "200": {
                         "content": {
@@ -14267,6 +14444,7 @@
                         "api_key": []
                     }
                 ],
+                "deprecated": true,
                 "responses": {
                     "200": {
                         "content": {
@@ -14806,6 +14984,113 @@
                 }
             }
         },
+        "/test_framework/v1/aiagents/{id}/history/": {
+            "get": {
+                "operationId": "aiagents-v1-history-list",
+                "description": "Paginated version history for an agent: name/language/description plus the mock\ntools, dynamic variables, and knowledge base files active at each version.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this ai agent.",
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "page",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "page_size",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedAIAgentHistoryList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/aiagents/{id}/history/edit/": {
+            "patch": {
+                "operationId": "aiagents-v1-history-edit-partial-update",
+                "description": "Aiagents v1 history edit",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this ai agent.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedAIAgentEditHistoryRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedAIAgentEditHistoryRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedAIAgentEditHistoryRequest"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AIAgentHistory"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/test_framework/v1/aiagents/{id}/knowledge_base/": {
             "get": {
                 "operationId": "aiagents-v1-knowledge-base-list",
@@ -14905,6 +15190,63 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/AIAgent"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/aiagents/{id}/restore/": {
+            "post": {
+                "operationId": "aiagents-v1-restore-create",
+                "description": "Restore an agent to a previous version, creating a new version for the restore.\n\nRestores the versioned concrete fields (name, language, description) and the related\ncollections: tools and dynamic variables are reverted in place to their\nlinked versions (ids preserved) and any not in the version are soft-deleted; knowledge\nbase files referenced by the version are reactivated and the rest soft-deleted.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this ai agent.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AIAgentRestoreRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AIAgentRestoreRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AIAgentRestoreRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AIAgentV2"
                                 }
                             }
                         },
@@ -40522,6 +40864,113 @@
                 }
             }
         },
+        "/test_framework/v2/aiagents/{id}/history/": {
+            "get": {
+                "operationId": "aiagents-history-list",
+                "description": "Paginated version history for an agent: name/language/description plus the mock\ntools, dynamic variables, and knowledge base files active at each version.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this ai agent.",
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "page",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "page_size",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedAIAgentHistoryList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/aiagents/{id}/history/edit/": {
+            "patch": {
+                "operationId": "aiagents-history-edit-partial-update",
+                "description": "Aiagents history edit",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this ai agent.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedAIAgentEditHistoryRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedAIAgentEditHistoryRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedAIAgentEditHistoryRequest"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AIAgentHistory"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/test_framework/v2/aiagents/{id}/knowledge_base/": {
             "get": {
                 "operationId": "aiagents-knowledge-base-list",
@@ -40652,6 +41101,63 @@
                         "enabled": true,
                         "name": "aiagents-personalities-list",
                         "description": "List the caller/tester personalities available to this agent's project. Filter with query params: type, language, enabled_only=true (only the personalities currently enabled for the project)."
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/aiagents/{id}/restore/": {
+            "post": {
+                "operationId": "aiagents-restore-create",
+                "description": "Restore an agent to a previous version, creating a new version for the restore.\n\nRestores the versioned concrete fields (name, language, description) and the related\ncollections: tools and dynamic variables are reverted in place to their\nlinked versions (ids preserved) and any not in the version are soft-deleted; knowledge\nbase files referenced by the version are reactivated and the rest soft-deleted.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this ai agent.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AIAgentRestoreRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AIAgentRestoreRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AIAgentRestoreRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AIAgentV2"
+                                }
+                            }
+                        },
+                        "description": ""
                     }
                 }
             }
@@ -50834,6 +51340,144 @@
                     "name"
                 ]
             },
+            "AIAgentHistory": {
+                "type": "object",
+                "description": "A single AIAgent version: versioned concrete fields + resolved related collections.\n\nManifests store child ``history_id`` lists (tools/dynamic vars) and uploaded-file ids\n(kb). The values are resolved on read. Use ``build_context()`` to batch the resolution\nacross a page of records and pass it as the serializer context (avoids N+1).",
+                "properties": {
+                    "history_id": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "history_date": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "history_type": {
+                        "enum": [
+                            "+",
+                            "~",
+                            "-"
+                        ],
+                        "type": "string",
+                        "description": "* `+` - Created\n* `~` - Changed\n* `-` - Deleted",
+                        "x-spec-enum-id": "c2e35addebb4f5da"
+                    },
+                    "history_change_reason": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "maxLength": 100
+                    },
+                    "history_user": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/UserInline"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "readOnly": true
+                    },
+                    "version_id": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "maxLength": 12
+                    },
+                    "version_name": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "maxLength": 255
+                    },
+                    "id": {
+                        "type": "integer",
+                        "maximum": 9223372036854775807,
+                        "minimum": -9223372036854775808,
+                        "format": "int64"
+                    },
+                    "agent_name": {
+                        "type": "string",
+                        "description": "Name of the AI agent.\nExample: `\"Customer Service Bot\"` or `\"Sales Assistant\"`",
+                        "maxLength": 255
+                    },
+                    "language": {
+                        "enum": [
+                            "af",
+                            "ar",
+                            "bn",
+                            "bg",
+                            "zh",
+                            "cs",
+                            "da",
+                            "nl",
+                            "en",
+                            "et",
+                            "fi",
+                            "fr",
+                            "de",
+                            "el",
+                            "gu",
+                            "hi",
+                            "he",
+                            "hu",
+                            "id",
+                            "it",
+                            "ja",
+                            "kn",
+                            "ko",
+                            "ms",
+                            "ml",
+                            "mr",
+                            "multi",
+                            "no",
+                            "pl",
+                            "pa",
+                            "pt",
+                            "ro",
+                            "ru",
+                            "sk",
+                            "es",
+                            "sv",
+                            "th",
+                            "tr",
+                            "tl",
+                            "ta",
+                            "te",
+                            "uk",
+                            "vi"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "b822ad429c7b7fec",
+                        "description": "Primary language for this agent.\nExample: `\"en\"` or `\"es\"`\n\n* `af` - Afrikaans\n* `ar` - Arabic\n* `bn` - Bengali\n* `bg` - Bulgarian\n* `zh` - Chinese Simplified\n* `cs` - Czech\n* `da` - Danish\n* `nl` - Dutch\n* `en` - English\n* `et` - Estonian\n* `fi` - Finnish\n* `fr` - French\n* `de` - German\n* `el` - Greek\n* `gu` - Gujarati\n* `hi` - Hindi\n* `he` - Hebrew\n* `hu` - Hungarian\n* `id` - Indonesian\n* `it` - Italian\n* `ja` - Japanese\n* `kn` - Kannada\n* `ko` - Korean\n* `ms` - Malay\n* `ml` - Malayalam\n* `mr` - Marathi\n* `multi` - Multilingual\n* `no` - Norwegian\n* `pl` - Polish\n* `pa` - Punjabi\n* `pt` - Portuguese\n* `ro` - Romanian\n* `ru` - Russian\n* `sk` - Slovak\n* `es` - Spanish\n* `sv` - Swedish\n* `th` - Thai\n* `tr` - Turkish\n* `tl` - Tagalog\n* `ta` - Tamil\n* `te` - Telugu\n* `uk` - Ukrainian\n* `vi` - Vietnamese"
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Description of the agent's purpose and capabilities.\nExample: `\"AI agent for handling customer support inquiries and resolving technical issues\"`"
+                    },
+                    "mock_tools": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "dynamic_variables": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "knowledge_base_files": {
+                        "type": "string",
+                        "readOnly": true
+                    }
+                },
+                "required": [
+                    "agent_name",
+                    "history_date",
+                    "history_type"
+                ]
+            },
             "AIAgentList": {
                 "type": "object",
                 "properties": {
@@ -50942,6 +51586,17 @@
                 "required": [
                     "agent_name",
                     "organization"
+                ]
+            },
+            "AIAgentRestoreRequest": {
+                "type": "object",
+                "properties": {
+                    "history_id": {
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "history_id"
                 ]
             },
             "AIAgentTestProfile": {
@@ -58365,6 +59020,37 @@
                     "price"
                 ]
             },
+            "PaginatedAIAgentHistoryList": {
+                "type": "object",
+                "required": [
+                    "count",
+                    "results"
+                ],
+                "properties": {
+                    "count": {
+                        "type": "integer",
+                        "example": 123
+                    },
+                    "next": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "https://api.cekura.ai/example/v1/example-external/?page=4"
+                    },
+                    "previous": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "https://api.cekura.ai/example/v1/example-external/?page=3"
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/AIAgentHistory"
+                        }
+                    }
+                }
+            },
             "PaginatedAIAgentList": {
                 "type": "object",
                 "required": [
@@ -59103,6 +59789,20 @@
                         "type": "string",
                         "format": "date-time",
                         "readOnly": true
+                    }
+                }
+            },
+            "PatchedAIAgentEditHistoryRequest": {
+                "type": "object",
+                "properties": {
+                    "history_id": {
+                        "type": "integer"
+                    },
+                    "version_name": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
                     }
                 }
             },
@@ -60956,6 +61656,11 @@
                         "readOnly": true,
                         "description": "Name of the agent associated with this result"
                     },
+                    "agent_version": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "The agent version (history record) this result ran against, or null."
+                    },
                     "status": {
                         "enum": [
                             "running",
@@ -61195,6 +61900,15 @@
                         "readOnly": true,
                         "description": "ID of the agent associated with this run"
                     },
+                    "agent_version": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ExpectedOutcome"
+                            }
+                        ],
+                        "readOnly": true,
+                        "description": "The agent version (history record) this run's result ran against, or null."
+                    },
                     "result_id": {
                         "type": "integer",
                         "readOnly": true
@@ -61209,11 +61923,7 @@
                         "readOnly": true
                     },
                     "expected_outcome": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ExpectedOutcome"
-                            }
-                        ],
+                        "type": "string",
                         "readOnly": true
                     },
                     "evaluation": {
@@ -64592,6 +65302,11 @@
                         "readOnly": true,
                         "description": "Run Execution Type"
                     },
+                    "agent_version": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "The agent version (history record) this result ran against, or null."
+                    },
                     "created_at": {
                         "type": "string",
                         "format": "date-time",
@@ -64628,6 +65343,11 @@
                         "type": "string",
                         "readOnly": true,
                         "description": "Name of the agent associated with this result"
+                    },
+                    "agent_version": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "The agent version (history record) this result ran against, or null."
                     },
                     "status": {
                         "enum": [
@@ -64941,6 +65661,15 @@
                         "readOnly": true,
                         "description": "ID of the agent associated with this run"
                     },
+                    "agent_version": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ExpectedOutcome"
+                            }
+                        ],
+                        "readOnly": true,
+                        "description": "The agent version (history record) this run's result ran against, or null."
+                    },
                     "result_id": {
                         "type": "integer",
                         "readOnly": true
@@ -64955,11 +65684,7 @@
                         "readOnly": true
                     },
                     "expected_outcome": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ExpectedOutcome"
-                            }
-                        ],
+                        "type": "string",
                         "readOnly": true
                     },
                     "evaluation": {
@@ -65294,6 +66019,11 @@
                         ],
                         "readOnly": true,
                         "description": "Run Execution Type"
+                    },
+                    "agent_version": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "The agent version (history record) this run's result ran against, or null."
                     }
                 }
             },
@@ -65779,8 +66509,13 @@
                         "description": "REMOVED FROM API. Reads return the historical value for legacy rows (`null` for new rows). Writes are no longer accepted — supplying a non-null value yields a 400 error. Put dynamic-variable values in `test_profile_data.information.main_agent_variables` instead: create the test profile via POST /test-profiles/ and attach it via the `test_profile` field on the scenario."
                     },
                     "generated_mock_tool_entries": {
-                        "readOnly": true,
-                        "description": "Expected mock tool calls generated for this evaluator during scenario auto-generation when the agent has mock tools attached. Each entry has shape {tool_id, tool_name, new_entry: {input, output}}."
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Expected mock tool calls for this evaluator. Each entry has shape {tool_id, tool_name, new_entry: {input, output}}. Auto-generated during scenario generation when the agent has mock tools attached; can also be set or edited manually."
                     },
                     "folder_path": {
                         "type": [
@@ -66255,6 +66990,15 @@
                             "integer",
                             "null"
                         ]
+                    },
+                    "generated_mock_tool_entries": {
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Mock tool data generated for this scenario. Format: [{tool_id, tool_name, new_entry: {input, output}}]. Stored for evaluation and debugging purposes."
                     }
                 },
                 "required": [
@@ -66871,8 +67615,13 @@
                         "description": "REMOVED FROM API. Reads return the historical value for legacy rows (`null` for new rows). Writes are no longer accepted — supplying a non-null value yields a 400 error. Put dynamic-variable values in `test_profile_data.information.main_agent_variables` instead: create the test profile via POST /test-profiles/ and attach it via the `test_profile` field on the scenario."
                     },
                     "generated_mock_tool_entries": {
-                        "readOnly": true,
-                        "description": "Expected mock tool calls generated for this evaluator during scenario auto-generation when the agent has mock tools attached. Each entry has shape {tool_id, tool_name, new_entry: {input, output}}."
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Expected mock tool calls for this evaluator. Each entry has shape {tool_id, tool_name, new_entry: {input, output}}. Auto-generated during scenario generation when the agent has mock tools attached; can also be set or edited manually."
                     },
                     "folder_path": {
                         "type": [
@@ -68750,8 +69499,13 @@
                         "description": "REMOVED FROM API. Reads return the historical value for legacy rows (`null` for new rows). Writes are no longer accepted — supplying a non-null value yields a 400 error. Put dynamic-variable values in `test_profile_data.information.main_agent_variables` instead: create the test profile via POST /test-profiles/ and attach it via the `test_profile` field on the scenario."
                     },
                     "generated_mock_tool_entries": {
-                        "readOnly": true,
-                        "description": "Expected mock tool calls generated for this evaluator during scenario auto-generation when the agent has mock tools attached. Each entry has shape {tool_id, tool_name, new_entry: {input, output}}."
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Expected mock tool calls for this evaluator. Each entry has shape {tool_id, tool_name, new_entry: {input, output}}. Auto-generated during scenario generation when the agent has mock tools attached; can also be set or edited manually."
                     },
                     "folder_path": {
                         "type": [

--- a/openapi.json
+++ b/openapi.json
@@ -6622,6 +6622,63 @@
                 }
             }
         },
+        "/observability/v1/metric-failure-mode-insights/{id}/fix-metric/": {
+            "post": {
+                "operationId": "metric-failure-mode-insights-fix-metric-create",
+                "description": "Add a sample of one failure mode's example calls to Labs.\n\nThe metric flagged these calls as failing; the user supplies feedback\nexplaining why and a corrected ``expected_value`` (the label these\ncalls should carry). We sample 2-3 of the mode's example calls and\ncreate a Labs metric review for each — expected value pinned to the\nuser's label, the feedback as the human note — so the metric can be\niterated on against them. When no label is sent we default to a pass.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric failure mode insight.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "observability"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricFailureModeFixMetric"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricFailureModeFixMetric"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricFailureModeFixMetric"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricFailureModeFixMetric"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/observability/v1/metric-failure-mode-insights/{id}/generate-scenario/": {
             "post": {
                 "operationId": "metric-failure-mode-insights-generate-scenario-create",
@@ -56071,6 +56128,34 @@
                 },
                 "required": [
                     "name"
+                ]
+            },
+            "MetricFailureModeFixMetric": {
+                "type": "object",
+                "description": "Request body for ``POST /metric-failure-mode-insights/{id}/fix_metric/``.\n\nSamples a few of one failure mode's example calls and adds them to Labs\nfor the insight's metric, carrying the user's feedback as the note and\n``expected_value`` as the corrected label.",
+                "properties": {
+                    "failure_mode_index": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "Index into the insight's failure_modes list to act on."
+                    },
+                    "feedback": {
+                        "type": "string",
+                        "description": "Human note attached to each sampled call's metric review in Labs."
+                    },
+                    "expected_value": {
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Corrected label to record for each sampled call in Labs: true/false for binary metrics, a 0-5 score for ratings, a number for numeric metrics, or null for N/A. Defaults to a passing value when omitted."
+                    }
+                },
+                "required": [
+                    "failure_mode_index",
+                    "feedback"
                 ]
             },
             "MetricFailureModeInsight": {


### PR DESCRIPTION
Auto-generated docs sync for backend PR [#9699](https://github.com/cekura-ai/vocera.backend/pull/9699).

Reviewers: @dileep-chagam, @atulcekura

## Summary

**Spec/overlay:** Spec regenerated post-merge. No MCP-exposed operations were added, removed, or modified. The PR adds trace_id propagation support for CUSTOM provider webhooks (internal observability feature). 13 unrelated operations flagged by spec diff but skipped (not related to PR changes, no user-facing MCP signal).

**Conceptual docs:** Updated documentation/integrations/custom-integration.mdx to document the new optional trace_id field that enables OpenTelemetry trace correlation for custom provider webhooks.

## Changes

- `openapi.json` — regenerate_from_backend
- `documentation/integrations/custom-integration.mdx` — update

---
*Auto-generated from backend PR #9699.*

<!-- mcp-sync:file-hashes -->
```json
{
  "documentation/integrations/custom-integration.mdx": "94e407e97c9c61d6929d0b134a5dfbb6e80ead6b16cb0224de69b44e498df43b"
}
```
<!-- /mcp-sync:file-hashes -->