### PR TITLE
Add 'Build a Metric with AI' docs page

### DIFF
--- a/documentation/key-concepts/metrics/build-with-ai.mdx
+++ b/documentation/key-concepts/metrics/build-with-ai.mdx
@@ -1,0 +1,95 @@
+---
+title: "Build a Metric with AI"
+description: "Refine an LLM Judge or Python metric with an AI agent that runs it on your real calls and runs, fixes clear edge cases itself, and asks you only when a decision is genuinely ambiguous"
+sidebarTitle: "Build with AI"
+icon: "wand-magic-sparkles"
+iconType: "solid"
+---
+
+import { CopyPageButton } from "/snippets/copy-page-button.mdx";
+
+<CopyPageButton />
+
+Writing a metric that behaves exactly the way you intend usually takes a few
+rounds of trial and error — write a definition, preview it on some calls,
+notice a case it gets wrong, tighten the wording, repeat. **Build with AI**
+collapses that loop into a single conversation.
+
+When you click **Improve** on a metric's definition, an AI agent:
+
+1. Cleans up your definition and runs it against a sample of the agent's real
+   **calls and runs**.
+2. Reviews the predictions and finds edge cases — early hang-ups, partial
+   completions, off-topic calls, caller-vs-agent fault, voicemail, transfers,
+   and so on.
+3. **Resolves the clear cases itself** by tightening the definition, and asks
+   you a short question only when a verdict depends on a policy it cannot infer
+   (for example, "should a partial completion count as PASS?").
+4. Proposes a refined definition for you to review and apply.
+
+<Note>
+Build with AI works for both **LLM Judge** metrics (it refines the natural-language
+description) and **Python** metrics (it makes surgical edits to your code — see
+below). You commit the final metric yourself; nothing is saved until you click
+**Use this metric** and then **Create**/**Update**.
+</Note>
+
+### Starting a build
+
+<Steps>
+  <Step title="Write a starting point">
+    For an **LLM Judge** metric, write a first-pass description of what success
+    looks like. For a **Python** metric, write your initial evaluation code.
+    You don't need to get it perfect — that's what the builder is for.
+  </Step>
+  <Step title="Click Improve">
+    The **Improve** button sits next to the Description (LLM Judge) or the Custom
+    Code editor (Python). Pick the agent whose calls and runs the builder should
+    sample from.
+  </Step>
+  <Step title="Chat with the builder">
+    The builder works through your calls and runs and either asks a clarifying
+    question or presents a refined definition. Answer questions by selecting an
+    option (the recommended default is marked) or typing your own guidance. You
+    can also message the builder at any time — for example, "make it stricter
+    about confirming the appointment time."
+  </Step>
+  <Step title="Review and apply">
+    When it's done, the builder shows a diff of the proposed definition against
+    your original, plus a short list of the edge cases it handled. Click
+    **Use this metric** to drop the refined definition into the form, then save.
+  </Step>
+</Steps>
+
+### Working in the background
+
+A build runs an AI agent over dozens of real calls and runs, so it typically
+takes **a few minutes** (usually 4–6). You don't have to wait on it:
+
+- **Minimize** the chat and it keeps running as a small card in the corner.
+- The card **follows you across the platform** — open another metric, inspect
+  the example calls the builder linked, or check a run, and the build keeps
+  going.
+- Reopen the card any time to see progress, answer a question, or apply the
+  result.
+
+The card shows the current step and elapsed time so you always know where the
+build is.
+
+### Python metrics
+
+For a Python metric the builder edits **code**, not prose. It runs your code on
+the sampled calls and runs, and when the code has a bug or misses a case it
+makes the smallest change that fixes it — keeping it valid, runnable Python in
+the same style as what you wrote. If your starting code throws an error, the
+builder sees the failure in the results and repairs it rather than giving up.
+
+Everything the builder produces is the exact code the metric will run in
+production, so what you review is what you ship.
+
+## Related Documentation
+
+- [LLM Judge Metric](/documentation/key-concepts/metrics/llm-judge-metric) - Evaluate calls with natural-language criteria
+- [Python Metric](/documentation/key-concepts/metrics/python-metric) - Write custom evaluation logic in Python
+- [Creating Good Metrics](/documentation/guides/creating-good-metric) - A complete guide to building high-fidelity metrics
+- [Metric Variables](/documentation/key-concepts/metrics/metric-variables) - Variables you can use in metric definitions

--- a/documentation/key-concepts/metrics/build-with-ai.mdx
+++ b/documentation/key-concepts/metrics/build-with-ai.mdx
@@ -97,17 +97,18 @@ production, so what you review is what you ship.
 
 ### Credits
 
-A build runs your metric against the sampled calls and runs on every pass. Those
-runs are billed exactly like normal evaluations:
+A build runs your metric against the sampled calls and runs, and consumes credits
+for each pass, priced the same way the metric optimizer is:
 
-- **LLM Judge metrics** (and Python metrics that call `evaluate_llm_judge_metric`)
-  consume credits — roughly the number of sampled items times the LLM-judge
-  per-evaluation rate, on each pass.
-- **Pure Python metrics are free** to build against — running Python over the
-  sample costs nothing.
+- **LLM Judge metrics** — and Python metrics that call `evaluate_llm_judge_metric`
+  — are charged at the **LLM-judge** per-evaluation rate.
+- **Pure Python metrics** are charged at the **custom-code** per-evaluation rate.
 
-Minimizing the chat doesn't stop the build; if you don't want to spend the
-credits, **Stop** it.
+The cost of a pass is roughly the number of sampled items (≈50) times that rate.
+A pass runs only when the metric definition actually changed, so answering a
+clarifying question or sending a note that doesn't alter the metric won't
+re-charge. Minimizing the chat doesn't stop the build; if you don't want to spend
+more credits, **Stop** it.
 
 ## Related Documentation
 

--- a/documentation/key-concepts/metrics/build-with-ai.mdx
+++ b/documentation/key-concepts/metrics/build-with-ai.mdx
@@ -17,15 +17,17 @@ collapses that loop into a single conversation.
 
 When you click **Improve** on a metric's definition, an AI agent:
 
-1. Cleans up your definition and runs it against a sample of the agent's real
-   **calls and runs**.
-2. Reviews the predictions and finds edge cases — early hang-ups, partial
+1. Cleans up your definition and gives it a quick check. If the intent is
+   unclear or the definition has an obvious gap, it asks you a short question
+   **up front** — before spending a run on calls it can't yet judge meaningfully.
+2. Runs the definition against a sample of the agent's real **calls and runs**.
+3. Reviews the predictions and finds edge cases — early hang-ups, partial
    completions, off-topic calls, caller-vs-agent fault, voicemail, transfers,
    and so on.
-3. **Resolves the clear cases itself** by tightening the definition, and asks
+4. **Resolves the clear cases itself** by tightening the definition, and asks
    you a short question only when a verdict depends on a policy it cannot infer
    (for example, "should a partial completion count as PASS?").
-4. Proposes a refined definition for you to review and apply.
+5. Proposes a refined definition for you to review and apply.
 
 <Note>
 Build with AI works for both **LLM Judge** metrics (it refines the natural-language

--- a/documentation/key-concepts/metrics/build-with-ai.mdx
+++ b/documentation/key-concepts/metrics/build-with-ai.mdx
@@ -97,10 +97,17 @@ production, so what you review is what you ship.
 
 ### Credits
 
-A build runs your metric against the sampled calls and runs on every pass, and —
-like any evaluation — those runs consume credits (roughly the number of sampled
-items times the metric's per-evaluation rate, on each pass). Minimizing the chat
-stops nothing; if you don't want to spend the credits, **Stop** the build.
+A build runs your metric against the sampled calls and runs on every pass. Those
+runs are billed exactly like normal evaluations:
+
+- **LLM Judge metrics** (and Python metrics that call `evaluate_llm_judge_metric`)
+  consume credits — roughly the number of sampled items times the LLM-judge
+  per-evaluation rate, on each pass.
+- **Pure Python metrics are free** to build against — running Python over the
+  sample costs nothing.
+
+Minimizing the chat doesn't stop the build; if you don't want to spend the
+credits, **Stop** it.
 
 ## Related Documentation
 

--- a/documentation/key-concepts/metrics/build-with-ai.mdx
+++ b/documentation/key-concepts/metrics/build-with-ai.mdx
@@ -102,6 +102,10 @@ for each pass, priced the same way the metric optimizer is:
 
 - **LLM Judge metrics** — and Python metrics that call `evaluate_llm_judge_metric`
   — are charged at the **LLM-judge** per-evaluation rate.
+- **Python metrics that judge audio** (calling `evaluate_llm_judge_metric` with
+  `audio=True`) are charged at the **audio** per-minute rate times each call's
+  duration. A time window (`audio_start_time`/`audio_end_time`) changes what the
+  judge listens to, not the charge.
 - **Pure Python metrics** are charged at the **custom-code** per-evaluation rate.
 
 The cost of a pass is roughly the number of sampled items (≈50) times that rate.

--- a/documentation/key-concepts/metrics/build-with-ai.mdx
+++ b/documentation/key-concepts/metrics/build-with-ai.mdx
@@ -78,14 +78,29 @@ build is.
 
 ### Python metrics
 
-For a Python metric the builder edits **code**, not prose. It runs your code on
-the sampled calls and runs, and when the code has a bug or misses a case it
-makes the smallest change that fixes it — keeping it valid, runnable Python in
-the same style as what you wrote. If your starting code throws an error, the
-builder sees the failure in the results and repairs it rather than giving up.
+For a Python metric the builder works in **code**. Before it runs anything, it
+cleans up your starting point — fixing syntax errors and obvious bugs — so a
+rough first draft doesn't stall the build. From there it runs your code on the
+sampled calls and runs and makes the smallest change that fixes each case it
+gets wrong, keeping it valid, runnable Python in the same style as what you
+wrote.
+
+<Tip>
+You don't have to start from code. Describe the metric in **plain English** in
+the Python editor and the builder turns it into a working Python metric on the
+first pass — then refines it against your real calls and runs like any other
+build.
+</Tip>
 
 Everything the builder produces is the exact code the metric will run in
 production, so what you review is what you ship.
+
+### Credits
+
+A build runs your metric against the sampled calls and runs on every pass, and —
+like any evaluation — those runs consume credits (roughly the number of sampled
+items times the metric's per-evaluation rate, on each pass). Minimizing the chat
+stops nothing; if you don't want to spend the credits, **Stop** the build.
 
 ## Related Documentation
 

--- a/documentation/key-concepts/metrics/llm-judge-metric.mdx
+++ b/documentation/key-concepts/metrics/llm-judge-metric.mdx
@@ -109,6 +109,7 @@ See [Python Metric — Audio-Based Analysis](/documentation/key-concepts/metrics
 
 ## Related Documentation
 
+- [Build a Metric with AI](/documentation/key-concepts/metrics/build-with-ai) - Refine this description with an AI agent that runs it on your real calls and runs
 - [Metric Variables](/documentation/key-concepts/metrics/metric-variables) - Variables you can use in metric descriptions
 - [Creating Good Metrics](/documentation/guides/creating-good-metric) - Complete guide for building high-fidelity metrics
 - [Python Metric](/documentation/key-concepts/metrics/python-metric) - Write custom evaluation logic in Python, including audio-based evaluation

--- a/documentation/key-concepts/metrics/python-metric.mdx
+++ b/documentation/key-concepts/metrics/python-metric.mdx
@@ -23,6 +23,12 @@ The set of variables available in Python metrics (the `data` dict keys) is the s
 
 Custom code metrics are executed in a secure Python environment with access to call data including transcripts, metadata, and dynamic variables. Your code must set specific output variables to provide the evaluation result and explanation.
 
+<Tip>
+Once you've written a first pass, the **Improve** button runs your code on real
+calls and runs and makes surgical fixes for the cases it gets wrong — including
+repairing code that errors out. See [Build a Metric with AI](/documentation/key-concepts/metrics/build-with-ai).
+</Tip>
+
 **Cost:** Python metrics do not consume credits. Unlike LLM judge or predefined metrics (which cost 0.2 credits per evaluation), Python metrics run free of charge regardless of evaluation volume.
 
 ### Available Data Variables

--- a/mint.json
+++ b/mint.json
@@ -97,6 +97,7 @@
             "documentation/key-concepts/metrics/pre-defined-metrics",
             "documentation/key-concepts/metrics/output-types-of-metric",
             "documentation/key-concepts/metrics/llm-judge-metric",
+            "documentation/key-concepts/metrics/build-with-ai",
             "documentation/key-concepts/metrics/metric-variables",
             "documentation/key-concepts/metrics/python-metric",
             "documentation/key-concepts/metrics/rubric",


### PR DESCRIPTION
Documents the metric-builder (Improve button) flow now shipping in the dashboard.

- New page **Build a Metric with AI** under Key Concepts → Metrics: what the Improve button does (runs the metric on real calls & runs, resolves clear edge cases itself, asks only on genuine ambiguity, proposes a refined definition to review + apply).
- Covers both **LLM Judge** and **Python** metrics, the **minimize / run-in-background** behaviour (the build follows you across the platform), and code repair for Python metrics.
- Wired into the metrics nav; cross-linked from the LLM Judge and Python metric pages.

Pairs with backend #10027 and frontend #3259.