### PR TITLE
[Auto] Sync docs for backend PR #10042

### DIFF
--- a/cekura-mcp-server/mcp_tools.json
+++ b/cekura-mcp-server/mcp_tools.json
@@ -119,9 +119,6 @@
   "aiagents_auto_fetch_progress_retrieve": {
     "description_suffix": "Poll with the progress_id from aiagents_auto_fetch_create. Status values: queued, in_progress, completed (with staged configuration), failed (with error)."
   },
-  "aiagents_toggle_mock_tools_progress_retrieve": {
-    "description_suffix": "Poll with the progress_id from aiagents_toggle_mock_tools_create. Status values: queued, in_progress, completed (mock mode applied), failed (with error)."
-  },
   "results_retrieve": {
     "description_suffix": "Dashboard link — this result opens at `https://dashboard.cekura.ai/<project_id>/results/<id>`, where `<id>` is this result's `id` and `<project_id>` is the project you are operating in."
   },

--- a/cekura-mcp-server/mcp_tools.json
+++ b/cekura-mcp-server/mcp_tools.json
@@ -119,9 +119,6 @@
   "aiagents_auto_fetch_progress_retrieve": {
     "description_suffix": "Poll with the progress_id from aiagents_auto_fetch_create. Status values: queued, in_progress, completed (with staged configuration), failed (with error)."
   },
-  "aiagents_toggle_mock_tools_create": {
-    "description_suffix": "Async — returns a progress_id. Poll aiagents_toggle_mock_tools_progress_retrieve with the progress_id until completed or failed. Run aiagents_auto_fetch_create first to populate mock tool data before enabling."
-  },
   "aiagents_toggle_mock_tools_progress_retrieve": {
     "description_suffix": "Poll with the progress_id from aiagents_toggle_mock_tools_create. Status values: queued, in_progress, completed (mock mode applied), failed (with error)."
   },

--- a/openapi.json
+++ b/openapi.json
@@ -1269,15 +1269,6 @@
                         "schema": {
                             "type": "integer"
                         }
-                    },
-                    {
-                        "name": "dashboard_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `dashboard_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -2775,18 +2766,7 @@
                         "name": "alerts-review-retrieve",
                         "description": "Aggregate every alert's fire activity over a rolling window. Returns KPI totals (total fires, unique alerts that fired, top firing alert), a time-bucketed timeline (hourly for 24h, 3-hour for 3d, 6-hour for 7d), and a per-alert breakdown with a sparkline of fires-per-bucket. Use to answer 'what alerts fired this week?' or 'is anything noisy right now?'. Pass `hours` (default 24, capped at 168) to widen the window. The response shape lets you compose a written report in a single call."
                     }
-                },
-                "parameters": [
-                    {
-                        "name": "project_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    }
-                ]
+                }
             }
         },
         "/observability/v1/alerts/summarize_progress/": {
@@ -5049,24 +5029,6 @@
                         },
                         "description": "Progress ID returned from create_scenarios endpoint",
                         "required": true
-                    },
-                    {
-                        "name": "agent_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    },
-                    {
-                        "name": "project_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -6425,8 +6387,7 @@
         "/observability/v1/metric-failure-mode-insights/{id}/generate-scenario/": {
             "post": {
                 "operationId": "metric-failure-mode-insights-generate-scenario-create",
-                "description": "Turn one failure mode of a metric failure-mode insight into a test scenario that reproduces the issue against a target agent. Choose the failure mode with `failure_mode_index` and the agent with `agent`. Set `redact_transcripts` to strip personal identifiers from the source call transcripts before they are used to draft the scenario. Runs in the background and returns a `progress_id`; poll scenario generation progress to retrieve the generated scenario id.",
-                "summary": "Generate a test scenario from an insight failure mode",
+                "description": "Queue generation of a test scenario from one failure mode.\n\nReturns a ``progress_id`` the frontend polls via the existing\n``scenarios/generate-progress`` endpoint; the generated scenario\nid lands in that progress state's ``scenarios_list`` when done.",
                 "parameters": [
                     {
                         "in": "path",
@@ -6476,14 +6437,6 @@
                             }
                         },
                         "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "metric-failure-mode-insights-generate-scenario-create",
-                        "description": "Turn one failure mode of a metric failure-mode insight into a test scenario that reproduces the issue against a target agent. Choose the failure mode with `failure_mode_index` and the agent with `agent`. Set `redact_transcripts` to strip personal identifiers from the source call transcripts before they are used to draft the scenario. Runs in the background and returns a `progress_id`; poll scenario generation progress to retrieve the generated scenario id."
                     }
                 }
             }
@@ -7219,15 +7172,6 @@
                             "type": "string"
                         },
                         "description": "\nFilter by project id\nExample: `123`\n"
-                    },
-                    {
-                        "name": "organization_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `organization_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -8276,18 +8220,7 @@
                         "name": "slack-slack-workspaces-list",
                         "description": "Return every Slack workspace connected to the project, with the bot's default `channel_id`, `team_name`, and verification status. Use to pick a `workspace_id` (and optionally a different `channel_id`) for the `notifications.slack` block on `alerts_create`. Access tokens and bot IDs are not returned."
                     }
-                },
-                "parameters": [
-                    {
-                        "name": "project_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    }
-                ]
+                }
             },
             "post": {
                 "operationId": "slack-slack-workspaces-create",
@@ -9569,18 +9502,7 @@
                         "name": "billing-info-retrieve",
                         "description": "Returns credits remaining, credits used, balance expiry, and subscription status for an organization. When called with an organization-scoped API key, the org is taken from the key. When called with a user session or OAuth bearer, pass `organization_id` as a query parameter — the caller must be an admin of that organization."
                     }
