### PR TITLE
Document minor-variation 0.1% penalty in Transcription Accuracy

### DIFF
--- a/documentation/key-concepts/metrics/pre-defined-metrics.mdx
+++ b/documentation/key-concepts/metrics/pre-defined-metrics.mdx
@@ -101,11 +101,11 @@ These metrics evaluate whether your agent provides correct and consistent inform
     | Names, common nouns, numbers | **1.0** |
     | Negation flips (e.g. "can" vs "can't", a dropped "no"/"not") | **1.0** |
     | Verbs | **0.5** |
-    | Everything else (articles, pronouns, fillers, prepositions…) | **0** (ignored) |
+    | Everything else (articles, pronouns, fillers, prepositions…) | **0** toward the weighted count — treated as a *minor variation* (see below) |
 
-    The same distinct word mistranscribed multiple times is only counted once. This POS-weighted approach works across common languages including Spanish. The weighted error count then maps to the score:
+    The same distinct significant word mistranscribed multiple times is only counted once. This POS-weighted approach works across common languages including Spanish. The weighted error count maps to a base score:
 
-    | Score | Weighted errors |
+    | Base score | Weighted errors |
     | --- | --- |
     | 100% | 0 |
     | 80% | 1–3 |
@@ -113,7 +113,9 @@ These metrics evaluate whether your agent provides correct and consistent inform
     | 40% | 7–12 |
     | 20% | 13+ |
 
-    **Reading the explanation.** Errors are grouped into **Major Variations** (affect the metric score) and **Minor Variations** (do not affect the score), so you can see exactly which mistranscriptions drove the score. Both sections always appear — `None` means there were no errors of that kind. A summary at the bottom shows the **Metric Score** and the **WER** percentage.
+    **Minor variations.** Every remaining difference — articles, pronouns, fillers, prepositions and other function words — is a *minor variation*. These don't count toward the weighted error count, but each one applies a small **absolute 0.1% penalty** to the score. So a transcript with no significant errors and, say, 3 minor variations scores 99.7% instead of a flat 100%, and a call scored 60% on significant errors with 6 minor variations lands at 59.4%. Significant errors still dominate; the minor penalty only lets you tell a flawless transcript apart from one with a few small differences by looking at the score alone. This applies to both Runs and Call Logs.
+
+    **Reading the explanation.** Errors are grouped into **Major Variations** (drive the base score) and **Minor Variations** (each applies the 0.1% penalty), so you can see exactly which mistranscriptions drove the score. Both sections always appear — `None` means there were no errors of that kind. A summary at the bottom shows the **Metric Score** and the **WER** percentage.
 
     **Interpretation**: Higher scores indicate better transcription accuracy. Use this metric when you need to verify that the agent's TTS is rendering content correctly (correct words, correct numbers), not just that speech is audible.
   </Accordion>


### PR DESCRIPTION
## Summary
- Transcription Accuracy now applies a small **absolute 0.1% penalty per minor variation** on top of the significant-error score (both Runs and Call Logs), so a flawless transcript with a few minor variations no longer reads as a flat 100%.
- Updates the scoring section: the weighted-error table now feeds a **base score**, and a new **Minor variations** paragraph explains the per-variation penalty with worked examples (99.7%, 59.4%).

Backend PR: cekura-ai/vocera.backend#9934