### PR TITLE
Transcription Accuracy: negation flips count as major for runs

### DIFF
--- a/documentation/key-concepts/metrics/pre-defined-metrics.mdx
+++ b/documentation/key-concepts/metrics/pre-defined-metrics.mdx
@@ -99,6 +99,7 @@ These metrics evaluate whether your agent provides correct and consistent inform
     | Word type | Weight per error |
     | --- | --- |
     | Names, common nouns, numbers | **1.0** |
+    | Negation flips (e.g. "can" vs "can't", a dropped "no"/"not") | **1.0** |
     | Verbs | **0.5** |
     | Everything else (articles, pronouns, fillers, prepositions…) | **0** (ignored) |
 


### PR DESCRIPTION
## Summary
- Adds a row to the Transcription Accuracy (runs/WER) weighting table: negation flips (e.g. "can" vs "can't", a dropped "no"/"not") now count as a major error at weight **1.0**, matching the backend change.

Backend PR: cekura-ai/vocera.backend#9826