-                },
-                "parameters": [
-                    {
-                        "name": "organization_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `organization_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    }
-                ]
+                }
             }
         },
         "/test_framework/billing/metric-usage/": {
@@ -14683,33 +14605,6 @@
                         "schema": {
                             "type": "integer"
                         }
-                    },
-                    {
-                        "name": "agent_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `category_id`, `metric_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    },
-                    {
-                        "name": "category_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `category_id`, `metric_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    },
-                    {
-                        "name": "metric_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `category_id`, `metric_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -18942,33 +18837,6 @@
                         },
                         "description": "progress_id returned from generate_clean_description_bg",
                         "required": true
-                    },
-                    {
-                        "name": "agent_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    },
-                    {
-                        "name": "project_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    },
-                    {
-                        "name": "assistant_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -19139,33 +19007,6 @@
                         },
                         "description": "Progress ID returned from the generate_metrics endpoint",
                         "required": true
-                    },
-                    {
-                        "name": "agent_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    },
-                    {
-                        "name": "project_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    },
-                    {
-                        "name": "assistant_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -19251,33 +19092,6 @@
                         },
                         "description": "Progress ID returned from the preview endpoint",
                         "required": true
-                    },
-                    {
-                        "name": "agent_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    },
-                    {
-                        "name": "project_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    },
-                    {
-                        "name": "assistant_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -19332,15 +19146,6 @@
                             "type": "integer"
                         },
                         "description": "Project ID for permission validation"
-                    },
-                    {
-                        "name": "assistant_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -19479,33 +19284,6 @@
                         },
                         "description": "Progress ID returned from simplify_prompt endpoint",
                         "required": true
-                    },
-                    {
-                        "name": "agent_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    },
-                    {
-                        "name": "project_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    },
-                    {
-                        "name": "assistant_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -20913,18 +20691,7 @@
                         "name": "phone-numbers-inbound-list",
                         "description": "Phone numbers inbound"
                     }
-                },
-                "parameters": [
-                    {
-                        "name": "organization_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `organization_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    }
-                ]
+                }
             }
         },
         "/test_framework/v1/phone-numbers/providers/list/": {
@@ -21942,15 +21709,6 @@
                             "type": "string"
                         },
                         "description": "Filter by scenario IDs — comma-separated string (e.g. '24270,24271'), not a JSON array."
-                    },
-                    {
-                        "name": "assistant_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `assistant_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -26493,33 +26251,6 @@
                         },
                         "description": "\nComma-separated list of run IDs.\nExample: `1,2,3`\n\nMust be a plain comma-separated string, not a JSON array — passing a JSON array returns a 400 error.\n",
                         "required": true
-                    },
-                    {
-                        "name": "agent_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `result_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    },
-                    {
-                        "name": "result_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `result_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    },
-                    {
-                        "name": "project_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `result_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -26616,18 +26347,7 @@
                         "name": "scenario-improvement-sessions-list",
                         "description": "List scenario-improvement sessions for a project. Each session tracks an AI-assisted refinement run over the project's scenarios. Requires `project_id`."
                     }
-                },
-                "parameters": [
-                    {
-                        "name": "project_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    }
-                ]
+                }
             },
             "post": {
                 "operationId": "scenario-improvement-sessions-create",
@@ -34136,24 +33856,6 @@
                             "type": "string"
                         },
                         "description": "Search folders by name (case-insensitive)"
-                    },
-                    {
-                        "name": "agent_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    },
-                    {
-                        "name": "assistant_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -34847,36 +34549,7 @@
                         "name": "scenarios-instructions-progress-retrieve",
                         "description": "Scenarios instructions progress"
                     }
-                },
-                "parameters": [
-                    {
-                        "name": "agent_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    },
-                    {
-                        "name": "project_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    },
-                    {
-                        "name": "assistant_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    }
-                ]
+                }
             }
         },
         "/test_framework/v1/scenarios/move_folder/": {
@@ -39293,15 +38966,6 @@
                             "type": "string"
                         },
                         "description": "Search agents by name. A numeric value also matches the agent id."
-                    },
-                    {
-                        "name": "organization_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `project_id`, `organization_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -48872,15 +48536,6 @@
                             "type": "integer"
                         },
                         "description": "Filter projects by organisation ID"
