### PR TITLE
docs(mcp): add Cekura + Claude Tag (Slack) guide

### DIFF
--- a/mcp/claude-tag-guide.mdx
+++ b/mcp/claude-tag-guide.mdx
@@ -9,10 +9,10 @@ import { CopyPageButton } from "/snippets/copy-page-button.mdx";
 
 <CopyPageButton />
 
-[Claude Tag](https://www.anthropic.com/news/introducing-claude-tag) is Anthropic's persistent AI teammate inside **Slack** — you delegate work by typing `@Claude` in a channel. Claude Tag supports **plugins and Skills** (not just MCP), so an admin can provision the full **Cekura plugin** — Cekura Skills **and** the Cekura MCP — and scope it to the channels where your team works.
+Add the Cekura plugin to [Claude Tag](https://www.anthropic.com/news/introducing-claude-tag) — the `@Claude` teammate in Slack — so anyone in a channel can run Cekura. The plugin gives `@Claude` Cekura Skills **and** MCP tools.
 
 <Note>
-Claude Tag is available on **Team and Enterprise** plans. Provisioning is an **Owner/admin** action: connections, plugins, and skills are configured per scope (a channel, a workspace, or the whole organization) via an **access bundle** — separate from any connectors a user set up in their own claude.ai account. What `@Claude` can reach depends on the channel you're in, not who you are.
+Claude Tag is **Team/Enterprise** only, and an **admin** provisions the plugin and scopes it to channels.
 </Note>
 
 ## Before you start

--- a/mcp/claude-tag-guide.mdx
+++ b/mcp/claude-tag-guide.mdx
@@ -1,0 +1,74 @@
+---
+title: "Using Cekura with Claude Tag"
+sidebarTitle: "Claude Tag"
+description: "Give Claude Tag (Anthropic's @Claude teammate in Slack) access to the Cekura MCP, so your team can run Cekura work from Slack."
+icon: "slack"
+---
+
+import { CopyPageButton } from "/snippets/copy-page-button.mdx";
+
+<CopyPageButton />
+
+[Claude Tag](https://www.anthropic.com/news/introducing-claude-tag) is Anthropic's persistent AI teammate inside **Slack** — you delegate work by typing `@Claude` in a channel. To use Cekura from Slack, an admin connects the Cekura MCP server to Claude Tag and scopes it to the channels where your team works.
+
+<Note>
+Claude Tag is available on **Team and Enterprise** plans. Connecting tools is an **admin** action — `@Claude`'s access to tools and data is provisioned by administrators and scoped per channel.
+</Note>
+
+## Before you start
+
+- Claude Tag is paired with your Slack workspace.
+- You're a Claude/Slack **admin** (tool provisioning is admin-only).
+- You're on a **Team or Enterprise** plan.
+
+## Connect Cekura (admin)
+
+In the Claude Tag admin settings, add Cekura as a tool/connector and enable it for the channels where you want it:
+
+<Steps>
+  <Step title="Add the Cekura connector">
+    Add Cekura as a custom connector using the MCP endpoint `https://api.cekura.ai/mcp` (or sync the `cekura-ai/cekura-skills` repo). Authenticate via OAuth — no API key needed.
+  </Step>
+
+  <Step title="Scope it to channels">
+    Enable the Cekura connector in the access bundle for the channels where your team should be able to use it. Access (and memories) stay scoped to those channels.
+  </Step>
+
+  <Step title="Test in a private channel">
+    Test `@Claude` with a Cekura request in a private channel before rolling it out.
+  </Step>
+</Steps>
+
+<Note>
+The exact admin panel steps live in Anthropic's Claude Tag provisioning settings — see the [Claude Tag announcement](https://www.anthropic.com/news/introducing-claude-tag) and [Claude connectors guide](https://support.claude.com/en/articles/11176164-use-connectors-to-extend-claude-s-capabilities). The MCP endpoint and OAuth flow are the same as every other Cekura client.
+</Note>
+
+## Use it in Slack
+
+In a channel where Cekura is enabled, mention `@Claude`:
+
+```plaintext
+@Claude using Cekura, list our Cekura agents, pick one, and propose 3 evaluators we should create first. Don't create anything until I approve.
+```
+
+`@Claude` should list real agents from your Cekura workspace. Because Claude Tag is multiplayer, anyone in the channel can follow up on the thread.
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="@Claude doesn't see Cekura tools">
+    Confirm the Cekura connector is enabled in the access bundle for **this** channel — tool access is scoped per channel. An admin can add the channel in the Claude Tag settings.
+  </Accordion>
+
+  <Accordion title="Authorization failed">
+    Re-authorize the Cekura connector and confirm it's signed into the intended Cekura dashboard account. The connection uses OAuth against `https://api.cekura.ai/mcp`.
+  </Accordion>
+
+  <Accordion title="Can't add the connector">
+    Claude Tag and tool provisioning require a Team or Enterprise plan and admin access. If you're not an admin, ask an Owner to add and scope the Cekura connector.
+  </Accordion>
+</AccordionGroup>
+
+## Want Skills and slash commands?
+
+Claude Tag gives your team the Cekura **tools** in Slack. For the full workflow experience — Cekura Skills, slash commands, and the failure hook — use [Claude Code](/mcp/claude-code-guide) or the [Claude app](/mcp/claude-desktop-guide).

--- a/mcp/claude-tag-guide.mdx
+++ b/mcp/claude-tag-guide.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Using Cekura with Claude Tag"
 sidebarTitle: "Claude Tag"
-description: "Give Claude Tag (Anthropic's @Claude teammate in Slack) access to the Cekura MCP, so your team can run Cekura work from Slack."
+description: "Give Claude Tag (Anthropic's @Claude teammate in Slack) the Cekura plugin — Skills and MCP — so your team can run Cekura work from Slack."
 icon: "slack"
 ---
 
@@ -9,38 +9,42 @@ import { CopyPageButton } from "/snippets/copy-page-button.mdx";
 
 <CopyPageButton />
 
-[Claude Tag](https://www.anthropic.com/news/introducing-claude-tag) is Anthropic's persistent AI teammate inside **Slack** — you delegate work by typing `@Claude` in a channel. To use Cekura from Slack, an admin connects the Cekura MCP server to Claude Tag and scopes it to the channels where your team works.
+[Claude Tag](https://www.anthropic.com/news/introducing-claude-tag) is Anthropic's persistent AI teammate inside **Slack** — you delegate work by typing `@Claude` in a channel. Claude Tag supports **plugins and Skills** (not just MCP), so an admin can provision the full **Cekura plugin** — Cekura Skills **and** the Cekura MCP — and scope it to the channels where your team works.
 
 <Note>
-Claude Tag is available on **Team and Enterprise** plans. Connecting tools is an **admin** action — `@Claude`'s access to tools and data is provisioned by administrators and scoped per channel.
+Claude Tag is available on **Team and Enterprise** plans. Provisioning is an **Owner/admin** action: connections, plugins, and skills are configured per scope (a channel, a workspace, or the whole organization) via an **access bundle** — separate from any connectors a user set up in their own claude.ai account. What `@Claude` can reach depends on the channel you're in, not who you are.
 </Note>
 
 ## Before you start
 
 - Claude Tag is paired with your Slack workspace.
-- You're a Claude/Slack **admin** (tool provisioning is admin-only).
+- You're a Claude **Owner/admin** (provisioning is admin-only).
 - You're on a **Team or Enterprise** plan.
 
-## Connect Cekura (admin)
+## Provision the Cekura plugin (admin)
 
-In the Claude Tag admin settings, add Cekura as a tool/connector and enable it for the channels where you want it:
+Add the Cekura plugin to an access bundle so `@Claude` gets Skills + MCP in the chosen channels:
 
 <Steps>
-  <Step title="Add the Cekura connector">
-    Add Cekura as a custom connector using the MCP endpoint `https://api.cekura.ai/mcp` (or sync the `cekura-ai/cekura-skills` repo). Authenticate via OAuth — no API key needed.
+  <Step title="Add the Cekura plugin to an access bundle">
+    In the Claude Tag admin settings, add the Cekura plugin (`cekura-ai/cekura-skills`) to the access bundle. The plugin bundles Cekura **Skills** and the **MCP server** (`https://api.cekura.ai/mcp`), so both come together.
+  </Step>
+
+  <Step title="Authenticate the MCP">
+    Complete the OAuth sign-in to your Cekura dashboard account — no API key needed.
   </Step>
 
   <Step title="Scope it to channels">
-    Enable the Cekura connector in the access bundle for the channels where your team should be able to use it. Access (and memories) stay scoped to those channels.
+    Enable the bundle for the channels where your team should use Cekura. Access (and memories) stay scoped to those channels.
   </Step>
 
   <Step title="Test in a private channel">
-    Test `@Claude` with a Cekura request in a private channel before rolling it out.
+    Mention `@Claude` with a Cekura request in a private channel before rolling it out.
   </Step>
 </Steps>
 
 <Note>
-The exact admin panel steps live in Anthropic's Claude Tag provisioning settings — see the [Claude Tag announcement](https://www.anthropic.com/news/introducing-claude-tag) and [Claude connectors guide](https://support.claude.com/en/articles/11176164-use-connectors-to-extend-claude-s-capabilities). The MCP endpoint and OAuth flow are the same as every other Cekura client.
+The exact admin-panel steps live in Anthropic's Claude Tag provisioning settings — see the [Claude Tag announcement](https://www.anthropic.com/news/introducing-claude-tag) and [Claude connectors guide](https://support.claude.com/en/articles/11176164-use-connectors-to-extend-claude-s-capabilities). The plugin, MCP endpoint, and OAuth flow are the same as every other Cekura client.
 </Note>
 
 ## Use it in Slack
@@ -51,24 +55,28 @@ In a channel where Cekura is enabled, mention `@Claude`:
 @Claude using Cekura, list our Cekura agents, pick one, and propose 3 evaluators we should create first. Don't create anything until I approve.
 ```
 
-`@Claude` should list real agents from your Cekura workspace. Because Claude Tag is multiplayer, anyone in the channel can follow up on the thread.
+`@Claude` should list real agents from your Cekura workspace and, thanks to the Skills, reason in Cekura terms (evaluators, metrics, test profiles). Because Claude Tag is multiplayer, anyone in the channel can pick up the thread.
+
+<Note>
+Skills guide `@Claude` through Cekura workflows; Claude Code's slash commands (like `/cekura-onboarding`) are a terminal feature and don't apply in Slack — just ask in plain language.
+</Note>
 
 ## Troubleshooting
 
 <AccordionGroup>
-  <Accordion title="@Claude doesn't see Cekura tools">
-    Confirm the Cekura connector is enabled in the access bundle for **this** channel — tool access is scoped per channel. An admin can add the channel in the Claude Tag settings.
+  <Accordion title="@Claude doesn't see Cekura tools or guidance">
+    Confirm the Cekura plugin is enabled in the access bundle for **this** channel — access is scoped per channel. An admin can add the channel in the Claude Tag settings.
   </Accordion>
 
   <Accordion title="Authorization failed">
-    Re-authorize the Cekura connector and confirm it's signed into the intended Cekura dashboard account. The connection uses OAuth against `https://api.cekura.ai/mcp`.
+    Re-authorize the Cekura MCP and confirm it's signed into the intended Cekura dashboard account. The connection uses OAuth against `https://api.cekura.ai/mcp`.
   </Accordion>
 
-  <Accordion title="Can't add the connector">
-    Claude Tag and tool provisioning require a Team or Enterprise plan and admin access. If you're not an admin, ask an Owner to add and scope the Cekura connector.
+  <Accordion title="Can't provision the plugin">
+    Claude Tag and provisioning require a Team or Enterprise plan and Owner/admin access. If you're not an admin, ask an Owner to add and scope the Cekura plugin.
   </Accordion>
 </AccordionGroup>
 
-## Want Skills and slash commands?
+## Other ways to use Cekura
 
-Claude Tag gives your team the Cekura **tools** in Slack. For the full workflow experience — Cekura Skills, slash commands, and the failure hook — use [Claude Code](/mcp/claude-code-guide) or the [Claude app](/mcp/claude-desktop-guide).
+Prefer the terminal or a per-developer setup? See [Claude Code](/mcp/claude-code-guide) (plugin with slash commands + hooks) or the [Claude app](/mcp/claude-desktop-guide).

--- a/mint.json
+++ b/mint.json
@@ -529,6 +529,7 @@
       "icon": "sparkles",
       "pages": [
         "mcp/claude-code-guide",
+        "mcp/claude-tag-guide",
         "mcp/claude-desktop-guide",
         "mcp/cursor-guide",
         "mcp/codex-guide",


### PR DESCRIPTION
## Problem

The MCP & Skills section documents every Cekura client (Claude Code, Claude Desktop, Cursor, Codex, Gemini), but not **Claude Tag** — Anthropic's new (June 2026) `@Claude` teammate in Slack (Team/Enterprise, beta). Users who work in Slack have no guide for adding Cekura there.

## Fix

New page `mcp/claude-tag-guide.mdx` ("Claude Tag"), slotted into **Set up your assistant** right after Claude Code:

- Frames Claude Tag correctly: `@Claude` in Slack, **Team/Enterprise**, **admin-provisioned** tools **scoped to channels**.
- Admin flow: add the Cekura connector (`https://api.cekura.ai/mcp`, OAuth) → scope to channels via access bundle → test in a private channel.
- Slack usage with an `@Claude … using Cekura …` verify prompt + troubleshooting (per-channel scope, auth, plan/admin gating).
- Points to Claude Code / the Claude app for Skills + slash commands.

Scope-honest: the **exact admin-panel click-path** links out to Anthropic's [Claude Tag announcement](https://www.anthropic.com/news/introducing-claude-tag) and [connectors guide](https://support.claude.com/en/articles/11176164-use-connectors-to-extend-claude-s-capabilities) rather than copying a third-party walkthrough; the MCP endpoint + OAuth flow are the same as every other Cekura client.

## Verification

- `python3 -m json.tool mint.json` passes.
- New page's internal links (`claude-code-guide`, `claude-desktop-guide`, `mcp-only#api-key-setup`) resolve on `main`.
- Diff vs `main` is exactly the new page + one nav line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)