### PR TITLE
[CEK-7843] Add async create-from-transcript endpoints, deprecate old

### DIFF
--- a/api-reference/test_framework/create-evaluator-from-transcript-bg.mdx
+++ b/api-reference/test_framework/create-evaluator-from-transcript-bg.mdx
@@ -1,5 +1,5 @@
 ---
-title: Create Evaluator from Transcript (Async)
+title: Create Evaluator from Transcript
 description: "Create a test scenario from a call transcript in the background"
 openapi: post /test_framework/v1/scenarios/create-from-transcript-bg/
 ---

--- a/api-reference/test_framework/create-evaluator-from-transcript-bg.mdx
+++ b/api-reference/test_framework/create-evaluator-from-transcript-bg.mdx
@@ -1,0 +1,5 @@
+---
+title: Create Evaluator from Transcript (Async)
+description: "Create a test scenario from a call transcript in the background"
+openapi: post /test_framework/v1/scenarios/create-from-transcript-bg/
+---

--- a/api-reference/test_framework/create-evaluator-from-transcript-progress.mdx
+++ b/api-reference/test_framework/create-evaluator-from-transcript-progress.mdx
@@ -1,0 +1,5 @@
+---
+title: Get Create-from-Transcript Progress
+description: "Poll progress of a transcript-based evaluator creation"
+openapi: get /test_framework/v1/scenarios/create-from-transcript-progress/
+---

--- a/api-reference/test_framework/create-evaluator-from-transcript.mdx
+++ b/api-reference/test_framework/create-evaluator-from-transcript.mdx
@@ -1,0 +1,13 @@
+---
+title: Create Evaluator from Transcript (Deprecated)
+description: "Deprecated — use the async endpoint instead. Create a test scenario from a call transcript."
+openapi: post /test_framework/v1/scenarios/create_scenario_from_transcript/
+slug: create-evaluator-from-transcript
+deprecated: true
+---
+
+<Warning>
+  This endpoint is deprecated and will be removed. Please migrate to the async
+  version: [Create Evaluator from Transcript (Async)](/api-reference/test_framework/create-evaluator-from-transcript-bg)
+  and poll [Get Create-from-Transcript Progress](/api-reference/test_framework/create-evaluator-from-transcript-progress).
+</Warning>

--- a/api-reference/test_framework/create-evaluator-from-transcript.mdx
+++ b/api-reference/test_framework/create-evaluator-from-transcript.mdx
@@ -1,6 +1,0 @@
----
-title: Create Evaluator from Transcript
-description: "Create a test scenario from a call transcript"
-openapi: post /test_framework/v1/scenarios/create_scenario_from_transcript/
-slug: create-evaluator-from-transcript
----

--- a/mint.json
+++ b/mint.json
@@ -313,7 +313,8 @@
             "api-reference/test_framework/run-evaluator-sip",
             "api-reference/test_framework/bulk-update-scenarios",
             "api-reference/test_framework/bulk-delete-scenarios",
-            "api-reference/test_framework/create-evaluator-from-transcript",
+            "api-reference/test_framework/create-evaluator-from-transcript-bg",
+            "api-reference/test_framework/create-evaluator-from-transcript-progress",
             "api-reference/schedules/create-cronjob",
             {
               "group": "Improve Evaluators",

--- a/mint.json
+++ b/mint.json
@@ -315,6 +315,7 @@
             "api-reference/test_framework/bulk-delete-scenarios",
             "api-reference/test_framework/create-evaluator-from-transcript-bg",
             "api-reference/test_framework/create-evaluator-from-transcript-progress",
+            "api-reference/test_framework/create-evaluator-from-transcript",
             "api-reference/schedules/create-cronjob",
             {
               "group": "Improve Evaluators",

--- a/openapi.json
+++ b/openapi.json
@@ -6622,6 +6622,63 @@
                 }
             }
         },
