### PR TITLE
docs(mcp): add per-platform auto-update steps

### DIFF
--- a/mcp/claude-code-guide.mdx
+++ b/mcp/claude-code-guide.mdx
@@ -120,11 +120,28 @@ Watch an end-to-end walkthrough of evaluating complex voice agents, running mult
 
 ## Keep it updated
 
-Run `/upgrade-skills` in any Claude Code session to pull the latest skills and commands. To update manually:
+Run `/upgrade-skills` in any Claude Code session — it refreshes the marketplace, re-pins the plugin to the latest version, and prompts you to run `/reload-plugins` (no restart needed in the common case). To update manually:
 
 ```bash
-cd ~/.claude/plugins/marketplaces/cekura-skills
-git pull origin main
+claude plugin marketplace update cekura-skills   # refresh catalog from GitHub
+claude plugin update cekura@cekura-skills         # move the installed pin to latest
+```
+
+Then run `/reload-plugins` to apply it. A plain `git pull` of the marketplace checkout does **not** move the version pin, so it won't upgrade you on its own.
+
+### Auto-update (optional)
+
+To pull new versions automatically at launch (it still prompts `/reload-plugins`), run `/setup-mcp` — which offers to enable it — or add this to `~/.claude/settings.json`:
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "cekura-skills": {
+      "source": { "source": "github", "repo": "cekura-ai/cekura-skills" },
+      "autoUpdate": true
+    }
+  }
+}
 ```
 
 ## Troubleshooting

--- a/mcp/codex-guide.mdx
+++ b/mcp/codex-guide.mdx
@@ -74,12 +74,18 @@ Set up [Skills + MCP manually](/mcp/mcp-only), or use the [behavior preset](/mcp
 
 ## Keep it updated
 
-Codex updates are manual — re-run to pull the latest version:
+Re-run both commands to pull the latest version — `marketplace upgrade` only refreshes the snapshot, and `plugin add` re-pins the installed plugin to it (running just the first leaves you on the old version):
 
 ```bash
 codex plugin marketplace upgrade cekura
 codex plugin add cekura@cekura
 ```
+
+Confirm with `codex plugin list` — the `cekura@cekura` row should show the new version.
+
+### Auto-update (optional)
+
+The plugin ships a `SessionStart` hook that runs the two commands above automatically on each launch (throttled to once/day). Codex requires you to trust the hook once: run `codex`, open `/hooks`, and trust the Cekura **SessionStart** hook. After that it's automatic — the manual commands still work to force an update immediately.
 
 ## Troubleshooting
 

--- a/mcp/cursor-guide.mdx
+++ b/mcp/cursor-guide.mdx
@@ -62,6 +62,8 @@ Re-import the marketplace from **Settings > Plugins > Team Marketplaces** to pul
 
 Cursor then re-indexes the marketplace at most once every ~10 minutes. Auto Refresh updates the *existing* plugin only — if a brand-new plugin is added to the repo later, re-import the marketplace.
 
+**Team-wide auto-install (Teams / Enterprise):** a workspace admin can mark the Cekura plugin **Required** for a distribution group in the Team Marketplace settings — that installs and keeps it updated for everyone automatically, with no per-developer action.
+
 ## No plugin?
 
 Set up [Skills + MCP manually](/mcp/mcp-only), or use the [behavior preset](/mcp/other-agents) fallback.

--- a/mcp/other-agents.mdx
+++ b/mcp/other-agents.mdx
@@ -74,12 +74,14 @@ If the assistant cannot list agents, MCP is not connected. If it lists agents bu
 Gemini CLI has a native Cekura extension that includes the **MCP server** and the Cekura context file. (Gemini extensions don't bundle Agent Skills yet, so this ships domain knowledge as context rather than `SKILL.md` skills.)
 
 ```bash
-gemini extensions install https://github.com/cekura-ai/cekura-skills
+gemini extensions install https://github.com/cekura-ai/cekura-skills --auto-update
 ```
+
+The `--auto-update` flag self-checks GitHub on each launch and applies new versions on the next restart — no manual updates. Omit it if you prefer to update manually.
 
 On first use of a Cekura MCP tool, Gemini runs an OAuth browser sign-in — no API key. The extension loads `GEMINI.md` (metric design, eval design, API reference, anti-patterns) as context.
 
-Update it with:
+To update manually, or to force it now:
 
 ```bash
 gemini extensions update cekura


### PR DESCRIPTION
## Problem

The `cekura-skills` repo (v0.8.1) documents how to enable **auto-update** on each client, but our setup guides were missing it. The Claude Code guide's manual-update step was also stale — a plain `git pull` of the marketplace checkout no longer moves the version pin, so it doesn't actually upgrade.

## Fix

Bring each guide in line with the repo:

- **Claude Code** — correct the manual upgrade (`claude plugin marketplace update` + `claude plugin update` + `/reload-plugins`); add **Auto-update (optional)** via `~/.claude/settings.json` `autoUpdate: true` (or `/setup-mcp` offers it).
- **Codex** — clarify both upgrade commands are required; add the **SessionStart auto-update hook** (trust once via `/hooks`).
- **Cursor** — add **team-wide auto-install** (admin marks the plugin **Required** for a distribution group).
- **Gemini CLI** — add the `--auto-update` install flag.

## Verification

- `mint.json` untouched; JSON still valid.
- `mintlify broken-links`: the 8 reported breaks are all pre-existing and in files this PR doesn't touch — zero new.
- Diff is limited to the four client guides.

Separate from #733 (Claude Tag guide) by design — different concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)