### PR TITLE
feat(CEK-7815): forward X-Client-Source for cekura_ai_agent tagging

### DIFF
--- a/cekura-mcp-server/http_client.py
+++ b/cekura-mcp-server/http_client.py
@@ -15,6 +15,7 @@ class CekuraAPIClient:
         mcp_tool: Optional[str] = None,
         mcp_skill: Optional[str] = None,
         conversation_id: Optional[str] = None,
+        client_source: str = "mcp",
     ):
         self.base_url = base_url
         self.credential_type = credential_type
@@ -38,7 +39,10 @@ class CekuraAPIClient:
             headers={
                 **auth_header,
                 "Content-Type": "application/json",
-                "X-Client-Source": "mcp",
+                # Defaults to "mcp"; the trusted Cekura sandbox passes
+                # "cekura_ai_agent" so the backend tags agents it creates as the
+                # in-dashboard AI builder rather than a user's own MCP (CEK-7815).
+                "X-Client-Source": client_source,
                 **telemetry_headers,
             },
             timeout=timeout,
@@ -191,6 +195,7 @@ def create_client(
     mcp_tool: Optional[str] = None,
     mcp_skill: Optional[str] = None,
     conversation_id: Optional[str] = None,
+    client_source: str = "mcp",
 ) -> CekuraAPIClient:
     return CekuraAPIClient(
         base_url,
@@ -202,4 +207,5 @@ def create_client(
         mcp_tool=mcp_tool,
         mcp_skill=mcp_skill,
         conversation_id=conversation_id,
+        client_source=client_source,
     )

--- a/cekura-mcp-server/openapi_mcp_server.py
+++ b/cekura-mcp-server/openapi_mcp_server.py
@@ -60,6 +60,9 @@ request_base_url: ContextVar[str] = ContextVar('request_base_url', default=None)
 # wires its conversation_id here). Per-call `_meta["com.cekura/conversation_id"]`
 # wins when both are present.
 request_conversation_id: ContextVar[str] = ContextVar('request_conversation_id', default=None)
+# Connection-level client source (X-Client-Source). Only the trusted Cekura
+# sandbox sets this (to "cekura_ai_agent"); see _resolve_client_source for the guard.
+request_client_source: ContextVar[str] = ContextVar('request_client_source', default=None)
 # X-CEKURA-BASE-URL override is only allowed when explicitly enabled (dev/staging only)
 _ALLOW_BASE_URL_OVERRIDE = os.environ.get("ALLOW_BASE_URL_OVERRIDE", "").lower() in ("1", "true", "yes")
 
@@ -779,6 +782,22 @@ def _read_request_meta() -> Dict[str, Any]:
         return {}
 
 
+# Client sources a caller may self-declare via X-Client-Source. Everything
+# else — and every API-key caller — is recorded as plain "mcp", so an external
+# MCP client cannot spoof a dashboard/cekura_ai_agent origin. Only the bearer-authed
+# Cekura sandbox declares "cekura_ai_agent" (CEK-7815).
+_SELF_DECLARABLE_CLIENT_SOURCES = {"cekura_ai_agent"}
+
+
+def _resolve_client_source(credential_type: str) -> str:
+    """The X-Client-Source to forward to the backend. Honour an incoming
+    self-declared value only for trusted bearer auth; default to "mcp"."""
+    incoming = (request_client_source.get() or "").lower()
+    if credential_type == "bearer" and incoming in _SELF_DECLARABLE_CLIENT_SOURCES:
+        return incoming
+    return "mcp"
+
+
 def _resolve_telemetry() -> Dict[str, Optional[str]]:
     """Resolve per-call telemetry fields once at the top of the handler.
 
@@ -894,6 +913,7 @@ def setup_dynamic_tool_handlers():
                 mcp_tool=name,
                 mcp_skill=telemetry["skill"],
                 conversation_id=telemetry["conversation_id"],
+                client_source=_resolve_client_source(credential_type),
             )
 
             # Forward the resolved per-property types so the HTTP client can respect
@@ -1022,6 +1042,16 @@ def main():
                 )
                 if conversation_header:
                     reset_tokens.append((request_conversation_id, request_conversation_id.set(conversation_header)))
+
+                # Connection-level client source (e.g. the Cekura sandbox sets
+                # "cekura_ai_agent"). Gated by _resolve_client_source so untrusted
+                # callers can't spoof a non-mcp origin.
+                client_source_header = (
+                    request.headers.get('X-Client-Source')
+                    or request.headers.get('x-client-source')
+                )
+                if client_source_header:
+                    reset_tokens.append((request_client_source, request_client_source.set(client_source_header)))
 
                 # Enforce auth at the transport layer for MCP traffic. Without this,
                 # FastMCP's `initialize` and `tools/list` succeed unauthenticated,

--- a/cekura-mcp-server/tests/test_client_source.py
+++ b/cekura-mcp-server/tests/test_client_source.py
@@ -1,0 +1,60 @@
+"""X-Client-Source forwarding + spoof-guard (CEK-7815).
+
+The gateway forwards a self-declared X-Client-Source only for the trusted
+bearer-authed Cekura sandbox; every other caller (and all API-key callers)
+is recorded as plain "mcp", so an external MCP client cannot spoof a
+dashboard/cekura_ai_agent origin.
+"""
+import pytest
+
+from http_client import CekuraAPIClient
+from openapi_mcp_server import _resolve_client_source, request_client_source
+
+
+@pytest.fixture
+def incoming():
+    """Set the connection-level X-Client-Source context var for one test."""
+    tokens = []
+
+    def _set(value):
+        tokens.append(request_client_source.set(value))
+
+    yield _set
+    for tok in reversed(tokens):
+        request_client_source.reset(tok)
+
+
+def test_default_outbound_header_is_mcp():
+    client = CekuraAPIClient("http://example.invalid", "tok")
+    assert client.client.headers["X-Client-Source"] == "mcp"
+
+
+def test_explicit_client_source_is_forwarded():
+    client = CekuraAPIClient("http://example.invalid", "tok", client_source="cekura_ai_agent")
+    assert client.client.headers["X-Client-Source"] == "cekura_ai_agent"
+
+
+def test_bearer_caller_may_declare_cekura_ai_agent(incoming):
+    incoming("cekura_ai_agent")
+    assert _resolve_client_source("bearer") == "cekura_ai_agent"
+
+
+def test_api_key_caller_cannot_spoof_cekura_ai_agent(incoming):
+    incoming("cekura_ai_agent")
+    assert _resolve_client_source("api_key") == "mcp"
+
+
+def test_non_self_declarable_source_is_forced_to_mcp(incoming):
+    # Even a bearer caller can only declare the allow-listed source.
+    incoming("dashboard")
+    assert _resolve_client_source("bearer") == "mcp"
+
+
+def test_declared_source_is_case_insensitive(incoming):
+    incoming("CEKURA_AI_AGENT")
+    assert _resolve_client_source("bearer") == "cekura_ai_agent"
+
+
+def test_no_incoming_header_defaults_to_mcp():
+    assert _resolve_client_source("bearer") == "mcp"
+    assert _resolve_client_source("api_key") == "mcp"


### PR DESCRIPTION
## What

Gateway half of [CEK-7815](https://linear.app/cekura/issue/CEK-7815/add-tracking-in-agent-on-how-the-agent-was-created) (agent creation tracking).

`cekura-mcp-server` hardcoded `X-Client-Source: mcp` on every forwarded request. That made agents created by the **in-dashboard Cekura AI agent** (the bearer-authed sandbox, which sends `X-Client-Source: cekura_ai_agent`) indistinguishable from a **user's own MCP client**.

## How

- `http_client.py`: `X-Client-Source` is now a parameter (`client_source`, default `"mcp"`) instead of a hardcoded literal.
- `openapi_mcp_server.py`: reads the inbound `X-Client-Source` into a context var and resolves it via `_resolve_client_source(credential_type)`:
  - **bearer auth + `cekura_ai_agent`** → `cekura_ai_agent` (only the trusted sandbox)
  - **everything else / API-key callers** → `mcp`

So a self-declared source is honored only for the trusted bearer-authed sandbox; an external MCP client (API key) cannot spoof a `cekura_ai_agent`/`dashboard` origin.

## Testing

- 23 existing `http_client` tests pass.
- Guard verified: `bearer + cekura_ai_agent → cekura_ai_agent`; `api_key + cekura_ai_agent → mcp` (spoof blocked); default → `mcp`.
- Ran the real forwarding code against a local backend: `mcp` path tags `created_via=mcp` end-to-end.

> Pairs with `vocera.backend#9846` and `vocera.frontend.product#3172`. Deploy this **with** the `agent-runtime` change (sandbox header) so the AI agent tags `cekura_ai_agent`; if only one lands, it falls back to `mcp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)