-                    },
-                    {
-                        "name": "project_id",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `organization_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -53777,6 +53432,7 @@
             },
             "CallLogDetail": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -53968,6 +53624,7 @@
             },
             "CallLogList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -55127,6 +54784,7 @@
             },
             "Dashboard": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -55258,6 +54916,7 @@
             },
             "DashboardList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -57539,6 +57198,7 @@
             },
             "MetricList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -60057,6 +59717,7 @@
             },
             "PatchedCallLogDetail": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -60485,6 +60146,7 @@
             },
             "PatchedDashboard": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -62904,6 +62566,7 @@
             },
             "PatchedSchemaPostScenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "agent": {
                         "type": [
@@ -62988,13 +62651,59 @@
                         "type": "integer",
                         "description": "The test profile ID to use for the evaluator"
                     },
-                    "phone_number": {
-                        "type": "integer",
-                        "description": "The phone number ID to use for the evaluator (works for both inbound and outbound)"
-                    },
                     "inbound_phone_number": {
                         "type": "integer",
-                        "description": "(Deprecated) The inbound phone number ID to use for the evaluator. Use phone_number instead, which works for both inbound and outbound."
+                        "description": "PhoneNumber ID to use for this evaluator's calls (works for both inbound and outbound)."
+                    },
+                    "scenario_language": {
+                        "enum": [
+                            "af",
+                            "ar",
+                            "bn",
+                            "bg",
+                            "zh",
+                            "cs",
+                            "da",
+                            "nl",
+                            "en",
+                            "et",
+                            "fi",
+                            "fr",
+                            "de",
+                            "el",
+                            "gu",
+                            "hi",
+                            "he",
+                            "hu",
+                            "id",
+                            "it",
+                            "ja",
+                            "kn",
+                            "ko",
+                            "ms",
+                            "ml",
+                            "mr",
+                            "multi",
+                            "no",
+                            "pl",
+                            "pa",
+                            "pt",
+                            "ro",
+                            "ru",
+                            "sk",
+                            "es",
+                            "sv",
+                            "th",
+                            "tr",
+                            "tl",
+                            "ta",
+                            "te",
+                            "uk",
+                            "vi"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "b822ad429c7b7fec",
+                        "description": "\nLanguage of the scenario\n\n\n* `af` - Afrikaans\n* `ar` - Arabic\n* `bn` - Bengali\n* `bg` - Bulgarian\n* `zh` - Chinese Simplified\n* `cs` - Czech\n* `da` - Danish\n* `nl` - Dutch\n* `en` - English\n* `et` - Estonian\n* `fi` - Finnish\n* `fr` - French\n* `de` - German\n* `el` - Greek\n* `gu` - Gujarati\n* `hi` - Hindi\n* `he` - Hebrew\n* `hu` - Hungarian\n* `id` - Indonesian\n* `it` - Italian\n* `ja` - Japanese\n* `kn` - Kannada\n* `ko` - Korean\n* `ms` - Malay\n* `ml` - Malayalam\n* `mr` - Marathi\n* `multi` - Multilingual\n* `no` - Norwegian\n* `pl` - Polish\n* `pa` - Punjabi\n* `pt` - Portuguese\n* `ro` - Romanian\n* `ru` - Russian\n* `sk` - Slovak\n* `es` - Spanish\n* `sv` - Swedish\n* `th` - Thai\n* `tr` - Turkish\n* `tl` - Tagalog\n* `ta` - Tamil\n* `te` - Telugu\n* `uk` - Ukrainian\n* `vi` - Vietnamese"
                     },
                     "folder_path": {
                         "type": [
@@ -66128,6 +65837,7 @@
             },
             "RunList": {
                 "type": "object",
+                "description": "Adds outbound dial-window fields read from cekura_metadata.",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -66604,6 +66314,7 @@
             },
             "Scenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -67486,6 +67197,7 @@
             },
             "ScenarioList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -67705,6 +67417,7 @@
             },
             "ScenarioSerializerV2": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -69180,6 +68893,7 @@
             },
             "SchemaPostRunScenarios": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "agent_id": {
                         "type": "integer",
@@ -69803,6 +69517,7 @@
             },
             "SchemaPostScenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "agent": {
                         "type": [
@@ -69887,13 +69602,59 @@
                         "type": "integer",
                         "description": "The test profile ID to use for the evaluator"
                     },
-                    "phone_number": {
-                        "type": "integer",
-                        "description": "The phone number ID to use for the evaluator (works for both inbound and outbound)"
-                    },
                     "inbound_phone_number": {
                         "type": "integer",
-                        "description": "(Deprecated) The inbound phone number ID to use for the evaluator. Use phone_number instead, which works for both inbound and outbound."
+                        "description": "PhoneNumber ID to use for this evaluator's calls (works for both inbound and outbound)."
+                    },
+                    "scenario_language": {
+                        "enum": [
+                            "af",
+                            "ar",
+                            "bn",
+                            "bg",
+                            "zh",
+                            "cs",
+                            "da",
+                            "nl",
+                            "en",
+                            "et",
+                            "fi",
+                            "fr",
+                            "de",
+                            "el",
+                            "gu",
+                            "hi",
+                            "he",
+                            "hu",
+                            "id",
+                            "it",
+                            "ja",
+                            "kn",
+                            "ko",
+                            "ms",
+                            "ml",
+                            "mr",
+                            "multi",
+                            "no",
+                            "pl",
+                            "pa",
+                            "pt",
+                            "ro",
+                            "ru",
+                            "sk",
+                            "es",
+                            "sv",
+                            "th",
+                            "tr",
+                            "tl",
+                            "ta",
+                            "te",
+                            "uk",
+                            "vi"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "b822ad429c7b7fec",
+                        "description": "\nLanguage of the scenario\n\n\n* `af` - Afrikaans\n* `ar` - Arabic\n* `bn` - Bengali\n* `bg` - Bulgarian\n* `zh` - Chinese Simplified\n* `cs` - Czech\n* `da` - Danish\n* `nl` - Dutch\n* `en` - English\n* `et` - Estonian\n* `fi` - Finnish\n* `fr` - French\n* `de` - German\n* `el` - Greek\n* `gu` - Gujarati\n* `hi` - Hindi\n* `he` - Hebrew\n* `hu` - Hungarian\n* `id` - Indonesian\n* `it` - Italian\n* `ja` - Japanese\n* `kn` - Kannada\n* `ko` - Korean\n* `ms` - Malay\n* `ml` - Malayalam\n* `mr` - Marathi\n* `multi` - Multilingual\n* `no` - Norwegian\n* `pl` - Polish\n* `pa` - Punjabi\n* `pt` - Portuguese\n* `ro` - Romanian\n* `ru` - Russian\n* `sk` - Slovak\n* `es` - Spanish\n* `sv` - Swedish\n* `th` - Thai\n* `tr` - Turkish\n* `tl` - Tagalog\n* `ta` - Tamil\n* `te` - Telugu\n* `uk` - Ukrainian\n* `vi` - Vietnamese"
                     },
                     "folder_path": {
                         "type": [
@@ -69952,6 +69713,7 @@
             },
             "SchemaScenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",

--- a/openapi.json
+++ b/openapi.json
@@ -1269,6 +1269,15 @@
                         "schema": {
                             "type": "integer"
                         }
+                    },
+                    {
+                        "name": "dashboard_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `dashboard_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -2766,7 +2775,18 @@
                         "name": "alerts-review-retrieve",
                         "description": "Aggregate every alert's fire activity over a rolling window. Returns KPI totals (total fires, unique alerts that fired, top firing alert), a time-bucketed timeline (hourly for 24h, 3-hour for 3d, 6-hour for 7d), and a per-alert breakdown with a sparkline of fires-per-bucket. Use to answer 'what alerts fired this week?' or 'is anything noisy right now?'. Pass `hours` (default 24, capped at 168) to widen the window. The response shape lets you compose a written report in a single call."
                     }