+        "/observability/v1/metric-failure-mode-insights/{id}/fix-metric/": {
+            "post": {
+                "operationId": "metric-failure-mode-insights-fix-metric-create",
+                "description": "Add a sample of one failure mode's example calls to Labs.\n\nThe metric flagged these calls as failing; the user supplies feedback\nexplaining why and a corrected ``expected_value`` (the label these\ncalls should carry). We sample 2-3 of the mode's example calls and\ncreate a Labs metric review for each — expected value pinned to the\nuser's label, the feedback as the human note — so the metric can be\niterated on against them. When no label is sent we default to a pass.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this metric failure mode insight.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "observability"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricFailureModeFixMetric"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricFailureModeFixMetric"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricFailureModeFixMetric"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricFailureModeFixMetric"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/observability/v1/metric-failure-mode-insights/{id}/generate-scenario/": {
             "post": {
                 "operationId": "metric-failure-mode-insights-generate-scenario-create",
@@ -8627,6 +8684,43 @@
                     }
                 },
                 "description": "Slack slack workspaces get channels"
+            }
+        },
+        "/slack/slack-workspaces/{id}/members/": {
+            "get": {
+                "operationId": "slack-slack-workspaces-members-retrieve",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this slack workspace.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "slack"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SlackWorkspace"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "description": "Slack slack workspaces members"
             }
         },
         "/slack/slack-workspaces/{id}/verify/": {
@@ -12007,7 +12101,7 @@
             },
             "delete": {
                 "operationId": "dynamic-variables-destroy",
-                "description": "Permanently deletes a single dynamic variable definition. ⚠ Irreversible.",
+                "description": "Soft-deletes a single dynamic variable definition by ID.",
                 "summary": "Delete a dynamic variable definition",
                 "parameters": [
                     {
@@ -12241,6 +12335,7 @@
                         "api_key": []
                     }
                 ],
+                "deprecated": true,
                 "responses": {
                     "200": {
                         "content": {
@@ -12289,6 +12384,7 @@
             "post": {
                 "operationId": "aiagents-tool-create",
                 "description": "Execute tool by matching input and returning corresponding output.\n\nSupports two payload formats:\n1. Flat input (default): {\"param1\": \"value1\", \"param2\": \"value2\"}\n2. VAPI function format: {\"message\": {\"type\": \"tool-calls\", \"toolCallList\": [{\"id\": \"...\", \"arguments\": {...}}]}}",
+                "summary": "Execute a mock tool (provider webhook)",
                 "parameters": [
                     {
                         "in": "path",
@@ -12316,6 +12412,7 @@
                         "api_key": []
                     }
                 ],
+                "deprecated": true,
                 "responses": {
                     "201": {
                         "description": "No response body"
@@ -12403,6 +12500,7 @@
                         "api_key": []
                     }
                 ],
+                "deprecated": true,
                 "responses": {
                     "200": {
                         "content": {
@@ -12451,7 +12549,7 @@
             },
             "delete": {
                 "operationId": "aiagents-tool-destroy",
-                "description": "⚠ Irreversible. Detaches the named tool from this agent by marking it deleted. The tool definition is not deleted — other agents referencing the same tool_name are unaffected.",
+                "description": "Detaches the named tool from this agent by marking it deleted. The tool definition is not deleted — other agents referencing the same tool_name are unaffected.",
                 "summary": "Remove a tool from an agent",
                 "parameters": [
                     {
@@ -12480,6 +12578,7 @@
                         "api_key": []
                     }
                 ],
+                "deprecated": true,
                 "responses": {
                     "204": {
                         "description": "No response body"
@@ -12526,6 +12625,7 @@
                         "api_key": []
                     }
                 ],
+                "deprecated": true,
                 "responses": {
                     "200": {
                         "content": {
@@ -12619,6 +12719,7 @@
                         "api_key": []
                     }
                 ],
+                "deprecated": true,
                 "responses": {
                     "201": {
                         "content": {
@@ -12727,6 +12828,7 @@
                         "api_key": []
                     }
                 ],
+                "deprecated": true,
                 "responses": {
                     "200": {
                         "content": {
@@ -12791,6 +12893,7 @@
                         "api_key": []
                     }
                 ],
+                "deprecated": true,
                 "responses": {
                     "200": {
                         "content": {
@@ -12858,6 +12961,7 @@
                         "api_key": []
                     }
                 ],
+                "deprecated": true,
                 "responses": {
                     "202": {
                         "content": {
@@ -12914,6 +13018,7 @@
                         "api_key": []
                     }
                 ],
+                "deprecated": true,
                 "responses": {
                     "200": {
                         "content": {
@@ -12981,6 +13086,7 @@
                         "api_key": []
                     }
                 ],
+                "deprecated": true,
                 "responses": {
                     "202": {
                         "content": {
@@ -13037,6 +13143,7 @@
                         "api_key": []
                     }
                 ],
+                "deprecated": true,
                 "responses": {
                     "200": {
                         "content": {
@@ -13085,6 +13192,7 @@
                         "api_key": []
                     }
                 ],
+                "deprecated": true,
                 "responses": {
                     "200": {
                         "content": {
@@ -13624,6 +13732,113 @@
                 }
             }
         },
+        "/test_framework/v1/aiagents/{id}/history/": {
+            "get": {
+                "operationId": "aiagents-v1-history-list",
+                "description": "Paginated version history for an agent: name/language/description plus the mock\ntools, dynamic variables, and knowledge base files active at each version.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this ai agent.",
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "page",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "page_size",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedAIAgentHistoryList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/aiagents/{id}/history/edit/": {
+            "patch": {
+                "operationId": "aiagents-v1-history-edit-partial-update",
+                "description": "Edit metadata (e.g. version name) on a specific agent version.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this ai agent.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedAIAgentEditHistoryRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedAIAgentEditHistoryRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedAIAgentEditHistoryRequest"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AIAgentHistory"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/test_framework/v1/aiagents/{id}/knowledge_base/": {
             "get": {
                 "operationId": "aiagents-v1-knowledge-base-list",
@@ -13731,6 +13946,63 @@
                 }
             }
         },
+        "/test_framework/v1/aiagents/{id}/restore/": {
+            "post": {
+                "operationId": "aiagents-v1-restore-create",
+                "description": "Restore an agent to a previous version, creating a new version for the restore.\n\nRestores the versioned concrete fields (name, language, description) and the related\ncollections: tools and dynamic variables are reverted in place to their\nlinked versions (ids preserved) and any not in the version are soft-deleted; knowledge\nbase files referenced by the version are reactivated and the rest soft-deleted.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this ai agent.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AIAgentRestoreRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AIAgentRestoreRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AIAgentRestoreRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AIAgentV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/test_framework/v1/aiagents/{id}/runs_overview/": {
             "get": {
                 "operationId": "aiagents-v1-runs-overview-retrieve",
@@ -13770,7 +14042,7 @@
         },
         "/test_framework/v1/aiagents/{id}/upload_knowledge_base/": {
             "post": {
-                "operationId": "aiagents-upload-knowledge-base_2",
+                "operationId": "aiagents-upload-knowledge-base",
                 "description": "Upload one or more files to the agent's knowledge base. Accepts either a `multipart/form-data` body (used by the web dashboard) or an `application/json` body where each entry carries base64-encoded file content.",
                 "parameters": [
                     {
@@ -28237,6 +28509,155 @@
                 }
             }
         },
+        "/test_framework/v1/scenarios-external/create-from-transcript-bg/": {
+            "post": {
+                "operationId": "scenarios-create-from-transcript-bg",
+                "description": "Create a new evaluator from a call transcript in the background. Returns a `progress_id` immediately; poll GET /scenarios/create-from-transcript-progress/?progress_id={id} until `status` is `completed` or `failed`.\n\nAnalyzes the transcript to extract caller behavior, expected outcomes, and conversation flow.\n\n**Response fields:** `progress_id` (UUID string) for polling.",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostSimulateScenario"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostSimulateScenario"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostSimulateScenario"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "progress_id": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/scenarios-external/create-from-transcript-progress/": {
+            "get": {
+                "operationId": "scenarios-create-from-transcript-progress",
+                "description": "Scenarios create from transcript progress",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "progress_id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "UUID progress identifier returned from create-from-transcript-bg endpoint",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "agent_id": {
+                                            "type": "integer"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "in_progress",
+                                                "completed",
+                                                "failed"
+                                            ]
+                                        },
+                                        "scenario_id": {
+                                            "type": "integer",
+                                            "nullable": true
+                                        },
+                                        "error": {
+                                            "type": "string",
+                                            "nullable": true
+                                        },
+                                        "scenario": {
+                                            "type": "object",
+                                            "nullable": true
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/test_framework/v1/scenarios-external/create_folder/": {
             "post": {
                 "operationId": "scenarios-folder-create",
@@ -28275,70 +28696,6 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/ScenarioFolder"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
-        },
-        "/test_framework/v1/scenarios-external/create_scenario_from_transcript/": {
-            "post": {
-                "operationId": "scenarios-create-from-transcript",
-                "description": "Create a new evaluator from a call transcript. Analyzes the transcript to extract caller behavior, expected outcomes, and conversation flow.\n\n**`transcript_json` format:** array of message objects. Each object requires:\n- `role` — must be one of: `\"Main Agent\"`, `\"Testing Agent\"`, `\"Function Call\"`, `\"Function Call Result\"`\n- `content` — the message text\n- `start_time` (optional) — seconds from call start as a float\n\nNote: this endpoint accepts only the above role names. The role names used in the observability transcript ingestion API (\"agent\", \"user\", etc.) are not valid here.\n\nExample `transcript_json`:\n```json\n[\n  {\"role\": \"Main Agent\", \"content\": \"Hello, how can I help?\", \"start_time\": 0.0},\n  {\"role\": \"Testing Agent\", \"content\": \"I need to reschedule.\", \"start_time\": 2.1},\n  {\"role\": \"Main Agent\", \"content\": \"Sure, what date works?\", \"start_time\": 3.5}\n]\n```\n\n**Agent lookup:** the `agent` field looks up agents scoped to the project associated with your API key. If the agent belongs to a different project, use `assistant_id` instead, which searches across all agents in your organization.",
-                "tags": [
-                    "test_framework"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/SchemaPostSimulateScenario"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/SchemaPostSimulateScenario"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/SchemaPostSimulateScenario"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ScenarioList"
-                                }
-                            }
-                        },
-                        "description": ""
-                    },
-                    "400": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "field_name": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
                                 }
                             }
                         },
@@ -32950,6 +33307,171 @@
                 }
             }
         },
+        "/test_framework/v1/scenarios/create-from-transcript-bg/": {
+            "post": {
+                "operationId": "scenarios-create-from-transcript-bg_2",
+                "description": "Create a new evaluator from a call transcript in the background. Returns a `progress_id` immediately; poll GET /scenarios/create-from-transcript-progress/?progress_id={id} until `status` is `completed` or `failed`.\n\nAnalyzes the transcript to extract caller behavior, expected outcomes, and conversation flow.\n\n**Response fields:** `progress_id` (UUID string) for polling.",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostSimulateScenario"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostSimulateScenario"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostSimulateScenario"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "progress_id": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "scenarios-create-from-transcript-bg",
+                        "description": "Create a new evaluator from a call transcript in the background. Returns a `progress_id` immediately; poll GET /scenarios/create-from-transcript-progress/?progress_id={id} until `status` is `completed` or `failed`.\n\nAnalyzes the transcript to extract caller behavior, expected outcomes, and conversation flow.\n\n**Response fields:** `progress_id` (UUID string) for polling."
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/scenarios/create-from-transcript-progress/": {
+            "get": {
+                "operationId": "scenarios-create-from-transcript-progress_2",
+                "description": "Scenarios create from transcript progress",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "progress_id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "UUID progress identifier returned from create-from-transcript-bg endpoint",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "agent_id": {
+                                            "type": "integer"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "in_progress",
+                                                "completed",
+                                                "failed"
+                                            ]
+                                        },
+                                        "scenario_id": {
+                                            "type": "integer",
+                                            "nullable": true
+                                        },
+                                        "error": {
+                                            "type": "string",
+                                            "nullable": true
+                                        },
+                                        "scenario": {
+                                            "type": "object",
+                                            "nullable": true
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "scenarios-create-from-transcript-progress",
+                        "description": "Scenarios create from transcript progress"
+                    }
+                }
+            }
+        },
         "/test_framework/v1/scenarios/create_folder/": {
             "post": {
                 "operationId": "scenarios-folder-create_2",
@@ -33000,78 +33522,6 @@
                         "enabled": true,
                         "name": "scenarios-folder-create",
                         "description": "Scenarios folder"
-                    }
-                }
-            }
-        },
-        "/test_framework/v1/scenarios/create_scenario_from_transcript/": {
-            "post": {
-                "operationId": "scenarios-create-from-transcript_2",
-                "description": "Create a new evaluator from a call transcript. Analyzes the transcript to extract caller behavior, expected outcomes, and conversation flow.\n\n**`transcript_json` format:** array of message objects. Each object requires:\n- `role` — must be one of: `\"Main Agent\"`, `\"Testing Agent\"`, `\"Function Call\"`, `\"Function Call Result\"`\n- `content` — the message text\n- `start_time` (optional) — seconds from call start as a float\n\nNote: this endpoint accepts only the above role names. The role names used in the observability transcript ingestion API (\"agent\", \"user\", etc.) are not valid here.\n\nExample `transcript_json`:\n```json\n[\n  {\"role\": \"Main Agent\", \"content\": \"Hello, how can I help?\", \"start_time\": 0.0},\n  {\"role\": \"Testing Agent\", \"content\": \"I need to reschedule.\", \"start_time\": 2.1},\n  {\"role\": \"Main Agent\", \"content\": \"Sure, what date works?\", \"start_time\": 3.5}\n]\n```\n\n**Agent lookup:** the `agent` field looks up agents scoped to the project associated with your API key. If the agent belongs to a different project, use `assistant_id` instead, which searches across all agents in your organization.",
-                "tags": [
-                    "test_framework"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/SchemaPostSimulateScenario"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/SchemaPostSimulateScenario"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/SchemaPostSimulateScenario"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ScenarioList"
-                                }
-                            }
-                        },
-                        "description": ""
-                    },
-                    "400": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "field_name": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "scenarios-create-from-transcript",
-                        "description": "Create a new evaluator from a call transcript. Analyzes the transcript to extract caller behavior, expected outcomes, and conversation flow.\n\n**`transcript_json` format:** array of message objects. Each object requires:\n- `role` — must be one of: `\"Main Agent\"`, `\"Testing Agent\"`, `\"Function Call\"`, `\"Function Call Result\"`\n- `content` — the message text\n- `start_time` (optional) — seconds from call start as a float\n\nNote: this endpoint accepts only the above role names. The role names used in the observability transcript ingestion API (\"agent\", \"user\", etc.) are not valid here.\n\nExample `transcript_json`:\n```json\n[\n  {\"role\": \"Main Agent\", \"content\": \"Hello, how can I help?\", \"start_time\": 0.0},\n  {\"role\": \"Testing Agent\", \"content\": \"I need to reschedule.\", \"start_time\": 2.1},\n  {\"role\": \"Main Agent\", \"content\": \"Sure, what date works?\", \"start_time\": 3.5}\n]\n```\n\n**Agent lookup:** the `agent` field looks up agents scoped to the project associated with your API key. If the agent belongs to a different project, use `assistant_id` instead, which searches across all agents in your organization."
                     }
                 }
             }
@@ -39340,6 +39790,113 @@
                 }
             }
         },
+        "/test_framework/v2/aiagents/{id}/history/": {
+            "get": {
+                "operationId": "aiagents-history-list",
+                "description": "Paginated version history for an agent: name/language/description plus the mock\ntools, dynamic variables, and knowledge base files active at each version.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this ai agent.",
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "page",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "page_size",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedAIAgentHistoryList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/aiagents/{id}/history/edit/": {
+            "patch": {
+                "operationId": "aiagents-history-edit-partial-update",
+                "description": "Edit metadata (e.g. version name) on a specific agent version.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this ai agent.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedAIAgentEditHistoryRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedAIAgentEditHistoryRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedAIAgentEditHistoryRequest"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AIAgentHistory"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/test_framework/v2/aiagents/{id}/knowledge_base/": {
             "get": {
                 "operationId": "aiagents-knowledge-base-list",
@@ -39470,6 +40027,63 @@
                         "enabled": true,
                         "name": "aiagents-personalities-list",
                         "description": "List the caller/tester personalities available to this agent's project. Filter with query params: type, language, enabled_only=true (only the personalities currently enabled for the project)."
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/aiagents/{id}/restore/": {
+            "post": {
+                "operationId": "aiagents-restore-create",
+                "description": "Restore an agent to a previous version, creating a new version for the restore.\n\nRestores the versioned concrete fields (name, language, description) and the related\ncollections: tools and dynamic variables are reverted in place to their\nlinked versions (ids preserved) and any not in the version are soft-deleted; knowledge\nbase files referenced by the version are reactivated and the rest soft-deleted.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this ai agent.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AIAgentRestoreRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AIAgentRestoreRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AIAgentRestoreRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AIAgentV2"
+                                }
+                            }
+                        },
+                        "description": ""
                     }
                 }
             }
@@ -39654,7 +40268,7 @@
         },
         "/test_framework/v2/aiagents/{id}/upload_knowledge_base/": {
             "post": {
-                "operationId": "aiagents-upload-knowledge-base_3",
+                "operationId": "aiagents-upload-knowledge-base_2",
                 "description": "Upload one or more files to the agent's knowledge base. Accepts either a `multipart/form-data` body (used by the web dashboard) or an `application/json` body where each entry carries base64-encoded file content.",
                 "parameters": [
                     {
@@ -40979,6 +41593,155 @@
                 }
             }
         },
+        "/test_framework/v2/scenarios/create-from-transcript-bg/": {
+            "post": {
+                "operationId": "scenarios-create-from-transcript-bg_3",
+                "description": "Create a new evaluator from a call transcript in the background. Returns a `progress_id` immediately; poll GET /scenarios/create-from-transcript-progress/?progress_id={id} until `status` is `completed` or `failed`.\n\nAnalyzes the transcript to extract caller behavior, expected outcomes, and conversation flow.\n\n**Response fields:** `progress_id` (UUID string) for polling.",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostSimulateScenario"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostSimulateScenario"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostSimulateScenario"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "progress_id": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/scenarios/create-from-transcript-progress/": {
+            "get": {
+                "operationId": "scenarios-create-from-transcript-progress_3",
+                "description": "Scenarios create from transcript progress",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "progress_id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "UUID progress identifier returned from create-from-transcript-bg endpoint",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "agent_id": {
+                                            "type": "integer"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "in_progress",
+                                                "completed",
+                                                "failed"
+                                            ]
+                                        },
+                                        "scenario_id": {
+                                            "type": "integer",
+                                            "nullable": true
+                                        },
+                                        "error": {
+                                            "type": "string",
+                                            "nullable": true
+                                        },
+                                        "scenario": {
+                                            "type": "object",
+                                            "nullable": true
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/test_framework/v2/scenarios/create_folder/": {
             "post": {
                 "operationId": "scenarios-folder-create_3",
@@ -41017,70 +41780,6 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/ScenarioFolder"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
-        },
-        "/test_framework/v2/scenarios/create_scenario_from_transcript/": {
-            "post": {
-                "operationId": "scenarios-create-from-transcript_3",
-                "description": "Create a new evaluator from a call transcript. Analyzes the transcript to extract caller behavior, expected outcomes, and conversation flow.\n\n**`transcript_json` format:** array of message objects. Each object requires:\n- `role` — must be one of: `\"Main Agent\"`, `\"Testing Agent\"`, `\"Function Call\"`, `\"Function Call Result\"`\n- `content` — the message text\n- `start_time` (optional) — seconds from call start as a float\n\nNote: this endpoint accepts only the above role names. The role names used in the observability transcript ingestion API (\"agent\", \"user\", etc.) are not valid here.\n\nExample `transcript_json`:\n```json\n[\n  {\"role\": \"Main Agent\", \"content\": \"Hello, how can I help?\", \"start_time\": 0.0},\n  {\"role\": \"Testing Agent\", \"content\": \"I need to reschedule.\", \"start_time\": 2.1},\n  {\"role\": \"Main Agent\", \"content\": \"Sure, what date works?\", \"start_time\": 3.5}\n]\n```\n\n**Agent lookup:** the `agent` field looks up agents scoped to the project associated with your API key. If the agent belongs to a different project, use `assistant_id` instead, which searches across all agents in your organization.",
-                "tags": [
-                    "test_framework"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/SchemaPostSimulateScenario"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/SchemaPostSimulateScenario"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/SchemaPostSimulateScenario"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ScenarioList"
-                                }
-                            }
-                        },
-                        "description": ""
-                    },
-                    "400": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "field_name": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
                                 }
                             }
                         },
@@ -49652,6 +50351,144 @@
                     "name"
                 ]
             },
+            "AIAgentHistory": {
+                "type": "object",
+                "description": "A single AIAgent version: versioned concrete fields + resolved related collections.\n\nManifests store child ``history_id`` lists (tools/dynamic vars) and uploaded-file ids\n(kb). The values are resolved on read. Use ``build_context()`` to batch the resolution\nacross a page of records and pass it as the serializer context (avoids N+1).",
+                "properties": {
+                    "history_id": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "history_date": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "history_type": {
+                        "enum": [
+                            "+",
+                            "~",
+                            "-"
+                        ],
+                        "type": "string",
+                        "description": "* `+` - Created\n* `~` - Changed\n* `-` - Deleted",
+                        "x-spec-enum-id": "c2e35addebb4f5da"
+                    },
+                    "history_change_reason": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "maxLength": 100
+                    },
+                    "history_user": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/UserInline"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "readOnly": true
+                    },
+                    "version_id": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "maxLength": 12
+                    },
+                    "version_name": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "maxLength": 255
+                    },
+                    "id": {
+                        "type": "integer",
+                        "maximum": 9223372036854775807,
+                        "minimum": -9223372036854775808,
+                        "format": "int64"
+                    },
+                    "agent_name": {
+                        "type": "string",
+                        "description": "Name of the AI agent.\nExample: `\"Customer Service Bot\"` or `\"Sales Assistant\"`",
+                        "maxLength": 255
+                    },
+                    "language": {
+                        "enum": [
+                            "af",
+                            "ar",
+                            "bn",
+                            "bg",
+                            "zh",
+                            "cs",
+                            "da",
+                            "nl",
+                            "en",
+                            "et",
+                            "fi",
+                            "fr",
+                            "de",
+                            "el",
+                            "gu",
+                            "hi",
+                            "he",
+                            "hu",
+                            "id",
+                            "it",
+                            "ja",
+                            "kn",
+                            "ko",
+                            "ms",
+                            "ml",
+                            "mr",
+                            "multi",
+                            "no",
+                            "pl",
+                            "pa",
+                            "pt",
+                            "ro",
+                            "ru",
+                            "sk",
+                            "es",
+                            "sv",
+                            "th",
+                            "tr",
+                            "tl",
+                            "ta",
+                            "te",
+                            "uk",
+                            "vi"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "b822ad429c7b7fec",
+                        "description": "Primary language for this agent.\nExample: `\"en\"` or `\"es\"`\n\n* `af` - Afrikaans\n* `ar` - Arabic\n* `bn` - Bengali\n* `bg` - Bulgarian\n* `zh` - Chinese Simplified\n* `cs` - Czech\n* `da` - Danish\n* `nl` - Dutch\n* `en` - English\n* `et` - Estonian\n* `fi` - Finnish\n* `fr` - French\n* `de` - German\n* `el` - Greek\n* `gu` - Gujarati\n* `hi` - Hindi\n* `he` - Hebrew\n* `hu` - Hungarian\n* `id` - Indonesian\n* `it` - Italian\n* `ja` - Japanese\n* `kn` - Kannada\n* `ko` - Korean\n* `ms` - Malay\n* `ml` - Malayalam\n* `mr` - Marathi\n* `multi` - Multilingual\n* `no` - Norwegian\n* `pl` - Polish\n* `pa` - Punjabi\n* `pt` - Portuguese\n* `ro` - Romanian\n* `ru` - Russian\n* `sk` - Slovak\n* `es` - Spanish\n* `sv` - Swedish\n* `th` - Thai\n* `tr` - Turkish\n* `tl` - Tagalog\n* `ta` - Tamil\n* `te` - Telugu\n* `uk` - Ukrainian\n* `vi` - Vietnamese"
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Description of the agent's purpose and capabilities.\nExample: `\"AI agent for handling customer support inquiries and resolving technical issues\"`"
+                    },
+                    "mock_tools": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "dynamic_variables": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "knowledge_base_files": {
+                        "type": "string",
+                        "readOnly": true
+                    }
+                },
+                "required": [
+                    "agent_name",
+                    "history_date",
+                    "history_type"
+                ]
+            },
             "AIAgentList": {
                 "type": "object",
                 "properties": {
@@ -49760,6 +50597,17 @@
                 "required": [
                     "agent_name",
                     "organization"
+                ]
+            },
+            "AIAgentRestoreRequest": {
+                "type": "object",
+                "properties": {
+                    "history_id": {
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "history_id"
                 ]
             },
             "AIAgentTestProfile": {
@@ -51785,7 +52633,6 @@
             },
             "CallLogDetail": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -51977,7 +52824,6 @@
             },
             "CallLogList": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -53103,7 +53949,6 @@
             },
             "Dashboard": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -53235,7 +54080,6 @@
             },
             "DashboardList": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -54948,6 +55792,34 @@
                     "name"
                 ]
             },
