### PR TITLE
Add deploy-mcp-server-new workflow + prod-new-usw2 task def

### DIFF
--- a/.github/workflows/deploy-mcp-server-new.yml
+++ b/.github/workflows/deploy-mcp-server-new.yml
@@ -5,10 +5,9 @@ name: Build and deploy MCP server (new account)
 # deploys to the new prod workload account (593108103736) us-west-2 cluster.
 
 on:
-  workflow_dispatch:
   push:
     branches:
-      - atul/mcp-prod-new-usw2
+      - main
     paths:
       - 'openapi.json'
       - 'cekura-mcp-server/**'

--- a/.github/workflows/deploy-mcp-server-new.yml
+++ b/.github/workflows/deploy-mcp-server-new.yml
@@ -1,0 +1,160 @@
+name: Build and deploy MCP server (new account)
+
+# Targets the new AWS account (cet-prd-cekura-workload-prod, us-west-2).
+# Builds + pushes image to shared-services ECR (212351099297), then
+# deploys to the new prod workload account (593108103736) us-west-2 cluster.
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - atul/mcp-prod-new-usw2
+    paths:
+      - 'openapi.json'
+      - 'cekura-mcp-server/**'
+      - 'mint.json'
+      - 'scripts/**'
+      - '.github/workflows/deploy-mcp-server-new.yml'
+
+env:
+  AWS_REGION: us-west-2
+  ECR_REPOSITORY: cekura/mcp-server
+  ECS_CLUSTER: cet-prd-usw2-cekura-ecs-cluster
+  ECS_SERVICE: cet-prd-usw2-mcp-server-ecs-service
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      image-tag: ${{ steps.construct-tag.outputs.image-tag }}
+      registry: ${{ steps.login-ecr.outputs.registry }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          version: latest
+
+      - name: Configure AWS credentials (shared services for ECR push)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN_SHARED_NEW }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Sync API descriptions from OpenAPI spec to MDX pages
+        run: python3 scripts/sync_descriptions.py --write
+
+      - name: Generate structured llms.txt
+        run: python3 scripts/generate_llms_txt.py --write
+
+      - name: Construct Docker image tag
+        id: construct-tag
+        run: |
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          BRANCH_NAME=${GITHUB_REF_NAME//\//-}
+          IMAGE_TAG="${BRANCH_NAME}-${SHORT_SHA}"
+          echo "image-tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+      - name: Build and push image to ECR
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./cekura-mcp-server/Dockerfile
+          push: true
+          tags: ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ steps.construct-tag.outputs.image-tag }}
+          cache-from: |
+            type=gha,scope=mcp-server-new-${{ github.ref_name }}
+            type=gha,scope=mcp-server-new-main
+          cache-to: type=gha,mode=max,scope=mcp-server-new-${{ github.ref_name }}
+
+  deploy:
+    name: deploy
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (workload account for ECS deploy)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN_PROD_NEW }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Render + register task definition
+        id: register
+        run: |
+          sed "s|<IMAGE_TAG>|${{ needs.build.outputs.image-tag }}|g" \
+            cekura-mcp-server/deployment/ecs/prod-new-usw2/mcp-server-task-def.json \
+            > /tmp/mcp-server-task-def.rendered.json
+          TASK_DEF_ARN=$(aws ecs register-task-definition \
+            --cli-input-json file:///tmp/mcp-server-task-def.rendered.json \
+            --query 'taskDefinition.taskDefinitionArn' --output text)
+          echo "task-def-arn=$TASK_DEF_ARN" >> "$GITHUB_OUTPUT"
+
+      - name: Update ECS service
+        run: |
+          aws ecs update-service \
+            --cluster "$ECS_CLUSTER" \
+            --service "$ECS_SERVICE" \
+            --task-definition "${{ steps.register.outputs.task-def-arn }}" \
+            --force-new-deployment \
+            --query 'service.[serviceName,taskDefinition,desiredCount]' --output text
+
+      - name: Wait for service stable
+        run: |
+          aws ecs wait services-stable --cluster "$ECS_CLUSTER" --services "$ECS_SERVICE"
+          echo "✅ Service stable"
+
+  notify:
+    needs: [build, deploy]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Compose message
+        id: collect
+        run: |
+          IMAGE_TAG="${{ needs.build.outputs.image-tag }}"
+          if [ "${{ needs.build.result }}" != "success" ]; then
+            echo "message=*❌ mcp-server build failed for prod-new!* (tag: ${IMAGE_TAG:-n/a})" >> "$GITHUB_OUTPUT"
+          elif [ "${{ needs.deploy.result }}" = "success" ]; then
+            echo "message=*✅ mcp-server deployed to prod-new* (tag: ${IMAGE_TAG})" >> "$GITHUB_OUTPUT"
+          else
+            DD_LINK="https://us5.datadoghq.com/logs?query=env%3Aprod-new%20version%3A${IMAGE_TAG}%20service%3Amcp-server"
+            echo "message=*❌ mcp-server deploy to prod-new failed* (tag: ${IMAGE_TAG}) - <${DD_LINK}|Datadog logs>" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Notify Slack
+        if: vars.SLACK_DEPLOYMENTS_CHANNEL != ''
+        env:
+          SLACK_TOKEN: ${{ secrets.SLACK_BOT_BEARER_TOKEN }}
+          SLACK_CHANNEL: ${{ vars.SLACK_DEPLOYMENTS_CHANNEL }}
+          MESSAGE: ${{ steps.collect.outputs.message }}
+        run: |
+          if [ -z "$SLACK_TOKEN" ] || [ -z "$SLACK_CHANNEL" ]; then
+            echo "(Slack creds missing — skipping notification)"
+            exit 0
+          fi
+          curl -sS -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer $SLACK_TOKEN" \
+            -H 'Content-Type: application/json; charset=utf-8' \
+            -d "$(jq -n --arg ch "$SLACK_CHANNEL" --arg msg "$MESSAGE" '{channel:$ch,text:$msg}')" \
+            | jq '{ok,error}'

