### PR TITLE
Revamp AI assistant setup docs

### DIFF
--- a/documentation/FAQ.mdx
+++ b/documentation/FAQ.mdx
@@ -1441,7 +1441,7 @@ npx skills update
 npx skills add cekura-ai/cekura-skills --all
 ```
 
-Cekura pushes skill updates whenever the underlying API or MCP server changes, so running the update command is all that is needed on your side. For full installation and update instructions, see [Skills](/mcp/skills#update-refresh).
+Cekura pushes skill updates whenever the underlying API or MCP server changes, so running the update command is all that is needed on your side. For full installation and update instructions, see [Skills](/mcp/skills#update).
 
 
 ## Can I compare Cekura metric results against my own manual or ground-truth scores?

--- a/documentation/guides/agent-integration.mdx
+++ b/documentation/guides/agent-integration.mdx
@@ -29,13 +29,15 @@ Cekura is designed to work seamlessly with AI coding agents. Whether you're usin
 
 ### 1. Connect via MCP
 
-The fastest way to integrate is through the MCP server. This gives your AI assistant direct access to Cekura's API tools.
+Connecting the MCP server gives your AI assistant direct access to Cekura's API tools. For the best experience, install [Cekura Skills](/mcp/overview) too — Skills teach your assistant the workflows, MCP lets it act.
 
 <Tabs>
   <Tab title="Claude Code">
     ```bash
-    claude mcp add --transport http cekura --scope user https://api.cekura.ai/mcp --header "X-CEKURA-API-KEY:YOUR_API_KEY"
+    claude mcp add --transport http cekura --scope user https://api.cekura.ai/mcp
     ```
+
+    OAuth opens a browser to sign in — no API key needed. For API-key auth, see [MCP-only setup](/mcp/mcp-only#api-key-setup).
   </Tab>
 
   <Tab title="Cursor / VS Code">
@@ -45,8 +47,7 @@ The fastest way to integrate is through the MCP server. This gives your AI assis
       "mcpServers": {
         "cekura": {
           "command": "npx",
-          "args": ["mcp-remote", "https://api.cekura.ai/mcp", "--header", "X-CEKURA-API-KEY:${CEKURA_API_KEY}"],
-          "env": { "CEKURA_API_KEY": "YOUR_API_KEY" }
+          "args": ["-y", "mcp-remote", "https://api.cekura.ai/mcp"]
         }
       }
     }

--- a/documentation/guides/agent-integration.mdx
+++ b/documentation/guides/agent-integration.mdx
@@ -47,11 +47,11 @@ Then connect the MCP server so your assistant can act on your workspace:
     claude mcp add --transport http cekura --scope user https://api.cekura.ai/mcp
     ```
 