+            "MetricFailureModeFixMetric": {
+                "type": "object",
+                "description": "Request body for ``POST /metric-failure-mode-insights/{id}/fix_metric/``.\n\nSamples a few of one failure mode's example calls and adds them to Labs\nfor the insight's metric, carrying the user's feedback as the note and\n``expected_value`` as the corrected label.",
+                "properties": {
+                    "failure_mode_index": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "Index into the insight's failure_modes list to act on."
+                    },
+                    "feedback": {
+                        "type": "string",
+                        "description": "Human note attached to each sampled call's metric review in Labs."
+                    },
+                    "expected_value": {
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Corrected label to record for each sampled call in Labs: true/false for binary metrics, a 0-5 score for ratings, a number for numeric metrics, or null for N/A. Defaults to a passing value when omitted."
+                    }
+                },
+                "required": [
+                    "failure_mode_index",
+                    "feedback"
+                ]
+            },
             "MetricFailureModeInsight": {
                 "type": "object",
                 "description": "Insight row exposed to the Observability → Insights UI.",
@@ -55459,7 +56331,6 @@
             },
             "MetricList": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -57155,6 +58026,37 @@
                     "price"
                 ]
             },
+            "PaginatedAIAgentHistoryList": {
+                "type": "object",
+                "required": [
+                    "count",
+                    "results"
+                ],
+                "properties": {
+                    "count": {
+                        "type": "integer",
+                        "example": 123
+                    },
+                    "next": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "https://api.cekura.ai/example/v1/example-external/?page=4"
+                    },
+                    "previous": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "https://api.cekura.ai/example/v1/example-external/?page=3"
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/AIAgentHistory"
+                        }
+                    }
+                }
+            },
             "PaginatedAIAgentList": {
                 "type": "object",
                 "required": [
@@ -57896,6 +58798,20 @@
                     }
                 }
             },
