### PR TITLE
docs: add Interruption Score and Unnecessary Repetition Score predefined metrics

### DIFF
--- a/documentation/key-concepts/metrics/pre-defined-metrics.mdx
+++ b/documentation/key-concepts/metrics/pre-defined-metrics.mdx
@@ -165,6 +165,14 @@ These metrics evaluate the flow and dynamics of the conversation.
     **Interpretation**: High counts may indicate Testing Agent frustration, Main Agent speaking too long, or poor turn-taking.
   </Accordion>
 
+  <Accordion title="Interruption Score">
+    **Result**: Score (0-5, shown as a percentage on the Results page) | **Cost**: 0 credits
+
+    Normalizes how often the Main Agent interrupts the Testing Agent against the number of turns: `5 * (1 - interruptions / turns)`, clamped to 0-5. Uses VAD on stereo audio where available, otherwise transcript analysis. The Results page shows it as a percentage of the 5-point maximum (e.g. 5.0 → 100%).
+
+    **Interpretation**: Higher is better. 5 (100%) means no interruptions; lower scores indicate the Main Agent increasingly talks over the Testing Agent.
+  </Accordion>
+
   <Accordion title="Latency (in ms)">
     **Result**: Numeric (average milliseconds) | **Cost**: 0 credits
 
@@ -181,6 +189,14 @@ These metrics evaluate the flow and dynamics of the conversation.
     Identifies instances where the Main Agent unnecessarily repeated information it had already provided. An LLM analyzes the conversation for redundant statements.
 
     **Interpretation**: Lower is better. Repetition wastes time and can frustrate the Testing Agent.
+  </Accordion>
+
+  <Accordion title="Unnecessary Repetition Score">
+    **Result**: Score (0-5) | **Cost**: 0.2 credits per call
+
+    The 0-5 score companion to **Unnecessary Repetition Count**, normalizing repetitions against the number of turns: `5 * (1 - repetitions / turns)`, clamped to 0-5. An LLM flags when the Main Agent re-confirms the same, unchanged information two or more times.
+
+    **Interpretation**: Higher is better. 5 means no unnecessary repetition; lower scores mean the agent keeps re-confirming the same information.
   </Accordion>
 
   <Accordion title="Verbosity">


### PR DESCRIPTION
Adds two predefined **Conversation Quality** metric entries that were missing from the Pre-defined Metrics page:

- **Interruption Score** — Score (0-5, shown as a percentage on the Results page); 0 credits. Normalizes the interruption count against turns: `5 * (1 - interruptions / turns)`. Uses VAD on stereo audio where available, otherwise transcript analysis.
- **Unnecessary Repetition Score** — Score (0-5); 0.2 credits per call. The score companion to the existing **Unnecessary Repetition Count**.

Both are placed beside their sibling metrics under **Conversation Quality Metrics**, matching the existing accordion format. Result ranges, scoring formulas, and credit costs were sourced from the backend implementation (`test_framework/metric_functions.py`) and confirmed with the team.

🤖 Generated with [Claude Code](https://claude.com/claude-code)