### PR TITLE
docs(cli-sdk): document new SDK/CLI resources; fix v2 read-shape examples

### DIFF
--- a/cli-sdk/agents.mdx
+++ b/cli-sdk/agents.mdx
@@ -18,15 +18,11 @@ An **agent** is the AI voice assistant under test. It links to a provider (Vapi,
 <Tabs>
   <Tab title="CLI">
     ```bash
-    cekura agents create \
-      --project-id 742 \
-      --name "Support Bot" \
-      --description "Inbound customer support agent" \
-      --provider vapi \
-      --vapi-assistant-id asst_abc123
+    # Interactive — prompts for name, provider, credentials, and telephony
+    cekura agents create --project-id 742
     ```
 
-    For complex configs, write a JSON file and pass it:
+    For provider/telephony config, write a JSON file and pass it:
 
     ```bash
     cekura agents create --from-file agent.json
@@ -43,8 +39,10 @@ An **agent** is the AI voice assistant under test. It links to a provider (Vapi,
         project=742,
         agent_name="Support Bot",
         description="Inbound customer support agent",
-        provider="vapi",
-        vapi_assistant_id="asst_abc123",
+        inbound=True,
+        assistant_provider="vapi",
+        assistant_id="asst_abc123",
+        vapi_api_key="...",
     )
     ```
   </Tab>

--- a/cli-sdk/cli.mdx
+++ b/cli-sdk/cli.mdx
@@ -69,7 +69,7 @@ cekura scenarios bulk-update --help
 Add `--format json` to any list/get command for clean stdout you can pipe into `jq`, `python -c`, or your own tools:
 
 ```bash
-cekura agents list --project-id 742 --format json | jq '.[].agent_name'
+cekura agents list --project-id 742 --format json | jq '.[].name'
 ```
 
 This works on every list and detail command and is the recommended mode for shell scripts and CI pipelines.
@@ -85,6 +85,11 @@ This works on every list and detail command and is the recommended mode for shel
 | `metrics` | Define evaluation metrics |
 | `run` / `runs` | Trigger evaluations and inspect individual runs |
 | `calls` | Production call logs and ad-hoc evaluation |
+| `results` | Evaluation run results and test-set outcomes |
+| `insights` | Metric failure-mode insights and scenario generation |
+| `alerts` | Observability alerts |
+| `scenario-improvement-sessions` | Iterative evaluator-refinement sessions |
+| `slack` | Connected Slack workspaces |
 | `dashboards` | Analytics dashboards and widgets |
 | `predefined-metrics`, `critical-metric-scenarios`, `metric-reviews` | Platform-managed metrics workflow |
 | `test-profiles`, `personalities`, `phone-numbers` | Reusable test configuration |

--- a/cli-sdk/sdk.mdx
+++ b/cli-sdk/sdk.mdx
@@ -68,7 +68,7 @@ async def main():
     async with AsyncCekura() as client:
         agents = await client.agents.list(project_id=742)
         for a in agents:
-            print(a["id"], a["agent_name"])
+            print(a["id"], a["name"])
 
 asyncio.run(main())
 ```
@@ -84,11 +84,15 @@ client.agents              client.cron_jobs
 client.scenarios           client.dashboards
 client.metrics             client.test_sets
 client.runs                client.metric_reviews
-client.calls               client.critical_metric_scenarios
-client.projects            client.predefined_metrics
-client.organizations       client.phone_numbers
-client.personalities       client.billing
-client.test_profiles       client.api_keys
+client.results             client.critical_metric_scenarios
+client.calls               client.predefined_metrics
+client.projects            client.phone_numbers
+client.organizations       client.billing
+client.personalities       client.api_keys
+client.test_profiles       client.alerts
+client.scenario_improvement_sessions
+client.metric_failure_mode_insights
+client.slack
 ```
 
 Use `dir(client)` in a REPL or `help(client.agents)` to discover everything available.


### PR DESCRIPTION
## Problem
The CLI & SDK docs drifted from the shipped surface (cekura-python 1.5.0, PR cekura-python#19):
- New command groups / SDK resources (`alerts`, `insights`/`metric_failure_mode_insights`, `results`, `scenario-improvement-sessions`, `slack`) weren't listed anywhere.
- Agent list/read examples used the pre-v2 field name `agent_name`; the v2 read shape returns `name`, so `jq '.[].agent_name'` and `a["agent_name"]` now yield null.
- The `agents create` examples referenced flags/fields that don't exist (`--provider`, `--vapi-assistant-id`, SDK `provider=`/`vapi_assistant_id=`).

## Fix
- `cli.mdx`: add the new groups to the command-group table; fix the `jq` example to `.[].name`.
- `sdk.mdx`: add `client.alerts`, `client.metric_failure_mode_insights`, `client.slack`, `client.results`, `client.scenario_improvement_sessions` to the resource map; fix the async example to read `a["name"]`.
- `agents.mdx`: correct the create examples to the real write contract — CLI is interactive or `--from-file`; SDK uses `assistant_provider` + `assistant_id` + `{provider}_api_key` + `inbound`.

## Verification
- Field names checked against the live v2 backend response shapes and the SDK write serializer.
- Behavioral/public content only — no internal paths, endpoints, or service names introduced.
- No Mintlify build run locally; changes are content-only edits to existing `.mdx` pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)