### PR TITLE
docs: document per-call trace_id for custom transcript provider

### DIFF
--- a/documentation/integrations/custom-integration.mdx
+++ b/documentation/integrations/custom-integration.mdx
@@ -82,6 +82,7 @@ Each call in the `calls` array should include:
 | `metadata` | object | No | Optional metadata as key-value pairs for additional call information |
 | `endedReason` | string | No | Reason call ended (default: "unknown", e.g., "assistant-ended-call", "customer-hungup") |
 | `run_id` | string | Conditionally required | Cekura Run ID for this call. Required on each call when `agent_id` is omitted at the top level. Intended for SIP integrations where run IDs are pre-known from SIP headers. |
+| `trace_id` | string | No | OpenTelemetry trace ID for this call (max 32 chars). When provided, it is attached to the matched run so the OTel trace links to the call in the Cekura dashboard. See [Tracing](/documentation/guides/observability/tracing). |
 
 <Tip>
 **Passing a recording URL:** The custom integration payload does not have a dedicated `voice_recording_url` field. To include a recording URL (or any other custom call context), add it to the `metadata` object:
@@ -127,6 +128,7 @@ Here's a complete example payload with two calls:
       "id": "0199e72d-795e-7ffe-b9b9-d3b08a3a11ae",
       "startedAt": "2025-10-15T09:22:21.787Z",
       "endedAt": "2025-10-15T09:24:30.229Z",
+      "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
       "to_phone_number": "+18646190758",
       "from_phone_number": "+14155551234",
       "messages": [


### PR DESCRIPTION
## Summary
Documents the new optional per-call `trace_id` field for the custom transcript provider webhook, added in [vocera.backend#9699](https://github.com/cekura-ai/vocera.backend/pull/9699).

When a call object in the webhook payload includes `trace_id` (max 32 chars), it is attached to the matched run so the OpenTelemetry trace links to the call in the Cekura dashboard.

## Changes
In `documentation/integrations/custom-integration.mdx`:
- Added a `trace_id` row to the **Call Object Structure** table, cross-linked to the Tracing guide.
- Added an example `trace_id` value to the first call in the **Complete Example**.

## Linear
Closes [CEK-7881](https://linear.app/cekura/issue/CEK-7881/update-docs-for-custom-transcript-provider-trace-ids)

🤖 Generated with [Claude Code](https://claude.com/claude-code)