### PR TITLE
[Auto] Sync docs for backend PR #10013

### DIFF
--- a/cekura-mcp-server/mcp_tools.json
+++ b/cekura-mcp-server/mcp_tools.json
@@ -130,5 +130,8 @@
   },
   "metrics_generate_metrics_progress_retrieve": {
     "description_suffix": "Async — initiated by metrics_generate. Poll until status is completed or failed. Returns generated_metrics[] on completion."
+  },
+  "metrics_simplify_prompt_progress_retrieve": {
+    "description_suffix": "Async — initiated by metrics_simplify_prompt_create. Poll until status is completed or failed."
   }
 }

--- a/cekura-mcp-server/mcp_tools.json
+++ b/cekura-mcp-server/mcp_tools.json
@@ -127,5 +127,8 @@
   },
   "scenarios_list": {
     "description_suffix": "Dashboard link — each scenario (test case) opens at `https://dashboard.cekura.ai/test-case/<id>` (not project-scoped; use the item's `id`)."
+  },
+  "metrics_generate_metrics_progress_retrieve": {
+    "description_suffix": "Async — initiated by metrics_generate. Poll until status is completed or failed. Returns generated_metrics[] on completion."
   }
 }

--- a/openapi.json
+++ b/openapi.json
@@ -1204,6 +1204,15 @@
                         "schema": {
                             "type": "integer"
                         }
+                    },
+                    {
+                        "name": "dashboard_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `dashboard_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -2701,7 +2710,18 @@
                         "name": "alerts-review-retrieve",
                         "description": "Aggregate every alert's fire activity over a rolling window. Returns KPI totals (total fires, unique alerts that fired, top firing alert), a time-bucketed timeline (hourly for 24h, 3-hour for 3d, 6-hour for 7d), and a per-alert breakdown with a sparkline of fires-per-bucket. Use to answer 'what alerts fired this week?' or 'is anything noisy right now?'. Pass `hours` (default 24, capped at 168) to widen the window. The response shape lets you compose a written report in a single call."
                     }
-                }
+                },
+                "parameters": [
+                    {
+                        "name": "project_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    }
+                ]
             }
         },
         "/observability/v1/alerts/summarize_progress/": {
@@ -4964,6 +4984,24 @@
                         },
                         "description": "Progress ID returned from create_scenarios endpoint",
                         "required": true
+                    },
+                    {
+                        "name": "agent_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "project_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -7107,6 +7145,15 @@
                             "type": "string"
                         },
                         "description": "\nFilter by project id\nExample: `123`\n"
+                    },
+                    {
+                        "name": "organization_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `organization_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -8155,7 +8202,18 @@
                         "name": "slack-slack-workspaces-list",
                         "description": "Return every Slack workspace connected to the project, with the bot's default `channel_id`, `team_name`, and verification status. Use to pick a `workspace_id` (and optionally a different `channel_id`) for the `notifications.slack` block on `alerts_create`. Access tokens and bot IDs are not returned."
                     }
-                }
+                },
+                "parameters": [
+                    {
+                        "name": "project_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    }
+                ]
             },
             "post": {
                 "operationId": "slack-slack-workspaces-create",
@@ -9437,7 +9495,18 @@
                         "name": "billing-info-retrieve",
                         "description": "Returns credits remaining, credits used, balance expiry, and subscription status for an organization. When called with an organization-scoped API key, the org is taken from the key. When called with a user session or OAuth bearer, pass `organization_id` as a query parameter — the caller must be an admin of that organization."
                     }
-                }
+                },
+                "parameters": [
+                    {
+                        "name": "organization_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `organization_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    }
+                ]
             }
         },
         "/test_framework/billing/metric-usage/": {
@@ -14540,6 +14609,33 @@
                         "schema": {
                             "type": "integer"
                         }
+                    },
+                    {
+                        "name": "agent_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `category_id`, `metric_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "category_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `category_id`, `metric_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "metric_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `category_id`, `metric_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -18772,6 +18868,33 @@
                         },
                         "description": "progress_id returned from generate_clean_description_bg",
                         "required": true
+                    },
+                    {
+                        "name": "agent_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "project_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "assistant_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -18942,6 +19065,33 @@
                         },
                         "description": "Progress ID returned from the generate_metrics endpoint",
                         "required": true
+                    },
+                    {
+                        "name": "agent_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "project_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "assistant_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -19027,6 +19177,33 @@
                         },
                         "description": "Progress ID returned from the preview endpoint",
                         "required": true
+                    },
+                    {
+                        "name": "agent_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "project_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "assistant_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -19081,6 +19258,15 @@
                             "type": "integer"
                         },
                         "description": "Project ID for permission validation"