+            "PatchedAIAgentEditHistoryRequest": {
+                "type": "object",
+                "properties": {
+                    "history_id": {
+                        "type": "integer"
+                    },
+                    "version_name": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    }
+                }
+            },
             "PatchedAlertUpdate": {
                 "type": "object",
                 "description": "",
@@ -57933,7 +58849,6 @@
             },
             "PatchedCallLogDetail": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -58362,7 +59277,6 @@
             },
             "PatchedDashboard": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -59746,6 +60660,11 @@
                         "readOnly": true,
                         "description": "Name of the agent associated with this result"
                     },
+                    "agent_version": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "The agent version (history record) this result ran against, or null."
+                    },
                     "status": {
                         "enum": [
                             "running",
@@ -59985,6 +60904,15 @@
                         "readOnly": true,
                         "description": "ID of the agent associated with this run"
                     },
+                    "agent_version": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ExpectedOutcome"
+                            }
+                        ],
+                        "readOnly": true,
+                        "description": "The agent version (history record) this run's result ran against, or null."
+                    },
                     "result_id": {
                         "type": "integer",
                         "readOnly": true
@@ -59999,11 +60927,7 @@
                         "readOnly": true
                     },
                     "expected_outcome": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ExpectedOutcome"
-                            }
-                        ],
+                        "type": "string",
                         "readOnly": true
                     },
                     "evaluation": {
@@ -60750,7 +61674,6 @@
             },
             "PatchedSchemaPostScenario": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "agent": {
                         "type": [
@@ -63382,6 +64305,11 @@
                         "readOnly": true,
                         "description": "Run Execution Type"
                     },
+                    "agent_version": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "The agent version (history record) this result ran against, or null."
+                    },
                     "created_at": {
                         "type": "string",
                         "format": "date-time",
@@ -63418,6 +64346,11 @@
                         "type": "string",
                         "readOnly": true,
                         "description": "Name of the agent associated with this result"
+                    },
+                    "agent_version": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "The agent version (history record) this result ran against, or null."
                     },
                     "status": {
                         "enum": [
@@ -63731,6 +64664,15 @@
                         "readOnly": true,
                         "description": "ID of the agent associated with this run"
                     },
+                    "agent_version": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ExpectedOutcome"
+                            }
+                        ],
+                        "readOnly": true,
+                        "description": "The agent version (history record) this run's result ran against, or null."
+                    },
                     "result_id": {
                         "type": "integer",
                         "readOnly": true
@@ -63745,11 +64687,7 @@
                         "readOnly": true
                     },
                     "expected_outcome": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ExpectedOutcome"