-                }
+                },
+                "parameters": [
+                    {
+                        "name": "project_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    }
+                ]
             }
         },
         "/observability/v1/alerts/summarize_progress/": {
@@ -5029,6 +5049,24 @@
                         },
                         "description": "Progress ID returned from create_scenarios endpoint",
                         "required": true
+                    },
+                    {
+                        "name": "agent_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "project_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -6387,7 +6425,8 @@
         "/observability/v1/metric-failure-mode-insights/{id}/generate-scenario/": {
             "post": {
                 "operationId": "metric-failure-mode-insights-generate-scenario-create",
-                "description": "Queue generation of a test scenario from one failure mode.\n\nReturns a ``progress_id`` the frontend polls via the existing\n``scenarios/generate-progress`` endpoint; the generated scenario\nid lands in that progress state's ``scenarios_list`` when done.",
+                "description": "Turn one failure mode of a metric failure-mode insight into a test scenario that reproduces the issue against a target agent. Choose the failure mode with `failure_mode_index` and the agent with `agent`. Set `redact_transcripts` to strip personal identifiers from the source call transcripts before they are used to draft the scenario. Runs in the background and returns a `progress_id`; poll scenario generation progress to retrieve the generated scenario id.",
+                "summary": "Generate a test scenario from an insight failure mode",
                 "parameters": [
                     {
                         "in": "path",
@@ -6437,6 +6476,14 @@
                             }
                         },
                         "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "metric-failure-mode-insights-generate-scenario-create",
+                        "description": "Turn one failure mode of a metric failure-mode insight into a test scenario that reproduces the issue against a target agent. Choose the failure mode with `failure_mode_index` and the agent with `agent`. Set `redact_transcripts` to strip personal identifiers from the source call transcripts before they are used to draft the scenario. Runs in the background and returns a `progress_id`; poll scenario generation progress to retrieve the generated scenario id."
                     }
                 }
             }
@@ -7172,6 +7219,15 @@
                             "type": "string"
                         },
                         "description": "\nFilter by project id\nExample: `123`\n"
+                    },
+                    {
+                        "name": "organization_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `organization_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -8220,7 +8276,18 @@
                         "name": "slack-slack-workspaces-list",
                         "description": "Return every Slack workspace connected to the project, with the bot's default `channel_id`, `team_name`, and verification status. Use to pick a `workspace_id` (and optionally a different `channel_id`) for the `notifications.slack` block on `alerts_create`. Access tokens and bot IDs are not returned."
                     }
-                }
+                },
+                "parameters": [
+                    {
+                        "name": "project_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    }
+                ]
             },
             "post": {
                 "operationId": "slack-slack-workspaces-create",
@@ -9502,7 +9569,18 @@
                         "name": "billing-info-retrieve",
                         "description": "Returns credits remaining, credits used, balance expiry, and subscription status for an organization. When called with an organization-scoped API key, the org is taken from the key. When called with a user session or OAuth bearer, pass `organization_id` as a query parameter — the caller must be an admin of that organization."
                     }
-                }
+                },
+                "parameters": [
+                    {
+                        "name": "organization_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `organization_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    }
+                ]
             }
         },
         "/test_framework/billing/metric-usage/": {
@@ -12716,256 +12794,6 @@
                 }
             }
         },