-    OAuth opens a browser to sign in — no API key needed. For API-key auth, see [MCP-only setup](/mcp/mcp-only#api-key-setup).
+    OAuth opens a browser to sign in — no API key needed. For API-key auth, see [API-key setup](/mcp/mcp-only#api-key-setup).
   </Tab>
 
   <Tab title="Cursor / VS Code">
-    Add to your MCP config (see [full setup guide](/mcp/mcp-only)):
+    Add to your MCP config (see [manual setup](/mcp/mcp-only)):
     ```json
     {
       "mcpServers": {
@@ -147,8 +147,8 @@ Each scenario captures the conversation flow and expected outcomes."
 ## Next Steps
 
 <CardGroup cols={2}>
-  <Card title="MCP Setup Guide" icon="gear" href="/mcp/mcp-only">
-    Detailed MCP server configuration for all supported clients
+  <Card title="Manual setup (Skills + MCP)" icon="gear" href="/mcp/mcp-only">
+    Install Skills, then configure the MCP server — for clients without a plugin
   </Card>
 
   <Card title="AGENTS.md Template" icon="file" href="/documentation/guides/agents-md-template">

--- a/documentation/guides/agent-integration.mdx
+++ b/documentation/guides/agent-integration.mdx
@@ -16,20 +16,30 @@ Cekura is designed to work seamlessly with AI coding agents. Whether you're usin
 ## Integration Options
 
 <CardGroup cols={2}>
-  <Card title="MCP Server" icon="plug" href="/mcp/overview">
-    Connect your AI assistant to Cekura's API via the Model Context Protocol for real-time tool access.
+  <Card title="MCP & Skills" icon="plug" href="/mcp/overview">
+    Install Cekura Skills so your assistant knows Cekura workflows, plus the MCP server so it can act on your workspace. Recommended setup.
   </Card>
 
-  <Card title="AGENTS.md" icon="file-code" href="/documentation/guides/agents-md-template">
-    Add an AGENTS.md file to your repo to teach AI assistants how to use Cekura for your project.
+  <Card title="AGENTS.md preset" icon="file-code" href="/documentation/guides/agents-md-template">
+    Portable fallback: drop an AGENTS.md file in your repo for assistants that don't load Agent Skills.
   </Card>
 </CardGroup>
 
 ## Quick Setup
 
-### 1. Connect via MCP
+### 1. Install Skills, then connect MCP
 
-Connecting the MCP server gives your AI assistant direct access to Cekura's API tools. For the best experience, install [Cekura Skills](/mcp/overview) too — Skills teach your assistant the workflows, MCP lets it act.
+First install Cekura Skills so your assistant knows Cekura workflows:
+
+```bash
+npx skills add cekura-ai/cekura-skills --all
+```
+
+<Note>
+Claude Code users: install the plugin instead — it bundles Skills, slash commands, and MCP config in one step. See [MCP & Skills setup](/mcp/overview).
+</Note>
+
+Then connect the MCP server so your assistant can act on your workspace:
 
 <Tabs>
   <Tab title="Claude Code">

--- a/documentation/guides/agent-integration.mdx
+++ b/documentation/guides/agent-integration.mdx
@@ -39,7 +39,7 @@ The fastest way to integrate is through the MCP server. This gives your AI assis
   </Tab>
 
   <Tab title="Cursor / VS Code">
-    Add to your MCP config (see [full setup guide](/mcp/overview)):
+    Add to your MCP config (see [full setup guide](/mcp/mcp-only)):
     ```json
     {
       "mcpServers": {
@@ -136,7 +136,7 @@ Each scenario captures the conversation flow and expected outcomes."
 ## Next Steps
 
 <CardGroup cols={2}>
-  <Card title="MCP Setup Guide" icon="gear" href="/mcp/overview">
+  <Card title="MCP Setup Guide" icon="gear" href="/mcp/mcp-only">
     Detailed MCP server configuration for all supported clients
   </Card>
 

--- a/documentation/introduction.mdx
+++ b/documentation/introduction.mdx
@@ -67,7 +67,7 @@ claude mcp add --transport http cekura --scope user https://api.cekura.ai/mcp
 ```
 </CodeGroup>
 
-OAuth opens a browser to sign in — no API key needed. **Claude Code users:** install the plugin for Skills, commands, and MCP in one step — see the [full MCP & Skills setup](/mcp/overview) for every client. Need a project-scoped or CI key instead? See [MCP-only setup](/mcp/mcp-only#api-key-setup).
+OAuth opens a browser to sign in — no API key needed. **Claude Code users:** install the plugin for Skills, commands, and MCP in one step — see the [full MCP & Skills setup](/mcp/overview) for every client. Need a project-scoped or CI key instead? See [API-key setup](/mcp/mcp-only#api-key-setup).
 
 ### What You Get
 

--- a/documentation/introduction.mdx
+++ b/documentation/introduction.mdx
@@ -41,7 +41,13 @@ Connect your AI assistant to Cekura and scaffold entire integrations with a sing
 
 ### Quick Setup
 
-Connect in seconds. For the best experience, install [Cekura Skills](/mcp/overview) alongside MCP — Skills teach your assistant the workflows, MCP lets it act.
+Install Cekura Skills so your assistant knows Cekura workflows:
+
+```bash
+npx skills add cekura-ai/cekura-skills --all
+```
+
+Then connect the MCP server so it can act on your workspace:
 
 <CodeGroup>
 ```bash Claude Code
@@ -61,7 +67,7 @@ claude mcp add --transport http cekura --scope user https://api.cekura.ai/mcp
 ```
 </CodeGroup>
 
-OAuth opens a browser to sign in — no API key needed. Need a project-scoped or CI key instead? See [MCP-only setup](/mcp/mcp-only#api-key-setup).
+OAuth opens a browser to sign in — no API key needed. **Claude Code users:** install the plugin for Skills, commands, and MCP in one step — see the [full MCP & Skills setup](/mcp/overview) for every client. Need a project-scoped or CI key instead? See [MCP-only setup](/mcp/mcp-only#api-key-setup).
 
 ### What You Get
 

--- a/documentation/introduction.mdx
+++ b/documentation/introduction.mdx
@@ -41,12 +41,11 @@ Connect your AI assistant to Cekura and scaffold entire integrations with a sing
 
 ### Quick Setup
 
-Connect in seconds with a single command:
+Connect in seconds. For the best experience, install [Cekura Skills](/mcp/overview) alongside MCP — Skills teach your assistant the workflows, MCP lets it act.
 
 <CodeGroup>
 ```bash Claude Code
-claude mcp add --transport http Cekura https://api.cekura.ai/mcp \
-  --header "X-CEKURA-API-KEY:YOUR_API_KEY"
+claude mcp add --transport http cekura --scope user https://api.cekura.ai/mcp
 ```
 
 ```bash Cursor / VS Code
@@ -55,14 +54,14 @@ claude mcp add --transport http Cekura https://api.cekura.ai/mcp \
   "mcpServers": {
     "cekura": {
       "command": "npx",
-      "args": ["-y", "mcp-remote", "https://api.cekura.ai/mcp",
-               "--header", "X-CEKURA-API-KEY:${CEKURA_API_KEY}"],
-      "env": {"CEKURA_API_KEY": "YOUR_API_KEY"}
+      "args": ["-y", "mcp-remote", "https://api.cekura.ai/mcp"]
     }
   }
 }
 ```
 </CodeGroup>
+
+OAuth opens a browser to sign in — no API key needed. Need a project-scoped or CI key instead? See [MCP-only setup](/mcp/mcp-only#api-key-setup).
 
 ### What You Get
 
@@ -81,8 +80,8 @@ claude mcp add --transport http Cekura https://api.cekura.ai/mcp \
   </Card>
 </CardGroup>
 
-<Card title="Get Started with MCP" icon="plug" href="/mcp/overview" horizontal>
-  View detailed setup instructions for Claude Desktop, Cursor, VS Code, and more →
+<Card title="Set up your AI assistant" icon="plug" href="/mcp/overview" horizontal>
+  Install Cekura Skills and MCP for Claude Code, Cursor, Codex, Claude Desktop, and more →
 </Card>
 
 ## Comprehensive Observability

--- a/mcp/auto-optimize-metrics.mdx
+++ b/mcp/auto-optimize-metrics.mdx
@@ -19,7 +19,7 @@ The [Metric Lab](/documentation/guides/metric-lab) **Auto Improve** button rewri
 
 <Steps>
   <Step title="Connect Claude Code to the Cekura MCP">
-    Follow the [MCP overview](/mcp/overview#2-configure-mcp-server) for the one-line `claude mcp add` setup. OAuth is recommended.
+    Follow the [Claude Code setup guide](/mcp/claude-code-guide) and run `/setup-mcp`. OAuth is recommended.
   </Step>
   <Step title="Have at least one metric with labelled test sets">
     The optimiser needs calls you've **Added to Lab** and **Annotated** through the [Metric Lab workflow](/documentation/guides/metric-lab#annotate) — annotations and feedback are what the optimiser learns from.

--- a/mcp/claude-code-guide.mdx
+++ b/mcp/claude-code-guide.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Using Cekura with Claude Code"
-sidebarTitle: "Claude Code Guide"
-description: "End-to-end walkthrough: evaluate complex voice agents using Claude Code, the Cekura MCP, and Cekura Skills"
+sidebarTitle: "Claude Code"
+description: "Recommended setup: install the Cekura Claude Code plugin, connect MCP, and use Skills plus slash commands."
 icon: "code"
 ---
 
@@ -9,8 +9,96 @@ import { CopyPageButton } from "/snippets/copy-page-button.mdx";
 
 <CopyPageButton />
 
+Claude Code is the best Cekura assistant experience. The Cekura plugin bundles Skills, slash commands, MCP configuration, update support, and MCP failure help.
 
-Watch an end-to-end walkthrough of evaluating complex voice agents—running multiple tools across coordinating agents—using Claude Code, the Cekura MCP, and Cekura Skills.
+## What you get
+
+| Capability | Included? | Why it matters |
+|---|---:|---|
+| Cekura Skills | Yes | Your assistant knows Cekura workflows and best practices |
+| Slash commands | Yes | Fast entry points like `/setup-mcp`, `/autogen-eval`, `/run-evals`, and `/cekura-report` |
+| MCP config | Yes | The plugin includes the Cekura MCP server config |
+| OAuth setup | Yes | `/setup-mcp` walks you through browser sign-in |
+| Update support | Yes | `/upgrade-skills` refreshes skills and commands |
+| Failure help | Yes | MCP failures are detected and surfaced with next steps |
+
+## Install the plugin
+
+<Tabs>
+  <Tab title="Claude Code CLI">
+    1. Start a Claude Code session.
+    2. Run `/plugin`.
+    3. Open **Marketplaces > Add Marketplace**.
+    4. Paste `https://github.com/cekura-ai/cekura-skills.git` and confirm.
+    5. Open **Discover**, search `cekura`, and install the `cekura` plugin.
+    6. Restart the Claude Code session if prompted.
+  </Tab>
+
+  <Tab title="Claude Code in VS Code">
+    1. Open the Claude Code chat panel.
+    2. Open **Manage Plugins > Marketplaces**.
+    3. Add `https://github.com/cekura-ai/cekura-skills.git`.
+    4. Open **Plugins**, search `cekura`, and install the plugin.
+    5. Restart VS Code if prompted.
+  </Tab>
+</Tabs>
+
+## Connect MCP
+
+Run this in Claude Code:
+
+```plaintext
+/setup-mcp
+```
+
+Choose OAuth unless you specifically need an API key. OAuth opens a browser, lets you sign into Cekura, and avoids storing keys in config files.
+
+<Tip>
+The plugin already includes the Cekura MCP server URL. `/setup-mcp` verifies whether MCP is working, registers the server if needed, and confirms connectivity.
+</Tip>
+
+## Verify setup
+
+Ask Claude Code:
+
+```plaintext
+Use the Cekura skills and MCP. List my Cekura agents, pick one, and propose 3 evaluators I should create first. Do not create anything until I approve.
+```
+
+If setup is working, Claude Code should list real agents from your workspace and use Cekura evaluator-design guidance before proposing next steps.
+
+## Start with onboarding
+
+For a guided first run, use:
+
+```plaintext
+/cekura-onboarding
+```
+
+You can also ask in plain English:
+
+```plaintext
+I'm new to Cekura. Walk me through setting up my first useful agent evaluation workflow.
+```
+
+## Common workflows
+
+| Goal | Use |
+|---|---|
+| Configure MCP | `/setup-mcp` |
+| Get started | `/cekura-onboarding` |
+| Create a metric | `/create-metric` |
+| Improve a metric | `/improve-metric` |
+| Generate evaluators | `/autogen-eval` |
+| Create one evaluator carefully | `/manual-create-update-eval` |
+| Run evaluators | `/run-evals` |
+| Review results | `/eval-results` |
+| Produce a quality report | `/cekura-report` |
+| Update the plugin | `/upgrade-skills` |
+
+## Example advanced workflow
+
+Watch an end-to-end walkthrough of evaluating complex voice agents, running multiple tools across coordinating agents, using Claude Code, the Cekura MCP, and Cekura Skills.
 
 <iframe
   style={{
@@ -27,34 +115,18 @@ Watch an end-to-end walkthrough of evaluating complex voice agents—running mul
   title="Using Cekura with Claude Code"
 />
 
-## Quick Guide
+## Troubleshooting
 
-<Steps>
-  <Step title="Connect Claude Code to Cekura">
-    Install the Cekura MCP server (see the [Claude Code tab in the MCP overview](/mcp/overview#2-configure-mcp-server)) and install the [Cekura Skills repository](https://github.com/cekura-ai/cekura-skills). Skills give Claude Code the playbook for creating evaluators, running tests, and analyzing results through Cekura.
-  </Step>
+<AccordionGroup>
+  <Accordion title="MCP is not connected">
+    Run `/setup-mcp` again and choose OAuth. Then ask Claude Code to list available Cekura tools or list your agents.
+  </Accordion>
 
-  <Step title="Set up mock data and cleanup hooks">
-    Complex agents depend on database state—ships, credits, sectors, user metadata. Stand up a lightweight webhook server that seeds mock data before a run and listens for Cekura's post-run webhook to reset the database. This keeps concurrent tests isolated and repeatable.
-  </Step>
+  <Accordion title="Commands do not appear">
+    Restart Claude Code after installing the plugin. If the plugin still does not appear, reinstall from the marketplace and confirm `cekura@cekura-skills` is listed.
+  </Accordion>
 
-  <Step title="Let Claude Code learn the schema">
-    Ask Claude Code to read your database schema and agent tools through the Cekura MCP. Once it has the lay of the land, prompt it to generate scenario coverage—for example: *"Using the Cekura skill, create 10 test cases covering ship movement, corp joins, and credit transfers."*
-  </Step>
-
-  <Step title="Run the full suite">
-    Kick off all evaluators at once through the MCP. Cekura executes them concurrently and surfaces pass/fail with full transcripts and traces.
-  </Step>
-
-  <Step title="Triage with Claude">
-    Ask Claude Code to pull failing runs and classify them: *"Analyze these 4 failures and tell me which are real bugs vs. flakes."* Because runs are non-deterministic, **rerun each failing test 3–4 times** and ask Claude to compute a pass rate. One pass out of four usually points to a prompt or tool-routing bug, not infra.
-  </Step>
-
-  <Step title="Get a root-cause report">
-    Claude Code stitches together Cekura run links, Pipecat session IDs, transcripts, and a per-scenario root cause into a final report—coverage summary, failure breakdown, and recommended prompt or tool fixes.
-  </Step>
-</Steps>
-
-<Tip>
-A good first prompt: *"Use the Cekura MCP to list my agents, then use the Cekura skill to generate 10 workflow evaluators covering the most common user flows."*
-</Tip>
+  <Accordion title="Plugin update looks stale">
+    Run `/upgrade-skills`. If it reports stale plugin entries, follow the reinstall steps in the [Skills Catalog](/mcp/skills#reinstall-claude-code-plugin).
+  </Accordion>
+</AccordionGroup>

--- a/mcp/claude-code-guide.mdx
+++ b/mcp/claude-code-guide.mdx
@@ -15,17 +15,14 @@ Claude Code is the best Cekura assistant experience. The Cekura plugin bundles S
 
 <Tabs>
   <Tab title="Claude Code CLI">
-    Run these in a Claude Code session. Each command copies on its own:
+    Run these in a Claude Code session:
 
     ```plaintext
     /plugin marketplace add cekura-ai/cekura-skills
-    ```
-
-    ```plaintext
     /plugin install cekura@cekura-skills
     ```
 
-    Restart the session if prompted.
+    Restart the session if prompted, then run `/setup-mcp`.
   </Tab>
 
   <Tab title="Claude Code in VS Code">

--- a/mcp/claude-code-guide.mdx
+++ b/mcp/claude-code-guide.mdx
@@ -29,7 +29,7 @@ Claude Code is the best Cekura assistant experience. The Cekura plugin bundles S
     1. Start a Claude Code session.
     2. Run `/plugin`.
     3. Open **Marketplaces > Add Marketplace**.
-    4. Paste `https://github.com/cekura-ai/cekura-skills.git` and confirm.
+    4. Paste `cekura-ai/cekura-skills` and confirm.
     5. Open **Discover**, search `cekura`, and install the `cekura` plugin.
     6. Restart the Claude Code session if prompted.
   </Tab>
@@ -37,7 +37,7 @@ Claude Code is the best Cekura assistant experience. The Cekura plugin bundles S
   <Tab title="Claude Code in VS Code">
     1. Open the Claude Code chat panel.
     2. Open **Manage Plugins > Marketplaces**.
-    3. Add `https://github.com/cekura-ai/cekura-skills.git`.
+    3. Add `cekura-ai/cekura-skills`.
     4. Open **Plugins**, search `cekura`, and install the plugin.
     5. Restart VS Code if prompted.
   </Tab>

--- a/mcp/claude-code-guide.mdx
+++ b/mcp/claude-code-guide.mdx
@@ -84,17 +84,6 @@ A typical first session, in order:
 6. Ask "create a metric for X" — design a metric
 7. `/cekura-report` — full end-to-end quality report
 
-## What you get
-
-| Capability | Included? | Why it matters |
-|---|---:|---|
-| Cekura Skills | Yes | Your assistant knows Cekura workflows and best practices |
-| Slash commands | Yes | Fast entry points like `/setup-mcp`, `/autogen-eval`, `/run-evals`, and `/cekura-report` |
-| MCP config | Yes | The plugin includes the Cekura MCP server config |
-| OAuth setup | Yes | `/setup-mcp` walks you through browser sign-in |
-| Update support | Yes | `/upgrade-skills` refreshes skills and commands |
-| Failure help | Yes | MCP failures are detected and surfaced with next steps |
-
 ## Common workflows
 
 | Goal | Use |

--- a/mcp/claude-code-guide.mdx
+++ b/mcp/claude-code-guide.mdx
@@ -11,27 +11,21 @@ import { CopyPageButton } from "/snippets/copy-page-button.mdx";
 
 Claude Code is the best Cekura assistant experience. The Cekura plugin bundles Skills, slash commands, MCP configuration, update support, and MCP failure help.
 
-## What you get
-
-| Capability | Included? | Why it matters |
-|---|---:|---|
-| Cekura Skills | Yes | Your assistant knows Cekura workflows and best practices |
-| Slash commands | Yes | Fast entry points like `/setup-mcp`, `/autogen-eval`, `/run-evals`, and `/cekura-report` |
-| MCP config | Yes | The plugin includes the Cekura MCP server config |
-| OAuth setup | Yes | `/setup-mcp` walks you through browser sign-in |
-| Update support | Yes | `/upgrade-skills` refreshes skills and commands |
-| Failure help | Yes | MCP failures are detected and surfaced with next steps |
-
 ## Install the plugin
 
 <Tabs>
   <Tab title="Claude Code CLI">
-    1. Start a Claude Code session.
-    2. Run `/plugin`.
-    3. Open **Marketplaces > Add Marketplace**.
-    4. Paste `cekura-ai/cekura-skills` and confirm.
-    5. Open **Discover**, search `cekura`, and install the `cekura` plugin.
-    6. Restart the Claude Code session if prompted.
+    Run these in a Claude Code session. Each command copies on its own:
+
+    ```plaintext
+    /plugin marketplace add cekura-ai/cekura-skills
+    ```
+
+    ```plaintext
+    /plugin install cekura@cekura-skills
+    ```
+
+    Restart the session if prompted.
   </Tab>
 
   <Tab title="Claude Code in VS Code">
@@ -80,6 +74,17 @@ You can also ask in plain English:
 ```plaintext
 I'm new to Cekura. Walk me through setting up my first useful agent evaluation workflow.
 ```
+
+## What you get
+
+| Capability | Included? | Why it matters |
+|---|---:|---|
+| Cekura Skills | Yes | Your assistant knows Cekura workflows and best practices |
+| Slash commands | Yes | Fast entry points like `/setup-mcp`, `/autogen-eval`, `/run-evals`, and `/cekura-report` |
+| MCP config | Yes | The plugin includes the Cekura MCP server config |
+| OAuth setup | Yes | `/setup-mcp` walks you through browser sign-in |
+| Update support | Yes | `/upgrade-skills` refreshes skills and commands |
+| Failure help | Yes | MCP failures are detected and surfaced with next steps |
 
 ## Common workflows
 

--- a/mcp/claude-code-guide.mdx
+++ b/mcp/claude-code-guide.mdx
@@ -72,6 +72,18 @@ You can also ask in plain English:
 I'm new to Cekura. Walk me through setting up my first useful agent evaluation workflow.
 ```
 
+### First-run flow
+
+A typical first session, in order:
+
+1. `/setup-mcp` — connect MCP
+2. `/cekura-onboarding` — guided setup (or say "I'm new to Cekura")
+3. Ask "set up my agent" — connect your voice agent
+4. `/autogen-eval` — auto-generate test scenarios
+5. `/run-evals` — run your first tests
+6. Ask "create a metric for X" — design a metric
+7. `/cekura-report` — full end-to-end quality report
+
 ## What you get
 
 | Capability | Included? | Why it matters |

--- a/mcp/claude-code-guide.mdx
+++ b/mcp/claude-code-guide.mdx
@@ -22,7 +22,7 @@ Claude Code is the best Cekura assistant experience. The Cekura plugin bundles S
     /plugin install cekura@cekura-skills
     ```
 
-    Restart the session if prompted, then run `/setup-mcp`.
+    Restart the session if prompted, then continue to **Connect MCP** below.
   </Tab>
 
   <Tab title="Claude Code in VS Code">

--- a/mcp/claude-code-guide.mdx
+++ b/mcp/claude-code-guide.mdx
@@ -117,6 +117,15 @@ Watch an end-to-end walkthrough of evaluating complex voice agents, running mult
   title="Using Cekura with Claude Code"
 />
 
+## Keep it updated
+
+Run `/upgrade-skills` in any Claude Code session to pull the latest skills and commands. To update manually:
+
+```bash
+cd ~/.claude/plugins/marketplaces/cekura-skills
+git pull origin main
+```
+
 ## Troubleshooting
 
 <AccordionGroup>

--- a/mcp/claude-desktop-guide.mdx
+++ b/mcp/claude-desktop-guide.mdx
@@ -74,6 +74,6 @@ Use Claude Code instead if you want:
   </Accordion>
 
   <Accordion title="I need API-key auth">
-    OAuth is the recommended Claude Desktop path. If your workspace requires API-key auth or custom headers, use the [MCP-only setup](/mcp/mcp-only#api-key-setup) or Claude Code.
+    OAuth is the recommended Claude Desktop path. If your workspace requires API-key auth or custom headers, use the [API-key setup](/mcp/mcp-only#api-key-setup) or Claude Code.
   </Accordion>
 </AccordionGroup>

--- a/mcp/claude-desktop-guide.mdx
+++ b/mcp/claude-desktop-guide.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Using Cekura with Claude Desktop"
-sidebarTitle: "Claude Desktop Guide"
-description: "End-to-end setup: install the Cekura plugin in Claude Desktop, connect the MCP, and add your own custom skills"
+sidebarTitle: "Claude Desktop"
+description: "Connect Claude Desktop to the Cekura MCP server with the native connector UI."
 icon: "desktop"
 ---
 
@@ -9,139 +9,71 @@ import { CopyPageButton } from "/snippets/copy-page-button.mdx";
 
 <CopyPageButton />
 
+Claude Desktop can connect to Cekura through its native MCP connector UI. This gives Claude access to Cekura MCP tools, but it does not install the Claude Code plugin, Cekura slash commands, plugin update support, or plugin hooks.
 
-This is the single-page setup for Claude Desktop. Everything you need — Cekura skills, the MCP server, and your own custom skills — installs in a few minutes through the Claude Desktop plugin marketplace.
+<Tip>
+For the full Cekura Skills experience, use [Claude Code](/mcp/claude-code-guide). Claude Desktop is the simpler MCP-connector path.
+</Tip>
 
-<Note>
-**One-line summary:** install the **`cekura`** plugin from `https://github.com/cekura-ai/cekura-skills.git` via **Settings → Plugins**, finish the MCP OAuth sign-in, and you're done. Custom skills live in the **`~/.claude/skills/`** folder or in your own marketplace fork.
-</Note>
+## What you get
 
-## What you'll set up
+| Capability | Claude Desktop connector |
+|---|---:|
+| MCP tools | Yes |
+| OAuth sign-in | Yes |
+| Cekura Skills plugin | No |
+| Cekura slash commands | No |
+| Plugin auto-update and hooks | No |
 
-1. **Cekura plugin** — bundles the nine Cekura skills and auto-configures the MCP server.
-2. **MCP authorization** — one-click OAuth into your Cekura workspace.
-3. **Custom skills** — your own organization-specific playbooks, installed alongside the Cekura ones.
-
-## Prerequisites
-
-- A [Cekura dashboard](https://dashboard.cekura.ai) account.
-- A current Claude Desktop build (Mac or Windows) with **Plugins** enabled. On Team/Enterprise, a workspace admin must enable Plugins and Connectors at the org level first.
-- No Node.js, no API keys, and no manual config-file editing for the default OAuth path.
-
-## 1. Install the Cekura plugin
-
-The plugin ships all nine Cekura skills plus the MCP server configuration in a single install — same `cekura-ai/cekura-skills` marketplace used by Claude Code.
+## Connect Cekura
 
 <Steps>
-  <Step title="Open the plugin manager">
-    Claude Desktop → **Settings** → **Plugins**.
+  <Step title="Open Connectors">
+    Open Claude Desktop and go to **Settings > Connectors**.
   </Step>
 
-  <Step title="Add the Cekura marketplace">
-    Click **Marketplaces** → **Add marketplace**. Paste:
-
-    ```
-    https://github.com/cekura-ai/cekura-skills.git
-    ```
-
-    Confirm. Claude Desktop fetches the marketplace manifest.
+  <Step title="Add Cekura">
+    Click **Add custom connector**. Set **Name** to `Cekura` and **URL** to `https://api.cekura.ai/mcp`.
   </Step>
 
-  <Step title="Install the `cekura` plugin">
-    Switch to the **Discover** (or **Plugins**) tab, search `cekura`, and install. This registers the nine skills and adds the Cekura MCP server to your connector list.
-  </Step>
-
-  <Step title="Authorize the MCP">
-    Open a new chat. On the first Cekura tool call, Claude Desktop opens a browser for OAuth — sign into your Cekura dashboard and click **Authorize**. The session token is managed for you.
+  <Step title="Authorize">
+    Save the connector. Claude Desktop opens a browser window. Sign into your Cekura dashboard account and click **Authorize**.
   </Step>
 
   <Step title="Verify">
-    Ask: *"Use the Cekura MCP to list my agents, then use the Cekura skills to propose 10 workflow evaluators covering the most common flows for the first agent."*
-
-    Claude should call `aiagents_list`, load the `cekura-eval-design` skill, and draft evaluators. If you get `401 Unauthorized`, reconnect from **Settings → Connectors → Cekura**.
+    Start a new chat and ask: *"List my Cekura agents."*
   </Step>
 </Steps>
 
-<Tip>
-**Auto-update.** In the plugin manager, select **cekura-skills → Enable auto-update**. New skill versions and tool overlays land in your next session without re-installing. Same mechanism as Claude Code.
-</Tip>
+## First useful prompt
 
-### What you get out of the box
-
-| Capability | What it does |
-|---|---|
-| 9 Cekura skills | Auto-activate on phrases like *"design a metric for…"* or *"fix this failing run…"* — full catalog in [Skills overview](/mcp/skills). |
-| Cekura MCP server | 84+ tools for agents, evaluators, metrics, runs, and call logs. Configuration in [MCP overview](/mcp/overview). |
-| Skill activation logs | Visible in Claude's chain-of-thought when the matching skill loads. |
-
-<Note>
-**Slash commands** (`/create-metric`, `/run-evals`, etc.) are a Claude Code-only feature today. In Claude Desktop, you describe the task in plain English and Claude auto-activates the matching skill. The end result is the same — Claude calls the same MCP tools under the hood.
-</Note>
-
-## 2. Add your own custom skills
-
-Custom skills encode organization-specific knowledge — naming conventions, compliance checks, internal runbooks — and activate the same way the Cekura ones do.
-
-### Skill structure
-
-A skill is a folder with one required file, `SKILL.md`, plus any supporting files it references.
-
-```
-my-team-eval-conventions/
-├── SKILL.md            ← required
-├── naming-rules.md     ← optional, referenced from SKILL.md
-└── examples/
-    └── good-eval.yaml
+```plaintext
+List my Cekura agents, pick one, and propose 3 evaluators I should create first. Do not create anything until I approve.
 ```
 
-`SKILL.md` starts with YAML frontmatter — `name` and a specific `description` (Claude matches your message against the description to decide whether to load the skill).
+Because Claude Desktop does not install Cekura Skills, phrase requests with the Cekura workflow you want: metrics, evaluators, runs, call logs, or reports.
 
-### Ways to install
+## When to switch to Claude Code
 
-| Path | When to use |
-|---|---|
-| Drop into `~/.claude/skills/<name>/` | Solo iteration. Restart Claude Desktop to pick it up. |
-| Fork the marketplace, install the plugin | Team rollout — same **Settings → Plugins → Add marketplace** flow as Cekura, pointing at your fork. |
-| Workspace upload | Team/Enterprise only — admin adds the marketplace at the org level. |
+Use Claude Code instead if you want:
 
-For format details, the `skill-creator` shortcut, and the full authoring guide, see [Anthropic's skills documentation](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/overview) and the [Agent Skills standard](https://agentskills.io).
-
-## 3. End-to-end example
-
-A typical "set up evals for a new agent" loop in Claude Desktop:
-
-1. *"List my Cekura agents."* — MCP returns agents.
-2. *"For agent `support-bot`, generate 10 workflow evaluators following our naming conventions."* — auto-loads `cekura-eval-design` **and** your custom `my-team-eval-conventions` skill, drafts the evaluators, calls the MCP to create them.
-3. *"Run every evaluator on `support-bot` and stream pass/fail."* — MCP runs them concurrently.
-4. *"For the 3 failures, rerun each 4 times and tell me which are real bugs vs. flakes."* — Claude triages with `cekura-fixing-prod-issues`.
-5. *"Draft a fix plan with the suspected prompt or tool changes for each real bug."* — Claude composes the report inline.
+- Cekura Skills that auto-load for metric, evaluator, onboarding, and debugging workflows.
+- Slash commands like `/cekura-onboarding`, `/autogen-eval`, `/run-evals`, and `/cekura-report`.
+- Plugin update support through `/upgrade-skills`.
+- MCP failure help from the plugin hook.
 
 ## Troubleshooting
 
-| Symptom | Fix |
-|---|---|
-| Plugin install fails or marketplace not found | Confirm the URL is exactly `https://github.com/cekura-ai/cekura-skills.git`. Re-run **Marketplace → Refresh**. |
-| `401 Unauthorized` from MCP tools | **Settings → Connectors → Cekura → Reconnect** to re-run OAuth. |
-| Cekura tools don't appear in a chat | Restart Claude Desktop after installing the plugin. Confirm the Cekura connector is **Enabled**. |
-| Skills don't activate | Confirm **Settings → Capabilities → Skills** is on, restart the app, and check that the skill's `description:` matches the phrasing you're using. |
-| Custom skill in `~/.claude/skills/` isn't loading | The folder must contain `SKILL.md` at its root (not nested), and the `name:` frontmatter field must match the folder name. |
-| Team workspace doesn't show Plugins or Connectors | An admin needs to enable them once at the org level. |
+<AccordionGroup>
+  <Accordion title="Authorization failed">
+    Reconnect the Cekura connector from **Settings > Connectors** and confirm your browser is signed into the intended Cekura account.
+  </Accordion>
 
-Deeper MCP-only troubleshooting (rate limits, header issues, Node.js edge cases) lives in [MCP overview → Troubleshooting](/mcp/overview#troubleshooting).
+  <Accordion title="Cekura tools do not appear">
+    Restart Claude Desktop, confirm the Cekura connector is enabled, and verify the URL is exactly `https://api.cekura.ai/mcp`.
+  </Accordion>
 
-## References
-
-<CardGroup cols={2}>
-  <Card title="MCP Overview" icon="shield-halved" href="/mcp/overview">
-    Full configuration matrix, auth options, request headers
-  </Card>
-  <Card title="Skills Catalog" icon="sparkles" href="/mcp/skills">
-    All nine Cekura skills and what each one activates on
-  </Card>
-  <Card title="Claude Code Guide" icon="code" href="/mcp/claude-code-guide">
-    The Claude Code equivalent (plugin marketplace + slash commands)
-  </Card>
-  <Card title="Dashboard" icon="gauge" href="https://dashboard.cekura.ai">
-    Manage projects, agents, and API keys
-  </Card>
-</CardGroup>
+  <Accordion title="I need API-key auth">
+    OAuth is the recommended Claude Desktop path. If your workspace requires API-key auth or custom headers, use the [MCP-only setup](/mcp/mcp-only#api-key-setup) or Claude Code.
+  </Accordion>
+</AccordionGroup>

--- a/mcp/claude-desktop-guide.mdx
+++ b/mcp/claude-desktop-guide.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Using Cekura with Claude Desktop"
 sidebarTitle: "Claude Desktop"
-description: "Connect Claude Desktop to the Cekura MCP server with the native connector UI."
+description: "Install the Cekura plugin in Claude Desktop for Skills + MCP, or connect the MCP server directly via the connector UI."
 icon: "desktop"
 ---
 
@@ -9,17 +9,41 @@ import { CopyPageButton } from "/snippets/copy-page-button.mdx";
 
 <CopyPageButton />
 
-Claude Desktop can connect to Cekura through its native MCP connector UI. This gives Claude access to Cekura MCP tools, but it does not install the Claude Code plugin, Cekura slash commands, plugin update support, or plugin hooks.
+Claude Desktop supports Cekura two ways: install the **plugin** (Skills + MCP, recommended) or add the MCP server as a **connector** (MCP only).
 
-<Tip>
-For the full Cekura Skills experience, use [Claude Code](/mcp/claude-code-guide). Claude Desktop is the simpler MCP-connector path.
-</Tip>
+## Install the plugin
 
-## Connect Cekura
+The plugin bundles Cekura Skills and the MCP server. Skills are available in both Chat and Cowork.
+
+<Steps>
+  <Step title="Open the Plugins tab">
+    In Claude Desktop, open the **Customize** menu → **Plugins**.
+  </Step>
+
+  <Step title="Add the Cekura marketplace">
+    In **Personal plugins**, click **+** → **Add marketplace** → **Add from a repository**, and enter `cekura-ai/cekura-skills`.
+  </Step>
+
+  <Step title="Install cekura">
+    Install the **cekura** plugin from the marketplace.
+  </Step>
+
+  <Step title="Authorize MCP">
+    Complete the OAuth browser sign-in to your Cekura dashboard account when prompted — no API key needed.
+  </Step>
+</Steps>
+
+<Note>
+Plugin **hooks and sub-agents run only in Cowork** (they appear grayed out in Chat). If MCP tools don't appear in a Chat session, add the connector below — it gives MCP in Chat.
+</Note>
+
+## Connect MCP via the connector (MCP only)
+
+Prefer MCP without Skills, or need MCP in Chat? Add the server as a connector:
 
 <Steps>
   <Step title="Open Connectors">
-    Open Claude Desktop and go to **Settings > Connectors**.
+    Go to **Settings → Connectors**.
   </Step>
 
   <Step title="Add Cekura">
@@ -27,53 +51,50 @@ For the full Cekura Skills experience, use [Claude Code](/mcp/claude-code-guide)
   </Step>
 
   <Step title="Authorize">
-    Save the connector. Claude Desktop opens a browser window. Sign into your Cekura dashboard account and click **Authorize**.
-  </Step>
-
-  <Step title="Verify">
-    Start a new chat and ask: *"List my Cekura agents."*
+    Save, then complete the browser OAuth sign-in to your Cekura dashboard account.
   </Step>
 </Steps>
 
-## First useful prompt
+## Verify setup
+
+Start a new chat and ask:
 
 ```plaintext
-List my Cekura agents, pick one, and propose 3 evaluators I should create first. Do not create anything until I approve.
+Use the Cekura skills and MCP. List my Cekura agents, pick one, and propose 3 evaluators I should create first. Do not create anything until I approve.
 ```
 
-Because Claude Desktop does not install Cekura Skills, phrase requests with the Cekura workflow you want: metrics, evaluators, runs, call logs, or reports.
+Claude should list real agents from your workspace. With the plugin installed, it also reasons in Cekura terms (evaluators, metrics, test profiles). On a connector-only setup, phrase requests with the workflow you want — metrics, evaluators, runs, call logs, or reports.
 
 ## What you get
 
-| Capability | Claude Desktop connector |
-|---|---:|
-| MCP tools | Yes |
-| OAuth sign-in | Yes |
-| Cekura Skills plugin | No |
-| Cekura slash commands | No |
-| Plugin auto-update and hooks | No |
+| Capability | Plugin | Connector only |
+|---|---:|---:|
+| Cekura Skills | Yes (Chat + Cowork) | No |
+| MCP tools | Yes | Yes |
+| OAuth sign-in | Yes | Yes |
+| Slash commands | No | No |
+| Hooks / sub-agents | Cowork only | No |
 
-## When to switch to Claude Code
+## Prefer the terminal or full plugin power?
 
-Use Claude Code instead if you want:
-
-- Cekura Skills that auto-load for metric, evaluator, onboarding, and debugging workflows.
-- Slash commands like `/cekura-onboarding`, `/autogen-eval`, `/run-evals`, and `/cekura-report`.
-- Plugin update support through `/upgrade-skills`.
-- MCP failure help from the plugin hook.
+Use [Claude Code](/mcp/claude-code-guide) — the CLI (or the Desktop app's **Code** tab) gives slash commands like `/cekura-onboarding`, `/autogen-eval`, and `/cekura-report`, plugin update support via `/upgrade-skills`, and the MCP failure hook.
 
 ## Troubleshooting
 
 <AccordionGroup>
-  <Accordion title="Authorization failed">
-    Reconnect the Cekura connector from **Settings > Connectors** and confirm your browser is signed into the intended Cekura account.
+  <Accordion title="MCP tools do not appear in Chat">
+    The plugin's MCP may run in Cowork. Add the Cekura connector (**Settings → Connectors**) to get MCP tools in Chat, then restart Claude Desktop.
   </Accordion>
 
-  <Accordion title="Cekura tools do not appear">
-    Restart Claude Desktop, confirm the Cekura connector is enabled, and verify the URL is exactly `https://api.cekura.ai/mcp`.
+  <Accordion title="Authorization failed">
+    Re-authorize from the plugin (or **Settings → Connectors**) and confirm your browser is signed into the intended Cekura account.
+  </Accordion>
+
+  <Accordion title="Plugin or tools do not appear">
+    Restart Claude Desktop, confirm the **cekura** plugin is installed under **Customize → Plugins**, and (for the connector) verify the URL is exactly `https://api.cekura.ai/mcp`.
   </Accordion>
 
   <Accordion title="I need API-key auth">
-    OAuth is the recommended Claude Desktop path. If your workspace requires API-key auth or custom headers, use the [API-key setup](/mcp/mcp-only#api-key-setup) or Claude Code.
+    OAuth is the recommended path. If your workspace requires API-key auth or custom headers, use the [API-key setup](/mcp/mcp-only#api-key-setup) or Claude Code.
   </Accordion>
 </AccordionGroup>

--- a/mcp/claude-desktop-guide.mdx
+++ b/mcp/claude-desktop-guide.mdx
@@ -34,26 +34,8 @@ The plugin bundles Cekura Skills and the MCP server. Skills are available in bot
 </Steps>
 
 <Note>
-Plugin **hooks and sub-agents run only in Cowork** (they appear grayed out in Chat). If MCP tools don't appear in a Chat session, add the connector below — it gives MCP in Chat.
+Plugin **hooks and sub-agents run only in Cowork** (they appear grayed out in Chat). If MCP tools don't appear in a Chat session, add the Cekura connector (**Settings → Connectors**) — see [manual setup](/mcp/mcp-only).
 </Note>
-
-## Connect MCP via the connector (MCP only)
-
-Prefer MCP without Skills, or need MCP in Chat? Add the server as a connector:
-
-<Steps>
-  <Step title="Open Connectors">
-    Go to **Settings → Connectors**.
-  </Step>
-
-  <Step title="Add Cekura">
-    Click **Add custom connector**. Set **Name** to `Cekura` and **URL** to `https://api.cekura.ai/mcp`.
-  </Step>
-
-  <Step title="Authorize">
-    Save, then complete the browser OAuth sign-in to your Cekura dashboard account.
-  </Step>
-</Steps>
 
 ## Verify setup
 
@@ -64,16 +46,6 @@ Use the Cekura skills and MCP. List my Cekura agents, pick one, and propose 3 ev
 ```
 
 Claude should list real agents from your workspace. With the plugin installed, it also reasons in Cekura terms (evaluators, metrics, test profiles). On a connector-only setup, phrase requests with the workflow you want — metrics, evaluators, runs, call logs, or reports.
-
-## What you get
-
-| Capability | Plugin | Connector only |
-|---|---:|---:|
-| Cekura Skills | Yes (Chat + Cowork) | No |
-| MCP tools | Yes | Yes |
-| OAuth sign-in | Yes | Yes |
-| Slash commands | No | No |
-| Hooks / sub-agents | Cowork only | No |
 
 ## Prefer the terminal or full plugin power?
 

--- a/mcp/claude-desktop-guide.mdx
+++ b/mcp/claude-desktop-guide.mdx
@@ -15,16 +15,6 @@ Claude Desktop can connect to Cekura through its native MCP connector UI. This g
 For the full Cekura Skills experience, use [Claude Code](/mcp/claude-code-guide). Claude Desktop is the simpler MCP-connector path.
 </Tip>
 
-## What you get
-
-| Capability | Claude Desktop connector |
-|---|---:|
-| MCP tools | Yes |
-| OAuth sign-in | Yes |
-| Cekura Skills plugin | No |
-| Cekura slash commands | No |
-| Plugin auto-update and hooks | No |
-
 ## Connect Cekura
 
 <Steps>
@@ -52,6 +42,16 @@ List my Cekura agents, pick one, and propose 3 evaluators I should create first.
 ```
 
 Because Claude Desktop does not install Cekura Skills, phrase requests with the Cekura workflow you want: metrics, evaluators, runs, call logs, or reports.
+
+## What you get
+
+| Capability | Claude Desktop connector |
+|---|---:|
+| MCP tools | Yes |
+| OAuth sign-in | Yes |
+| Cekura Skills plugin | No |
+| Cekura slash commands | No |
+| Plugin auto-update and hooks | No |
 
 ## When to switch to Claude Code
 

--- a/mcp/codex-guide.mdx
+++ b/mcp/codex-guide.mdx
@@ -11,16 +11,6 @@ import { CopyPageButton } from "/snippets/copy-page-button.mdx";
 
 Use Codex with Cekura Skills for workflow guidance and the Cekura MCP server for live workspace actions.
 
-## What you get
-
-| Capability | Codex setup |
-|---|---:|
-| Cekura workflow guidance | Yes, via Agent Skills or `AGENTS.md` fallback |
-| MCP tools | Yes |
-| OAuth sign-in | Yes, through MCP |
-| Claude Code slash commands | No |
-| Claude Code plugin hooks | No |
-
 ## 1. Install Cekura Skills
 
 Start with the Agent Skills install:
@@ -60,6 +50,16 @@ Use the Cekura skills and MCP. List my Cekura agents, pick one, and propose 3 ev
 ```
 
 If Codex can list agents but does not use Cekura-specific evaluator or metric guidance, keep the `AGENTS.md` fallback in the repo.
+
+## What you get
+
+| Capability | Codex setup |
+|---|---:|
+| Cekura workflow guidance | Yes, via Agent Skills or `AGENTS.md` fallback |
+| MCP tools | Yes |
+| OAuth sign-in | Yes, through MCP |
+| Claude Code slash commands | No |
+| Claude Code plugin hooks | No |
 
 ## Recommended workflow
 

--- a/mcp/codex-guide.mdx
+++ b/mcp/codex-guide.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Using Cekura with Codex"
 sidebarTitle: "Codex"
-description: "Set up Codex with Cekura Skills, an AGENTS.md fallback, and the Cekura MCP server."
+description: "Install the Cekura plugin in Codex — it bundles Cekura Skills and the MCP server, then authenticate with one command."
 icon: "terminal"
 ---
 
@@ -9,37 +9,34 @@ import { CopyPageButton } from "/snippets/copy-page-button.mdx";
 
 <CopyPageButton />
 
-Use Codex with Cekura Skills for workflow guidance and the Cekura MCP server for live workspace actions.
+Codex has native Cekura plugin support. The plugin gives you Cekura Skills **and** the Cekura MCP server — you just authenticate the MCP once.
 
-## Install Cekura Skills
+## Install the plugin
 
-Start with the Agent Skills install:
-
-```bash
-npx skills add cekura-ai/cekura-skills --all
-```
-
-If your Codex build does not load Agent Skills yet, use the portable `AGENTS.md` fallback in the repo where you run Codex:
+Three commands — add the marketplace, install the plugin, then authenticate MCP:
 
 ```bash
-curl -L https://raw.githubusercontent.com/cekura-ai/cekura-skills/main/codex/AGENTS.md -o AGENTS.md
+codex plugin marketplace add cekura-ai/cekura-skills
+codex plugin add cekura@cekura
+codex mcp login cekura
 ```
 
-The fallback gives Codex Cekura metric, evaluator, API, and anti-pattern guidance in one file.
+`codex mcp login` opens a browser for OAuth sign-in — no API key. Prefer the TUI? Run `codex`, open `/plugins` to install **cekura**, then `/mcp` to authenticate.
 
-## Connect MCP
+<Note>
+Codex plugins don't carry slash commands; the bundled Skills cover those workflows — they activate by context or when you invoke one with `@`.
+</Note>
 
-Add this to `~/.codex/config.toml`. The `mcp-remote` shim handles the OAuth browser sign-in for Codex:
+Verify it worked:
 
-```toml
-[mcp_servers.cekura]
-command = "npx"
-args = ["-y", "mcp-remote", "https://api.cekura.ai/mcp"]
+```bash
+codex plugin list   # cekura listed as installed
+codex mcp list      # cekura shows connected after login
 ```
 
-On first use, Codex opens a browser to authorize against your Cekura dashboard account. This path needs Node.js 20.18.1 or higher.
-
-For API-key auth, see [MCP-only setup](/mcp/mcp-only#api-key-setup).
+<Tip>
+Added the marketplace before a recent release? Refresh it first: `codex plugin marketplace upgrade cekura`. For API-key auth instead of OAuth, see [MCP-only setup](/mcp/mcp-only#api-key-setup).
+</Tip>
 
 ## Verify setup
 
@@ -49,17 +46,31 @@ Start Codex from your agent repo and ask:
 Use the Cekura skills and MCP. List my Cekura agents, pick one, and propose 3 evaluators I should create first. Do not create anything until I approve.
 ```
 
-If Codex can list agents but does not use Cekura-specific evaluator or metric guidance, keep the `AGENTS.md` fallback in the repo.
+Codex should list real agents from your workspace and reason in Cekura terms (evaluators, metrics, test profiles, run results).
 
 ## What you get
 
-| Capability | Codex setup |
+| Capability | Codex plugin |
 |---|---:|
-| Cekura workflow guidance | Yes, via Agent Skills or `AGENTS.md` fallback |
-| MCP tools | Yes |
-| OAuth sign-in | Yes, through MCP |
+| Cekura Skills | Yes |
+| MCP tools | Yes (auto-configured) |
+| OAuth sign-in | Yes (`codex mcp login`) |
 | Claude Code slash commands | No |
 | Claude Code plugin hooks | No |
+
+## No-MCP fallback
+
+If you can't use the plugin, install Skills (guidance only — no live workspace tools):
+
+```bash
+npx skills add cekura-ai/cekura-skills --all
+```
+
+Or drop the portable behavior preset in the repo where you run Codex:
+
+```bash
+curl -L https://raw.githubusercontent.com/cekura-ai/cekura-skills/main/codex/AGENTS.md -o AGENTS.md
+```
 
 ## Recommended workflow
 
@@ -84,15 +95,15 @@ If Codex can list agents but does not use Cekura-specific evaluator or metric gu
 ## Troubleshooting
 
 <AccordionGroup>
-  <Accordion title="Skills do not seem to load">
-    Add `AGENTS.md` to the repo where you run Codex, restart Codex, and ask explicitly: *"Use the Cekura guidance in AGENTS.md to design evaluators."*
+  <Accordion title="Plugin not found or out of date">
+    Run `codex plugin marketplace upgrade cekura`, then `codex plugin add cekura@cekura` again. Confirm with `codex plugin list`.
   </Accordion>
 
   <Accordion title="MCP tools do not appear">
-    Confirm `~/.codex/config.toml` contains the `cekura` MCP server, restart Codex, and verify the URL is `https://api.cekura.ai/mcp`.
+    Run `codex mcp login cekura` and confirm `codex mcp list` shows `cekura` connected. Restart Codex if needed.
   </Accordion>
 
   <Accordion title="OAuth does not complete">
-    Re-run the MCP authorization flow and confirm your browser is signed into the correct Cekura account.
+    Re-run `codex mcp login cekura` and confirm your browser is signed into the correct Cekura account.
   </Accordion>
 </AccordionGroup>

--- a/mcp/codex-guide.mdx
+++ b/mcp/codex-guide.mdx
@@ -1,59 +1,97 @@
 ---
 title: "Using Cekura with Codex"
-sidebarTitle: "Codex Guide"
-description: "End-to-end walkthrough: evaluate complex voice agents using OpenAI Codex CLI and the Cekura MCP"
-icon: "code"
+sidebarTitle: "Codex"
+description: "Set up Codex with Cekura Skills, an AGENTS.md fallback, and the Cekura MCP server."
+icon: "terminal"
 ---
 
 import { CopyPageButton } from "/snippets/copy-page-button.mdx";
 
 <CopyPageButton />
 
+Use Codex with Cekura Skills for workflow guidance and the Cekura MCP server for live workspace actions.
 
-Use OpenAI's Codex CLI together with the Cekura MCP to design evaluators, run them against your voice agents, and triage the results — all from your terminal.
+## What you get
 
-## Quick Guide
+| Capability | Codex setup |
+|---|---:|
+| Cekura workflow guidance | Yes, via Agent Skills or `AGENTS.md` fallback |
+| MCP tools | Yes |
+| OAuth sign-in | Yes, through MCP |
+| Claude Code slash commands | No |
+| Claude Code plugin hooks | No |
+
+## 1. Install Cekura Skills
+
+Start with the Agent Skills install:
+
+```bash
+npx skills add cekura-ai/cekura-skills --all
+```
+
+If your Codex build does not load Agent Skills yet, use the portable `AGENTS.md` fallback in the repo where you run Codex:
+
+```bash
+curl -L https://raw.githubusercontent.com/cekura-ai/cekura-skills/main/codex/AGENTS.md -o AGENTS.md
+```
+
+The fallback gives Codex Cekura metric, evaluator, API, and anti-pattern guidance in one file.
+
+## 2. Connect MCP
+
+Add this to `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.cekura]
+url = "https://api.cekura.ai/mcp"
+```
+
+On first use, Codex opens a browser to authorize against your Cekura dashboard account.
+
+For API-key auth, see [MCP-only setup](/mcp/mcp-only#api-key-setup).
+
+## 3. Verify setup
+
+Start Codex from your agent repo and ask:
+
+```plaintext
+Use the Cekura skills and MCP. List my Cekura agents, pick one, and propose 3 evaluators I should create first. Do not create anything until I approve.
+```
+
+If Codex can list agents but does not use Cekura-specific evaluator or metric guidance, keep the `AGENTS.md` fallback in the repo.
+
+## Recommended workflow
 
 <Steps>
-  <Step title="Connect Codex to Cekura">
-    Add the Cekura MCP server to Codex. Edit `~/.codex/config.toml` and add:
-
-    ```toml
-    [mcp_servers.cekura]
-    url = "https://api.cekura.ai/mcp"
-    ```
-
-    On first use Codex opens a browser to authorize against your Cekura dashboard. For API-key-based auth (project-scoped credentials, shared CI access), use the CLI form instead:
-
-    ```bash
-    codex mcp add cekura --env CEKURA_API_KEY=YOUR_API_KEY_HERE -- \
-      sh -c 'npx -y mcp-remote https://api.cekura.ai/mcp --header "X-CEKURA-API-KEY:$CEKURA_API_KEY"'
-    ```
-
-    Verify by starting Codex and asking: *"List my Cekura agents."*
+  <Step title="Run Codex from the agent repo">
+    Codex should have access to prompts, tool definitions, schemas, and local tests before it creates Cekura evaluators.
   </Step>
 
-  <Step title="Set up mock data and cleanup hooks">
-    Complex agents depend on database state — users, accounts, sessions, entitlements. Stand up a lightweight webhook server that seeds mock data before a run and listens for Cekura's post-run webhook to reset the database. This keeps concurrent tests isolated and repeatable.
+  <Step title="Plan first, then create">
+    Ask Codex for a coverage matrix. Approve the plan before creating evaluators or metrics.
   </Step>
 
-  <Step title="Let Codex learn the schema">
-    Run Codex from your agent's repo so it can read your tool definitions, prompts, and database schema directly. Then prompt it to generate scenario coverage through the Cekura MCP — for example: *"Read the agent's tools and prompts in this repo, then create 10 Cekura evaluators covering the most common user flows."*
+  <Step title="Run a small test batch">
+    Run a small set of evaluators first, inspect transcripts, then scale to broader regression runs.
   </Step>
 
-  <Step title="Run the full suite">
-    Kick off all evaluators at once through the MCP: *"Run every evaluator on agent X and report pass/fail."* Cekura executes them concurrently and surfaces pass/fail with full transcripts and traces.
-  </Step>
-
-  <Step title="Triage with Codex">
-    Ask Codex to pull failing runs and classify them: *"Fetch the failures from the last run and tell me which are real bugs vs. flakes."* Because runs are non-deterministic, **rerun each failing test 3–4 times** and ask Codex to compute a pass rate. One pass out of four usually points to a prompt or tool-routing bug, not infra.
-  </Step>
-
-  <Step title="Fix in-place and re-run">
-    With both your codebase and the Cekura MCP in the same Codex session, you can go from failing transcript → suspected prompt or tool bug → edit → re-run the failing evaluator without leaving the terminal.
+  <Step title="Patch and re-run">
+    When a run fails, ask Codex to compare the transcript against your prompt or code, patch the likely issue, and rerun the targeted evaluator.
   </Step>
 </Steps>
 
-<Tip>
-A good first prompt: *"Use the Cekura MCP to list my agents, then read the prompt for the first one and propose 10 workflow evaluators covering the most common user flows."*
-</Tip>
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="Skills do not seem to load">
+    Add `AGENTS.md` to the repo where you run Codex, restart Codex, and ask explicitly: *"Use the Cekura guidance in AGENTS.md to design evaluators."*
+  </Accordion>
+
+  <Accordion title="MCP tools do not appear">
+    Confirm `~/.codex/config.toml` contains the `cekura` MCP server, restart Codex, and verify the URL is `https://api.cekura.ai/mcp`.
+  </Accordion>
+
+  <Accordion title="OAuth does not complete">
+    Re-run the MCP authorization flow and confirm your browser is signed into the correct Cekura account.
+  </Accordion>
+</AccordionGroup>

--- a/mcp/codex-guide.mdx
+++ b/mcp/codex-guide.mdx
@@ -39,14 +39,15 @@ The fallback gives Codex Cekura metric, evaluator, API, and anti-pattern guidanc
 
 ## 2. Connect MCP
 
-Add this to `~/.codex/config.toml`:
+Add this to `~/.codex/config.toml`. The `mcp-remote` shim handles the OAuth browser sign-in for Codex:
 
 ```toml
 [mcp_servers.cekura]
-url = "https://api.cekura.ai/mcp"
+command = "npx"
+args = ["-y", "mcp-remote", "https://api.cekura.ai/mcp"]
 ```
 
-On first use, Codex opens a browser to authorize against your Cekura dashboard account.
+On first use, Codex opens a browser to authorize against your Cekura dashboard account. This path needs Node.js 20.18.1 or higher.
 
 For API-key auth, see [MCP-only setup](/mcp/mcp-only#api-key-setup).
 

--- a/mcp/codex-guide.mdx
+++ b/mcp/codex-guide.mdx
@@ -35,7 +35,7 @@ codex mcp list      # cekura shows connected after login
 ```
 
 <Tip>
-Added the marketplace before a recent release? Refresh it first: `codex plugin marketplace upgrade cekura`. For API-key auth instead of OAuth, see [MCP-only setup](/mcp/mcp-only#api-key-setup).
+Added the marketplace before a recent release? Refresh it first: `codex plugin marketplace upgrade cekura`. For API-key auth instead of OAuth, see [API-key setup](/mcp/mcp-only#api-key-setup).
 </Tip>
 
 ## Verify setup
@@ -91,6 +91,15 @@ curl -L https://raw.githubusercontent.com/cekura-ai/cekura-skills/main/codex/AGE
     When a run fails, ask Codex to compare the transcript against your prompt or code, patch the likely issue, and rerun the targeted evaluator.
   </Step>
 </Steps>
+
+## Keep it updated
+
+Codex updates are manual — re-run to pull the latest version:
+
+```bash
+codex plugin marketplace upgrade cekura
+codex plugin add cekura@cekura
+```
 
 ## Troubleshooting
 

--- a/mcp/codex-guide.mdx
+++ b/mcp/codex-guide.mdx
@@ -11,7 +11,7 @@ import { CopyPageButton } from "/snippets/copy-page-button.mdx";
 
 Use Codex with Cekura Skills for workflow guidance and the Cekura MCP server for live workspace actions.
 
-## 1. Install Cekura Skills
+## Install Cekura Skills
 
 Start with the Agent Skills install:
 
@@ -27,7 +27,7 @@ curl -L https://raw.githubusercontent.com/cekura-ai/cekura-skills/main/codex/AGE
 
 The fallback gives Codex Cekura metric, evaluator, API, and anti-pattern guidance in one file.
 
-## 2. Connect MCP
+## Connect MCP
 
 Add this to `~/.codex/config.toml`. The `mcp-remote` shim handles the OAuth browser sign-in for Codex:
 
@@ -41,7 +41,7 @@ On first use, Codex opens a browser to authorize against your Cekura dashboard a
 
 For API-key auth, see [MCP-only setup](/mcp/mcp-only#api-key-setup).
 
-## 3. Verify setup
+## Verify setup
 
 Start Codex from your agent repo and ask:
 

--- a/mcp/codex-guide.mdx
+++ b/mcp/codex-guide.mdx
@@ -48,29 +48,9 @@ Use the Cekura skills and MCP. List my Cekura agents, pick one, and propose 3 ev
 
 Codex should list real agents from your workspace and reason in Cekura terms (evaluators, metrics, test profiles, run results).
 
-## What you get
+## No plugin?
 
-| Capability | Codex plugin |
-|---|---:|
-| Cekura Skills | Yes |
-| MCP tools | Yes (auto-configured) |
-| OAuth sign-in | Yes (`codex mcp login`) |
-| Claude Code slash commands | No |
-| Claude Code plugin hooks | No |
-
-## No-MCP fallback
-
-If you can't use the plugin, install Skills (guidance only — no live workspace tools):
-
-```bash
-npx skills add cekura-ai/cekura-skills --all
-```
-
-Or drop the portable behavior preset in the repo where you run Codex:
-
-```bash
-curl -L https://raw.githubusercontent.com/cekura-ai/cekura-skills/main/codex/AGENTS.md -o AGENTS.md
-```
+Set up [Skills + MCP manually](/mcp/mcp-only), or use the [behavior preset](/mcp/other-agents) fallback.
 
 ## Recommended workflow
 

--- a/mcp/cursor-guide.mdx
+++ b/mcp/cursor-guide.mdx
@@ -11,7 +11,7 @@ import { CopyPageButton } from "/snippets/copy-page-button.mdx";
 
 Use Cursor with Cekura Skills for workflow guidance and the Cekura MCP server for live workspace actions.
 
-## 1. Install Cekura Skills
+## Install Cekura Skills
 
 Start with the Agent Skills install:
 
@@ -27,7 +27,7 @@ mkdir -p .cursor/rules && curl -L https://raw.githubusercontent.com/cekura-ai/ce
 
 You can also add the downloaded file as a global Cursor rule if you want Cekura guidance in every project.
 
-## 2. Connect MCP
+## Connect MCP
 
 Open **Cursor Settings > MCP > Add new MCP server**, or edit your Cursor MCP config directly:
 
@@ -46,7 +46,7 @@ On first use, Cursor opens a browser to authorize against your Cekura dashboard 
 
 For API-key auth, see [MCP-only setup](/mcp/mcp-only#api-key-setup).
 
-## 3. Verify setup
+## Verify setup
 
 Ask Cursor:
 

--- a/mcp/cursor-guide.mdx
+++ b/mcp/cursor-guide.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Using Cekura with Cursor"
-sidebarTitle: "Cursor Guide"
-description: "End-to-end walkthrough: evaluate complex voice agents using Cursor and the Cekura MCP"
+sidebarTitle: "Cursor"
+description: "Set up Cursor with Cekura Skills, a rules-file fallback, and the Cekura MCP server."
 icon: "code"
 ---
 
@@ -9,52 +9,95 @@ import { CopyPageButton } from "/snippets/copy-page-button.mdx";
 
 <CopyPageButton />
 
+Use Cursor with Cekura Skills for workflow guidance and the Cekura MCP server for live workspace actions.
 
-Use Cursor's agent mode together with the Cekura MCP to design evaluators, run them against your voice agents, and triage the results — all without leaving the editor.
+## What you get
 
-## Quick Guide
+| Capability | Cursor setup |
+|---|---:|
+| Cekura workflow guidance | Yes, via Agent Skills or rules fallback |
+| MCP tools | Yes |
+| OAuth sign-in | Yes, through MCP |
+| Claude Code slash commands | No |
+| Claude Code plugin hooks | No |
+
+## 1. Install Cekura Skills
+
+Start with the Agent Skills install:
+
+```bash
+npx skills add cekura-ai/cekura-skills --all
+```
+
+If your Cursor setup does not load Agent Skills yet, use the rules-file fallback:
+
+```bash
+mkdir -p .cursor/rules && curl -L https://raw.githubusercontent.com/cekura-ai/cekura-skills/main/codex/AGENTS.md -o .cursor/rules/cekura.md
+```
+
+You can also add the downloaded file as a global Cursor rule if you want Cekura guidance in every project.
+
+## 2. Connect MCP
+
+Open **Cursor Settings > MCP > Add new MCP server**, or edit your Cursor MCP config directly:
+
+```json
+{
+  "mcpServers": {
+    "cekura": {
+      "command": "npx",
+      "args": ["mcp-remote", "https://api.cekura.ai/mcp"]
+    }
+  }
+}
+```
+
+On first use, Cursor opens a browser to authorize against your Cekura dashboard account.
+
+For API-key auth, see [MCP-only setup](/mcp/mcp-only#api-key-setup).
+
+## 3. Verify setup
+
+Ask Cursor:
+
+```plaintext
+Use the Cekura skills and MCP. List my Cekura agents, pick one, and propose 3 evaluators I should create first. Do not create anything until I approve.
+```
+
+If Cursor can list agents but does not use Cekura-specific evaluator or metric guidance, keep the rules-file fallback installed.
+
+## Recommended workflow
 
 <Steps>
-  <Step title="Connect Cursor to Cekura">
-    Add the Cekura MCP server to Cursor. Open **Cursor Settings → MCP → Add new MCP server** (or edit `~/.cursor/mcp.json` directly) and paste:
-
-    ```json
-    {
-      "mcpServers": {
-        "cekura": {
-          "command": "npx",
-          "args": ["mcp-remote", "https://api.cekura.ai/mcp"]
-        }
-      }
-    }
-    ```
-
-    On first use Cursor opens a browser to authorize against your Cekura dashboard. For API-key-based auth (project-scoped credentials, shared CI access), see the [MCP overview](/mcp/overview#configure-mcp-server-full-matrix).
-
-    Verify by asking Cursor's agent: *"List my Cekura agents."*
+  <Step title="Let Cursor read your agent repo">
+    Ask Cursor to inspect prompts, tool definitions, schemas, and test data so the evaluator plan is grounded in your actual agent behavior.
   </Step>
 
-  <Step title="Set up mock data and cleanup hooks">
-    Complex agents depend on database state — users, accounts, sessions, entitlements. Stand up a lightweight webhook server that seeds mock data before a run and listens for Cekura's post-run webhook to reset the database. This keeps concurrent tests isolated and repeatable.
+  <Step title="Design coverage before creating anything">
+    Ask for workflow, edge-case, regression, and tool-call coverage. Approve the plan before creating evaluators.
   </Step>
 
-  <Step title="Let Cursor learn the schema">
-    Open your agent's repo in Cursor and ask the agent to read your tool definitions, prompts, and database schema. Then prompt it to generate scenario coverage through the Cekura MCP — for example: *"Read the agent's tools in `src/agent/tools.ts`, then create 10 Cekura evaluators covering the most common user flows."*
+  <Step title="Run evaluators through MCP">
+    Once approved, ask Cursor to run the evaluators with a low frequency first. Increase frequency after the first run succeeds.
   </Step>
 
-  <Step title="Run the full suite">
-    Kick off all evaluators at once through the MCP: *"Run every evaluator on agent X and stream the results."* Cekura executes them concurrently and surfaces pass/fail with full transcripts and traces.
-  </Step>
-
-  <Step title="Triage with Cursor">
-    Ask Cursor's agent to pull failing runs and classify them: *"Fetch the failures from the last run and tell me which are real bugs vs. flakes."* Because runs are non-deterministic, **rerun each failing test 3–4 times** and ask Cursor to compute a pass rate. One pass out of four usually points to a prompt or tool-routing bug, not infra.
-  </Step>
-
-  <Step title="Fix in-place and re-run">
-    Because Cursor has both your codebase and the Cekura MCP in the same context, you can go from failing transcript → suspected prompt or tool bug → edit → re-run the failing evaluator in a single thread.
+  <Step title="Triage failures in context">
+    Cursor can compare Cekura transcripts against your prompt and codebase, then propose fixes and rerun targeted evaluators.
   </Step>
 </Steps>
 
-<Tip>
-A good first prompt: *"Use the Cekura MCP to list my agents, then read the prompt for the first one and propose 10 workflow evaluators covering the most common user flows."*
-</Tip>
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="Skills do not seem to load">
+    Install the rules fallback with `.cursor/rules/cekura.md`, restart Cursor, and ask explicitly: *"Use the Cekura guidance in this repo to design evaluators."*
+  </Accordion>
+
+  <Accordion title="MCP tools do not appear">
+    Restart Cursor after editing MCP config. Confirm the URL is `https://api.cekura.ai/mcp` and that Node.js is 20.18.1 or higher if you use `mcp-remote`.
+  </Accordion>
+
+  <Accordion title="OAuth opens the wrong account">
+    Sign out of the wrong Cekura account in your browser, reconnect the MCP server, and authorize again.
+  </Accordion>
+</AccordionGroup>

--- a/mcp/cursor-guide.mdx
+++ b/mcp/cursor-guide.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Using Cekura with Cursor"
 sidebarTitle: "Cursor"
-description: "Set up Cursor with Cekura Skills, a rules-file fallback, and the Cekura MCP server."
+description: "Install the Cekura plugin in Cursor — it bundles Cekura Skills and the MCP server, no separate MCP setup."
 icon: "code"
 ---
 
@@ -9,42 +9,31 @@ import { CopyPageButton } from "/snippets/copy-page-button.mdx";
 
 <CopyPageButton />
 
-Use Cursor with Cekura Skills for workflow guidance and the Cekura MCP server for live workspace actions.
+Cursor has native Cekura plugin support. Installing the plugin gives you Cekura Skills **and** the Cekura MCP server in one step — no separate MCP configuration.
 
-## Install Cekura Skills
+## Install the plugin
 
-Start with the Agent Skills install:
+<Steps>
+  <Step title="Open the marketplace importer">
+    In Cursor, go to **Settings > Plugins > Team Marketplaces > Add Marketplace > Import from Repo**.
+  </Step>
 
-```bash
-npx skills add cekura-ai/cekura-skills --all
-```
+  <Step title="Point it at the Cekura repo">
+    Enter `https://github.com/cekura-ai/cekura-skills` and import.
+  </Step>
 
-If your Cursor setup does not load Agent Skills yet, use the rules-file fallback:
+  <Step title="Install the plugin">
+    Install **cekura** from the imported marketplace.
+  </Step>
 
-```bash
-mkdir -p .cursor/rules && curl -L https://raw.githubusercontent.com/cekura-ai/cekura-skills/main/codex/AGENTS.md -o .cursor/rules/cekura.md
-```
+  <Step title="Authorize MCP">
+    When prompted, complete the OAuth browser sign-in to your Cekura dashboard account. No API key needed — the plugin already includes the MCP server config.
+  </Step>
+</Steps>
 
-You can also add the downloaded file as a global Cursor rule if you want Cekura guidance in every project.
-
-## Connect MCP
-
-Open **Cursor Settings > MCP > Add new MCP server**, or edit your Cursor MCP config directly:
-
-```json
-{
-  "mcpServers": {
-    "cekura": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote", "https://api.cekura.ai/mcp"]
-    }
-  }
-}
-```
-
-On first use, Cursor opens a browser to authorize against your Cekura dashboard account.
-
-For API-key auth, see [MCP-only setup](/mcp/mcp-only#api-key-setup).
+<Note>
+Cursor plugins don't carry Claude-style slash commands; the bundled Skills cover those workflows and activate automatically when your request matches.
+</Note>
 
 ## Verify setup
 
@@ -54,17 +43,50 @@ Ask Cursor:
 Use the Cekura skills and MCP. List my Cekura agents, pick one, and propose 3 evaluators I should create first. Do not create anything until I approve.
 ```
 
-If Cursor can list agents but does not use Cekura-specific evaluator or metric guidance, keep the rules-file fallback installed.
+Cursor should list real agents from your workspace and reason in Cekura terms (evaluators, metrics, test profiles, run results).
+
+## Keep it updated
+
+Re-import the marketplace from **Settings > Plugins > Team Marketplaces** to pull the latest version.
+
+**Auto Refresh (optional)** — have Cursor update automatically:
+
+<Steps>
+  <Step title="Install the Cursor GitHub App">
+    Install it on the `cekura-ai/cekura-skills` repository (Cursor prompts for this; it's required for Auto Refresh).
+  </Step>
+  <Step title="Enable Auto Refresh">
+    In **Settings > Plugins > Team Marketplaces**, find the imported Cekura marketplace and toggle on **Auto Refresh**.
+  </Step>
+</Steps>
+
+Cursor then re-indexes the marketplace at most once every ~10 minutes. Auto Refresh updates the *existing* plugin only — if a brand-new plugin is added to the repo later, re-import the marketplace.
 
 ## What you get
 
-| Capability | Cursor setup |
+| Capability | Cursor plugin |
 |---|---:|
-| Cekura workflow guidance | Yes, via Agent Skills or rules fallback |
-| MCP tools | Yes |
-| OAuth sign-in | Yes, through MCP |
+| Cekura Skills | Yes |
+| MCP tools | Yes (auto-configured) |
+| OAuth sign-in | Yes |
 | Claude Code slash commands | No |
 | Claude Code plugin hooks | No |
+
+## No-MCP fallback
+
+If you can't use the plugin, install Skills (guidance only — no live workspace tools):
+
+```bash
+npx skills add cekura-ai/cekura-skills --all
+```
+
+Or drop the portable behavior preset as a Cursor project rule:
+
+```bash
+mkdir -p .cursor/rules && curl -L https://raw.githubusercontent.com/cekura-ai/cekura-skills/main/codex/AGENTS.md -o .cursor/rules/cekura.md
+```
+
+To add MCP manually on top of either fallback, see [MCP-only setup](/mcp/mcp-only).
 
 ## Recommended workflow
 
@@ -89,15 +111,15 @@ If Cursor can list agents but does not use Cekura-specific evaluator or metric g
 ## Troubleshooting
 
 <AccordionGroup>
-  <Accordion title="Skills do not seem to load">
-    Install the rules fallback with `.cursor/rules/cekura.md`, restart Cursor, and ask explicitly: *"Use the Cekura guidance in this repo to design evaluators."*
+  <Accordion title="Plugin or MCP tools do not appear">
+    Re-import the marketplace from **Settings > Plugins > Team Marketplaces**, confirm **cekura** is installed, and restart Cursor. Make sure you completed the OAuth sign-in when prompted.
   </Accordion>
 
-  <Accordion title="MCP tools do not appear">
-    Restart Cursor after editing MCP config. Confirm the URL is `https://api.cekura.ai/mcp` and that Node.js is 20.18.1 or higher if you use `mcp-remote`.
+  <Accordion title="Skills do not seem to load">
+    Confirm the plugin is installed, then ask explicitly: *"Use the Cekura skills to design evaluators."* If you're on the rules-file fallback instead, confirm `.cursor/rules/cekura.md` exists.
   </Accordion>
 
   <Accordion title="OAuth opens the wrong account">
-    Sign out of the wrong Cekura account in your browser, reconnect the MCP server, and authorize again.
+    Sign out of the wrong Cekura account in your browser, re-authorize the plugin, and sign in with the intended account.
   </Accordion>
 </AccordionGroup>

--- a/mcp/cursor-guide.mdx
+++ b/mcp/cursor-guide.mdx
@@ -11,16 +11,6 @@ import { CopyPageButton } from "/snippets/copy-page-button.mdx";
 
 Use Cursor with Cekura Skills for workflow guidance and the Cekura MCP server for live workspace actions.
 
-## What you get
-
-| Capability | Cursor setup |
-|---|---:|
-| Cekura workflow guidance | Yes, via Agent Skills or rules fallback |
-| MCP tools | Yes |
-| OAuth sign-in | Yes, through MCP |
-| Claude Code slash commands | No |
-| Claude Code plugin hooks | No |
-
 ## 1. Install Cekura Skills
 
 Start with the Agent Skills install:
@@ -65,6 +55,16 @@ Use the Cekura skills and MCP. List my Cekura agents, pick one, and propose 3 ev
 ```
 
 If Cursor can list agents but does not use Cekura-specific evaluator or metric guidance, keep the rules-file fallback installed.
+
+## What you get
+
+| Capability | Cursor setup |
+|---|---:|
+| Cekura workflow guidance | Yes, via Agent Skills or rules fallback |
+| MCP tools | Yes |
+| OAuth sign-in | Yes, through MCP |
+| Claude Code slash commands | No |
+| Claude Code plugin hooks | No |
 
 ## Recommended workflow
 

--- a/mcp/cursor-guide.mdx
+++ b/mcp/cursor-guide.mdx
@@ -86,7 +86,7 @@ Or drop the portable behavior preset as a Cursor project rule:
 mkdir -p .cursor/rules && curl -L https://raw.githubusercontent.com/cekura-ai/cekura-skills/main/codex/AGENTS.md -o .cursor/rules/cekura.md
 ```
 
-To add MCP manually on top of either fallback, see [MCP-only setup](/mcp/mcp-only).
+To add MCP manually on top of either fallback, see [manual setup](/mcp/mcp-only).
 
 ## Recommended workflow
 

--- a/mcp/cursor-guide.mdx
+++ b/mcp/cursor-guide.mdx
@@ -36,7 +36,7 @@ Open **Cursor Settings > MCP > Add new MCP server**, or edit your Cursor MCP con
   "mcpServers": {
     "cekura": {
       "command": "npx",
-      "args": ["mcp-remote", "https://api.cekura.ai/mcp"]
+      "args": ["-y", "mcp-remote", "https://api.cekura.ai/mcp"]
     }
   }
 }

--- a/mcp/cursor-guide.mdx
+++ b/mcp/cursor-guide.mdx
@@ -62,31 +62,9 @@ Re-import the marketplace from **Settings > Plugins > Team Marketplaces** to pul
 
 Cursor then re-indexes the marketplace at most once every ~10 minutes. Auto Refresh updates the *existing* plugin only — if a brand-new plugin is added to the repo later, re-import the marketplace.
 
-## What you get
+## No plugin?
 
-| Capability | Cursor plugin |
-|---|---:|
-| Cekura Skills | Yes |
-| MCP tools | Yes (auto-configured) |
-| OAuth sign-in | Yes |
-| Claude Code slash commands | No |
-| Claude Code plugin hooks | No |
-
-## No-MCP fallback
-
-If you can't use the plugin, install Skills (guidance only — no live workspace tools):
-
-```bash
-npx skills add cekura-ai/cekura-skills --all
-```
-
-Or drop the portable behavior preset as a Cursor project rule:
-
-```bash
-mkdir -p .cursor/rules && curl -L https://raw.githubusercontent.com/cekura-ai/cekura-skills/main/codex/AGENTS.md -o .cursor/rules/cekura.md
-```
-
-To add MCP manually on top of either fallback, see [manual setup](/mcp/mcp-only).
+Set up [Skills + MCP manually](/mcp/mcp-only), or use the [behavior preset](/mcp/other-agents) fallback.
 
 ## Recommended workflow
 

--- a/mcp/mcp-only.mdx
+++ b/mcp/mcp-only.mdx
@@ -65,7 +65,7 @@ OAuth is recommended for most users. Your MCP client opens a browser, you sign i
       "mcpServers": {
         "cekura": {
           "command": "npx",
-          "args": ["mcp-remote", "https://api.cekura.ai/mcp"]
+          "args": ["-y", "mcp-remote", "https://api.cekura.ai/mcp"]
         }
       }
     }
@@ -113,6 +113,7 @@ Use an API key only when you need a project-scoped credential, a shared service 
         "cekura": {
           "command": "npx",
           "args": [
+            "-y",
             "mcp-remote",
             "https://api.cekura.ai/mcp",
             "--header",

--- a/mcp/mcp-only.mdx
+++ b/mcp/mcp-only.mdx
@@ -68,7 +68,7 @@ Your MCP client opens a browser, you sign into Cekura, and the client manages th
     5. Set **URL** to `https://api.cekura.ai/mcp`.
     6. Save, then finish the browser authorization flow.
 
-    Claude Desktop uses MCP connectors only. For Cekura Skills, slash commands, update commands, and hooks, use the [Claude Code guide](/mcp/claude-code-guide).
+    This connector gives MCP only. To get Cekura Skills too, install the plugin instead — see the [Claude Desktop guide](/mcp/claude-desktop-guide).
   </Tab>
 
   <Tab title="Cursor / VS Code">

--- a/mcp/mcp-only.mdx
+++ b/mcp/mcp-only.mdx
@@ -10,7 +10,7 @@ import { CopyPageButton } from "/snippets/copy-page-button.mdx";
 <CopyPageButton />
 
 <Warning>
-This is the advanced path for direct MCP/API access. If you want the best guided Cekura experience, start with the [MCP & Skills setup](/mcp/overview) and install Cekura Skills too.
+This is the advanced path for direct MCP/API access. Most clients (Claude Code, Cursor, Codex, Gemini CLI) have a native plugin that sets up MCP **and** Skills for you — see the [MCP & Skills setup](/mcp/overview). Use the manual steps below only if your client has no plugin or you specifically want MCP without Skills.
 </Warning>
 
 ## What MCP gives you

--- a/mcp/mcp-only.mdx
+++ b/mcp/mcp-only.mdx
@@ -73,11 +73,12 @@ OAuth is recommended for most users. Your MCP client opens a browser, you sign i
   </Tab>
 
   <Tab title="Codex">
-    Add this to `~/.codex/config.toml`:
+    Add this to `~/.codex/config.toml`. The `mcp-remote` shim handles the OAuth browser sign-in (needs Node.js 20.18.1+):
 
     ```toml
     [mcp_servers.cekura]
-    url = "https://api.cekura.ai/mcp"
+    command = "npx"
+    args = ["-y", "mcp-remote", "https://api.cekura.ai/mcp"]
     ```
   </Tab>
 </Tabs>

--- a/mcp/mcp-only.mdx
+++ b/mcp/mcp-only.mdx
@@ -10,7 +10,7 @@ import { CopyPageButton } from "/snippets/copy-page-button.mdx";
 <CopyPageButton />
 
 <Warning>
-This is the advanced path for direct MCP/API access. If you want the best guided Cekura experience, start with [AI assistant setup](/mcp/overview) and install Cekura Skills too.
+This is the advanced path for direct MCP/API access. If you want the best guided Cekura experience, start with the [MCP & Skills setup](/mcp/overview) and install Cekura Skills too.
 </Warning>
 
 ## What MCP gives you

--- a/mcp/mcp-only.mdx
+++ b/mcp/mcp-only.mdx
@@ -1,0 +1,208 @@
+---
+title: "MCP-only setup"
+sidebarTitle: "MCP only"
+description: "Connect an AI assistant directly to the Cekura MCP server without installing Cekura Skills."
+icon: "shield-halved"
+---
+
+import { CopyPageButton } from "/snippets/copy-page-button.mdx";
+
+<CopyPageButton />
+
+<Warning>
+This is the advanced path for direct MCP/API access. If you want the best guided Cekura experience, start with [AI assistant setup](/mcp/overview) and install Cekura Skills too.
+</Warning>
+
+## What MCP gives you
+
+Cekura's MCP server exposes documentation search and Cekura API operations through one endpoint:
+
+```plaintext
+https://api.cekura.ai/mcp
+```
+
+Your assistant can search docs, list agents, create metrics, generate evaluators, run tests, inspect results, and analyze call logs through typed tools.
+
+## Prerequisites
+
+- Access to the [Cekura Dashboard](https://dashboard.cekura.ai)
+- Node.js 20.18.1 or higher if your client uses the `mcp-remote` shim
+- No Node.js requirement for Claude Code's native HTTP transport, Claude Desktop connectors, or Codex native HTTP config
+
+## OAuth setup
+
+OAuth is recommended for most users. Your MCP client opens a browser, you sign into Cekura, and the client manages the session token.
+
+<Tabs>
+  <Tab title="Claude Code">
+    ```bash
+    claude mcp add --transport http cekura --scope user https://api.cekura.ai/mcp
+    ```
+
+    Verify:
+
+    ```bash
+    claude mcp list
+    ```
+  </Tab>
+
+  <Tab title="Claude Desktop">
+    1. Open Claude Desktop.
+    2. Go to **Settings > Connectors**.
+    3. Click **Add custom connector**.
+    4. Set **Name** to `Cekura`.
+    5. Set **URL** to `https://api.cekura.ai/mcp`.
+    6. Save, then finish the browser authorization flow.
+
+    Claude Desktop uses MCP connectors only. For Cekura Skills, slash commands, update commands, and hooks, use the [Claude Code guide](/mcp/claude-code-guide).
+  </Tab>
+
+  <Tab title="Cursor / VS Code">
+    Add this to your Cursor MCP config or `.vscode/mcp.json`:
+
+    ```json
+    {
+      "mcpServers": {
+        "cekura": {
+          "command": "npx",
+          "args": ["mcp-remote", "https://api.cekura.ai/mcp"]
+        }
+      }
+    }
+    ```
+  </Tab>
+
+  <Tab title="Codex">
+    Add this to `~/.codex/config.toml`:
+
+    ```toml
+    [mcp_servers.cekura]
+    url = "https://api.cekura.ai/mcp"
+    ```
+  </Tab>
+</Tabs>
+
+## API-key setup
+
+Use an API key only when you need a project-scoped credential, a shared service credential, or a client that cannot complete OAuth. Create keys in **Settings > API Keys** in the Cekura dashboard.
+
+<Tabs>
+  <Tab title="Claude Code">
+    ```bash
+    claude mcp add --transport http cekura --scope user https://api.cekura.ai/mcp --header "X-CEKURA-API-KEY:YOUR_API_KEY_HERE"
+    ```
+
+    Verify:
+
+    ```bash
+    claude mcp list
+    ```
+  </Tab>
+
+  <Tab title="Claude Desktop">
+    Claude Desktop's connector UI is best with OAuth. Use the OAuth flow above unless your workspace specifically requires an API key.
+
+    If your workspace requires API-key auth, use Claude Code or another MCP client that supports custom headers.
+  </Tab>
+
+  <Tab title="Cursor / VS Code">
+    ```json
+    {
+      "mcpServers": {
+        "cekura": {
+          "command": "npx",
+          "args": [
+            "mcp-remote",
+            "https://api.cekura.ai/mcp",
+            "--header",
+            "X-CEKURA-API-KEY:${CEKURA_API_KEY}"
+          ],
+          "env": {
+            "CEKURA_API_KEY": "YOUR_API_KEY_HERE"
+          }
+        }
+      }
+    }
+    ```
+  </Tab>
+
+  <Tab title="Codex">
+    Native HTTP config:
+
+    ```toml
+    [mcp_servers.cekura]
+    url = "https://api.cekura.ai/mcp"
+    http_headers = { "X-CEKURA-API-KEY" = "YOUR_API_KEY_HERE" }
+    ```
+
+    CLI form:
+
+    ```bash
+    codex mcp add cekura --env CEKURA_API_KEY=YOUR_API_KEY_HERE -- sh -c 'npx -y mcp-remote https://api.cekura.ai/mcp --header "X-CEKURA-API-KEY:$CEKURA_API_KEY"'
+    ```
+  </Tab>
+</Tabs>
+
+## Verify the connection
+
+Restart your assistant and ask:
+
+```plaintext
+List my Cekura agents.
+```
+
+If configured correctly, your assistant returns agents from your Cekura workspace.
+
+## Request headers
+
+| Header | Used by | Description |
+|---|---|---|
+| `Authorization: Bearer <token>` | OAuth | Set automatically by your MCP client after sign-in |
+| `X-CEKURA-API-KEY` | API-key path | Required when using an API key |
+| `Content-Type: application/json` | Both | Request payload format |
+
+## Available tool areas
+
+<CardGroup cols={2}>
+  <Card title="Documentation Search" icon="magnifying-glass" color="#A6A7EA">
+    Search integration guides, schemas, examples, and workflow docs.
+  </Card>
+
+  <Card title="Testing" icon="flask" color="#A6A7EA">
+    Create agents, create evaluators, define metrics, run tests, and inspect results.
+  </Card>
+
+  <Card title="Observability" icon="eye" color="#A6A7EA">
+    List call logs, evaluate production calls, and analyze call performance.
+  </Card>
+
+  <Card title="Automation" icon="clock" color="#A6A7EA">
+    Create scheduled jobs, recurring tests, and metric-improvement workflows.
+  </Card>
+</CardGroup>
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="Auth failed">
+    A `401 Unauthorized` usually means the OAuth session expired or the API key is invalid.
+
+    For OAuth, reconnect from your client and confirm you are signed into the right Cekura account. For API keys, confirm the header name is exactly `X-CEKURA-API-KEY` and the key is active.
+  </Accordion>
+
+  <Accordion title="Tools are not showing up">
+    Restart your assistant after changing MCP config. Confirm the URL is exactly `https://api.cekura.ai/mcp`, check JSON or TOML syntax, and inspect your assistant's MCP logs.
+  </Accordion>
+
+  <Accordion title="Node.js version errors">
+    If `mcp-remote` fails with an engine or `File is not defined` error, upgrade Node.js to 20.18.1 or higher and make sure your client is using that Node.js version.
+  </Accordion>
+
+  <Accordion title="Rate limits">
+    If you hit `429 Too Many Requests`, reduce concurrency, narrow the request, or check usage in **Settings > API Usage**.
+  </Accordion>
+</AccordionGroup>
+
+## Next step
+
+If you want your assistant to understand Cekura workflows instead of only calling tools, install [Cekura Skills](/mcp/skills).

--- a/mcp/mcp-only.mdx
+++ b/mcp/mcp-only.mdx
@@ -1,17 +1,17 @@
 ---
-title: "MCP-only setup"
-sidebarTitle: "MCP only"
-description: "Connect an AI assistant directly to the Cekura MCP server without installing Cekura Skills."
-icon: "shield-halved"
+title: "Set up Skills + MCP manually"
+sidebarTitle: "Manual setup"
+description: "For clients without a native Cekura plugin: install Cekura Skills, then connect the MCP server separately."
+icon: "wrench"
 ---
 
 import { CopyPageButton } from "/snippets/copy-page-button.mdx";
 
 <CopyPageButton />
 
-<Warning>
-This is the advanced path for direct MCP/API access. Most clients (Claude Code, Cursor, Codex, Gemini CLI) have a native plugin that sets up MCP **and** Skills for you — see the [MCP & Skills setup](/mcp/overview). Use the manual steps below only if your client has no plugin or you specifically want MCP without Skills.
-</Warning>
+<Note>
+Most clients — Claude Code, Cursor, Codex, Gemini CLI — have a [native plugin](/mcp/overview#set-up) that installs Skills **and** MCP in one step. Use this page only if your client has no plugin. You'll set up the two pieces separately: **Skills first, then MCP.**
+</Note>
 
 ## What MCP gives you
 
@@ -29,9 +29,23 @@ Your assistant can search docs, list agents, create metrics, generate evaluators
 - Node.js 20.18.1 or higher if your client uses the `mcp-remote` shim
 - No Node.js requirement for Claude Code's native HTTP transport, Claude Desktop connectors, or Codex native HTTP config
 
-## OAuth setup
+## Install Skills
 
-OAuth is recommended for most users. Your MCP client opens a browser, you sign into Cekura, and the client manages the session token.
+Install Cekura Skills first, so your assistant knows Cekura workflows — not just raw tools:
+
+```bash
+npx skills add cekura-ai/cekura-skills --all
+```
+
+If your assistant doesn't load Agent Skills, use the portable [behavior preset](/mcp/other-agents) instead. (Only need raw tools, e.g. for CI? Skip ahead to Connect MCP.)
+
+## Connect MCP
+
+Then connect the MCP server. OAuth is recommended; use an API key only for CI or project-scoped credentials.
+
+### OAuth setup
+
+Your MCP client opens a browser, you sign into Cekura, and the client manages the session token.
 
 <Tabs>
   <Tab title="Claude Code">
@@ -83,7 +97,7 @@ OAuth is recommended for most users. Your MCP client opens a browser, you sign i
   </Tab>
 </Tabs>
 
-## API-key setup
+### API-key setup
 
 Use an API key only when you need a project-scoped credential, a shared service credential, or a client that cannot complete OAuth. Create keys in **Settings > API Keys** in the Cekura dashboard.
 
@@ -207,4 +221,4 @@ If configured correctly, your assistant returns agents from your Cekura workspac
 
 ## Next step
 
-If you want your assistant to understand Cekura workflows instead of only calling tools, install [Cekura Skills](/mcp/skills).
+If your client turns out to have a native plugin, switch to it — it bundles Skills + MCP and keeps both updated. See the [setup overview](/mcp/overview#set-up). Browse the [Skills catalog](/mcp/skills) for what the Skills cover.

--- a/mcp/other-agents.mdx
+++ b/mcp/other-agents.mdx
@@ -20,7 +20,7 @@ Use this page for assistants that are not Claude Code, Claude Desktop, Cursor, o
 | Behavior preset only | Your assistant has no MCP support | Cekura guidance without live workspace actions |
 | MCP only | You only want direct Cekura tools | API access without Cekura workflow guidance |
 
-## 1. Install Cekura guidance
+## Install Cekura guidance
 
 Try Agent Skills first:
 
@@ -36,7 +36,7 @@ curl -L https://raw.githubusercontent.com/cekura-ai/cekura-skills/main/codex/AGE
 
 For assistants with a dedicated rules directory, place the file there instead.
 
-## 2. Connect MCP
+## Connect MCP
 
 If your assistant supports HTTP MCP, use:
 
@@ -59,7 +59,7 @@ If your assistant requires a local command shim, use `mcp-remote`:
 
 For client-specific OAuth and API-key examples, see [MCP-only setup](/mcp/mcp-only).
 
-## 3. Verify setup
+## Verify setup
 
 Ask your assistant:
 

--- a/mcp/other-agents.mdx
+++ b/mcp/other-agents.mdx
@@ -9,23 +9,7 @@ import { CopyPageButton } from "/snippets/copy-page-button.mdx";
 
 <CopyPageButton />
 
-Use this page for assistants that are not Claude Code, Claude Desktop, Cursor, or Codex. Gemini CLI has a native extension (below); for everything else the pattern is the same: install Cekura guidance, then connect MCP if your assistant supports it.
-
-## Gemini CLI
-
-Gemini CLI has a native Cekura extension that includes the **MCP server** and the Cekura context file. (Gemini extensions don't bundle Agent Skills yet, so this ships domain knowledge as context rather than `SKILL.md` skills.)
-
-```bash
-gemini extensions install https://github.com/cekura-ai/cekura-skills
-```
-
-On first use of a Cekura MCP tool, Gemini runs an OAuth browser sign-in — no API key. The extension loads `GEMINI.md` (metric design, eval design, API reference, anti-patterns) as context.
-
-Update it with:
-
-```bash
-gemini extensions update cekura
-```
+Use this page for assistants without a native Cekura plugin. The generic pattern is the same: install Cekura guidance, then connect MCP if your assistant supports it. Gemini CLI is an exception — it has a native extension, covered at the end.
 
 ## Choose the right path
 
@@ -73,7 +57,7 @@ If your assistant requires a local command shim, use `mcp-remote`:
 }
 ```
 
-For client-specific OAuth and API-key examples, see [MCP-only setup](/mcp/mcp-only).
+For client-specific OAuth and API-key examples, see [manual setup](/mcp/mcp-only).
 
 ## Verify setup
 
@@ -84,6 +68,22 @@ Use the Cekura skills and MCP. List my Cekura agents, pick one, and propose 3 ev
 ```
 
 If the assistant cannot list agents, MCP is not connected. If it lists agents but gives generic testing advice, add the behavior preset or confirm Agent Skills are enabled.
+
+## Gemini CLI
+
+Gemini CLI has a native Cekura extension that includes the **MCP server** and the Cekura context file. (Gemini extensions don't bundle Agent Skills yet, so this ships domain knowledge as context rather than `SKILL.md` skills.)
+
+```bash
+gemini extensions install https://github.com/cekura-ai/cekura-skills
+```
+
+On first use of a Cekura MCP tool, Gemini runs an OAuth browser sign-in — no API key. The extension loads `GEMINI.md` (metric design, eval design, API reference, anti-patterns) as context.
+
+Update it with:
+
+```bash
+gemini extensions update cekura
+```
 
 ## When to use Claude Code instead
 

--- a/mcp/other-agents.mdx
+++ b/mcp/other-agents.mdx
@@ -51,7 +51,7 @@ If your assistant requires a local command shim, use `mcp-remote`:
   "mcpServers": {
     "cekura": {
       "command": "npx",
-      "args": ["mcp-remote", "https://api.cekura.ai/mcp"]
+      "args": ["-y", "mcp-remote", "https://api.cekura.ai/mcp"]
     }
   }
 }

--- a/mcp/other-agents.mdx
+++ b/mcp/other-agents.mdx
@@ -9,7 +9,23 @@ import { CopyPageButton } from "/snippets/copy-page-button.mdx";
 
 <CopyPageButton />
 
-Use this page for assistants that are not Claude Code, Claude Desktop, Cursor, or Codex. The setup pattern is the same: install Cekura guidance, then connect MCP if your assistant supports it.
+Use this page for assistants that are not Claude Code, Claude Desktop, Cursor, or Codex. Gemini CLI has a native extension (below); for everything else the pattern is the same: install Cekura guidance, then connect MCP if your assistant supports it.
+
+## Gemini CLI
+
+Gemini CLI has a native Cekura extension that includes the **MCP server** and the Cekura context file. (Gemini extensions don't bundle Agent Skills yet, so this ships domain knowledge as context rather than `SKILL.md` skills.)
+
+```bash
+gemini extensions install https://github.com/cekura-ai/cekura-skills
+```
+
+On first use of a Cekura MCP tool, Gemini runs an OAuth browser sign-in — no API key. The extension loads `GEMINI.md` (metric design, eval design, API reference, anti-patterns) as context.
+
+Update it with:
+
+```bash
+gemini extensions update cekura
+```
 
 ## Choose the right path
 

--- a/mcp/other-agents.mdx
+++ b/mcp/other-agents.mdx
@@ -1,0 +1,74 @@
+---
+title: "Using Cekura with other assistants"
+sidebarTitle: "Other assistants"
+description: "Set up OpenCode, Windsurf, and other AI assistants with Cekura Skills, MCP, or a portable behavior preset."
+icon: "wand-magic-sparkles"
+---
+
+import { CopyPageButton } from "/snippets/copy-page-button.mdx";
+
+<CopyPageButton />
+
+Use this page for assistants that are not Claude Code, Claude Desktop, Cursor, or Codex. The setup pattern is the same: install Cekura guidance, then connect MCP if your assistant supports it.
+
+## Choose the right path
+
+| Path | Use when | Result |
+|---|---|---|
+| Agent Skills + MCP | Your assistant supports Agent Skills and MCP | Best non-Claude-Code setup |
+| Behavior preset + MCP | Your assistant supports rules/context files and MCP | Good fallback when Agent Skills are not loaded automatically |
+| Behavior preset only | Your assistant has no MCP support | Cekura guidance without live workspace actions |
+| MCP only | You only want direct Cekura tools | API access without Cekura workflow guidance |
+
+## 1. Install Cekura guidance
+
+Try Agent Skills first:
+
+```bash
+npx skills add cekura-ai/cekura-skills --all
+```
+
+If your assistant does not load Agent Skills, install the portable behavior preset wherever your assistant reads project rules or agent instructions:
+
+```bash
+curl -L https://raw.githubusercontent.com/cekura-ai/cekura-skills/main/codex/AGENTS.md -o AGENTS.md
+```
+
+For assistants with a dedicated rules directory, place the file there instead.
+
+## 2. Connect MCP
+
+If your assistant supports HTTP MCP, use:
+
+```plaintext
+https://api.cekura.ai/mcp
+```
+
+If your assistant requires a local command shim, use `mcp-remote`:
+
+```json
+{
+  "mcpServers": {
+    "cekura": {
+      "command": "npx",
+      "args": ["mcp-remote", "https://api.cekura.ai/mcp"]
+    }
+  }
+}
+```
+
+For client-specific OAuth and API-key examples, see [MCP-only setup](/mcp/mcp-only).
+
+## 3. Verify setup
+
+Ask your assistant:
+
+```plaintext
+Use the Cekura skills and MCP. List my Cekura agents, pick one, and propose 3 evaluators I should create first. Do not create anything until I approve.
+```
+
+If the assistant cannot list agents, MCP is not connected. If it lists agents but gives generic testing advice, add the behavior preset or confirm Agent Skills are enabled.
+
+## When to use Claude Code instead
+
+Use [Claude Code](/mcp/claude-code-guide) if you want the full Cekura plugin experience: Skills, slash commands, MCP auto-configuration, update support, and MCP failure help.

--- a/mcp/overview.mdx
+++ b/mcp/overview.mdx
@@ -15,67 +15,69 @@ Recommended setup: install both **Cekura Skills** and the **Cekura MCP server**.
 Skills teach your assistant how to work with Cekura. MCP lets it safely act in your Cekura workspace.
 </Note>
 
-## Fastest path
+## Set up
 
-Pick the route that matches your tool. Every command copies on its own.
+Pick the tab for your tool. Every command copies on its own.
 
-### Claude Code — recommended
+<Tabs>
+  <Tab title="Claude Code — recommended">
+    The plugin bundles Skills, slash commands, and MCP config in one install. Run these in a Claude Code session:
 
-The plugin bundles Skills, slash commands, and MCP config in one install. Run these in a Claude Code session:
+    ```plaintext
+    /plugin marketplace add cekura-ai/cekura-skills
+    ```
 
-```plaintext
-/plugin marketplace add cekura-ai/cekura-skills
-```
+    ```plaintext
+    /plugin install cekura@cekura-skills
+    ```
 
-```plaintext
-/plugin install cekura@cekura-skills
-```
+    ```plaintext
+    /setup-mcp
+    ```
 
-```plaintext
-/setup-mcp
-```
+    `/setup-mcp` connects MCP over OAuth (a browser sign-in, no API key). Then run `/cekura-onboarding` for a guided first run.
+  </Tab>
 
-`/setup-mcp` connects MCP over OAuth (a browser sign-in, no API key). Then run `/cekura-onboarding` for a guided first run.
+  <Tab title="Cursor, Codex & others">
+    Install Skills, then connect MCP:
 
-### Cursor, Codex, Windsurf, OpenCode
+    ```bash
+    npx skills add cekura-ai/cekura-skills --all
+    ```
 
-Install Skills, then connect MCP:
+    MCP setup differs per client — follow your [assistant's guide](#start-here) for the exact connect step.
+  </Tab>
 
-```bash
-npx skills add cekura-ai/cekura-skills --all
-```
+  <Tab title="MCP only">
+    Point your MCP client at this endpoint:
 
-MCP setup differs per client — follow your [assistant's guide](#start-here) for the exact connect step.
+    ```plaintext
+    https://api.cekura.ai/mcp
+    ```
 
-### Just the MCP tools — any client
+    In Claude Code, that's one command (OAuth opens a browser — no API key):
 
-Point your MCP client at this endpoint:
+    ```bash
+    claude mcp add --transport http cekura --scope user https://api.cekura.ai/mcp
+    ```
 
-```plaintext
-https://api.cekura.ai/mcp
-```
+    For Cursor, Codex, and other clients, see [MCP-only setup](/mcp/mcp-only).
 
-In Claude Code, that's one command (OAuth opens a browser — no API key):
+    <Tip>
+    Skills make these tools far more useful — they teach your assistant how to design evaluators, choose metrics, and debug runs instead of guessing. Add them with one of the other tabs.
+    </Tip>
+  </Tab>
+</Tabs>
 
-```bash
-claude mcp add --transport http cekura --scope user https://api.cekura.ai/mcp
-```
+## Which setup fits you?
 
-For Cursor, Codex, and other clients, see [MCP-only setup](/mcp/mcp-only).
-
-<Tip>
-Skills make these tools far more useful — they teach your assistant how to design evaluators, choose metrics, and debug runs instead of guessing. Add them with one of the paths above.
-</Tip>
-
-## Pick your setup
-
-| Setup | Use this if | What you get |
+| Setup | Best for | What you get |
 |---|---|---|
-| Claude Code plugin | You use Claude Code in the terminal or VS Code | Best experience: Skills, slash commands, MCP config, update command, and MCP failure help |
-| Skills + MCP | You use Cursor, Codex, OpenCode, Windsurf, or another coding assistant | Cekura workflow guidance plus live access to agents, metrics, evaluators, runs, and call logs |
-| Skills only | You want planning and best-practice guidance without workspace actions | The assistant can design and review Cekura workflows, but cannot call Cekura APIs |
-| MCP only | You only want direct API/tool access | Live Cekura tools without the Cekura workflow playbooks |
-| Claude Desktop connector | You use Claude Desktop chat | MCP access through the native connector UI. For Skills, commands, and hooks, use Claude Code |
+| **Claude Code plugin** ⭐ | Claude Code (terminal or VS Code) | Everything — Skills, slash commands, MCP, auto-update, failure hook |
+| **Skills + MCP** | Cursor, Codex, Windsurf, OpenCode | Workflow guidance **+** live workspace tools |
+| **Skills only** | Planning and review, no actions | Guidance only — can't call Cekura APIs |
+| **MCP only** | Direct API/tool access | Live tools, no workflow playbooks |
+| **Claude Desktop** | Claude Desktop chat | MCP via the connector UI (no Skills or commands) |
 
 ## Start here
 

--- a/mcp/overview.mdx
+++ b/mcp/overview.mdx
@@ -1,414 +1,125 @@
 ---
-title: "Model Context Protocol (MCP)"
-description: "Connect your AI assistant to Cekura for instant access to documentation and APIs"
+title: "Set up Cekura in your AI assistant"
+sidebarTitle: "Overview"
+description: "Install Cekura Skills and MCP so your AI assistant can design, run, and improve voice-agent evaluations."
+icon: "sparkles"
 ---
 
 import { CopyPageButton } from "/snippets/copy-page-button.mdx";
 
 <CopyPageButton />
 
-
 <Note>
-**One Connection, Complete Access:** Cekura's MCP server provides both documentation search and API operations in a single endpoint. Ask questions about Cekura, search integration guides, create agents, run tests, and analyze results—all through natural language with your AI assistant.
+Recommended setup: install both **Cekura Skills** and the **Cekura MCP server**.
+
+Skills teach your assistant how to work with Cekura. MCP lets it safely act in your Cekura workspace.
 </Note>
 
-## Quickstart — OAuth in one click
+## Pick your setup
 
-For most users, MCP setup is two commands and a browser sign-in. No API keys, no env vars, no config files.
+| Setup | Use this if | What you get |
+|---|---|---|
+| Claude Code plugin | You use Claude Code in the terminal or VS Code | Best experience: Skills, slash commands, MCP config, update command, and MCP failure help |
+| Skills + MCP | You use Cursor, Codex, OpenCode, Windsurf, or another coding assistant | Cekura workflow guidance plus live access to agents, metrics, evaluators, runs, and call logs |
+| Skills only | You want planning and best-practice guidance without workspace actions | The assistant can design and review Cekura workflows, but cannot call Cekura APIs |
+| MCP only | You only want direct API/tool access | Live Cekura tools without the Cekura workflow playbooks |
+| Claude Desktop connector | You use Claude Desktop chat | MCP access through the native connector UI. For Skills, commands, and hooks, use Claude Code |
 
-<Tabs>
-  <Tab title="Claude Code">
-    ```bash
-    claude mcp add --transport http cekura --scope user https://api.cekura.ai/mcp
-    ```
-
-    On first use, Claude Code opens a browser window — sign into your Cekura dashboard, click **Authorize**, and you're done. The session token is managed by Claude Code automatically.
-
-    Verify:
-    ```bash
-    claude mcp list
-    ```
-  </Tab>
-
-  <Tab title="Claude Desktop">
-    1. **Settings → Connectors → Add custom connector**
-    2. Name: `Cekura`, URL: `https://api.cekura.ai/mcp`
-    3. Save → browser opens → sign in → done.
-
-    No config files, no Node.js, no keys.
-  </Tab>
-</Tabs>
-
-That's the entire setup. Skip to **Verify Connection** below.
-
-For Cursor, VS Code, Codex, or other clients, see the full configuration matrix below. For API-key-based auth (only needed for project-scoped credentials or shared CI access), expand the **API Key** path.
-
-## Prerequisites
-
-Before setting up MCP, ensure you have:
-
-1. Access to the [Cekura Dashboard](https://dashboard.cekura.ai)
-2. **Node.js 20.18.1 or higher** installed — *only* if you're configuring Cursor, VS Code, or another client that uses the `mcp-remote` shim. Claude Code and Claude Desktop don't need Node.js.
-   - Check your version: `node --version`
-   - Download from: [nodejs.org](https://nodejs.org/)
-
-## Configure MCP Server (full matrix)
-
-OAuth is the recommended path for nearly every user. Pick the API Key tab only if you need a project-scoped credential, want to share access via a key, or your client doesn't support OAuth.
-
-<Tabs>
-  <Tab title="OAuth (recommended)">
-    No header required. On first use, your client opens a browser window — sign into Cekura, click Authorize, and the session token is managed automatically.
-
-    <Tabs>
-      <Tab title="Claude Code">
-        ```bash
-        claude mcp add --transport http cekura --scope user https://api.cekura.ai/mcp
-        ```
-
-        Verify:
-        ```bash
-        claude mcp list
-        ```
-      </Tab>
-
-      <Tab title="Claude Desktop">
-        Use the in-app Connectors UI — no config file editing required.
-
-        1. Open Claude Desktop → **Settings** → **Connectors**.
-        2. Click **Add custom connector**.
-        3. Set **Name** to `Cekura` and **URL** to `https://api.cekura.ai/mcp`.
-        4. Save. Claude Desktop opens a browser window to authorize against your Cekura dashboard account.
-        5. Once authorized, Cekura tools appear in the connector list and are available in any new chat.
-
-        No Node.js required for this path — Claude Desktop's native connector handles the remote MCP transport directly.
-      </Tab>
-
-      <Tab title="Cursor / VS Code">
-        Add to your Cursor MCP config or `.vscode/mcp.json`:
-
-        ```json
-        {
-          "mcpServers": {
-            "cekura": {
-              "command": "npx",
-              "args": ["mcp-remote", "https://api.cekura.ai/mcp"]
-            }
-          }
-        }
-        ```
-      </Tab>
-
-      <Tab title="Codex">
-        Add to `~/.codex/config.toml`:
-
-        ```toml
-        [mcp_servers.cekura]
-        url = "https://api.cekura.ai/mcp"
-        ```
-      </Tab>
-    </Tabs>
-  </Tab>
-
-  <Tab title="API Key">
-    Use this if you want a project-scoped credential, want to share access via a key, or your client doesn't support OAuth. Replace `YOUR_API_KEY_HERE` with the key from **Settings → API Keys**.
-
-    <Tabs>
-      <Tab title="Claude Code">
-        ```bash
-        claude mcp add --transport http cekura --scope user https://api.cekura.ai/mcp --header "X-CEKURA-API-KEY:YOUR_API_KEY_HERE"
-        ```
-
-        Verify:
-        ```bash
-        claude mcp list
-        ```
-      </Tab>
-
-      <Tab title="Claude Desktop">
-        <Tip>
-        If you don't specifically need an API key, use the OAuth tab above — Claude Desktop has a much simpler Connectors-UI flow that doesn't require editing config files.
-        </Tip>
-
-        ```json
-        {
-          "mcpServers": {
-            "cekura": {
-              "command": "npx",
-              "args": [
-                "mcp-remote",
-                "https://api.cekura.ai/mcp",
-                "--header",
-                "X-CEKURA-API-KEY:${CEKURA_API_KEY}"
-              ],
-              "env": {
-                "CEKURA_API_KEY": "YOUR_API_KEY_HERE"
-              }
-            }
-          }
-        }
-        ```
-      </Tab>
-
-      <Tab title="Cursor">
-        ```json
-        {
-          "mcpServers": {
-            "cekura": {
-              "command": "npx",
-              "args": [
-                "mcp-remote",
-                "https://api.cekura.ai/mcp",
-                "--header",
-                "X-CEKURA-API-KEY:${CEKURA_API_KEY}"
-              ],
-              "env": {
-                "CEKURA_API_KEY": "YOUR_API_KEY_HERE"
-              }
-            }
-          }
-        }
-        ```
-      </Tab>
-
-      <Tab title="VS Code">
-        Create or edit `.vscode/mcp.json`:
-
-        ```json
-        {
-          "mcpServers": {
-            "cekura": {
-              "command": "npx",
-              "args": [
-                "mcp-remote",
-                "https://api.cekura.ai/mcp",
-                "--header",
-                "X-CEKURA-API-KEY:${CEKURA_API_KEY}"
-              ],
-              "env": {
-                "CEKURA_API_KEY": "YOUR_API_KEY_HERE"
-              }
-            }
-          }
-        }
-        ```
-      </Tab>
-
-      <Tab title="Codex">
-        **CLI:**
-        ```bash
-        codex mcp add cekura --env CEKURA_API_KEY=YOUR_API_KEY_HERE -- sh -c 'npx -y mcp-remote https://api.cekura.ai/mcp --header "X-CEKURA-API-KEY:$CEKURA_API_KEY"'
-        ```
-
-        **Or, native HTTP via `~/.codex/config.toml`:**
-        ```toml
-        [mcp_servers.cekura]
-        url = "https://api.cekura.ai/mcp"
-        http_headers = { "X-CEKURA-API-KEY" = "YOUR_API_KEY_HERE" }
-        ```
-      </Tab>
-    </Tabs>
-  </Tab>
-</Tabs>
-
-## Verify Connection
-
-Restart your AI assistant and ask:
-
-```plaintext
-"List my Cekura agents"
-```
-
-If configured correctly, your assistant returns your agents from the Cekura API.
-
-## How MCP Works
-
-<Steps>
-  <Step title="Unified Access">
-    One connection exposes 84+ tools spanning documentation search and API operations.
-  </Step>
-  <Step title="Documentation Search (no auth)">
-    Search Cekura's knowledge base for guides, schemas, and examples without an API key.
-  </Step>
-  <Step title="API Operations (auth required)">
-    Create agents, run tests, analyze results, and manage your workspace via natural language.
-  </Step>
-  <Step title="Smart Tool Selection">
-    Your assistant picks the right tool based on intent—answers questions or takes action.
-  </Step>
-  <Step title="Secure Authentication">
-    OAuth uses a session-bound Bearer token your client manages automatically. API-key clients send `X-CEKURA-API-KEY`.
-  </Step>
-</Steps>
-
-## Working with MCP
-
-<AccordionGroup>
-  <Accordion title="Learn, then execute">
-    Ask your assistant a question first, then take action with the same context:
-
-    ```plaintext
-    "How do I integrate with Retell?" → searches docs
-    "Create a Retell agent named 'Support Bot' with assistant ID abc123" → creates it
-    ```
-  </Accordion>
-
-  <Accordion title="Combine documentation with your data">
-    "Show me how custom metrics work, then list the metrics on my Support Bot agent" — your assistant reads docs and your live workspace in one turn.
-  </Accordion>
-
-  <Accordion title="Run scenarios over the right connection">
-    Each `scenarios_run_*` tool drives one connection type — telephony (`scenarios_run_voice`), SIP (`scenarios_run_sip`), provider WebRTC (`scenarios_run_vapi_webrtc`, `scenarios_run_retell_webrtc`, …), chat (`scenarios_run_text`) — and only works if that connection is configured on the agent. Just like the dashboard's Connections picker, retrieve the agent first (`aiagents_retrieve`) and check `provider.type` and the `telephony` block to see which connections are set up.
-  </Accordion>
-</AccordionGroup>
-
-For deeper end-to-end walkthroughs, see the [Claude Code Guide](/mcp/claude-code-guide) or the [Claude Desktop Guide](/mcp/claude-desktop-guide) (covers Connectors, Skills, and authoring custom skills).
-
-## Request Headers
-
-| Header | Used by | Description |
-|--------|---------|-------------|
-| `Authorization: Bearer <token>` | OAuth | Set automatically by your MCP client after sign-in |
-| `X-CEKURA-API-KEY` | API key path | Required header when using an API key |
-| `Content-Type: application/json` | Both | Request payload format |
-
-## Tool Configuration
-
-Tools are auto-generated from Cekura's OpenAPI spec — every documented endpoint becomes an MCP tool with a typed `inputSchema`. You don't author them; the server handles registration and stays in sync with the API. See the [API Reference](/api-reference) for endpoint details.
-
-## Best Practices
-
-<AccordionGroup>
-  <Accordion title="Auth hygiene">
-    - **OAuth (preferred):** Re-authorize when your session expires; revoke MCP access from the dashboard if a device is lost.
-    - **API key:** Never commit keys to version control. Use environment variables. Rotate regularly. Use separate keys per environment. If you're using an API key only because OAuth wasn't obvious, switch — OAuth is simpler to revoke and avoids leaks via config files.
-  </Accordion>
-
-  <Accordion title="Handle rate limits">
-    Cekura enforces per-plan rate limits. If you hit `429`, slow down or upgrade your plan. Check usage in **Settings → API Usage**.
-  </Accordion>
-
-  <Accordion title="Test before production">
-    Start with read-only operations (list agents, fetch results), then move to writes. Test in dev with a separate account or API key before pointing at production data.
-  </Accordion>
-</AccordionGroup>
-
-<Warning>
-Large responses (detailed transcripts, full call logs) consume context. Ask for filtered or summarized results when possible.
-</Warning>
-
-## Available Tools
-
-Cekura's MCP server provides 84+ tools across four categories:
+## Start here
 
 <CardGroup cols={2}>
-  <Card title="Documentation Search" icon="magnifying-glass" color="#A6A7EA">
-    **No auth required**
-    - Search integration guides
-    - Find API schemas and examples
-    - Understand features and workflows
+  <Card title="Claude Code" icon="code" href="/mcp/claude-code-guide">
+    Recommended. Install the Cekura plugin, run `/setup-mcp`, then use Skills, slash commands, and MCP tools together.
   </Card>
 
-  <Card title="Testing" icon="flask" color="#A6A7EA">
-    **Auth required**
-    - Create and manage agents
-    - Run test scenarios and evaluators
-    - Define custom metrics
-    - View and analyze results
+  <Card title="Cursor" icon="code" href="/mcp/cursor-guide">
+    Install Cekura Skills, connect the Cekura MCP server, and keep the rules-file fallback if your Cursor setup does not load Agent Skills yet.
   </Card>
 
-  <Card title="Observability" icon="eye" color="#A6A7EA">
-    **Auth required**
-    - List and search call logs
-    - Send calls for evaluation
-    - Analyze call performance
+  <Card title="Codex" icon="terminal" href="/mcp/codex-guide">
+    Install Cekura Skills, configure the Cekura MCP server, and keep the `AGENTS.md` fallback for Codex builds without Agent Skills support.
   </Card>
 
-  <Card title="Automation" icon="clock" color="#A6A7EA">
-    **Auth required**
-    - Create scheduled jobs
-    - Manage cronjobs
-    - Automate recurring tests
+  <Card title="Claude Desktop" icon="desktop" href="/mcp/claude-desktop-guide">
+    Use Claude Desktop's native connector UI to authorize the Cekura MCP server. This is MCP-only.
+  </Card>
+
+  <Card title="Other assistants" icon="wand-magic-sparkles" href="/mcp/other-agents">
+    OpenCode, Windsurf, and other assistants can use Agent Skills, MCP, or a portable behavior preset.
+  </Card>
+
+  <Card title="MCP-only setup" icon="shield-halved" href="/mcp/mcp-only">
+    Advanced path for users who only want direct MCP/API access without Cekura Skills.
   </Card>
 </CardGroup>
 
-For per-endpoint details, see the [API Reference](/api-reference).
+## Why install both?
 
-## Other MCP Clients
+<CardGroup cols={2}>
+  <Card title="Skills add judgment" icon="sparkles" color="#A6A7EA">
+    Skills tell your assistant what good Cekura work looks like: how to design evaluators, choose metrics, debug failing runs, and improve prompts safely.
+  </Card>
 
-The Cekura MCP server speaks standard HTTP MCP, so any MCP-compatible client (Make.com, Zapier, custom servers, etc.) can connect to `https://api.cekura.ai/mcp` using the same OAuth or API-key flow.
+  <Card title="MCP adds action" icon="plug" color="#A6A7EA">
+    MCP gives your assistant permissioned tools to list agents, create metrics, generate evaluators, run tests, inspect transcripts, and analyze results.
+  </Card>
+</CardGroup>
 
-## Troubleshooting
+With Skills only, your assistant can advise. With MCP only, your assistant can call tools. With both, it can choose the right workflow and complete it.
+
+## Verify your setup
+
+After setup, ask your assistant:
+
+```plaintext
+Use the Cekura skills and MCP. List my Cekura agents, pick one, and propose 3 evaluators I should create first. Do not create anything until I approve.
+```
+
+You should see two things:
+
+- The assistant can access your Cekura workspace and list real agents.
+- The assistant reasons in Cekura terms like evaluators, metrics, expected outcomes, test profiles, and run results.
+
+## What you can ask next
 
 <AccordionGroup>
-  <Accordion title="Auth failed">
-    **Error**: `401 Unauthorized`
-
-    - **OAuth:** Re-run the sign-in flow (your client usually re-prompts automatically). Confirm you're signed into the right Cekura account in your browser.
-    - **API key:** Verify the header name is `X-CEKURA-API-KEY` (case-sensitive) and the key is active in the dashboard. Generate a fresh key if needed.
+  <Accordion title="First-time onboarding">
+    ```plaintext
+    I'm new to Cekura. Walk me through setting up my first agent, metrics, evaluators, and test run.
+    ```
   </Accordion>
 
-  <Accordion title="Tools Not Showing Up">
-    **Issue**: AI assistant doesn't see Cekura tools
-
-    - Restart your AI assistant after configuration
-    - Verify the URL is `https://api.cekura.ai/mcp`
-    - Check your config file syntax is valid JSON / TOML
-    - Look for connection errors in the assistant's logs
+  <Accordion title="Create evaluator coverage">
+    ```plaintext
+    Read my agent's purpose and propose a coverage plan with workflow, edge-case, and regression evaluators. Wait for approval before creating them.
+    ```
   </Accordion>
 
-  <Accordion title="Node.js Version Error (Windows)">
-    **Error**: `Unsupported engine` or `ReferenceError: File is not defined`
-
-    **Cause**: Multiple Node.js versions installed, wrong version being used.
-
-    **Solution**:
-    1. List Node installs: `where node`
-    2. Find your Node v20+ path: `node -e "console.log(process.execPath)"`
-    3. Use the absolute path in your config:
-       ```json
-       {
-         "mcpServers": {
-           "cekura": {
-             "command": "C:\\Full\\Path\\To\\node.exe",
-             "args": [
-               "C:\\Full\\Path\\To\\npx-cli.js",
-               "-y",
-               "mcp-remote",
-               "https://api.cekura.ai/mcp"
-             ]
-           }
-         }
-       }
-       ```
-    4. Or uninstall older Node.js versions.
+  <Accordion title="Run scenarios over the right connection">
+    Each `scenarios_run_*` tool drives one connection type: telephony (`scenarios_run_voice`), SIP (`scenarios_run_sip`), provider WebRTC (`scenarios_run_vapi_webrtc`, `scenarios_run_retell_webrtc`), or chat (`scenarios_run_text`). It only works if that connection is configured on the agent. Retrieve the agent first and check `provider.type` and the `telephony` block before running evaluators.
   </Accordion>
 
-  <Accordion title="Rate Limit Exceeded">
-    **Error**: `429 Too Many Requests`
+  <Accordion title="Design better metrics">
+    ```plaintext
+    Create a metric that checks whether the agent resolves the caller's issue without escalating unnecessarily. Show me the rubric before saving.
+    ```
+  </Accordion>
 
-    - Check current usage in **Settings → API Usage**
-    - Throttle requests in your workflow
-    - Upgrade your plan or contact support for higher limits
+  <Accordion title="Triage failed tests">
+    ```plaintext
+    Pull the failures from my latest Cekura run, group them by root cause, and tell me which ones are real bugs versus flaky runs.
+    ```
   </Accordion>
 </AccordionGroup>
 
-## References
+## Reference
 
 <CardGroup cols={2}>
-  <Card title="API Reference" icon="book" href="/api-reference">
-    Complete API documentation
+  <Card title="Skills Catalog" icon="sparkles" href="/mcp/skills">
+    See every Cekura Skill, install path, update path, and compatibility note.
   </Card>
 
-  <Card title="Cekura Skills" icon="sparkles" href="/mcp/skills">
-    Install Cekura skills into your AI coding agent
-  </Card>
-
-  <Card title="Dashboard" icon="gauge" href="https://dashboard.cekura.ai">
-    Manage auth, projects, and API keys
-  </Card>
-
-  <Card title="Support" icon="life-ring" href="mailto:support@cekura.ai">
-    Get help with MCP setup
+  <Card title="MCP-only Setup" icon="shield-halved" href="/mcp/mcp-only">
+    OAuth and API-key configuration snippets for Claude Code, Claude Desktop, Cursor, VS Code, Codex, and other MCP clients.
   </Card>
 </CardGroup>

--- a/mcp/overview.mdx
+++ b/mcp/overview.mdx
@@ -38,7 +38,13 @@ Install the Cekura plugin for your assistant — it bundles Skills **and** MCP, 
   </Tab>
 
   <Tab title="Cursor">
-    In Cursor, go to **Settings > Plugins > Team Marketplaces > Add Marketplace > Import from Repo**, enter `https://github.com/cekura-ai/cekura-skills`, and install **cekura**. Authorize MCP via OAuth when prompted — the plugin includes Skills + MCP. [Full guide →](/mcp/cursor-guide)
+    The plugin includes Skills + MCP. In Cursor:
+
+    1. Open **Settings → Plugins → Team Marketplaces → Add Marketplace → Import from Repo**
+    2. Enter `https://github.com/cekura-ai/cekura-skills`
+    3. Install **cekura**, and authorize MCP via OAuth when prompted
+
+    [Full guide →](/mcp/cursor-guide)
   </Tab>
 
   <Tab title="Codex">

--- a/mcp/overview.mdx
+++ b/mcp/overview.mdx
@@ -17,15 +17,20 @@ Skills teach your assistant how to work with Cekura. MCP lets it safely act in y
 
 ## Set up
 
-Pick the tab for your tool. Every command copies on its own.
+Pick the tab for your tool, then copy the setup.
 
 <Tabs>
   <Tab title="Claude Code — recommended">
-    The plugin bundles Skills, slash commands, and MCP config in one install. Run these in a Claude Code session:
+    The plugin bundles Skills, slash commands, and MCP config in one install. In a Claude Code session, run:
 
     ```plaintext
     /plugin marketplace add cekura-ai/cekura-skills
     /plugin install cekura@cekura-skills
+    ```
+
+    Once the plugin loads (restart the session if prompted), connect MCP:
+
+    ```plaintext
     /setup-mcp
     ```
 
@@ -68,12 +73,12 @@ Pick the tab for your tool. Every command copies on its own.
 | Setup | Best for | What you get |
 |---|---|---|
 | ⭐ [**Claude Code plugin**](/mcp/claude-code-guide) | Claude Code | Skills, commands, MCP, auto-update, failure hook |
-| [**Skills + MCP**](/mcp/cursor-guide) | Cursor, Codex, Windsurf, OpenCode | Workflow guidance + live workspace tools |
+| **Skills + MCP** | [Cursor](/mcp/cursor-guide), [Codex](/mcp/codex-guide), [others](/mcp/other-agents) | Workflow guidance + live workspace tools |
 | [**Skills only**](/mcp/skills) | Planning & review | Guidance only, no API calls |
 | [**MCP only**](/mcp/mcp-only) | Direct API/tool access | Live tools, no playbooks |
 | [**Claude Desktop**](/mcp/claude-desktop-guide) | Claude Desktop chat | MCP connector UI, no Skills |
 
-Each row links to its full guide. Cursor, Codex, and other assistants are covered under **Set up your assistant** in the sidebar.
+Each link opens the full guide for that setup.
 
 ## Verify your setup
 
@@ -87,6 +92,10 @@ You should see two things:
 
 - The assistant can access your Cekura workspace and list real agents.
 - The assistant reasons in Cekura terms like evaluators, metrics, expected outcomes, test profiles, and run results.
+
+<Note>
+On an **MCP-only** setup (no Skills), verify with just `List my Cekura agents` — you'll get live tool access but not the workflow guidance that Skills add.
+</Note>
 
 ## Why install both?
 

--- a/mcp/overview.mdx
+++ b/mcp/overview.mdx
@@ -17,7 +17,7 @@ Skills teach your assistant how to work with Cekura. MCP lets it safely act in y
 
 ## Set up
 
-Pick the tab for your tool, then copy the setup.
+Install the Cekura plugin for your assistant — it bundles Skills **and** MCP, so there's no separate MCP setup. Pick your tab.
 
 <Tabs>
   <Tab title="Claude Code — recommended">
@@ -34,36 +34,52 @@ Pick the tab for your tool, then copy the setup.
     /setup-mcp
     ```
 
-    `/setup-mcp` connects MCP over OAuth (a browser sign-in, no API key). Then run `/cekura-onboarding` for a guided first run.
+    OAuth opens a browser to sign in — no API key. Then run `/cekura-onboarding` for a guided first run. [Full guide →](/mcp/claude-code-guide)
   </Tab>
 
-  <Tab title="Cursor, Codex & others">
-    Install Skills, then connect MCP:
+  <Tab title="Cursor">
+    In Cursor, go to **Settings > Plugins > Team Marketplaces > Add Marketplace > Import from Repo**, enter `https://github.com/cekura-ai/cekura-skills`, and install **cekura**. Authorize MCP via OAuth when prompted — the plugin includes Skills + MCP. [Full guide →](/mcp/cursor-guide)
+  </Tab>
+
+  <Tab title="Codex">
+    The plugin bundles Skills + MCP. Add the marketplace, install, then authenticate:
 
     ```bash
-    npx skills add cekura-ai/cekura-skills --all
+    codex plugin marketplace add cekura-ai/cekura-skills
+    codex plugin add cekura@cekura
+    codex mcp login cekura
     ```
 
-    MCP setup differs per client — follow your [assistant's guide](#which-setup-fits-you) for the exact connect step.
+    `codex mcp login` opens a browser for OAuth — no API key. [Full guide →](/mcp/codex-guide)
+  </Tab>
+
+  <Tab title="Gemini CLI">
+    Install the extension — it includes the Cekura MCP server and context:
+
+    ```bash
+    gemini extensions install https://github.com/cekura-ai/cekura-skills
+    ```
+
+    OAuth runs on first use of a Cekura tool. [Details →](/mcp/other-agents#gemini-cli)
   </Tab>
 
   <Tab title="MCP only">
-    Point your MCP client at this endpoint:
+    No plugin? Point any MCP client at this endpoint:
 
     ```plaintext
     https://api.cekura.ai/mcp
     ```
 
-    In Claude Code, that's one command (OAuth opens a browser — no API key):
+    In Claude Code that's one command (OAuth, no API key):
 
     ```bash
     claude mcp add --transport http cekura --scope user https://api.cekura.ai/mcp
     ```
 
-    For Cursor, Codex, and other clients, see [MCP-only setup](/mcp/mcp-only).
+    See [MCP-only setup](/mcp/mcp-only) for every client.
 
     <Tip>
-    Skills make these tools far more useful — they teach your assistant how to design evaluators, choose metrics, and debug runs instead of guessing. Add them with one of the other tabs.
+    Skills make these tools far more useful — they teach your assistant how to design evaluators, choose metrics, and debug runs. Where a plugin exists (the other tabs), it adds Skills for you.
     </Tip>
   </Tab>
 </Tabs>
@@ -72,13 +88,13 @@ Pick the tab for your tool, then copy the setup.
 
 | Setup | Best for | What you get |
 |---|---|---|
-| ⭐ [**Claude Code plugin**](/mcp/claude-code-guide) | Claude Code | Skills, commands, MCP, auto-update, failure hook |
-| **Skills + MCP** | [Cursor](/mcp/cursor-guide), [Codex](/mcp/codex-guide), [others](/mcp/other-agents) | Workflow guidance + live workspace tools |
-| [**Skills only**](/mcp/skills) | Planning & review | Guidance only, no API calls |
-| [**MCP only**](/mcp/mcp-only) | Direct API/tool access | Live tools, no playbooks |
-| [**Claude Desktop**](/mcp/claude-desktop-guide) | Claude Desktop chat | MCP connector UI, no Skills |
+| ⭐ **Native plugin** | Claude Code, Cursor, Codex, Gemini CLI | Skills **+** MCP, auto-configured (Claude Code also adds slash commands + hooks) |
+| [**Skills only**](/mcp/skills) | Any Agent Skills client, no live tools | Workflow guidance via `npx skills add`; no MCP |
+| [**MCP only**](/mcp/mcp-only) | Direct API/tool access | Live tools, no workflow playbooks |
+| [**Behavior preset**](/mcp/other-agents) | Windsurf & assistants without a plugin | Domain knowledge via rules / `AGENTS.md`; no MCP |
+| [**Claude Desktop**](/mcp/claude-desktop-guide) | Claude Desktop chat | MCP via connector UI; no Skills |
 
-Each link opens the full guide for that setup.
+Per-client install commands are in **Set up** above. Not sure? Use the plugin — it's the least setup.
 
 ## Verify your setup
 

--- a/mcp/overview.mdx
+++ b/mcp/overview.mdx
@@ -25,13 +25,7 @@ Pick the tab for your tool. Every command copies on its own.
 
     ```plaintext
     /plugin marketplace add cekura-ai/cekura-skills
-    ```
-
-    ```plaintext
     /plugin install cekura@cekura-skills
-    ```
-
-    ```plaintext
     /setup-mcp
     ```
 
@@ -73,13 +67,13 @@ Pick the tab for your tool. Every command copies on its own.
 
 | Setup | Best for | What you get |
 |---|---|---|
-| [**Claude Code plugin**](/mcp/claude-code-guide) ⭐ | Claude Code (terminal or VS Code) | Everything — Skills, slash commands, MCP, auto-update, failure hook |
-| **Skills + MCP** | [Cursor](/mcp/cursor-guide), [Codex](/mcp/codex-guide), [Windsurf/OpenCode/others](/mcp/other-agents) | Workflow guidance **+** live workspace tools |
-| [**Skills only**](/mcp/skills) | Planning and review, no actions | Guidance only — can't call Cekura APIs |
-| [**MCP only**](/mcp/mcp-only) | Direct API/tool access | Live tools, no workflow playbooks |
-| [**Claude Desktop**](/mcp/claude-desktop-guide) | Claude Desktop chat | MCP via the connector UI (no Skills or commands) |
+| ⭐ [**Claude Code plugin**](/mcp/claude-code-guide) | Claude Code | Skills, commands, MCP, auto-update, failure hook |
+| [**Skills + MCP**](/mcp/cursor-guide) | Cursor, Codex, Windsurf, OpenCode | Workflow guidance + live workspace tools |
+| [**Skills only**](/mcp/skills) | Planning & review | Guidance only, no API calls |
+| [**MCP only**](/mcp/mcp-only) | Direct API/tool access | Live tools, no playbooks |
+| [**Claude Desktop**](/mcp/claude-desktop-guide) | Claude Desktop chat | MCP connector UI, no Skills |
 
-Each setup links to its full guide. Not sure? Start with the recommended Claude Code path above.
+Each row links to its full guide. Cursor, Codex, and other assistants are covered under **Set up your assistant** in the sidebar.
 
 ## Verify your setup
 

--- a/mcp/overview.mdx
+++ b/mcp/overview.mdx
@@ -20,7 +20,7 @@ Skills teach your assistant how to work with Cekura. MCP lets it safely act in y
 Install the Cekura plugin for your assistant — it bundles Skills **and** MCP, so there's no separate MCP setup. Pick your tab.
 
 <Tabs>
-  <Tab title="Claude Code — recommended">
+  <Tab title="Claude Code">
     The plugin bundles Skills, slash commands, and MCP config in one install. In a Claude Code session, run:
 
     ```plaintext
@@ -35,6 +35,16 @@ Install the Cekura plugin for your assistant — it bundles Skills **and** MCP, 
     ```
 
     OAuth opens a browser to sign in — no API key. Then run `/cekura-onboarding` for a guided first run. [Full guide →](/mcp/claude-code-guide)
+  </Tab>
+
+  <Tab title="Claude Desktop">
+    The plugin bundles Skills + MCP (Skills work in Chat and Cowork). In Claude Desktop:
+
+    1. Open **Customize → Plugins**
+    2. **Personal plugins → + → Add marketplace → Add from a repository**, and enter `cekura-ai/cekura-skills`
+    3. Install **cekura**, and authorize MCP via OAuth when prompted
+
+    [Full guide →](/mcp/claude-desktop-guide)
   </Tab>
 
   <Tab title="Cursor">
@@ -68,23 +78,13 @@ Install the Cekura plugin for your assistant — it bundles Skills **and** MCP, 
 
     OAuth runs on first use of a Cekura tool. [Details →](/mcp/other-agents#gemini-cli)
   </Tab>
-
-  <Tab title="Claude Desktop">
-    The plugin bundles Skills + MCP (Skills work in Chat and Cowork). In Claude Desktop:
-
-    1. Open **Customize → Plugins**
-    2. **Personal plugins → + → Add marketplace → Add from a repository**, and enter `cekura-ai/cekura-skills`
-    3. Install **cekura**, and authorize MCP via OAuth when prompted
-
-    [Full guide →](/mcp/claude-desktop-guide)
-  </Tab>
 </Tabs>
 
 ## Which setup fits you?
 
 | Setup | Best for | What you get |
 |---|---|---|
-| ⭐ **Native plugin** | Claude Code, Cursor, Codex, Gemini CLI, Claude Desktop | Skills **+** MCP, auto-configured (Claude Code also adds slash commands + hooks) |
+| ⭐ **Native plugin** | Claude Code, Claude Desktop, Cursor, Codex, Gemini CLI | Skills **+** MCP, auto-configured (Claude Code also adds slash commands + hooks) |
 | [**Manual (Skills + MCP)**](/mcp/mcp-only) | Clients without a plugin | Install Skills, then connect MCP separately |
 | [**Skills only**](/mcp/skills) | Any Agent Skills client, no live tools | Workflow guidance via `npx skills add`; no MCP |
 | [**Behavior preset**](/mcp/other-agents) | Windsurf & assistants without a plugin | Domain knowledge via rules / `AGENTS.md`; no MCP |

--- a/mcp/overview.mdx
+++ b/mcp/overview.mdx
@@ -17,21 +17,55 @@ Skills teach your assistant how to work with Cekura. MCP lets it safely act in y
 
 ## Fastest path
 
-<CodeGroup>
-```plaintext Claude Code
-# Run inside a Claude Code session:
+Pick the route that matches your tool. Every command copies on its own.
+
+### Claude Code — recommended
+
+The plugin bundles Skills, slash commands, and MCP config in one install. Run these in a Claude Code session:
+
+```plaintext
 /plugin marketplace add cekura-ai/cekura-skills
+```
+
+```plaintext
 /plugin install cekura@cekura-skills
+```
+
+```plaintext
 /setup-mcp
 ```
 
-```bash Cursor, Codex, Windsurf, OpenCode
-npx skills add cekura-ai/cekura-skills --all
-# then connect MCP from your client's guide below
-```
-</CodeGroup>
+`/setup-mcp` connects MCP over OAuth (a browser sign-in, no API key). Then run `/cekura-onboarding` for a guided first run.
 
-The Claude Code plugin bundles Skills, slash commands, and MCP config in one install. Other assistants get Skills now and connect MCP in one more step. Not sure which fits? The table below maps each setup to its best use.
+### Cursor, Codex, Windsurf, OpenCode
+
+Install Skills, then connect MCP:
+
+```bash
+npx skills add cekura-ai/cekura-skills --all
+```
+
+MCP setup differs per client — follow your [assistant's guide](#start-here) for the exact connect step.
+
+### Just the MCP tools — any client
+
+Point your MCP client at this endpoint:
+
+```plaintext
+https://api.cekura.ai/mcp
+```
+
+In Claude Code, that's one command (OAuth opens a browser — no API key):
+
+```bash
+claude mcp add --transport http cekura --scope user https://api.cekura.ai/mcp
+```
+
+For Cursor, Codex, and other clients, see [MCP-only setup](/mcp/mcp-only).
+
+<Tip>
+Skills make these tools far more useful — they teach your assistant how to design evaluators, choose metrics, and debug runs instead of guessing. Add them with one of the paths above.
+</Tip>
 
 ## Pick your setup
 
@@ -71,6 +105,19 @@ The Claude Code plugin bundles Skills, slash commands, and MCP config in one ins
   </Card>
 </CardGroup>
 
+## Verify your setup
+
+After setup, ask your assistant:
+
+```plaintext
+Use the Cekura skills and MCP. List my Cekura agents, pick one, and propose 3 evaluators I should create first. Do not create anything until I approve.
+```
+
+You should see two things:
+
+- The assistant can access your Cekura workspace and list real agents.
+- The assistant reasons in Cekura terms like evaluators, metrics, expected outcomes, test profiles, and run results.
+
 ## Why install both?
 
 <CardGroup cols={2}>
@@ -84,19 +131,6 @@ The Claude Code plugin bundles Skills, slash commands, and MCP config in one ins
 </CardGroup>
 
 With Skills only, your assistant can advise. With MCP only, your assistant can call tools. With both, it can choose the right workflow and complete it.
-
-## Verify your setup
-
-After setup, ask your assistant:
-
-```plaintext
-Use the Cekura skills and MCP. List my Cekura agents, pick one, and propose 3 evaluators I should create first. Do not create anything until I approve.
-```
-
-You should see two things:
-
-- The assistant can access your Cekura workspace and list real agents.
-- The assistant reasons in Cekura terms like evaluators, metrics, expected outcomes, test profiles, and run results.
 
 ## What you can ask next
 

--- a/mcp/overview.mdx
+++ b/mcp/overview.mdx
@@ -62,25 +62,9 @@ Install the Cekura plugin for your assistant — it bundles Skills **and** MCP, 
 
     OAuth runs on first use of a Cekura tool. [Details →](/mcp/other-agents#gemini-cli)
   </Tab>
-
-  <Tab title="Manual (no plugin)">
-    No native plugin for your client? Set up the two pieces separately — Skills first, then MCP.
-
-    Install Skills:
-
-    ```bash
-    npx skills add cekura-ai/cekura-skills --all
-    ```
-
-    Then connect MCP (Claude Code shown — one command, OAuth, no API key):
-
-    ```bash
-    claude mcp add --transport http cekura --scope user https://api.cekura.ai/mcp
-    ```
-
-    For other clients' MCP config, see [manual setup](/mcp/mcp-only).
-  </Tab>
 </Tabs>
+
+Using Windsurf, OpenCode, or another assistant without a plugin? Install Skills, then connect MCP separately — see [manual setup](/mcp/mcp-only).
 
 ## Which setup fits you?
 

--- a/mcp/overview.mdx
+++ b/mcp/overview.mdx
@@ -68,17 +68,26 @@ Install the Cekura plugin for your assistant — it bundles Skills **and** MCP, 
 
     OAuth runs on first use of a Cekura tool. [Details →](/mcp/other-agents#gemini-cli)
   </Tab>
+
+  <Tab title="Claude Desktop">
+    The plugin bundles Skills + MCP (Skills work in Chat and Cowork). In Claude Desktop:
+
+    1. Open **Customize → Plugins**
+    2. **Personal plugins → + → Add marketplace → Add from a repository**, and enter `cekura-ai/cekura-skills`
+    3. Install **cekura**, and authorize MCP via OAuth when prompted
+
+    [Full guide →](/mcp/claude-desktop-guide)
+  </Tab>
 </Tabs>
 
 ## Which setup fits you?
 
 | Setup | Best for | What you get |
 |---|---|---|
-| ⭐ **Native plugin** | Claude Code, Cursor, Codex, Gemini CLI | Skills **+** MCP, auto-configured (Claude Code also adds slash commands + hooks) |
+| ⭐ **Native plugin** | Claude Code, Cursor, Codex, Gemini CLI, Claude Desktop | Skills **+** MCP, auto-configured (Claude Code also adds slash commands + hooks) |
 | [**Manual (Skills + MCP)**](/mcp/mcp-only) | Clients without a plugin | Install Skills, then connect MCP separately |
 | [**Skills only**](/mcp/skills) | Any Agent Skills client, no live tools | Workflow guidance via `npx skills add`; no MCP |
 | [**Behavior preset**](/mcp/other-agents) | Windsurf & assistants without a plugin | Domain knowledge via rules / `AGENTS.md`; no MCP |
-| [**Claude Desktop**](/mcp/claude-desktop-guide) | Claude Desktop chat | MCP via connector UI; no Skills |
 
 Per-client install commands are in **Set up** above. Not sure? Use the plugin — it's the least setup.
 

--- a/mcp/overview.mdx
+++ b/mcp/overview.mdx
@@ -63,24 +63,22 @@ Install the Cekura plugin for your assistant — it bundles Skills **and** MCP, 
     OAuth runs on first use of a Cekura tool. [Details →](/mcp/other-agents#gemini-cli)
   </Tab>
 
-  <Tab title="MCP only">
-    No plugin? Point any MCP client at this endpoint:
+  <Tab title="Manual (no plugin)">
+    No native plugin for your client? Set up the two pieces separately — Skills first, then MCP.
 
-    ```plaintext
-    https://api.cekura.ai/mcp
+    Install Skills:
+
+    ```bash
+    npx skills add cekura-ai/cekura-skills --all
     ```
 
-    In Claude Code that's one command (OAuth, no API key):
+    Then connect MCP (Claude Code shown — one command, OAuth, no API key):
 
     ```bash
     claude mcp add --transport http cekura --scope user https://api.cekura.ai/mcp
     ```
 
-    See [MCP-only setup](/mcp/mcp-only) for every client.
-
-    <Tip>
-    Skills make these tools far more useful — they teach your assistant how to design evaluators, choose metrics, and debug runs. Where a plugin exists (the other tabs), it adds Skills for you.
-    </Tip>
+    For other clients' MCP config, see [manual setup](/mcp/mcp-only).
   </Tab>
 </Tabs>
 
@@ -89,8 +87,8 @@ Install the Cekura plugin for your assistant — it bundles Skills **and** MCP, 
 | Setup | Best for | What you get |
 |---|---|---|
 | ⭐ **Native plugin** | Claude Code, Cursor, Codex, Gemini CLI | Skills **+** MCP, auto-configured (Claude Code also adds slash commands + hooks) |
+| [**Manual (Skills + MCP)**](/mcp/mcp-only) | Clients without a plugin | Install Skills, then connect MCP separately |
 | [**Skills only**](/mcp/skills) | Any Agent Skills client, no live tools | Workflow guidance via `npx skills add`; no MCP |
-| [**MCP only**](/mcp/mcp-only) | Direct API/tool access | Live tools, no workflow playbooks |
 | [**Behavior preset**](/mcp/other-agents) | Windsurf & assistants without a plugin | Domain knowledge via rules / `AGENTS.md`; no MCP |
 | [**Claude Desktop**](/mcp/claude-desktop-guide) | Claude Desktop chat | MCP via connector UI; no Skills |
 
@@ -166,7 +164,7 @@ With Skills only, your assistant can advise. With MCP only, your assistant can c
     See every Cekura Skill, install path, update path, and compatibility note.
   </Card>
 
-  <Card title="MCP-only Setup" icon="shield-halved" href="/mcp/mcp-only">
-    OAuth and API-key configuration snippets for Claude Code, Claude Desktop, Cursor, VS Code, Codex, and other MCP clients.
+  <Card title="Manual setup (Skills + MCP)" icon="wrench" href="/mcp/mcp-only">
+    For clients without a plugin: install Skills, then OAuth/API-key MCP config for Claude Code, Claude Desktop, Cursor, VS Code, and Codex.
   </Card>
 </CardGroup>

--- a/mcp/overview.mdx
+++ b/mcp/overview.mdx
@@ -70,8 +70,6 @@ Install the Cekura plugin for your assistant — it bundles Skills **and** MCP, 
   </Tab>
 </Tabs>
 
-Using Windsurf, OpenCode, or another assistant without a plugin? Install Skills, then connect MCP separately — see [manual setup](/mcp/mcp-only).
-
 ## Which setup fits you?
 
 | Setup | Best for | What you get |

--- a/mcp/overview.mdx
+++ b/mcp/overview.mdx
@@ -28,7 +28,7 @@ Install the Cekura plugin for your assistant — it bundles Skills **and** MCP, 
     /plugin install cekura@cekura-skills
     ```
 
-    Once the plugin loads (restart the session if prompted), connect MCP:
+    The plugin already includes the MCP server **config**; `/setup-mcp` signs you in (OAuth) and verifies the connection. Once the plugin loads (restart the session if prompted), run:
 
     ```plaintext
     /setup-mcp

--- a/mcp/overview.mdx
+++ b/mcp/overview.mdx
@@ -15,6 +15,24 @@ Recommended setup: install both **Cekura Skills** and the **Cekura MCP server**.
 Skills teach your assistant how to work with Cekura. MCP lets it safely act in your Cekura workspace.
 </Note>
 
+## Fastest path
+
+<CodeGroup>
+```plaintext Claude Code
+# Run inside a Claude Code session:
+/plugin marketplace add cekura-ai/cekura-skills
+/plugin install cekura@cekura-skills
+/setup-mcp
+```
+
+```bash Cursor, Codex, Windsurf, OpenCode
+npx skills add cekura-ai/cekura-skills --all
+# then connect MCP from your client's guide below
+```
+</CodeGroup>
+
+The Claude Code plugin bundles Skills, slash commands, and MCP config in one install. Other assistants get Skills now and connect MCP in one more step. Not sure which fits? The table below maps each setup to its best use.
+
 ## Pick your setup
 
 | Setup | Use this if | What you get |

--- a/mcp/overview.mdx
+++ b/mcp/overview.mdx
@@ -17,7 +17,7 @@ Skills teach your assistant how to work with Cekura. MCP lets it safely act in y
 
 ## Set up
 
-Install the Cekura plugin for your assistant — it bundles Skills **and** MCP, so there's no separate MCP setup. Pick your tab.
+Install the Cekura plugin for your assistant — it bundles Skills **and** MCP. Pick your tab.
 
 <Tabs>
   <Tab title="Claude Code">

--- a/mcp/overview.mdx
+++ b/mcp/overview.mdx
@@ -45,7 +45,7 @@ Pick the tab for your tool. Every command copies on its own.
     npx skills add cekura-ai/cekura-skills --all
     ```
 
-    MCP setup differs per client — follow your [assistant's guide](#start-here) for the exact connect step.
+    MCP setup differs per client — follow your [assistant's guide](#which-setup-fits-you) for the exact connect step.
   </Tab>
 
   <Tab title="MCP only">
@@ -73,39 +73,13 @@ Pick the tab for your tool. Every command copies on its own.
 
 | Setup | Best for | What you get |
 |---|---|---|
-| **Claude Code plugin** ⭐ | Claude Code (terminal or VS Code) | Everything — Skills, slash commands, MCP, auto-update, failure hook |
-| **Skills + MCP** | Cursor, Codex, Windsurf, OpenCode | Workflow guidance **+** live workspace tools |
-| **Skills only** | Planning and review, no actions | Guidance only — can't call Cekura APIs |
-| **MCP only** | Direct API/tool access | Live tools, no workflow playbooks |
-| **Claude Desktop** | Claude Desktop chat | MCP via the connector UI (no Skills or commands) |
+| [**Claude Code plugin**](/mcp/claude-code-guide) ⭐ | Claude Code (terminal or VS Code) | Everything — Skills, slash commands, MCP, auto-update, failure hook |
+| **Skills + MCP** | [Cursor](/mcp/cursor-guide), [Codex](/mcp/codex-guide), [Windsurf/OpenCode/others](/mcp/other-agents) | Workflow guidance **+** live workspace tools |
+| [**Skills only**](/mcp/skills) | Planning and review, no actions | Guidance only — can't call Cekura APIs |
+| [**MCP only**](/mcp/mcp-only) | Direct API/tool access | Live tools, no workflow playbooks |
+| [**Claude Desktop**](/mcp/claude-desktop-guide) | Claude Desktop chat | MCP via the connector UI (no Skills or commands) |
 
-## Start here
-
-<CardGroup cols={2}>
-  <Card title="Claude Code" icon="code" href="/mcp/claude-code-guide">
-    Recommended. Install the Cekura plugin, run `/setup-mcp`, then use Skills, slash commands, and MCP tools together.
-  </Card>
-
-  <Card title="Cursor" icon="code" href="/mcp/cursor-guide">
-    Install Cekura Skills, connect the Cekura MCP server, and keep the rules-file fallback if your Cursor setup does not load Agent Skills yet.
-  </Card>
-
-  <Card title="Codex" icon="terminal" href="/mcp/codex-guide">
-    Install Cekura Skills, configure the Cekura MCP server, and keep the `AGENTS.md` fallback for Codex builds without Agent Skills support.
-  </Card>
-
-  <Card title="Claude Desktop" icon="desktop" href="/mcp/claude-desktop-guide">
-    Use Claude Desktop's native connector UI to authorize the Cekura MCP server. This is MCP-only.
-  </Card>
-
-  <Card title="Other assistants" icon="wand-magic-sparkles" href="/mcp/other-agents">
-    OpenCode, Windsurf, and other assistants can use Agent Skills, MCP, or a portable behavior preset.
-  </Card>
-
-  <Card title="MCP-only setup" icon="shield-halved" href="/mcp/mcp-only">
-    Advanced path for users who only want direct MCP/API access without Cekura Skills.
-  </Card>
-</CardGroup>
+Each setup links to its full guide. Not sure? Start with the recommended Claude Code path above.
 
 ## Verify your setup
 
@@ -150,7 +124,7 @@ With Skills only, your assistant can advise. With MCP only, your assistant can c
   </Accordion>
 
   <Accordion title="Run scenarios over the right connection">
-    Each `scenarios_run_*` tool drives one connection type: telephony (`scenarios_run_voice`), SIP (`scenarios_run_sip`), provider WebRTC (`scenarios_run_vapi_webrtc`, `scenarios_run_retell_webrtc`), or chat (`scenarios_run_text`). It only works if that connection is configured on the agent. Retrieve the agent first and check `provider.type` and the `telephony` block before running evaluators.
+    Each `scenarios_run_*` tool drives one connection type, and only works if that connection is configured on the agent. Common ones include `scenarios_run_voice` (telephony), `scenarios_run_sip` (SIP), `scenarios_run_vapi_webrtc` / `scenarios_run_retell_webrtc` (provider WebRTC), and `scenarios_run_text` (chat) — with more for ElevenLabs, LiveKit, Pipecat, Agora, and raw WebSocket. Retrieve the agent first and check `provider.type` and the `telephony` block to pick the right one.
   </Accordion>
 
   <Accordion title="Design better metrics">

--- a/mcp/skills.mdx
+++ b/mcp/skills.mdx
@@ -19,7 +19,7 @@ Cekura Skills give your AI assistant the playbook for designing evaluators, crea
 
 | Install path | Best for | Skills | Slash commands | MCP config | Hooks |
 |---|---|---:|---:|---:|---:|
-| Native plugin | Claude Code, Cursor, Codex | Yes | Claude Code only | Yes | Claude Code only |
+| Native plugin | Claude Code, Cursor, Codex, Claude Desktop | Yes | Claude Code only | Yes | Claude Code only |
 | Native extension | Gemini CLI | Context file | No | Yes | No |
 | `npx skills add` | Any Agent Skills client | Yes | No | No | No |
 | Behavior preset | Assistants without a plugin | Rules only | No | No | No |
@@ -188,7 +188,7 @@ After reinstalling, `claude plugin list` should show one `cekura@cekura-skills` 
 | Cursor | Native plugin | Skills + MCP via the marketplace plugin; `npx skills add` / `.cursor/rules` are no-MCP fallbacks |
 | Codex | Native plugin | Skills + MCP via `codex plugin add` + `codex mcp login`; no slash commands |
 | Gemini CLI | Native extension | MCP + `GEMINI.md` context via `gemini extensions install`; no Skills bundling yet |
-| Claude Desktop | MCP connector | Connector gives MCP access only; use Claude Code for Skills and commands |
+| Claude Desktop | Native plugin | Customize → Plugins gives Skills + MCP (Skills in Chat & Cowork); the connector UI is the MCP-only alternative |
 | Windsurf, other assistants | `npx skills add` or behavior preset | Skills (no MCP) or portable `AGENTS.md`; add MCP manually if supported |
 
 ### Why didn't `/plugin marketplace add` install the plugin automatically?

--- a/mcp/skills.mdx
+++ b/mcp/skills.mdx
@@ -19,12 +19,13 @@ Cekura Skills give your AI assistant the playbook for designing evaluators, crea
 
 | Install path | Best for | Skills | Slash commands | MCP config | Hooks |
 |---|---|---:|---:|---:|---:|
-| Claude Code plugin | Full Claude Code experience | Yes | Yes | Yes | Yes |
-| `npx skills add` | Agent Skills-compatible coding assistants | Yes | No | No | No |
-| Behavior preset | Assistants that do not load Agent Skills yet | Rules only | No | No | No |
+| Native plugin | Claude Code, Cursor, Codex | Yes | Claude Code only | Yes | Claude Code only |
+| Native extension | Gemini CLI | Context file | No | Yes | No |
+| `npx skills add` | Any Agent Skills client | Yes | No | No | No |
+| Behavior preset | Assistants without a plugin | Rules only | No | No | No |
 | MCP only | Direct API/tool access | No | No | Yes | No |
 
-The Claude Code plugin is the preferred route because it bundles Skills, slash commands, MCP configuration, update support, and MCP failure help in one install.
+The native plugin is the preferred route on every client that has one — it bundles Skills and the MCP server (no separate MCP setup), and on Claude Code it adds slash commands, update support, and the MCP failure hook. See your [assistant's guide](/mcp/overview#set-up) for the exact install.
 
 ## Install
 
@@ -172,11 +173,12 @@ After reinstalling, `claude plugin list` should show one `cekura@cekura-skills` 
 
 | Client | Recommended path | Notes |
 |---|---|---|
-| Claude Code | Plugin + `/setup-mcp` | Full Skills, commands, MCP config, update support, and hooks |
-| Claude Desktop | MCP connector | Desktop connector gives MCP access only; use Claude Code for Skills and commands |
-| Cursor | Agent Skills + MCP, with rules fallback | Keep the `.cursor/rules` fallback if your Cursor setup does not load Agent Skills yet |
-| Codex | Agent Skills + MCP, with `AGENTS.md` fallback | Keep the behavior preset fallback for Codex builds without Agent Skills support |
-| OpenCode, Windsurf, other assistants | Agent Skills + MCP, with behavior preset fallback | Use the assistant's MCP configuration plus the portable preset when needed |
+| Claude Code | Plugin + `/setup-mcp` | Full Skills, slash commands, MCP config, update support, and hooks |
+| Cursor | Native plugin | Skills + MCP via the marketplace plugin; `npx skills add` / `.cursor/rules` are no-MCP fallbacks |
+| Codex | Native plugin | Skills + MCP via `codex plugin add` + `codex mcp login`; no slash commands |
+| Gemini CLI | Native extension | MCP + `GEMINI.md` context via `gemini extensions install`; no Skills bundling yet |
+| Claude Desktop | MCP connector | Connector gives MCP access only; use Claude Code for Skills and commands |
+| Windsurf, other assistants | `npx skills add` or behavior preset | Skills (no MCP) or portable `AGENTS.md`; add MCP manually if supported |
 
 ### Why didn't `/plugin marketplace add` install the plugin automatically?
 

--- a/mcp/skills.mdx
+++ b/mcp/skills.mdx
@@ -161,17 +161,8 @@ If plugin install or upgrade reports stale entries, run these in Claude Code, in
 
 ```plaintext
 /plugin marketplace remove cekura-skills
-```
-
-```plaintext
 /plugin marketplace add cekura-ai/cekura-skills
-```
-
-```plaintext
 /plugin marketplace update cekura-skills
-```
-
-```plaintext
 /plugin install cekura@cekura-skills
 ```
 

--- a/mcp/skills.mdx
+++ b/mcp/skills.mdx
@@ -10,7 +10,7 @@ import { CopyPageButton } from "/snippets/copy-page-button.mdx";
 <CopyPageButton />
 
 <Note>
-If you are setting up Cekura for the first time, start with [AI assistant setup](/mcp/overview). This page is the Skills catalog and maintenance reference.
+If you are setting up Cekura for the first time, start with the [MCP & Skills setup](/mcp/overview). This page is the Skills catalog and maintenance reference.
 </Note>
 
 Cekura Skills give your AI assistant the playbook for designing evaluators, creating metrics, running tests, improving prompts, and triaging production failures on Cekura.
@@ -181,7 +181,7 @@ Marketplaces and plugins are separate concerns in Claude Code. `marketplace add`
 ## Links
 
 <CardGroup cols={2}>
-  <Card title="AI Assistant Setup" icon="sparkles" href="/mcp/overview">
+  <Card title="MCP & Skills Setup" icon="sparkles" href="/mcp/overview">
     Choose the right install path for your assistant.
   </Card>
 

--- a/mcp/skills.mdx
+++ b/mcp/skills.mdx
@@ -156,6 +156,17 @@ Slash commands are available only through the Claude Code plugin install.
   </Tab>
 </Tabs>
 
+## Remove
+
+For `npx skills` installs:
+
+```bash
+npx skills remove cekura-coordinator   # one skill
+npx skills remove --all                 # everything
+```
+
+For the Claude Code plugin, remove the marketplace entry with `/plugin marketplace remove cekura-skills` (see [Reinstall](#reinstall-claude-code-plugin) for the full sequence).
+
 ## Reinstall Claude Code plugin
 
 If plugin install or upgrade reports stale entries, run these in Claude Code, in order:

--- a/mcp/skills.mdx
+++ b/mcp/skills.mdx
@@ -57,7 +57,7 @@ The native plugin is the preferred route on every client that has one — it bun
     npx skills add cekura-ai/cekura-skills --all
     ```
 
-    This installs Skills only. Pair it with [MCP-only setup](/mcp/mcp-only) if you want live Cekura workspace access.
+    This installs Skills only. Pair it with [manual MCP setup](/mcp/mcp-only) if you want live Cekura workspace access.
   </Tab>
 
   <Tab title="Behavior preset fallback">
@@ -195,8 +195,8 @@ Marketplaces and plugins are separate concerns in Claude Code. `marketplace add`
     Recommended plugin-based setup.
   </Card>
 
-  <Card title="MCP-only Setup" icon="shield-halved" href="/mcp/mcp-only">
-    Direct MCP configuration for supported clients.
+  <Card title="Manual setup" icon="wrench" href="/mcp/mcp-only">
+    Install Skills, then connect MCP — for clients without a plugin.
   </Card>
 
   <Card title="GitHub" icon="github" href="https://github.com/cekura-ai/cekura-skills">

--- a/mcp/skills.mdx
+++ b/mcp/skills.mdx
@@ -36,7 +36,7 @@ The Claude Code plugin is the preferred route because it bundles Skills, slash c
 
     1. Run `/plugin` inside a Claude Code session.
     2. Open **Marketplaces > Add Marketplace**.
-    3. Paste `https://github.com/cekura-ai/cekura-skills.git` and confirm.
+    3. Paste `cekura-ai/cekura-skills` and confirm.
     4. Open **Discover**, search `cekura`, and install the `cekura` plugin.
     5. Run `/setup-mcp` and complete the OAuth sign-in.
 
@@ -44,7 +44,7 @@ The Claude Code plugin is the preferred route because it bundles Skills, slash c
 
     1. Open the Claude Code chat panel.
     2. Open **Manage Plugins > Marketplaces**.
-    3. Add `https://github.com/cekura-ai/cekura-skills.git`.
+    3. Add `cekura-ai/cekura-skills`.
     4. Install the `cekura` plugin.
     5. Restart VS Code, then run `/setup-mcp`.
   </Tab>

--- a/mcp/skills.mdx
+++ b/mcp/skills.mdx
@@ -76,6 +76,10 @@ The Claude Code plugin is the preferred route because it bundles Skills, slash c
 
 ## Skills catalog
 
+<Note>
+The [cekura-skills repo](https://github.com/cekura-ai/cekura-skills) is the canonical, always-current list. The catalog below may lag when new skills ship.
+</Note>
+
 | Skill | Use when |
 |---|---|
 | `cekura-coordinator` | The user asks what Cekura can do or which workflow to use |
@@ -153,12 +157,21 @@ Slash commands are available only through the Claude Code plugin install.
 
 ## Reinstall Claude Code plugin
 
-If plugin install or upgrade reports stale entries, run these commands in Claude Code:
+If plugin install or upgrade reports stale entries, run these in Claude Code, in order:
 
 ```plaintext
 /plugin marketplace remove cekura-skills
+```
+
+```plaintext
 /plugin marketplace add cekura-ai/cekura-skills
+```
+
+```plaintext
 /plugin marketplace update cekura-skills
+```
+
+```plaintext
 /plugin install cekura@cekura-skills
 ```
 

--- a/mcp/skills.mdx
+++ b/mcp/skills.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Cekura Skills"
-sidebarTitle: "Skills"
-description: "Install Cekura skills into Claude Code, Cursor, Codex, or any Agent Skills client."
+sidebarTitle: "Skills Catalog"
+description: "Reference for Cekura Skills, install paths, slash commands, updates, and compatibility."
 icon: "sparkles"
 ---
 
@@ -9,218 +9,191 @@ import { CopyPageButton } from "/snippets/copy-page-button.mdx";
 
 <CopyPageButton />
 
-
-Cekura skills give your AI coding agent the playbook for designing evaluators, creating metrics, running tests, and triaging results on the Cekura platform. They auto-activate when your conversation matches a relevant task.
-
-## What you get
-
-Nine skills, scoped to specific Cekura workflows:
-
-| Skill | Activates on |
-|---|---|
-| `cekura-coordinator` | "What can Cekura do?" — routes to the right skill |
-| `cekura-onboarding` | "Get started with Cekura" — full platform walkthrough |
-| `cekura-create-agent` | "Connect my voice agent to Cekura" |
-| `cekura-self-improving-agent` | "Improve my agent / auto-tune from eval results" |
-| `cekura-metric-design` | "Create a metric / measure call quality" |
-| `cekura-metric-improvement` | "Improve a metric / fix metric accuracy" |
-| `cekura-predefined-metrics` | "What predefined metrics are available / which built-in metrics should I use" |
-| `cekura-eval-design` | "Design test scenarios for my voice agent" |
-| `cekura-fixing-prod-issues` | "Fix a production call bug / reproduce and test a fix before raising a PR" |
-
 <Note>
-**Best with MCP, but optional.** Skills work standalone as a knowledge layer (workflows, design patterns, anti-patterns) and pair best with the Cekura MCP server, which lets the agent perform platform actions for you. Without MCP, the agent walks you through direct API calls or dashboard steps. See [MCP overview](/mcp/overview) for setup.
+If you are setting up Cekura for the first time, start with [AI assistant setup](/mcp/overview). This page is the Skills catalog and maintenance reference.
 </Note>
+
+Cekura Skills give your AI assistant the playbook for designing evaluators, creating metrics, running tests, improving prompts, and triaging production failures on Cekura.
+
+## Install paths
+
+| Install path | Best for | Skills | Slash commands | MCP config | Hooks |
+|---|---|---:|---:|---:|---:|
+| Claude Code plugin | Full Claude Code experience | Yes | Yes | Yes | Yes |
+| `npx skills add` | Agent Skills-compatible coding assistants | Yes | No | No | No |
+| Behavior preset | Assistants that do not load Agent Skills yet | Rules only | No | No | No |
+| MCP only | Direct API/tool access | No | No | Yes | No |
+
+The Claude Code plugin is the preferred route because it bundles Skills, slash commands, MCP configuration, update support, and MCP failure help in one install.
 
 ## Install
 
-**Claude Code users — install the marketplace plugin.** It bundles all 9 skills, 14 slash commands, the MCP server config, and a failure-detection hook in a single install. Other agents (Cursor, Codex, Windsurf, etc.) use `npx skills add` to get the skills only.
-
 <Tabs>
-  <Tab title="Claude Code (recommended)">
-    The full marketplace install — skills, slash commands, MCP auto-config, and hooks. **This is the recommended path for any Claude Code user.**
+  <Tab title="Claude Code plugin">
+    Use this for Claude Code in the terminal or VS Code.
 
-    **CLI:**
-    1. Run `/plugin` inside a Claude Code session
-    2. **Marketplaces** tab → **Add Marketplace**
-    3. Paste `https://github.com/cekura-ai/cekura-skills.git` and confirm
-    4. **Discover** tab → search `cekura` → install the `cekura` plugin
-    5. Restart your Claude Code session
-    6. Run `/setup-mcp` to configure the MCP server (or follow the [MCP overview](/mcp/overview) for the OAuth flow — it's a one-click sign-in)
+    **Terminal:**
+
+    1. Run `/plugin` inside a Claude Code session.
+    2. Open **Marketplaces > Add Marketplace**.
+    3. Paste `https://github.com/cekura-ai/cekura-skills.git` and confirm.
+    4. Open **Discover**, search `cekura`, and install the `cekura` plugin.
+    5. Run `/setup-mcp` and complete the OAuth sign-in.
 
     **VS Code:**
-    1. Open the Claude Code chat panel
-    2. **Manage Plugins** → **Marketplaces** → paste the same URL → **Add**
-    3. **Plugins** tab → install the `cekura` plugin
-    4. Restart VS Code, then run `/setup-mcp`
 
-    After install you get all 14 commands (`/cekura-onboarding`, `/setup-mcp`, `/upgrade-skills`, `/report-bug`, `/create-metric`, `/list-metrics`, `/evaluate-calls`, `/improve-metric`, `/autogen-eval`, `/manual-create-update-eval`, `/list-evals`, `/run-evals`, `/eval-results`, `/cekura-report`) plus the auto-configured MCP server and the MCP-failure detection hook.
+    1. Open the Claude Code chat panel.
+    2. Open **Manage Plugins > Marketplaces**.
+    3. Add `https://github.com/cekura-ai/cekura-skills.git`.
+    4. Install the `cekura` plugin.
+    5. Restart VS Code, then run `/setup-mcp`.
   </Tab>
 
-  <Tab title="Other agents (npx skills)">
-    For Cursor, Codex, Windsurf, OpenCode, Antigravity, and any other [Agent Skills](https://agentskills.io)–compatible client. Installs **skills only** — no slash commands, no auto-MCP-config, no hooks.
-
-    ```bash
-    npx skills add cekura-ai/cekura-skills
-    ```
-
-    The CLI prompts you to pick which skills to install and which agents to install them into. Install everything non-interactively:
+  <Tab title="Agent Skills">
+    Use this for Agent Skills-compatible clients when you do not need Claude Code slash commands.
 
     ```bash
     npx skills add cekura-ai/cekura-skills --all
     ```
 
-    Pair this with the [MCP setup](/mcp/overview) — OAuth gives you the same API access as Claude Code without managing keys.
+    This installs Skills only. Pair it with [MCP-only setup](/mcp/mcp-only) if you want live Cekura workspace access.
+  </Tab>
+
+  <Tab title="Behavior preset fallback">
+    Use this when your assistant does not load Agent Skills yet, or when you want a portable project-level rules file.
+
+    ```bash
+    curl -L https://raw.githubusercontent.com/cekura-ai/cekura-skills/main/codex/AGENTS.md -o AGENTS.md
+    ```
+
+    For Cursor project rules:
+
+    ```bash
+    mkdir -p .cursor/rules && curl -L https://raw.githubusercontent.com/cekura-ai/cekura-skills/main/codex/AGENTS.md -o .cursor/rules/cekura.md
+    ```
   </Tab>
 </Tabs>
 
-## Update / refresh
+## Skills catalog
+
+| Skill | Use when |
+|---|---|
+| `cekura-coordinator` | The user asks what Cekura can do or which workflow to use |
+| `cekura-onboarding` | First-time setup, testing path, observability path, and platform walkthroughs |
+| `cekura-create-agent` | Connecting a voice agent, provider setup, mock tools, knowledge base, and dynamic variables |
+| `cekura-self-improving-agent` | Improving an agent from evaluation results and re-validating changes |
+| `cekura-metric-design` | Designing new metrics or choosing the right metric type |
+| `cekura-metric-improvement` | Improving metric accuracy with feedback, labs, and iteration |
+| `cekura-predefined-metrics` | Understanding built-in metrics, configuration, cost, and constraints |
+| `cekura-eval-design` | Designing evaluator coverage, test profiles, conditional actions, and regression suites |
+| `cekura-fixing-prod-issues` | Turning a production failure into a reproduced, fixed, and regression-tested issue |
+| `cekura-infra-test-suite` | Creating CI/CD infrastructure tests for voice pipelines and local bots |
+| `cekura-generate-scenarios` | Converting production call failures into reproducible evaluator scenarios |
+
+## Claude Code slash commands
+
+Slash commands are available only through the Claude Code plugin install.
+
+| Command | What it does |
+|---|---|
+| `/cekura-onboarding` | Guided end-to-end setup with state-aware resume |
+| `/setup-mcp` | Configure the Cekura MCP server |
+| `/upgrade-skills` | Pull the latest plugin and skill updates |
+| `/report-bug` | Report a setup, MCP, skill, or command issue |
+| `/create-metric` | Create or update a metric |
+| `/list-metrics` | List metrics for an agent or project |
+| `/evaluate-calls` | Run metrics on selected production calls |
+| `/improve-metric` | Improve metric accuracy through feedback and lab workflows |
+| `/autogen-eval` | Generate evaluators or bulk-create from structured input |
+| `/manual-create-update-eval` | Create or update one evaluator with a guided field walkthrough |
+| `/list-evals` | List evaluators for an agent or project |
+| `/run-evals` | Run evaluator suites |
+| `/eval-results` | Review a test run's results |
+| `/cekura-report` | Generate, run, and summarize an end-to-end quality report |
+
+## Update
 
 <Tabs>
-  <Tab title="Claude Code marketplace">
-    Run `/upgrade-skills` in any Claude Code session, or pull manually:
+  <Tab title="Claude Code plugin">
+    Run this in Claude Code:
 
-    ```bash
-    cd ~/.claude/plugins/marketplaces/cekura-skills
-    git pull origin main
+    ```plaintext
+    /upgrade-skills
     ```
 
-    Restart Claude Code after upgrading.
-
-    <Tip>
-      **Enable auto-update for hands-off refreshes.** Claude Code can auto-refresh marketplaces and installed plugins at startup, but third-party marketplaces are opt-in. Turn it on once and you're done:
-
-      1. Run `/plugin` to open the plugin manager
-      2. Go to the **Marketplaces** tab
-      3. Select **cekura-skills**
-      4. Choose **Enable auto-update**
-
-      Every Claude Code session will then refresh the marketplace and install the latest plugin versions automatically. If anything updated, you'll see a prompt to run `/reload-plugins`.
-
-      Or set `FORCE_AUTOUPDATE_PLUGINS=1` in your shell environment to force auto-update for every marketplace globally.
-    </Tip>
+    You can also enable marketplace auto-update from the Claude Code plugin manager so new skill versions are picked up automatically on startup.
   </Tab>
 
-  <Tab title="Other agents (npx skills)">
+  <Tab title="Agent Skills">
     <Note>
-      Auto-update is not available for `npx skills` installs. Unlike the Claude Code marketplace, Codex, Cursor, Windsurf, and other agents have no background refresh option — run the commands below manually whenever you want the latest skills.
+      Auto-update is not available for `npx skills` installs. Unlike the Claude Code marketplace, Codex, Cursor, Windsurf, and other agents have no background refresh option. Run the commands below manually whenever you want the latest skills.
     </Note>
 
-    ```bash
-    # Refresh existing skills
-    npx skills update
+    Refresh existing skills:
 
-    # Or refresh existing AND pick up any newly-added skills
+    ```bash
+    npx skills update
+    ```
+
+    Refresh existing skills and pick up newly added skills:
+
+    ```bash
     npx skills add cekura-ai/cekura-skills --all
+    ```
+  </Tab>
+
+  <Tab title="Behavior preset">
+    Re-download the preset:
+
+    ```bash
+    curl -L https://raw.githubusercontent.com/cekura-ai/cekura-skills/main/codex/AGENTS.md -o AGENTS.md
     ```
   </Tab>
 </Tabs>
 
-## Reinstall
+## Reinstall Claude Code plugin
 
-If `/upgrade-skills` reports stale plugin entries, or `/plugin install` fails with `Source path does not exist`, your Claude Code install needs a clean reinstall. Run these 4 commands in order in any Claude Code session:
+If plugin install or upgrade reports stale entries, run these commands in Claude Code:
 
-```
+```plaintext
 /plugin marketplace remove cekura-skills
 /plugin marketplace add cekura-ai/cekura-skills
 /plugin marketplace update cekura-skills
 /plugin install cekura@cekura-skills
 ```
 
-Step 3 is the critical one — it forces Claude Code to re-read the marketplace manifest. After step 4, `claude plugin list` should show one `cekura@cekura-skills` entry and all 14 slash commands resolve under `cekura:*`.
-
-If `/plugin install` still errors after step 4, fully restart Claude Code (close and reopen the session), then redo steps 2–4.
-
-## Remove
-
-```bash
-# npx skills install
-npx skills remove cekura-coordinator   # one skill
-npx skills remove --all                 # everything
-```
-
-For the Claude Code marketplace install, remove the marketplace from `/plugins` → **Marketplaces**.
+After reinstalling, `claude plugin list` should show one `cekura@cekura-skills` entry and the Cekura slash commands should resolve.
 
 ## Compatibility
 
-| Client | Method | Skills | Slash commands | MCP tools |
-|---|---|---|---|---|
-| Any Agent Skills client | `npx skills add` | ✅ | — | — |
-| Claude Code (CLI / VS Code) | Marketplace install | ✅ | ✅ | ✅ |
-| Cursor | `npx skills add` | ✅ | — | — |
-| Codex | `npx skills add` | ✅ | — | — |
-| Windsurf / others | `npx skills add` | ✅ | — | — |
-
-MCP tools work in any client that supports MCP — see [MCP overview](/mcp/overview) for client-specific config.
-
-## Frequently asked questions
-
-### What are Cekura skills?
-
-Cekura skills are domain-specific instructions that teach AI coding agents how to work with the Cekura platform — designing metrics, building test scenarios, onboarding voice agents, and improving evaluation accuracy. They activate automatically when you describe a relevant task.
-
-### Which AI agents are supported?
-
-Any agent that supports the [Agent Skills](https://agentskills.io) format. Verified compatibility includes Claude Code (VS Code and CLI), Cursor, OpenAI Codex, Antigravity, OpenCode, Amp, Goose, Junie, GitHub Copilot, Roo Code, Letta, Firebender, Mistral Vibe, and others.
-
-### Do I need a Cekura account?
-
-Yes — sign up free at [dashboard.cekura.ai](https://dashboard.cekura.ai). OAuth is the default; use an API key only if you need project/org scoping or want to share one credential across CI / teammates.
-
-### Should I use the Claude Code plugin install or `npx skills add`?
-
-| You want | Use |
-|---|---|
-| Full Claude Code experience (slash commands, MCP auto-config, hooks) | Plugin marketplace |
-| Skills only, on Cursor / Codex / Antigravity / any other agent | `npx skills add` |
-| A lighter Claude Code install without slash commands | `npx skills add` |
-
-### What's the difference between a skill and a slash command?
-
-- **Skill** — knowledge / behavior the agent loads when you describe a related task (e.g., "design a metric that..."). Works on every Agent Skills-compatible agent.
-- **Slash command** — a Claude Code-specific shortcut that performs a specific operation (e.g., `/create-metric` actually creates a metric via the API). Only available with the Claude Code plugin install.
-
-You can use skills without commands. Commands always come with their corresponding skill.
-
-### How do skills activate?
-
-Two ways:
-
-1. **Automatically by description** — describe what you want ("create a metric for call quality"), the agent loads the matching skill.
-2. **Explicitly** — type `/skill-name` (Cursor, Codex) or mention the skill by name.
-
-### Can I customize a skill?
-
-Yes — skills are plain markdown files. After install, edit `SKILL.md` directly, or fork [cekura-ai/cekura-skills](https://github.com/cekura-ai/cekura-skills) and install from your fork:
-
-```bash
-npx skills add <your-org>/cekura-skills
-```
-
-### Are skills shared across my team?
-
-Per-user install in most cases — share the install command in your team's onboarding doc. The Claude API custom-skills upload path supports workspace-wide sharing once a skill is uploaded.
+| Client | Recommended path | Notes |
+|---|---|---|
+| Claude Code | Plugin + `/setup-mcp` | Full Skills, commands, MCP config, update support, and hooks |
+| Claude Desktop | MCP connector | Desktop connector gives MCP access only; use Claude Code for Skills and commands |
+| Cursor | Agent Skills + MCP, with rules fallback | Keep the `.cursor/rules` fallback if your Cursor setup does not load Agent Skills yet |
+| Codex | Agent Skills + MCP, with `AGENTS.md` fallback | Keep the behavior preset fallback for Codex builds without Agent Skills support |
+| OpenCode, Windsurf, other assistants | Agent Skills + MCP, with behavior preset fallback | Use the assistant's MCP configuration plus the portable preset when needed |
 
 ### Why didn't `/plugin marketplace add` install the plugin automatically?
 
-Marketplaces and plugins are separate concerns in Claude Code. `marketplace add` registers where to find plugins; `plugin install <name>@<marketplace>` installs a specific plugin from a registered marketplace. Adding a marketplace doesn't auto-install everything in it — see the [Reinstall](#reinstall) section for the full clean-install sequence.
+Marketplaces and plugins are separate concerns in Claude Code. `marketplace add` registers where to find plugins; `plugin install <name>@<marketplace>` installs a specific plugin from a registered marketplace. Adding a marketplace does not auto-install everything in it. See [Reinstall Claude Code plugin](#reinstall-claude-code-plugin) for the full clean-install sequence.
 
 ## Links
 
 <CardGroup cols={2}>
-  <Card title="GitHub" icon="github" href="https://github.com/cekura-ai/cekura-skills">
-    Source, issues, and changelog
+  <Card title="AI Assistant Setup" icon="sparkles" href="/mcp/overview">
+    Choose the right install path for your assistant.
   </Card>
-  <Card title="MCP Overview" icon="shield-halved" href="/mcp/overview">
-    Set up MCP (required for full skill functionality)
-  </Card>
+
   <Card title="Claude Code Guide" icon="code" href="/mcp/claude-code-guide">
-    End-to-end walkthrough using skills + MCP
+    Recommended plugin-based setup.
   </Card>
-  <Card title="Claude Desktop Guide" icon="desktop" href="/mcp/claude-desktop-guide">
-    Connector setup, skill upload, and writing custom skills
+
+  <Card title="MCP-only Setup" icon="shield-halved" href="/mcp/mcp-only">
+    Direct MCP configuration for supported clients.
   </Card>
-  <Card title="Dashboard" icon="gauge" href="https://dashboard.cekura.ai">
-    Manage your Cekura workspace
+
+  <Card title="GitHub" icon="github" href="https://github.com/cekura-ai/cekura-skills">
+    Source, issues, and changelog.
   </Card>
 </CardGroup>

--- a/mint.json
+++ b/mint.json
@@ -40,9 +40,9 @@
       "icon": "gear"
     },
     {
-      "name": "MCP",
+      "name": "AI Assistants",
       "url": "mcp",
-      "icon": "shield-halved"
+      "icon": "sparkles"
     },
     {
       "name": "CLI & SDK",
@@ -527,10 +527,35 @@
       ]
     },
     {
-      "group": "MCP",
+      "group": "AI Assistant Setup",
       "pages": [
         "mcp/overview",
-        "mcp/skills"
+        {
+          "group": "Recommended Setup",
+          "icon": "sparkles",
+          "pages": [
+            "mcp/claude-code-guide",
+            "mcp/cursor-guide",
+            "mcp/codex-guide",
+            "mcp/claude-desktop-guide",
+            "mcp/other-agents"
+          ]
+        },
+        {
+          "group": "Reference",
+          "icon": "book-open",
+          "pages": [
+            "mcp/skills"
+          ]
+        },
+        {
+          "group": "Advanced",
+          "icon": "gear",
+          "pages": [
+            "mcp/mcp-only",
+            "mcp/auto-optimize-metrics"
+          ]
+        }
       ]
     },
     {
@@ -549,16 +574,6 @@
             "cli-sdk/calls"
           ]
         }
-      ]
-    },
-    {
-      "group": "Guides",
-      "pages": [
-        "mcp/claude-code-guide",
-        "mcp/claude-desktop-guide",
-        "mcp/cursor-guide",
-        "mcp/codex-guide",
-        "mcp/auto-optimize-metrics"
       ]
     }
   ],

--- a/mint.json
+++ b/mint.json
@@ -40,7 +40,7 @@
       "icon": "gear"
     },
     {
-      "name": "AI Assistants",
+      "name": "MCP & Skills",
       "url": "mcp",
       "icon": "sparkles"
     },
@@ -527,7 +527,7 @@
       ]
     },
     {
-      "group": "AI Assistant Setup",
+      "group": "Setup",
       "pages": [
         "mcp/overview",
         {

--- a/mint.json
+++ b/mint.json
@@ -537,9 +537,9 @@
       "icon": "sparkles",
       "pages": [
         "mcp/claude-code-guide",
+        "mcp/claude-desktop-guide",
         "mcp/cursor-guide",
         "mcp/codex-guide",
-        "mcp/claude-desktop-guide",
         "mcp/other-agents"
       ]
     },

--- a/mint.json
+++ b/mint.json
@@ -527,35 +527,35 @@
       ]
     },
     {
-      "group": "Setup",
+      "group": "Get started",
       "pages": [
-        "mcp/overview",
-        {
-          "group": "Recommended Setup",
-          "icon": "sparkles",
-          "pages": [
-            "mcp/claude-code-guide",
-            "mcp/cursor-guide",
-            "mcp/codex-guide",
-            "mcp/claude-desktop-guide",
-            "mcp/other-agents"
-          ]
-        },
-        {
-          "group": "Reference",
-          "icon": "book-open",
-          "pages": [
-            "mcp/skills"
-          ]
-        },
-        {
-          "group": "Advanced",
-          "icon": "gear",
-          "pages": [
-            "mcp/mcp-only",
-            "mcp/auto-optimize-metrics"
-          ]
-        }
+        "mcp/overview"
+      ]
+    },
+    {
+      "group": "Set up your assistant",
+      "icon": "sparkles",
+      "pages": [
+        "mcp/claude-code-guide",
+        "mcp/cursor-guide",
+        "mcp/codex-guide",
+        "mcp/claude-desktop-guide",
+        "mcp/other-agents"
+      ]
+    },
+    {
+      "group": "Reference",
+      "icon": "book-open",
+      "pages": [
+        "mcp/skills",
+        "mcp/mcp-only"
+      ]
+    },
+    {
+      "group": "Workflows",
+      "icon": "wand-magic-sparkles",
+      "pages": [
+        "mcp/auto-optimize-metrics"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- Reframe the MCP docs tab as AI Assistants and consolidate MCP/Skills setup navigation
- Rewrite the overview as a setup decision page that prioritizes Claude Code plugin, Skills + MCP, then MCP-only
- Add MCP-only and other-assistants pages, and update Claude Code, Claude Desktop, Cursor, Codex, and Skills catalog guidance

## Validation
- python3 -m json.tool mint.json
- navigation reference check for all pages in mint.json
- grep check for conflict markers and stale MCP overview anchors
- mintlify broken-links (reports existing unrelated broken links outside the changed MCP/AI assistant setup pages)