-                            }
-                        ],
+                        "type": "string",
                         "readOnly": true
                     },
                     "evaluation": {
@@ -63939,7 +64877,6 @@
             },
             "RunList": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -64084,6 +65021,11 @@
                         ],
                         "readOnly": true,
                         "description": "Run Execution Type"
+                    },
+                    "agent_version": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "The agent version (history record) this run's result ran against, or null."
                     }
                 }
             },
@@ -64367,7 +65309,6 @@
             },
             "Scenario": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -64569,8 +65510,13 @@
                         "description": "REMOVED FROM API. Reads return the historical value for legacy rows (`null` for new rows). Writes are no longer accepted — supplying a non-null value yields a 400 error. Put dynamic-variable values in `test_profile_data.information.main_agent_variables` instead: create the test profile via POST /test-profiles/ and attach it via the `test_profile` field on the scenario."
                     },
                     "generated_mock_tool_entries": {
-                        "readOnly": true,
-                        "description": "Expected mock tool calls generated for this evaluator during scenario auto-generation when the agent has mock tools attached. Each entry has shape {tool_id, tool_name, new_entry: {input, output}}."
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Expected mock tool calls for this evaluator. Each entry has shape {tool_id, tool_name, new_entry: {input, output}}. Auto-generated during scenario generation when the agent has mock tools attached; can also be set or edited manually."
                     },
                     "folder_path": {
                         "type": [
@@ -65045,6 +65991,15 @@
                             "integer",
                             "null"
                         ]
+                    },
+                    "generated_mock_tool_entries": {
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Mock tool data generated for this scenario. Format: [{tool_id, tool_name, new_entry: {input, output}}]. Stored for evaluation and debugging purposes."
                     }
                 },
                 "required": [
@@ -65236,7 +66191,6 @@
             },
             "ScenarioList": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -65456,7 +66410,6 @@
             },
             "ScenarioSerializerV2": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -65661,8 +66614,13 @@
                         "description": "REMOVED FROM API. Reads return the historical value for legacy rows (`null` for new rows). Writes are no longer accepted — supplying a non-null value yields a 400 error. Put dynamic-variable values in `test_profile_data.information.main_agent_variables` instead: create the test profile via POST /test-profiles/ and attach it via the `test_profile` field on the scenario."
                     },
                     "generated_mock_tool_entries": {
-                        "readOnly": true,
-                        "description": "Expected mock tool calls generated for this evaluator during scenario auto-generation when the agent has mock tools attached. Each entry has shape {tool_id, tool_name, new_entry: {input, output}}."
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Expected mock tool calls for this evaluator. Each entry has shape {tool_id, tool_name, new_entry: {input, output}}. Auto-generated during scenario generation when the agent has mock tools attached; can also be set or edited manually."
                     },
                     "folder_path": {
                         "type": [
@@ -66929,7 +67887,6 @@
             },
             "SchemaPostRunScenarios": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "agent_id": {
                         "type": "integer",
@@ -67178,7 +68135,6 @@
             },
             "SchemaPostScenario": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "agent": {
                         "type": [
@@ -67313,6 +68269,13 @@
                     "expected_outcome_prompt": {
                         "type": "string",
                         "description": "Prompt describing the expected outcome of the scenario"
+                    },
+                    "folder_path": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "Folder path to assign the scenario to (e.g. 'folder_name' or 'parent.child')"
                     }
                 },
                 "required": [
@@ -67338,7 +68301,6 @@
             },
             "SchemaScenario": {
                 "type": "object",
-                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -67540,8 +68502,13 @@
                         "description": "REMOVED FROM API. Reads return the historical value for legacy rows (`null` for new rows). Writes are no longer accepted — supplying a non-null value yields a 400 error. Put dynamic-variable values in `test_profile_data.information.main_agent_variables` instead: create the test profile via POST /test-profiles/ and attach it via the `test_profile` field on the scenario."
                     },
                     "generated_mock_tool_entries": {
-                        "readOnly": true,
-                        "description": "Expected mock tool calls generated for this evaluator during scenario auto-generation when the agent has mock tools attached. Each entry has shape {tool_id, tool_name, new_entry: {input, output}}."
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Expected mock tool calls for this evaluator. Each entry has shape {tool_id, tool_name, new_entry: {input, output}}. Auto-generated during scenario generation when the agent has mock tools attached; can also be set or edited manually."
                     },
                     "folder_path": {
                         "type": [

--- a/openapi.json
+++ b/openapi.json
@@ -28704,6 +28704,70 @@
                 }
             }
         },