+                    },
+                    {
+                        "name": "assistant_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -19219,6 +19405,33 @@
                         },
                         "description": "Progress ID returned from simplify_prompt endpoint",
                         "required": true
+                    },
+                    {
+                        "name": "agent_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "project_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "assistant_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -20626,7 +20839,18 @@
                         "name": "phone-numbers-inbound-list",
                         "description": "Phone numbers inbound"
                     }
-                }
+                },
+                "parameters": [
+                    {
+                        "name": "organization_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `organization_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    }
+                ]
             }
         },
         "/test_framework/v1/phone-numbers/providers/list/": {
@@ -21644,6 +21868,15 @@
                             "type": "string"
                         },
                         "description": "Filter by scenario IDs — comma-separated string (e.g. '24270,24271'), not a JSON array."
+                    },
+                    {
+                        "name": "assistant_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `assistant_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -26172,6 +26405,33 @@
                         },
                         "description": "\nComma-separated list of run IDs.\nExample: `1,2,3`\n\nMust be a plain comma-separated string, not a JSON array — passing a JSON array returns a 400 error.\n",
                         "required": true
+                    },
+                    {
+                        "name": "agent_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `result_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "result_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `result_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "project_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `result_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -26268,7 +26528,18 @@
                         "name": "scenario-improvement-sessions-list",
                         "description": "List scenario-improvement sessions for a project. Each session tracks an AI-assisted refinement run over the project's scenarios. Requires `project_id`."
                     }
-                }
+                },
+                "parameters": [
+                    {
+                        "name": "project_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    }
+                ]
             },
             "post": {
                 "operationId": "scenario-improvement-sessions-create",
@@ -33777,6 +34048,24 @@
                             "type": "string"
                         },
                         "description": "Search folders by name (case-insensitive)"
+                    },
+                    {
+                        "name": "agent_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "assistant_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -34470,7 +34759,36 @@
                         "name": "scenarios-instructions-progress-retrieve",
                         "description": "Scenarios instructions progress"
                     }
-                }
+                },
+                "parameters": [
+                    {
+                        "name": "agent_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "project_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "assistant_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    }
+                ]
             }
         },
         "/test_framework/v1/scenarios/move_folder/": {
@@ -38887,6 +39205,15 @@
                             "type": "string"
                         },
                         "description": "Search agents by name. A numeric value also matches the agent id."
+                    },
+                    {
+                        "name": "organization_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `project_id`, `organization_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -48457,6 +48784,15 @@
                             "type": "integer"
                         },
                         "description": "Filter projects by organisation ID"
+                    },
+                    {
+                        "name": "project_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `organization_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [


### PR DESCRIPTION
Auto-generated docs sync for backend PR [#10013](https://github.com/cekura-ai/vocera.backend/pull/10013).

Reviewers: @dileep-chagam

## Summary

**Spec/overlay:** 20 MCP-exposed GET operations gained tenant-scoping query parameters (agent_id, project_id, assistant_id) via the new document_permission_query_params hook. 2 new async progress overlays added for metrics_generate_metrics_progress_retrieve and metrics_simplify_prompt_progress_retrieve. 1 existing overlay preserved (D2 precedence). No Bucket C suggestions, no renames, no SDK follow-ups.

**Conceptual docs:** No edits — this PR is a spec-generation fix that documents `permission_query_params` in the OpenAPI spec (20 MCP-exposed operations now carry 'Tenant scope' parameter descriptions). The conceptual MCP docs (`mcp/overview.mdx`, `mcp/claude-code-guide.mdx`) are setup guides focused on installation and OAuth connection; they appropriately don't enumerate per-tool query parameters, which belong in the API reference (generated from the spec). The spec fix makes these parameters discoverable to MCP tool callers programmatically, which is the correct solution. The `scenario-agent-progress` authorization change is an internal security fix with no user-visible behavior change. No conceptual docs misrepresent the post-PR behavior.

## Changes

- `openapi.json` — regenerate_from_backend
- `cekura-mcp-server/mcp_tools.json` — patch_json
- `cekura-mcp-server/mcp_tools.json` — patch_json

## Overlay notes (stale prose, manual review)

- `metrics_generate_clean_description_progress_retrieve`: Existing mcp_tools.json overlay present; transport-quirk signals fired (async_progress_pairing) but D2 precedence preserves the existing entry. Review manually if stale.

---
*Auto-generated from backend PR #10013.*

<!-- mcp-sync:file-hashes -->
```json
{}
```
<!-- /mcp-sync:file-hashes -->