-        "/test_framework/v1/aiagents/{agent_id}/tools/disable-mock/": {
-            "post": {
-                "operationId": "aiagents-tools-disable-mock-create",
-                "description": "Restore the agent's tools to their original (non-mock) state. For managed providers this PATCHes the provider assistant back to its `original_tool_ids` and deletes the cloned tools. For provider=\"custom\" this only flips `mock_enabled` off; the `mcp_server_url` is preserved so re-enable works.",
-                "summary": "Disable mock tools for an agent",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "agent_id",
-                        "schema": {
-                            "type": "string",
-                            "pattern": "^\\d+$"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "test_framework"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/DisableMockToolsRequest"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/DisableMockToolsRequest"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/DisableMockToolsRequest"
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "deprecated": true,
-                "responses": {
-                    "202": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/DisableMockToolsResponse"
-                                }
-                            }
-                        },
-                        "description": ""
-                    },
-                    "400": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/DisableMockErrorResponse"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
-        },
-        "/test_framework/v1/aiagents/{agent_id}/tools/disable-mock-progress/": {
-            "get": {
-                "operationId": "aiagents-tools-disable-mock-progress-retrieve",
-                "description": "Poll the status of a background disable-mock task.",
-                "summary": "Poll status of a disable-mock task",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "agent_id",
-                        "schema": {
-                            "type": "string",
-                            "pattern": "^\\d+$"
-                        },
-                        "required": true
-                    },
-                    {
-                        "in": "query",
-                        "name": "progress_id",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "test_framework"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "deprecated": true,
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/DisableMockProgressResponse"
-                                }
-                            }
-                        },
-                        "description": ""
-                    },
-                    "400": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/DisableMockProgressErrorResponse"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
-        },
-        "/test_framework/v1/aiagents/{agent_id}/tools/enable-mock/": {
-            "post": {
-                "operationId": "aiagents-tools-enable-mock-create",
-                "description": "Activate mock-tool mode using the data created by `auto-fetch`. For managed providers (vapi/retell/elevenlabs) this clones the provider's tools at the provider and swaps URLs to Cekura-hosted endpoints. For provider=\"custom\" it just registers `mcp_sub_tool_map` so MockMCPView can serve `/mcp/N/` calls. Returns a `progress_id`; poll `enable-mock-progress/` for the resulting `mcp_endpoints`. Run `auto-fetch` first.",
-                "summary": "Enable mock tools for an agent",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "agent_id",
-                        "schema": {
-                            "type": "string",
-                            "pattern": "^\\d+$"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "test_framework"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/EnableMockToolsRequest"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/EnableMockToolsRequest"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/EnableMockToolsRequest"
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "deprecated": true,
-                "responses": {
-                    "202": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/EnableMockToolsResponse"
-                                }
-                            }
-                        },
-                        "description": ""
-                    },
-                    "400": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/EnableMockErrorResponse"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
-        },
-        "/test_framework/v1/aiagents/{agent_id}/tools/enable-mock-progress/": {
-            "get": {
-                "operationId": "aiagents-tools-enable-mock-progress-retrieve",
-                "description": "Poll the status of a background enable-mock task.",
-                "summary": "Poll status of an enable-mock task",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "agent_id",
-                        "schema": {
-                            "type": "string",
-                            "pattern": "^\\d+$"
-                        },
-                        "required": true
-                    },
-                    {
-                        "in": "query",
-                        "name": "progress_id",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "test_framework"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "deprecated": true,
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/EnableMockProgressResponse"
-                                }
-                            }
-                        },
-                        "description": ""
-                    },
-                    "400": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/EnableMockProgressErrorResponse"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
-        },
         "/test_framework/v1/aiagents/{agent_id}/tools/mock-status/": {
             "get": {
                 "operationId": "aiagents-tools-mock-status-retrieve",
@@ -14605,6 +14433,33 @@
                         "schema": {
                             "type": "integer"
                         }
+                    },
+                    {
+                        "name": "agent_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `category_id`, `metric_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "category_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `category_id`, `metric_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "metric_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `category_id`, `metric_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -18837,6 +18692,33 @@
                         },
                         "description": "progress_id returned from generate_clean_description_bg",
                         "required": true
+                    },
+                    {
+                        "name": "agent_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "project_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "assistant_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -19007,6 +18889,33 @@
                         },
                         "description": "Progress ID returned from the generate_metrics endpoint",
                         "required": true
+                    },
+                    {
+                        "name": "agent_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "project_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "assistant_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -19092,6 +19001,33 @@
                         },
                         "description": "Progress ID returned from the preview endpoint",
                         "required": true
+                    },
+                    {
+                        "name": "agent_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "project_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "assistant_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -19146,6 +19082,15 @@
                             "type": "integer"
                         },
                         "description": "Project ID for permission validation"
+                    },
+                    {
+                        "name": "assistant_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -19284,6 +19229,33 @@
                         },
                         "description": "Progress ID returned from simplify_prompt endpoint",
                         "required": true
+                    },
+                    {
+                        "name": "agent_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "project_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "assistant_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -20691,7 +20663,18 @@
                         "name": "phone-numbers-inbound-list",
                         "description": "Phone numbers inbound"
                     }
-                }
+                },
+                "parameters": [
+                    {
+                        "name": "organization_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `organization_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    }
+                ]
             }
         },
         "/test_framework/v1/phone-numbers/providers/list/": {
@@ -21709,6 +21692,15 @@
                             "type": "string"
                         },
                         "description": "Filter by scenario IDs — comma-separated string (e.g. '24270,24271'), not a JSON array."
+                    },
+                    {
+                        "name": "assistant_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `assistant_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -26251,6 +26243,33 @@
                         },
                         "description": "\nComma-separated list of run IDs.\nExample: `1,2,3`\n\nMust be a plain comma-separated string, not a JSON array — passing a JSON array returns a 400 error.\n",
                         "required": true
+                    },
+                    {
+                        "name": "agent_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `result_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "result_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `result_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "project_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `result_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -26347,7 +26366,18 @@
                         "name": "scenario-improvement-sessions-list",
                         "description": "List scenario-improvement sessions for a project. Each session tracks an AI-assisted refinement run over the project's scenarios. Requires `project_id`."
                     }
-                }
+                },
+                "parameters": [
+                    {
+                        "name": "project_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    }
+                ]
             },
             "post": {
                 "operationId": "scenario-improvement-sessions-create",
@@ -33856,6 +33886,24 @@
                             "type": "string"
                         },
                         "description": "Search folders by name (case-insensitive)"
+                    },
+                    {
+                        "name": "agent_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "assistant_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -34549,7 +34597,36 @@
                         "name": "scenarios-instructions-progress-retrieve",
                         "description": "Scenarios instructions progress"
                     }
-                }
+                },
+                "parameters": [
+                    {
+                        "name": "agent_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "project_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    },
+                    {
+                        "name": "assistant_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Tenant scope. Supply one of `agent_id`, `project_id`, `assistant_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    }
+                ]
             }
         },
         "/test_framework/v1/scenarios/move_folder/": {
@@ -38966,6 +39043,15 @@
                             "type": "string"
                         },
                         "description": "Search agents by name. A numeric value also matches the agent id."
