### PR TITLE
docs: document Custom Skills for the Cekura Agent

### DIFF
--- a/documentation/guides/cekura-agent.mdx
+++ b/documentation/guides/cekura-agent.mdx
@@ -136,9 +136,9 @@ response are preserved; you can follow up with a clarification or a new prompt.
 
 Beyond its built-in skills, the Cekura Agent can be extended with your organization's own **custom skills**, so it can run org-specific workflows on your behalf. Custom skills are org-scoped. Once added, they're available to the Agent for everyone in your org, and any member can view the active list.
 
-Add a skill as a **source**: either a **single file**, a **GitHub repository** (provide the repo URL) or an **uploaded archive** (`.zip` / `.tar.gz`). You can then **enable / disable or delete** individual skills, and **re-sync** a GitHub source to pick up changes you've pushed. 
+Add a skill as a **source**: either a **single file**, a **GitHub repository** (provide the repo URL), or an **uploaded archive** (`.zip` / `.tar.gz`). You can then **enable, disable, or delete** individual skills, and **re-sync** a GitHub source to pick up changes you've pushed.
 
-To **add custom skills**, navigate to **Settings** -> **Custom Skills** in the UI.
+To **add custom skills**, navigate to **Settings** → **Custom Skills** in the UI.
 
 ## Limitations
 

--- a/documentation/guides/cekura-agent.mdx
+++ b/documentation/guides/cekura-agent.mdx
@@ -132,6 +132,14 @@ If the agent is taking too long or heading in the wrong direction, click the
 **Stop** button to cancel the current response. Your message and partial
 response are preserved; you can follow up with a clarification or a new prompt.
 
+### Custom skills
+
+Beyond its built-in skills, the Cekura Agent can be extended with your organization's own **custom skills**, so it can run org-specific workflows on your behalf. Custom skills are org-scoped. Once added, they're available to the Agent for everyone in your org, and any member can view the active list.
+
+Add a skill as a **source**: either a **single file**, a **GitHub repository** (provide the repo URL) or an **uploaded archive** (`.zip` / `.tar.gz`). You can then **enable / disable or delete** individual skills, and **re-sync** a GitHub source to pick up changes you've pushed. 
+
+To **add custom skills**, navigate to **Settings** -> **Custom Skills** in the UI.
+
 ## Limitations
 
 - **No delete operations.** The agent cannot delete agents, scenarios,


### PR DESCRIPTION
Adds a **Custom Skills** subsection to the Cekura Agent guide (under **Features**).

Documents that the Cekura Agent can be extended with an organization's own custom skills:
- **Org-scoped** — once added, available to the Agent for everyone in the org; any member can view the active list.
- Added as a **source**: a single file, a **GitHub repository** (repo URL), or an uploaded **`.zip` / `.tar.gz`** archive.
- **Manage** them (enable / disable / delete) and **re-sync** a GitHub source to pick up pushed changes.
- Added via **Settings → Custom Skills** in the UI.

Fills a documentation gap — this capability was previously only visible in the API spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)