+        "/test_framework/v1/scenarios-external/create_scenario_from_transcript/": {
+            "post": {
+                "operationId": "scenarios-create-from-transcript",
+                "description": "Create a new evaluator from a call transcript. Analyzes the transcript to extract caller behavior, expected outcomes, and conversation flow.\n\n**`transcript_json` format:** array of message objects. Each object requires:\n- `role` — must be one of: `\"Main Agent\"`, `\"Testing Agent\"`, `\"Function Call\"`, `\"Function Call Result\"`\n- `content` — the message text\n- `start_time` (optional) — seconds from call start as a float\n\nNote: this endpoint accepts only the above role names. The role names used in the observability transcript ingestion API (\"agent\", \"user\", etc.) are not valid here.\n\nExample `transcript_json`:\n```json\n[\n  {\"role\": \"Main Agent\", \"content\": \"Hello, how can I help?\", \"start_time\": 0.0},\n  {\"role\": \"Testing Agent\", \"content\": \"I need to reschedule.\", \"start_time\": 2.1},\n  {\"role\": \"Main Agent\", \"content\": \"Sure, what date works?\", \"start_time\": 3.5}\n]\n```\n\n**Agent lookup:** the `agent` field looks up agents scoped to the project associated with your API key. If the agent belongs to a different project, use `assistant_id` instead, which searches across all agents in your organization.",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostSimulateScenario"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostSimulateScenario"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostSimulateScenario"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ScenarioList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/test_framework/v1/scenarios-external/delete_folder/": {
             "post": {
                 "operationId": "scenarios-folder-delete",
@@ -33522,6 +33586,78 @@
                         "enabled": true,
                         "name": "scenarios-folder-create",
                         "description": "Scenarios folder"
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/scenarios/create_scenario_from_transcript/": {
+            "post": {
+                "operationId": "scenarios-create-from-transcript_2",
+                "description": "Create a new evaluator from a call transcript. Analyzes the transcript to extract caller behavior, expected outcomes, and conversation flow.\n\n**`transcript_json` format:** array of message objects. Each object requires:\n- `role` — must be one of: `\"Main Agent\"`, `\"Testing Agent\"`, `\"Function Call\"`, `\"Function Call Result\"`\n- `content` — the message text\n- `start_time` (optional) — seconds from call start as a float\n\nNote: this endpoint accepts only the above role names. The role names used in the observability transcript ingestion API (\"agent\", \"user\", etc.) are not valid here.\n\nExample `transcript_json`:\n```json\n[\n  {\"role\": \"Main Agent\", \"content\": \"Hello, how can I help?\", \"start_time\": 0.0},\n  {\"role\": \"Testing Agent\", \"content\": \"I need to reschedule.\", \"start_time\": 2.1},\n  {\"role\": \"Main Agent\", \"content\": \"Sure, what date works?\", \"start_time\": 3.5}\n]\n```\n\n**Agent lookup:** the `agent` field looks up agents scoped to the project associated with your API key. If the agent belongs to a different project, use `assistant_id` instead, which searches across all agents in your organization.",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostSimulateScenario"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostSimulateScenario"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostSimulateScenario"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ScenarioList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "scenarios-create-from-transcript",
+                        "description": "Create a new evaluator from a call transcript. Analyzes the transcript to extract caller behavior, expected outcomes, and conversation flow.\n\n**`transcript_json` format:** array of message objects. Each object requires:\n- `role` — must be one of: `\"Main Agent\"`, `\"Testing Agent\"`, `\"Function Call\"`, `\"Function Call Result\"`\n- `content` — the message text\n- `start_time` (optional) — seconds from call start as a float\n\nNote: this endpoint accepts only the above role names. The role names used in the observability transcript ingestion API (\"agent\", \"user\", etc.) are not valid here.\n\nExample `transcript_json`:\n```json\n[\n  {\"role\": \"Main Agent\", \"content\": \"Hello, how can I help?\", \"start_time\": 0.0},\n  {\"role\": \"Testing Agent\", \"content\": \"I need to reschedule.\", \"start_time\": 2.1},\n  {\"role\": \"Main Agent\", \"content\": \"Sure, what date works?\", \"start_time\": 3.5}\n]\n```\n\n**Agent lookup:** the `agent` field looks up agents scoped to the project associated with your API key. If the agent belongs to a different project, use `assistant_id` instead, which searches across all agents in your organization."
                     }
                 }
             }
@@ -41780,6 +41916,70 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/ScenarioFolder"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/scenarios/create_scenario_from_transcript/": {
+            "post": {
+                "operationId": "scenarios-create-from-transcript_3",
+                "description": "Create a new evaluator from a call transcript. Analyzes the transcript to extract caller behavior, expected outcomes, and conversation flow.\n\n**`transcript_json` format:** array of message objects. Each object requires:\n- `role` — must be one of: `\"Main Agent\"`, `\"Testing Agent\"`, `\"Function Call\"`, `\"Function Call Result\"`\n- `content` — the message text\n- `start_time` (optional) — seconds from call start as a float\n\nNote: this endpoint accepts only the above role names. The role names used in the observability transcript ingestion API (\"agent\", \"user\", etc.) are not valid here.\n\nExample `transcript_json`:\n```json\n[\n  {\"role\": \"Main Agent\", \"content\": \"Hello, how can I help?\", \"start_time\": 0.0},\n  {\"role\": \"Testing Agent\", \"content\": \"I need to reschedule.\", \"start_time\": 2.1},\n  {\"role\": \"Main Agent\", \"content\": \"Sure, what date works?\", \"start_time\": 3.5}\n]\n```\n\n**Agent lookup:** the `agent` field looks up agents scoped to the project associated with your API key. If the agent belongs to a different project, use `assistant_id` instead, which searches across all agents in your organization.",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostSimulateScenario"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostSimulateScenario"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostSimulateScenario"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ScenarioList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
                                 }
                             }
                         },


### PR DESCRIPTION
## Summary
- Adds two new API reference pages for the async `create-from-transcript-bg` and `create-from-transcript-progress` endpoints
- Marks the old `create_scenario_from_transcript` endpoint as deprecated in docs
- Updates `mint.json` navigation to surface the new async endpoints above the old one
- Updates `openapi.json` with the new endpoint specs

🤖 Generated with [Claude Code](https://claude.com/claude-code)