+                    },
+                    {
+                        "name": "organization_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `project_id`, `organization_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -40441,147 +40527,6 @@
                             }
                         },
                         "description": ""
-                    }
-                }
-            }
-        },
-        "/test_framework/v2/aiagents/{id}/toggle-mock-tools/": {
-            "post": {
-                "operationId": "aiagents-toggle-mock-tools-create",
-                "description": "Toggle mock-tool mode on the agent's provider. `enabled=true` replaces the provider tools with Cekura-hosted mocks; `enabled=false` restores the originals (mock data is preserved). Returns a `progress_id`; poll `toggle-mock-tools-progress/`. Run `auto-fetch` first to populate mock tool data before enabling.",
-                "summary": "Enable or disable mock tools on the provider",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "A unique integer value identifying this ai agent.",
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "test_framework"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/AgentToggleMockToolsRequest"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/AgentToggleMockToolsRequest"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/AgentToggleMockToolsRequest"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "202": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/AgentToggleMockToolsResponse"
-                                }
-                            }
-                        },
-                        "description": ""
-                    },
-                    "400": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/AgentToggleMockToolsErrorResponse"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mcp-destructive": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-toggle-mock-tools-create",
-                        "description": "Toggle mock-tool mode on the agent's provider. `enabled=true` replaces the provider tools with Cekura-hosted mocks; `enabled=false` restores the originals (mock data is preserved). Returns a `progress_id`; poll `toggle-mock-tools-progress/`. Run `auto-fetch` first to populate mock tool data before enabling."
-                    }
-                }
-            }
-        },
-        "/test_framework/v2/aiagents/{id}/toggle-mock-tools-progress/": {
-            "get": {
-                "operationId": "aiagents-toggle-mock-tools-progress-retrieve",
-                "description": "Poll the enable/disable task. The progress_id is unique, so we resolve it\nagainst both task namespaces and return whichever holds it.",
-                "summary": "Poll status of a toggle-mock-tools task",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "A unique integer value identifying this ai agent.",
-                        "required": true
-                    },
-                    {
-                        "in": "query",
-                        "name": "progress_id",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "test_framework"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/AgentToggleMockToolsProgressResponse"
-                                }
-                            }
-                        },
-                        "description": ""
-                    },
-                    "400": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/AgentToggleMockToolsProgressErrorResponse"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "aiagents-toggle-mock-tools-progress-retrieve",
-                        "description": "Poll the enable/disable task. The progress_id is unique, so we resolve it\nagainst both task namespaces and return whichever holds it."
                     }
                 }
             }
@@ -48536,6 +48481,15 @@
                             "type": "integer"
                         },
                         "description": "Filter projects by organisation ID"
+                    },
+                    {
+                        "name": "project_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `organization_id`, `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ],
                 "tags": [
@@ -52119,101 +52073,6 @@
                     }
                 }
             },
-            "AgentToggleMockToolsErrorResponse": {
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "detail"
-                ]
-            },
-            "AgentToggleMockToolsProgressErrorResponse": {
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "detail"
-                ]
-            },
-            "AgentToggleMockToolsProgressResponse": {
-                "type": "object",
-                "properties": {
-                    "status": {
-                        "enum": [
-                            "in_progress",
-                            "completed",
-                            "failed"
-                        ],
-                        "type": "string",
-                        "description": "* `in_progress` - in_progress\n* `completed` - completed\n* `failed` - failed",
-                        "x-spec-enum-id": "6e9575e5767aaee0"
-                    },
-                    "mock_enabled": {
-                        "type": [
-                            "boolean",
-                            "null"
-                        ]
-                    },
-                    "mcp_endpoints": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/ToggleMockToolsMCPEndpoint"
-                        },
-                        "description": "MCP mock endpoints registered after enabling. Empty for agents without MCP tools or when disabling."
-                    },
-                    "message": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    },
-                    "error": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    }
-                },
-                "required": [
-                    "error",
-                    "message",
-                    "mock_enabled",
-                    "status"
-                ]
-            },
-            "AgentToggleMockToolsRequest": {
-                "type": "object",
-                "properties": {
-                    "enabled": {
-                        "type": "boolean",
-                        "description": "True to enable mock mode, false to disable."
-                    },
-                    "api_key": {
-                        "type": "string",
-                        "description": "Optional API key. If not provided, stored credentials are used."
-                    }
-                },
-                "required": [
-                    "enabled"
-                ]
-            },
-            "AgentToggleMockToolsResponse": {
-                "type": "object",
-                "properties": {
-                    "progress_id": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "progress_id"
-                ]
-            },
             "AgentforceChatConfig": {
                 "type": "object",
                 "description": "Agentforce (Salesforce) chat configuration.",
@@ -55210,87 +55069,6 @@
                     "project_id"
                 ]
             },