--- a/cekura-mcp-server/deployment/ecs/prod-new-usw2/mcp-server-task-def.json
+++ b/cekura-mcp-server/deployment/ecs/prod-new-usw2/mcp-server-task-def.json
@@ -1,0 +1,125 @@
+{
+  "containerDefinitions": [
+    {
+      "name": "mcp-server",
+      "image": "212351099297.dkr.ecr.us-west-2.amazonaws.com/cekura/mcp-server:<IMAGE_TAG>",
+      "cpu": 0,
+      "portMappings": [
+        {
+          "containerPort": 8001,
+          "hostPort": 8001,
+          "protocol": "tcp",
+          "name": "mcp-server-8001-port",
+          "appProtocol": "http"
+        }
+      ],
+      "essential": true,
+      "environment": [
+        {
+          "name": "AWS_SECRET_NAME",
+          "value": "arn:aws:secretsmanager:us-west-2:593108103736:secret:cet-prd-usw2-mcp-secret-HnC2v3"
+        },
+        {
+          "name": "CEKURA_BASE_URL",
+          "value": "https://api.cekura.ai"
+        },
+        {
+          "name": "CEKURA_OPENAPI_SPEC_PATH",
+          "value": "/app/openapi.json"
+        }
+      ],
+      "mountPoints": [],
+      "volumesFrom": [],
+      "secrets": [],
+      "logConfiguration": {
+        "logDriver": "awsfirelens",
+        "options": {
+          "dd_message_key": "log",
+          "provider": "ecs",
+          "dd_service": "mcp-server",
+          "Host": "http-intake.logs.us5.datadoghq.com",
+          "TLS": "on",
+          "dd_source": "mcp-server",
+          "dd_tags": "env:prod-new,version:<IMAGE_TAG>",
+          "Name": "datadog"
+        },
+        "secretOptions": [
+          {
+            "name": "apikey",
+            "valueFrom": "arn:aws:secretsmanager:us-west-2:593108103736:secret:cet-prd-usw2-datadog-api-key-secret-HSzirQ"
+          }
+        ]
+      },
+      "systemControls": []
+    },
+    {
+      "name": "log_router",
+      "image": "public.ecr.aws/aws-observability/aws-for-fluent-bit:stable",
+      "cpu": 0,
+      "memoryReservation": 51,
+      "portMappings": [],
+      "essential": false,
+      "environment": [],
+      "mountPoints": [],
+      "volumesFrom": [],
+      "user": "0",
+      "systemControls": [],
+      "firelensConfiguration": {
+        "type": "fluentbit",
+        "options": {
+          "enable-ecs-log-metadata": "true"
+        }
+      }
+    },
+    {
+      "name": "datadog-agent",
+      "image": "212351099297.dkr.ecr.us-west-2.amazonaws.com/datadog/agent:7.70.0",
+      "cpu": 0,
+      "portMappings": [],
+      "essential": false,
+      "environment": [
+        {
+          "name": "ECS_FARGATE",
+          "value": "true"
+        },
+        {
+          "name": "DD_APM_ENABLED",
+          "value": "true"
+        },
+        {
+          "name": "DD_TAGS",
+          "value": "service:mcp-server env:prod-new version:<IMAGE_TAG>"
+        },
+        {
+          "name": "DD_SITE",
+          "value": "us5.datadoghq.com"
+        }
+      ],
+      "environmentFiles": [],
+      "mountPoints": [],
+      "volumesFrom": [],
+      "secrets": [
+        {
+          "name": "DD_API_KEY",
+          "valueFrom": "arn:aws:secretsmanager:us-west-2:593108103736:secret:cet-prd-usw2-datadog-api-key-secret-HSzirQ"
+        }
+      ],
+      "systemControls": []
+    }
+  ],
+  "family": "mcp-server",
+  "taskRoleArn": "arn:aws:iam::593108103736:role/cet-prd-usw2-mcp-server-task-iam-role",
+  "executionRoleArn": "arn:aws:iam::593108103736:role/cet-prd-usw2-backend-task-exec-iam-role",
+  "networkMode": "awsvpc",
+  "volumes": [],
+  "placementConstraints": [],
+  "runtimePlatform": {
+    "cpuArchitecture": "X86_64",
+    "operatingSystemFamily": "LINUX"
+  },
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "cpu": "1024",
+  "memory": "2048"
+}


### PR DESCRIPTION
## Summary
- Adds `deploy-mcp-server-new.yml` workflow targeting the new AWS accounts (workload `593108103736`, shared-services `212351099297`).
- Adds ECS task definition for `prod-new-usw2` mcp-server.

Part of the AWS account migration. mcp-server runs only in usw2. Deploy is triggered via `workflow_dispatch` from this branch; merging captures the workflow file in `main`.