-            "DisableMockErrorResponse": {
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "detail"
-                ]
-            },
-            "DisableMockProgressErrorResponse": {
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "detail"
-                ]
-            },
-            "DisableMockProgressResponse": {
-                "type": "object",
-                "properties": {
-                    "status": {
-                        "enum": [
-                            "in_progress",
-                            "completed",
-                            "failed"
-                        ],
-                        "type": "string",
-                        "description": "* `in_progress` - in_progress\n* `completed` - completed\n* `failed` - failed",
-                        "x-spec-enum-id": "6e9575e5767aaee0"
-                    },
-                    "mock_enabled": {
-                        "type": [
-                            "boolean",
-                            "null"
-                        ]
-                    },
-                    "message": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    },
-                    "error": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    }
-                },
-                "required": [
-                    "error",
-                    "message",
-                    "mock_enabled",
-                    "status"
-                ]
-            },
-            "DisableMockToolsRequest": {
-                "type": "object",
-                "properties": {
-                    "api_key": {
-                        "type": "string",
-                        "description": "Optional API key for the provider. If not provided, will use stored credentials."
-                    }
-                }
-            },
-            "DisableMockToolsResponse": {
-                "type": "object",
-                "properties": {
-                    "progress_id": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "progress_id"
-                ]
-            },
             "DisablePersonalitiesRequest": {
                 "type": "object",
                 "properties": {
@@ -55403,94 +55181,6 @@
                 },
                 "required": [
                     "personalities"
-                ]
-            },
-            "EnableMockErrorResponse": {
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "detail"
-                ]
-            },
-            "EnableMockProgressErrorResponse": {
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "detail"
-                ]
-            },
-            "EnableMockProgressResponse": {
-                "type": "object",
-                "properties": {
-                    "status": {
-                        "enum": [
-                            "in_progress",
-                            "completed",
-                            "failed"
-                        ],
-                        "type": "string",
-                        "description": "* `in_progress` - in_progress\n* `completed` - completed\n* `failed` - failed",
-                        "x-spec-enum-id": "6e9575e5767aaee0"
-                    },
-                    "mock_enabled": {
-                        "type": [
-                            "boolean",
-                            "null"
-                        ]
-                    },
-                    "mcp_endpoints": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/MockMCPEndpoint"
-                        },
-                        "description": "MCP mock endpoints registered for this agent (one per MCP-typed tool). Empty for agents without MCP tools."
-                    },
-                    "message": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    },
-                    "error": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    }
-                },
-                "required": [
-                    "error",
-                    "message",
-                    "mock_enabled",
-                    "status"
-                ]
-            },
-            "EnableMockToolsRequest": {
-                "type": "object",
-                "properties": {
-                    "api_key": {
-                        "type": "string",
-                        "description": "Optional API key. If not provided, uses stored credentials."
-                    }
-                }
-            },
-            "EnableMockToolsResponse": {
-                "type": "object",
-                "properties": {
-                    "progress_id": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "progress_id"
                 ]
             },
             "EnablePersonalitiesRequest": {
@@ -57934,28 +57624,6 @@
                 },
                 "required": [
                     "metric"
-                ]
-            },
-            "MockMCPEndpoint": {
-                "type": "object",
-                "properties": {
-                    "mock_index": {
-                        "type": "integer"
-                    },
-                    "url": {
-                        "type": "string"
-                    },
-                    "tool_names": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "required": [
-                    "mock_index",
-                    "tool_names",
-                    "url"
                 ]
             },
             "MockStatusMCPEndpoint": {
@@ -61756,6 +61424,11 @@
                         "type": "string",
                         "readOnly": true,
                         "default": "Scenario Deleted"
+                    },
+                    "scenario_type": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "Type of the run's scenario (e.g. instruction, conditional_actions), null if the scenario was deleted"
                     },
                     "personality": {
                         "type": [
@@ -65586,6 +65259,11 @@
                         "readOnly": true,
                         "default": "Scenario Deleted"
                     },
+                    "scenario_type": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "Type of the run's scenario (e.g. instruction, conditional_actions), null if the scenario was deleted"
+                    },
                     "personality": {
                         "type": [
                             "integer",
@@ -66123,6 +65801,16 @@
                         },
                         "description": "List of test profile IDs to override for this run. If not provided, uses the scenario's default test profile."
                     },
+                    "mock_tool_names": {
+                        "type": [
+                            "array",
+                            "null"
+                        ],
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Names of mock tools to activate for this run. Omit or pass an empty list to mock every tool configured on the agent."
+                    },
                     "livekit_data": {
                         "allOf": [
                             {
@@ -66240,6 +65928,13 @@
                     },
                     "concurrency_limit": {
                         "type": "integer"
+                    },
+                    "mock_tool_names": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Names of mock tools to activate for this run. Omit or pass an empty list to mock every tool configured on the agent."
                     }
                 },
                 "required": [
@@ -66276,6 +65971,13 @@
                     },
                     "concurrency_limit": {
                         "type": "integer"
+                    },
+                    "mock_tool_names": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Names of mock tools to activate for this run. Omit or pass an empty list to mock every tool configured on the agent."
                     }
                 },
                 "required": [
@@ -66305,6 +66007,16 @@
                         "maximum": 100,
                         "minimum": 1,
                         "description": "Frequency to run"
+                    },
+                    "mock_tool_names": {
+                        "type": [
+                            "array",
+                            "null"
+                        ],
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Names of mock tools to activate for this run. Omit or pass an empty list to mock every tool configured on the agent."
                     }
                 },
                 "required": [
@@ -68992,6 +68704,13 @@
                         "type": "integer",
                         "minimum": 1,
                         "description": "\nCap on the number of evaluator runs executed in parallel. Default: unbounded (subject to your provider's rate limits).\nUse this to avoid hitting provider rate limits on large frequency or folder runs.\nExample: `5`\n"
+                    },
+                    "mock_tool_names": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "\nNames of mock tools to activate for this run. Cekura swaps those tools' URLs to mock endpoints while the\nrun is active and restores the originals when it finishes. Omit or pass an empty list to mock every tool\nconfigured on the agent. Example: `[\"get_appointments\", \"cancel_booking\"]`\n"
                     }
                 }
             },
@@ -69096,6 +68815,13 @@
                         "type": "integer",
                         "minimum": 1,
                         "description": "\nCap on the number of evaluator runs executed in parallel. Default: unbounded (subject to your provider's rate limits).\nUse this to avoid hitting provider rate limits on large frequency or folder runs.\nExample: `5`\n"
+                    },
+                    "mock_tool_names": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "\nNames of mock tools to activate for this run. Cekura swaps those tools' URLs to mock endpoints while the\nrun is active and restores the originals when it finishes. Omit or pass an empty list to mock every tool\nconfigured on the agent. Example: `[\"get_appointments\", \"cancel_booking\"]`\n"
                     },
                     "websocket_url": {
                         "type": "string",
@@ -69205,6 +68931,13 @@
                         "minimum": 1,
                         "description": "\nCap on the number of evaluator runs executed in parallel. Default: unbounded (subject to your provider's rate limits).\nUse this to avoid hitting provider rate limits on large frequency or folder runs.\nExample: `5`\n"
                     },
+                    "mock_tool_names": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "\nNames of mock tools to activate for this run. Cekura swaps those tools' URLs to mock endpoints while the\nrun is active and restores the originals when it finishes. Omit or pass an empty list to mock every tool\nconfigured on the agent. Example: `[\"get_appointments\", \"cancel_booking\"]`\n"
+                    },
                     "elevenlabs_agent_id": {
                         "type": "string",
                         "description": "ElevenLabs agent ID to test against. Overrides the agent's stored assistant_id for this run."
@@ -69233,6 +68966,16 @@
                     "agent": {
                         "type": "integer",
                         "description": "Agent ID to run the scenarios against. If omitted, the agent is derived from the first scenario's configured agent."
+                    },
+                    "mock_tool_names": {
+                        "type": [
+                            "array",
+                            "null"
+                        ],
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Names of mock tools to activate for this run. Omit or pass an empty list to mock every tool configured on the agent."
                     }
                 },
                 "required": [
@@ -69283,6 +69026,16 @@
                             "type": "integer"
                         },
                         "description": "List of test profile IDs to override for this run. If not provided, uses the scenario's default test profile."
+                    },
+                    "mock_tool_names": {
+                        "type": [
+                            "array",
+                            "null"
+                        ],
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Names of mock tools to activate for this run. Omit or pass an empty list to mock every tool configured on the agent."
                     },
                     "personality_id": {
                         "type": [
@@ -69420,6 +69173,13 @@
                         "minimum": 1,
                         "description": "\nCap on the number of evaluator runs executed in parallel. Default: unbounded (subject to your provider's rate limits).\nUse this to avoid hitting provider rate limits on large frequency or folder runs.\nExample: `5`\n"
                     },
+                    "mock_tool_names": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "\nNames of mock tools to activate for this run. Cekura swaps those tools' URLs to mock endpoints while the\nrun is active and restores the originals when it finishes. Omit or pass an empty list to mock every tool\nconfigured on the agent. Example: `[\"get_appointments\", \"cancel_booking\"]`\n"
+                    },
                     "sip_endpoint": {
                         "type": "string",
                         "description": "Override the agent's stored SIP endpoint for this run."
@@ -69512,6 +69272,13 @@
                         "type": "integer",
                         "minimum": 1,
                         "description": "\nCap on the number of evaluator runs executed in parallel. Default: unbounded (subject to your provider's rate limits).\nUse this to avoid hitting provider rate limits on large frequency or folder runs.\nExample: `5`\n"
+                    },
+                    "mock_tool_names": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "\nNames of mock tools to activate for this run. Cekura swaps those tools' URLs to mock endpoints while the\nrun is active and restores the originals when it finishes. Omit or pass an empty list to mock every tool\nconfigured on the agent. Example: `[\"get_appointments\", \"cancel_booking\"]`\n"
                     }
                 }
             },
@@ -71072,28 +70839,6 @@
                 },
                 "required": [
                     "agent"
-                ]
-            },
-            "ToggleMockToolsMCPEndpoint": {
-                "type": "object",
-                "properties": {
-                    "mock_index": {
-                        "type": "integer"
-                    },
-                    "url": {
-                        "type": "string"
-                    },
-                    "tool_names": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "required": [
-                    "mock_index",
-                    "tool_names",
-                    "url"
                 ]
             },
             "TokenRefresh": {


### PR DESCRIPTION
Auto-generated docs sync for backend PR [#10042](https://github.com/cekura-ai/vocera.backend/pull/10042).

Reviewers: @dileep-chagam

## Summary

**Spec/overlay:** Schema-only refresh: scenario write fields adjusted (phone_number removed from writable schema, scenario_language now advertised, inbound_phone_number help_text clarified). 2 mock-tools operations un-exposed (aiagents toggle-mock-tools endpoints). No overlay changes needed — schema updates carry on their own without transport-quirk signals. 2 SDK/CLI removal follow-ups filed.

## Changes

- `openapi.json` — regenerate_from_backend
- `cekura-mcp-server/mcp_tools.json` — patch_json
- `cekura-mcp-server/mcp_tools.json` — patch_json

## SDK / CLI parity follow-ups

- `aiagents_toggle_mock_tools_create` (POST `/test_framework/v2/aiagents/{id}/toggle-mock-tools/`) — remove
- `aiagents_toggle_mock_tools_progress_retrieve` (GET `/test_framework/v2/aiagents/{id}/toggle-mock-tools-progress/`) — remove

## Stale / missing api-reference pages (spec-side)

- Operation `aiagents-toggle-mock-tools-create` removed from spec. If a hand-authored api-reference page exists, consider archiving.
- Operation `aiagents-toggle-mock-tools-progress-retrieve` removed from spec. If a hand-authored api-reference page exists, consider archiving.

---
*Auto-generated from backend PR #10042.*

<!-- mcp-sync:file-hashes -->
```json
{}
```
<!-- /mcp-sync:file-hashes -->