### PR TITLE
feat(mcp): call-time skill gate (off→shadow→warn→enforce) + load_skill + activation

### DIFF
--- a/cekura-mcp-server/ack_tags.snapshot.json
+++ b/cekura-mcp-server/ack_tags.snapshot.json
@@ -1,0 +1,14 @@
+{
+  "_comment": "Offline fallback snapshot of cekura-skills/cekura/ack-tags.json. The server prefers the live copy at startup and only uses this when that fetch fails. Append-only; keep in sync with the source manifest on plugin releases.",
+  "cekura-eval-design": ["ack:cekura-eval-design:7k3m4q"],
+  "cekura-generate-scenarios": ["ack:cekura-generate-scenarios:4b6t2w"],
+  "cekura-self-improving-agent": ["ack:cekura-self-improving-agent:5x7n3d"],
+  "cekura-infra-test-suite": ["ack:cekura-infra-test-suite:2h6r7k"],
+  "manual-create-update-eval": ["ack:manual-create-update-eval:5m4p7c"],
+  "autogen-eval": ["ack:autogen-eval:3w6k5b"],
+  "cekura-metric-design": ["ack:cekura-metric-design:6n2q5r"],
+  "cekura-metric-improvement": ["ack:cekura-metric-improvement:6t4d5m"],
+  "cekura-predefined-metrics": ["ack:cekura-predefined-metrics:2k7b3x"],
+  "create-metric": ["ack:create-metric:5p4w7h"],
+  "improve-metric": ["ack:improve-metric:4r6m2t"]
+}

--- a/cekura-mcp-server/config.py
+++ b/cekura-mcp-server/config.py
@@ -10,6 +10,12 @@ load_dotenv()
 # Each has a dedicated opt-in env flag so ops teams can enable them explicitly.
 DEFAULT_DANGEROUS_TOOLS: Set[str] = {"projects_destroy"}
 
+# Skill-gate rollout ladder. `off` ships inert (no schema change, no evaluation).
+# `shadow` logs would-block volume; `warn` appends a nudge but still proceeds;
+# `enforce` HOLDS a gated write with no valid ack (deny + ask-the-user recovery).
+# `strict` currently uses `enforce` behavior (tag-redaction hardening deferred).
+VALID_SKILL_GATE_MODES = ("off", "shadow", "warn", "enforce", "strict")
+
 
 class MCPServerConfig(BaseModel):
     base_url: str = Field(default_factory=lambda: os.getenv("CEKURA_BASE_URL", "https://api.cekura.ai"))
@@ -18,6 +24,7 @@ class MCPServerConfig(BaseModel):
     expose_project_destroy: bool = Field(default_factory=lambda: _parse_bool_env("CEKURA_EXPOSE_PROJECT_DESTROY", False))
     blocked_tools: List[str] = Field(default_factory=lambda: _parse_list_env("CEKURA_BLOCKED_TOOLS") or [])
     max_examples_per_tool: int = Field(default_factory=lambda: _parse_int_env("CEKURA_MAX_EXAMPLES_PER_TOOL") or 2)
+    skill_gate_mode: str = Field(default_factory=lambda: _parse_gate_mode_env())
 
     def resolve_blocked_tools(self) -> Set[str]:
         """Final set of tool names to suppress at registration."""
@@ -63,6 +70,12 @@ def _parse_bool_env(key: str, default: bool = False) -> bool:
     if value is None:
         return default
     return value.strip().lower() in ("1", "true", "yes", "on")
+
+
+def _parse_gate_mode_env() -> str:
+    """Resolve CEKURA_SKILL_GATE_MODE; unknown/absent values fall back to `off`."""
+    raw = (os.getenv("CEKURA_SKILL_GATE_MODE") or "off").strip().lower()
+    return raw if raw in VALID_SKILL_GATE_MODES else "off"
 
 
 def load_config() -> MCPServerConfig:

--- a/cekura-mcp-server/http_client.py
+++ b/cekura-mcp-server/http_client.py
@@ -3,6 +3,39 @@ from typing import Dict, Any, Optional
 import json
 
 
+def build_mcp_headers(
+    credential: str,
+    credential_type: str = "api_key",
+    mcp_call_id: Optional[str] = None,
+    mcp_client_id: Optional[str] = None,
+    mcp_tool: Optional[str] = None,
+    mcp_skill: Optional[str] = None,
+    conversation_id: Optional[str] = None,
+) -> Dict[str, str]:
+    """Standard header set for any request the MCP server makes to the Cekura
+    API: the credential header for the given type, the client-source marker,
+    and the X-MCP-* telemetry headers the analytics pipeline reads. Single home
+    for this composition — used by both the API client and one-off posts."""
+    headers = {
+        "Content-Type": "application/json",
+        "X-Client-Source": "mcp",
+    }
+    if credential_type == "bearer":
+        headers["Authorization"] = f"Bearer {credential}"
+    else:
+        headers["X-CEKURA-API-KEY"] = credential
+    for name, value in (
+        ("X-MCP-Call-Id", mcp_call_id),
+        ("X-MCP-Client", mcp_client_id),
+        ("X-MCP-Tool", mcp_tool),
+        ("X-MCP-Skill", mcp_skill),
+        ("X-Cekura-Conversation-Id", conversation_id),
+    ):
+        if value:
+            headers[name] = value
+    return headers
+
+
 class CekuraAPIClient:
     def __init__(
         self,
@@ -18,29 +51,16 @@ class CekuraAPIClient:
     ):
         self.base_url = base_url
         self.credential_type = credential_type
-        auth_header = (
-            {"Authorization": f"Bearer {credential}"}
-            if credential_type == "bearer"
-            else {"X-CEKURA-API-KEY": credential}
-        )
-        telemetry_headers = {
-            name: value
-            for name, value in (
-                ("X-MCP-Call-Id", mcp_call_id),
-                ("X-MCP-Client", mcp_client_id),
-                ("X-MCP-Tool", mcp_tool),
-                ("X-MCP-Skill", mcp_skill),
-                ("X-Cekura-Conversation-Id", conversation_id),
-            )
-            if value
-        }
         self.client = httpx.AsyncClient(
-            headers={
-                **auth_header,
-                "Content-Type": "application/json",
-                "X-Client-Source": "mcp",
-                **telemetry_headers,
-            },
+            headers=build_mcp_headers(
+                credential,
+                credential_type,
+                mcp_call_id=mcp_call_id,
+                mcp_client_id=mcp_client_id,
+                mcp_tool=mcp_tool,
+                mcp_skill=mcp_skill,
+                conversation_id=conversation_id,
+            ),
             timeout=timeout,
         )
 

--- a/cekura-mcp-server/http_client.py
+++ b/cekura-mcp-server/http_client.py
@@ -14,8 +14,8 @@ def build_mcp_headers(
 ) -> Dict[str, str]:
     """Standard header set for any request the MCP server makes to the Cekura
     API: the credential header for the given type, the client-source marker,
-    and the X-MCP-* telemetry headers the analytics pipeline reads. Single home
-    for this composition — used by both the API client and one-off posts."""
+    and the X-MCP-* telemetry headers. Single home for this composition — used
+    by both the API client and one-off posts."""
     headers = {
         "Content-Type": "application/json",
         "X-Client-Source": "mcp",

--- a/cekura-mcp-server/openapi_mcp_server.py
+++ b/cekura-mcp-server/openapi_mcp_server.py
@@ -755,9 +755,7 @@ async def cekura_skill_started(
         tag = skill_gate.current_tag_for_slug(skill_name)
         if tag:
             response["skill_ack"] = tag
-            response["skill_ack_hint"] = (
-                "Pass this value as `skill_ack` on gated authoring calls in this session."
-            )
+            response["skill_ack_hint"] = skill_gate.ack_hint_for_slug(skill_name)
             logger.info(json.dumps({
                 "event": "legacy_beacon", "skill": skill_name, "event_id": event_id,
             }))
@@ -857,8 +855,7 @@ async def cekura_load_skill(skill_name: str) -> Dict[str, Any]:
         "source": source,
         "verification_tag": tag,
         "skill_ack_hint": (
-            "Pass verification_tag as `skill_ack` on gated authoring calls."
-            if tag else None
+            skill_gate.ack_hint_for_slug(slug, subject="verification_tag") if tag else None
         ),
         "playbook": content,
     }

--- a/cekura-mcp-server/openapi_mcp_server.py
+++ b/cekura-mcp-server/openapi_mcp_server.py
@@ -624,7 +624,7 @@ def _is_older_version(reported: str, latest: str) -> bool:
 
 
 def _latest_plugin_version() -> str:
-    return os.environ.get("CEKURA_LATEST_PLUGIN_VERSION", "0.8.1")
+    return os.environ.get("CEKURA_LATEST_PLUGIN_VERSION", "0.9.0")
 
 
 def _update_command_for_client() -> str:

--- a/cekura-mcp-server/openapi_mcp_server.py
+++ b/cekura-mcp-server/openapi_mcp_server.py
@@ -25,6 +25,7 @@ if os.getenv("AWS_SECRET_NAME"):
     _config = json.loads(_secret_value["SecretString"])
     os.environ.update({key: str(value) for key, value in _config.items()})
 
+import skill_gate
 from config import load_config
 from http_client import create_client
 from openapi_parser import load_openapi_spec
@@ -212,6 +213,9 @@ async def initialize_server():
                 tool_description = maybe_append_org_project_hint(tool_name, input_schema, tool_description)
                 tool_description = apply_overlay_to_description(tool_name, tool_description)
                 input_schema = apply_overlay_to_schema(tool_name, input_schema)
+                input_schema = skill_gate.maybe_inject_skill_ack(
+                    tool_name, input_schema, server_config.skill_gate_mode
+                )
 
                 annotations = compute_annotations(operation)
                 register_tool(tool_name, tool_description, input_schema, operation, annotations=annotations)
@@ -250,6 +254,26 @@ async def initialize_server():
         # Register Mintlify documentation search tool
         register_mintlify_search_tool()
         logger.info("Registered Mintlify documentation search tool")
+
+        # Load the skill-gate tag manifest (remote with baked fallback) and
+        # report the active mode. `off` is inert; enforce/strict behave as warn.
+        gate_mode = server_config.skill_gate_mode
+        manifest_source = await skill_gate.load_manifest()
+        logger.info(
+            f"Skill gate: mode={gate_mode}, manifest_source={manifest_source}, "
+            f"slugs={len(skill_gate.get_manifest())}"
+        )
+        if gate_mode in ("enforce", "strict"):
+            logger.warning(
+                f"Skill gate mode '{gate_mode}' HOLDS gated writes that lack a valid "
+                "skill_ack (deny + ask-the-user recovery). Flip only after shadow shows "
+                "installed traffic reliably threads the ack."
+            )
+        if gate_mode == "strict":
+            logger.warning(
+                "Skill gate 'strict' currently uses 'enforce' behavior; strict-specific "
+                "hardening (tag redaction) is deferred."
+            )
 
         setup_dynamic_tool_handlers()
 
@@ -569,6 +593,87 @@ async def cekura_report_issue(
 # -- Skill activation beacon -------------------------------------------------
 
 
+def _parse_version(v: Any) -> Tuple[int, ...]:
+    parts: List[int] = []
+    for chunk in str(v).split("."):
+        digits = "".join(ch for ch in chunk if ch.isdigit())
+        parts.append(int(digits) if digits else 0)
+    return tuple(parts)
+
+
+def _is_older_version(reported: str, latest: str) -> bool:
+    try:
+        return _parse_version(reported) < _parse_version(latest)
+    except Exception:
+        return False
+
+
+def _latest_plugin_version() -> str:
+    return os.environ.get("CEKURA_LATEST_PLUGIN_VERSION", "0.8.1")
+
+
+def _update_command_for_client() -> str:
+    # Match the documented update paths (mcp/skills.mdx). Only Claude Code has a
+    # first-class slash command; everyone else is routed to the docs update
+    # section, which carries the per-client (npx / marketplace) instructions.
+    client = (_resolve_client_identifier() or "").lower()
+    if "claude" in client:
+        return "run /upgrade-skills (docs: https://docs.cekura.ai/mcp/skills#update)"
+    return "https://docs.cekura.ai/mcp/skills#update"
+
+
+async def _forward_skill_activation(
+    event: str,
+    skill_slug: str,
+    verification_tag: Optional[str],
+    plugin_version: Optional[str],
+    skill_version: Optional[str],
+    client_id: Optional[str],
+) -> None:
+    """Best-effort, fire-and-forget activation report so skill usage can be joined
+    to the canonical principal backend-side. Never raises; never blocks a write."""
+    try:
+        credential, credential_type = get_request_credential()
+    except ValueError:
+        return
+    base_url = request_base_url.get() or (server_config.base_url if server_config else None)
+    if not base_url:
+        return
+
+    headers = {
+        "Content-Type": "application/json",
+        "X-MCP-Call-Id": f"call_{uuid.uuid4().hex[:16]}",
+    }
+    if credential_type == "bearer":
+        headers["Authorization"] = f"Bearer {credential}"
+    else:
+        headers["X-CEKURA-API-KEY"] = credential
+    skill_header = skill_slug or ""
+    if plugin_version:
+        skill_header = f"{skill_header}@{plugin_version}"
+    if verification_tag:
+        skill_header = f"{skill_header}#{verification_tag}"
+    if skill_header:
+        headers["X-MCP-Skill"] = skill_header
+    if client_id:
+        headers["X-MCP-Client"] = client_id
+
+    body: Dict[str, Any] = {"event": event, "skill_slug": skill_slug}
+    if verification_tag:
+        body["verification_tag"] = verification_tag
+    if plugin_version:
+        body["plugin_version"] = plugin_version
+    if skill_version:
+        body["skill_version"] = skill_version
+
+    url = f"{base_url}/observability/v1/mcp-skill-activations/"
+    try:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(1.5, connect=1.0)) as client:
+            await client.post(url, headers=headers, json=body)
+    except Exception:
+        pass
+
+
 @mcp.tool(
     name="cekura_skill_started",
     description=(
@@ -578,7 +683,11 @@ async def cekura_report_issue(
         "  skill_name: the slug of the skill — e.g. \"autogen-eval\".\n"
         "  triggering_intent: optional one-sentence description of what the "
         "user wanted that led you to pick this skill.\n"
-        "  conversation_id: optional Cekura sandbox / chat conversation ID."
+        "  conversation_id: optional Cekura sandbox / chat conversation ID.\n"
+        "  verification_tag: optional tag carried in the skill/command (the value "
+        "to thread as `skill_ack` on gated authoring calls).\n"
+        "  plugin_version: optional installed Cekura plugin version (e.g. \"0.8.1\").\n"
+        "  skill_version: optional per-skill version if the skill declares one."
     ),
     annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, openWorldHint=False),
 )
@@ -586,10 +695,14 @@ async def cekura_skill_started(
     skill_name: str,
     triggering_intent: Optional[str] = None,
     conversation_id: Optional[str] = None,
+    verification_tag: Optional[str] = None,
+    plugin_version: Optional[str] = None,
+    skill_version: Optional[str] = None,
 ) -> Dict[str, Any]:
     cred_hash = _credential_fingerprint()
     intent_redacted = (_redact_pii(triggering_intent) or "")[:200] or None
     event_id = f"skill_{uuid.uuid4().hex[:12]}"
+    client_id = _resolve_client_identifier()
 
     logger.info(json.dumps({
         "event": "skill_started",
@@ -597,11 +710,132 @@ async def cekura_skill_started(
         "skill": skill_name,
         "triggering_intent": intent_redacted,
         "conversation_id": conversation_id,
-        "client_id": _resolve_client_identifier(),
+        "verification_tag": verification_tag,
+        "plugin_version": plugin_version,
+        "skill_version": skill_version,
+        "client_id": client_id,
         "cred_hash": cred_hash,
     }))
 
-    return {"status": "ok", "event_id": event_id}
+    response: Dict[str, Any] = {"status": "ok", "event_id": event_id}
+
+    # `off` keeps the beacon exactly as before: log-only, instant, same contract.
+    gate_mode = server_config.skill_gate_mode if server_config else "off"
+    if gate_mode == "off":
+        return response
+
+    await _forward_skill_activation(
+        "skill_started", skill_name, verification_tag, plugin_version, skill_version, client_id
+    )
+
+    # Migration grace: a recognised skill/command that reported no tag (an older
+    # installed version) is handed the current tag so it can still thread an ack.
+    if not verification_tag:
+        tag = skill_gate.current_tag_for_slug(skill_name)
+        if tag:
+            response["skill_ack"] = tag
+            response["skill_ack_hint"] = (
+                "Pass this value as `skill_ack` on gated authoring calls in this session."
+            )
+            logger.info(json.dumps({
+                "event": "legacy_beacon", "skill": skill_name, "event_id": event_id,
+            }))
+            # No tag AND no version is the pre-tagging signature — recommend an
+            # update (informational; the grace tag above already unblocks them).
+            if not plugin_version:
+                response["update_recommended"] = True
+                response["update_hint"] = (
+                    "Your Cekura skills look outdated (no verification tag). Update them "
+                    f"for the best experience: {_update_command_for_client()}."
+                )
+
+    # Freshness nudge — recommendation only, never blocks anything.
+    latest = _latest_plugin_version()
+    if plugin_version and latest and _is_older_version(plugin_version, latest):
+        response["status"] = "update_available"
+        response["current_version"] = plugin_version
+        response["latest_version"] = latest
+        response["update_command"] = _update_command_for_client()
+        response["docs_url"] = "https://docs.cekura.ai/mcp/overview"
+
+    return response
+
+
+# -- Server-delivered skill playbooks ----------------------------------------
+
+_LOADABLE_SKILLS = [
+    "cekura-eval-design",
+    "cekura-generate-scenarios",
+    "cekura-self-improving-agent",
+    "cekura-infra-test-suite",
+    "cekura-metric-design",
+    "cekura-metric-improvement",
+    "cekura-predefined-metrics",
+]
+
+_SKILL_RAW_BASE = os.environ.get(
+    "CEKURA_SKILL_RAW_BASE",
+    "https://raw.githubusercontent.com/cekura-ai/cekura-skills/main/cekura/skills",
+)
+_SKILL_CONTENT_TTL_SECONDS = 900
+_skill_content_cache: Dict[str, Tuple[float, str]] = {}
+
+
+async def _fetch_skill_content(slug: str) -> Tuple[str, str]:
+    """Return (playbook_text, source). Fetches the public SKILL.md with a short
+    in-process cache; on any failure returns a graceful pointer to the docs."""
+    now = time.time()
+    cached = _skill_content_cache.get(slug)
+    if cached and now - cached[0] < _SKILL_CONTENT_TTL_SECONDS:
+        return cached[1], "cache"
+    url = f"{_SKILL_RAW_BASE}/{slug}/SKILL.md"
+    try:
+        async with httpx.AsyncClient(
+            timeout=httpx.Timeout(8.0, connect=3.0), follow_redirects=True
+        ) as client:
+            resp = await client.get(url)
+            resp.raise_for_status()
+            content = resp.text
+            _skill_content_cache[slug] = (now, content)
+            return content, "remote"
+    except Exception as e:
+        logger.warning("load_skill: fetch failed for %s: %s", slug, e)
+        return (
+            f"The {slug} playbook could not be fetched right now. For the full, "
+            "always-current guidance install the Cekura plugin/skills: "
+            "https://docs.cekura.ai/mcp/overview",
+            "unavailable",
+        )
+
+
+@mcp.tool(
+    name="cekura_load_skill",
+    description=(
+        "Load a Cekura design playbook into context when the plugin/skills are "
+        "not installed. Returns the skill's guidance plus a verification tag to "
+        "thread as `skill_ack` on gated authoring calls. Prefer this BEFORE "
+        "authoring scenarios, test profiles, or metrics.\n\n"
+        "skill_name must be one of: " + ", ".join(_LOADABLE_SKILLS) + "."
+    ),
+    annotations=ToolAnnotations(readOnlyHint=True),
+)
+async def cekura_load_skill(skill_name: str) -> Dict[str, Any]:
+    slug = (skill_name or "").strip()
+    if slug not in _LOADABLE_SKILLS:
+        return {"status": "unknown_skill", "available": _LOADABLE_SKILLS}
+    content, source = await _fetch_skill_content(slug)
+    tag = skill_gate.current_tag_for_slug(slug)
+    return {
+        "status": "ok",
+        "skill": slug,
+        "source": source,
+        "verification_tag": tag,
+        "skill_ack_hint": (
+            "Pass verification_tag as `skill_ack` on gated authoring calls."
+            if tag else None
+        ),
+        "playbook": content,
+    }
 
 
 def _claude_jsonl_to_cekura_transcript(jsonl_text: str) -> List[Dict[str, object]]:
@@ -891,6 +1125,81 @@ def setup_dynamic_tool_handlers():
         telemetry = _resolve_telemetry()
         mcp_call_id = telemetry["call_id"]
         call_id_suffix = f"\n\n[cekura_mcp_call_id: {mcp_call_id}]"
+
+        # Strip the optional skill-gate ack from tool args up front so it never
+        # reaches the backend (request body stays byte-identical to today). This
+        # happens in EVERY mode, including `off`.
+        skill_ack = None
+        if arguments and "skill_ack" in arguments:
+            skill_ack = arguments.pop("skill_ack")
+
+        gate_nudge = None
+        gate_mode = server_config.skill_gate_mode if server_config else "off"
+        if gate_mode != "off" and name in skill_gate.GATED_TOOLS:
+            # Quality gate. Fails open on any error (a write is never lost to a
+            # gate bug). Only `enforce`/`strict` hold the write (action=deny).
+            try:
+                decision = skill_gate.evaluate(
+                    name, skill_ack, gate_mode,
+                    is_sandbox=bool(telemetry["conversation_id"]),
+                )
+                if decision.action == "deny":
+                    logger.info(json.dumps({
+                        "event": "skill_gate_blocked",
+                        "mode": gate_mode,
+                        "tool": name,
+                        "family": decision.family,
+                        "ack_present": decision.ack_present,
+                        "blocked": True,
+                        "client_id": telemetry["client_id"],
+                        "cred_hash": _credential_fingerprint(),
+                        "call_id": mcp_call_id,
+                    }))
+                    # Write withheld; hand the model the ask-the-user recovery.
+                    return [{"type": "text", "text": f"{decision.nudge}{call_id_suffix}"}]
+                if decision.action in ("shadow_block", "warn"):
+                    logger.info(json.dumps({
+                        "event": "skill_gate_blocked",
+                        "mode": gate_mode,
+                        "tool": name,
+                        "family": decision.family,
+                        "ack_present": decision.ack_present,
+                        "blocked": False,
+                        "client_id": telemetry["client_id"],
+                        "cred_hash": _credential_fingerprint(),
+                        "call_id": mcp_call_id,
+                    }))
+                    if decision.action == "warn":
+                        gate_nudge = decision.nudge
+                elif decision.reason == "user_override":
+                    logger.info(json.dumps({
+                        "event": "skill_gate_user_override",
+                        "mode": gate_mode,
+                        "tool": name,
+                        "family": decision.family,
+                        "client_id": telemetry["client_id"],
+                        "cred_hash": _credential_fingerprint(),
+                        "call_id": mcp_call_id,
+                    }))
+                elif decision.ack_valid:
+                    # Thread-rate signal: a gated write carried a valid ack.
+                    logger.info(json.dumps({
+                        "event": "skill_gate_ack_ok",
+                        "mode": gate_mode,
+                        "tool": name,
+                        "family": decision.family,
+                        "call_id": mcp_call_id,
+                    }))
+                elif decision.reason == "sandbox_bypass":
+                    logger.info(json.dumps({
+                        "event": "skill_gate_sandbox_bypass",
+                        "tool": name,
+                        "family": decision.family,
+                        "call_id": mcp_call_id,
+                    }))
+            except Exception:
+                logger.exception("skill_gate_error tool=%s (failing open)", name)
+
         try:
             tool_data = operations_registry[name]
 
@@ -937,7 +1246,8 @@ def setup_dynamic_tool_handlers():
                 await user_api_client.close()
 
             text = json.dumps(result, default=str, ensure_ascii=False)
-            return [{"type": "text", "text": f"{text}{call_id_suffix}"}]
+            nudge = gate_nudge or ""
+            return [{"type": "text", "text": f"{text}{nudge}{call_id_suffix}"}]
 
         except ValueError as e:
             return [{"type": "text", "text": f"Authentication Error: {e}{call_id_suffix}"}]

--- a/cekura-mcp-server/openapi_mcp_server.py
+++ b/cekura-mcp-server/openapi_mcp_server.py
@@ -263,6 +263,12 @@ async def initialize_server():
             f"Skill gate: mode={gate_mode}, manifest_source={manifest_source}, "
             f"slugs={len(skill_gate.get_manifest())}"
         )
+        if gate_mode != "off" and manifest_source != "remote":
+            logger.warning(
+                f"Skill gate is '{gate_mode}' but the tag manifest came from "
+                f"'{manifest_source}' — tags added after this build won't be "
+                "recognized until connectivity to the manifest URL is restored."
+            )
         if gate_mode in ("enforce", "strict"):
             logger.warning(
                 f"Skill gate mode '{gate_mode}' HOLDS gated writes that lack a valid "
@@ -452,6 +458,15 @@ def _redact_pii(text: Optional[str]) -> Optional[str]:
     for pattern, replacement in _PII_PATTERNS:
         redacted = pattern.sub(replacement, redacted)
     return redacted
+
+
+def _clip(value: Any, limit: int) -> Optional[str]:
+    """Bound a caller-supplied identifier for logs and header composition:
+    collapse control whitespace, trim, cap the length. None when empty."""
+    if not isinstance(value, str):
+        return None
+    cleaned = re.sub(r"[\r\n\t]+", " ", value).strip()
+    return cleaned[:limit] or None
 
 
 def _credential_fingerprint() -> str:
@@ -650,6 +665,10 @@ async def _forward_skill_activation(
         credential_type,
         mcp_call_id=f"call_{uuid.uuid4().hex[:16]}",
         mcp_client_id=client_id,
+        mcp_tool={
+            "skill_started": "cekura_skill_started",
+            "load_skill": "cekura_load_skill",
+        }.get(event),
         mcp_skill=skill_header or None,
     )
 
@@ -673,7 +692,7 @@ async def _forward_skill_activation(
     name="cekura_skill_started",
     description=(
         "Call this as the FIRST action of any Cekura skill or command. Lets us "
-        "know which skills are actually being used. Returns immediately.\n\n"
+        "know which skills are actually being used. Returns quickly.\n\n"
         "Args:\n"
         "  skill_name: the slug of the skill — e.g. \"autogen-eval\".\n"
         "  triggering_intent: optional one-sentence description of what the "
@@ -694,6 +713,13 @@ async def cekura_skill_started(
     plugin_version: Optional[str] = None,
     skill_version: Optional[str] = None,
 ) -> Dict[str, Any]:
+    # Bound caller-supplied identifiers before they reach logs or the
+    # X-MCP-Skill header composition.
+    skill_name = _clip(skill_name, 80) or ""
+    verification_tag = _clip(verification_tag, 120)
+    plugin_version = _clip(plugin_version, 40)
+    skill_version = _clip(skill_version, 40)
+
     cred_hash = _credential_fingerprint()
     intent_redacted = (_redact_pii(triggering_intent) or "")[:200] or None
     event_id = f"skill_{uuid.uuid4().hex[:12]}"

--- a/cekura-mcp-server/openapi_mcp_server.py
+++ b/cekura-mcp-server/openapi_mcp_server.py
@@ -27,7 +27,7 @@ if os.getenv("AWS_SECRET_NAME"):
 
 import skill_gate
 from config import load_config
-from http_client import create_client
+from http_client import build_mcp_headers, create_client
 from openapi_parser import load_openapi_spec
 from tool_generator import (
     apply_overlay_to_description,
@@ -640,23 +640,18 @@ async def _forward_skill_activation(
     if not base_url:
         return
 
-    headers = {
-        "Content-Type": "application/json",
-        "X-MCP-Call-Id": f"call_{uuid.uuid4().hex[:16]}",
-    }
-    if credential_type == "bearer":
-        headers["Authorization"] = f"Bearer {credential}"
-    else:
-        headers["X-CEKURA-API-KEY"] = credential
     skill_header = skill_slug or ""
     if plugin_version:
         skill_header = f"{skill_header}@{plugin_version}"
     if verification_tag:
         skill_header = f"{skill_header}#{verification_tag}"
-    if skill_header:
-        headers["X-MCP-Skill"] = skill_header
-    if client_id:
-        headers["X-MCP-Client"] = client_id
+    headers = build_mcp_headers(
+        credential,
+        credential_type,
+        mcp_call_id=f"call_{uuid.uuid4().hex[:16]}",
+        mcp_client_id=client_id,
+        mcp_skill=skill_header or None,
+    )
 
     body: Dict[str, Any] = {"event": event, "skill_slug": skill_slug}
     if verification_tag:
@@ -763,16 +758,6 @@ async def cekura_skill_started(
 
 # -- Server-delivered skill playbooks ----------------------------------------
 
-_LOADABLE_SKILLS = [
-    "cekura-eval-design",
-    "cekura-generate-scenarios",
-    "cekura-self-improving-agent",
-    "cekura-infra-test-suite",
-    "cekura-metric-design",
-    "cekura-metric-improvement",
-    "cekura-predefined-metrics",
-]
-
 _SKILL_RAW_BASE = os.environ.get(
     "CEKURA_SKILL_RAW_BASE",
     "https://raw.githubusercontent.com/cekura-ai/cekura-skills/main/cekura/skills",
@@ -815,16 +800,31 @@ async def _fetch_skill_content(slug: str) -> Tuple[str, str]:
         "not installed. Returns the skill's guidance plus a verification tag to "
         "thread as `skill_ack` on gated authoring calls. Prefer this BEFORE "
         "authoring scenarios, test profiles, or metrics.\n\n"
-        "skill_name must be one of: " + ", ".join(_LOADABLE_SKILLS) + "."
+        "skill_name must be one of: " + ", ".join(skill_gate.LOADABLE_SKILLS) + "."
     ),
     annotations=ToolAnnotations(readOnlyHint=True),
 )
 async def cekura_load_skill(skill_name: str) -> Dict[str, Any]:
     slug = (skill_name or "").strip()
-    if slug not in _LOADABLE_SKILLS:
-        return {"status": "unknown_skill", "available": _LOADABLE_SKILLS}
+    if slug not in skill_gate.LOADABLE_SKILLS:
+        logger.info(json.dumps({
+            "event": "load_skill",
+            "skill": slug[:80],
+            "status": "unknown_skill",
+            "client_id": _resolve_client_identifier(),
+            "cred_hash": _credential_fingerprint(),
+        }))
+        return {"status": "unknown_skill", "available": list(skill_gate.LOADABLE_SKILLS)}
     content, source = await _fetch_skill_content(slug)
     tag = skill_gate.current_tag_for_slug(slug)
+    logger.info(json.dumps({
+        "event": "load_skill",
+        "skill": slug,
+        "status": "ok",
+        "source": source,
+        "client_id": _resolve_client_identifier(),
+        "cred_hash": _credential_fingerprint(),
+    }))
     return {
         "status": "ok",
         "skill": slug,
@@ -1126,79 +1126,21 @@ def setup_dynamic_tool_handlers():
         mcp_call_id = telemetry["call_id"]
         call_id_suffix = f"\n\n[cekura_mcp_call_id: {mcp_call_id}]"
 
-        # Strip the optional skill-gate ack from tool args up front so it never
-        # reaches the backend (request body stays byte-identical to today). This
-        # happens in EVERY mode, including `off`.
-        skill_ack = None
-        if arguments and "skill_ack" in arguments:
-            skill_ack = arguments.pop("skill_ack")
-
-        gate_nudge = None
-        gate_mode = server_config.skill_gate_mode if server_config else "off"
-        if gate_mode != "off" and name in skill_gate.GATED_TOOLS:
-            # Quality gate. Fails open on any error (a write is never lost to a
-            # gate bug). Only `enforce`/`strict` hold the write (action=deny).
-            try:
-                decision = skill_gate.evaluate(
-                    name, skill_ack, gate_mode,
-                    is_sandbox=bool(telemetry["conversation_id"]),
-                )
-                if decision.action == "deny":
-                    logger.info(json.dumps({
-                        "event": "skill_gate_blocked",
-                        "mode": gate_mode,
-                        "tool": name,
-                        "family": decision.family,
-                        "ack_present": decision.ack_present,
-                        "blocked": True,
-                        "client_id": telemetry["client_id"],
-                        "cred_hash": _credential_fingerprint(),
-                        "call_id": mcp_call_id,
-                    }))
-                    # Write withheld; hand the model the ask-the-user recovery.
-                    return [{"type": "text", "text": f"{decision.nudge}{call_id_suffix}"}]
-                if decision.action in ("shadow_block", "warn"):
-                    logger.info(json.dumps({
-                        "event": "skill_gate_blocked",
-                        "mode": gate_mode,
-                        "tool": name,
-                        "family": decision.family,
-                        "ack_present": decision.ack_present,
-                        "blocked": False,
-                        "client_id": telemetry["client_id"],
-                        "cred_hash": _credential_fingerprint(),
-                        "call_id": mcp_call_id,
-                    }))
-                    if decision.action == "warn":
-                        gate_nudge = decision.nudge
-                elif decision.reason == "user_override":
-                    logger.info(json.dumps({
-                        "event": "skill_gate_user_override",
-                        "mode": gate_mode,
-                        "tool": name,
-                        "family": decision.family,
-                        "client_id": telemetry["client_id"],
-                        "cred_hash": _credential_fingerprint(),
-                        "call_id": mcp_call_id,
-                    }))
-                elif decision.ack_valid:
-                    # Thread-rate signal: a gated write carried a valid ack.
-                    logger.info(json.dumps({
-                        "event": "skill_gate_ack_ok",
-                        "mode": gate_mode,
-                        "tool": name,
-                        "family": decision.family,
-                        "call_id": mcp_call_id,
-                    }))
-                elif decision.reason == "sandbox_bypass":
-                    logger.info(json.dumps({
-                        "event": "skill_gate_sandbox_bypass",
-                        "tool": name,
-                        "family": decision.family,
-                        "call_id": mcp_call_id,
-                    }))
-            except Exception:
-                logger.exception("skill_gate_error tool=%s (failing open)", name)
+        # Skill gate. Strips `skill_ack` from the args in EVERY mode (the backend
+        # request stays byte-identical to a call that never carried it); may hold
+        # the write in enforce/strict; fails open on any internal error.
+        gate_deny, gate_nudge = skill_gate.apply_gate(
+            name,
+            arguments,
+            server_config.skill_gate_mode if server_config else "off",
+            is_sandbox=bool(telemetry["conversation_id"]),
+            client_id=telemetry["client_id"],
+            call_id=mcp_call_id,
+            cred_hash_fn=_credential_fingerprint,
+        )
+        if gate_deny:
+            # Write withheld; hand the model the ask-the-user recovery.
+            return [{"type": "text", "text": f"{gate_deny}{call_id_suffix}"}]
 
         try:
             tool_data = operations_registry[name]

--- a/cekura-mcp-server/openapi_mcp_server.py
+++ b/cekura-mcp-server/openapi_mcp_server.py
@@ -645,8 +645,8 @@ async def _forward_skill_activation(
     skill_version: Optional[str],
     client_id: Optional[str],
 ) -> None:
-    """Best-effort, fire-and-forget activation report so skill usage can be joined
-    to the canonical principal backend-side. Never raises; never blocks a write."""
+    """Best-effort, fire-and-forget activation report so skill usage can be
+    recorded. Never raises; never blocks a write."""
     try:
         credential, credential_type = get_request_credential()
     except ValueError:

--- a/cekura-mcp-server/skill_gate.py
+++ b/cekura-mcp-server/skill_gate.py
@@ -185,8 +185,15 @@ async def load_manifest(client_factory=httpx.AsyncClient):
                 _manifest_source = "remote"
                 _rebuild_family_tags()
                 return _manifest_source
-    except Exception:
-        pass
+        logger.warning(
+            "ack-tag manifest at %s fetched but empty/unparseable — falling back to baked snapshot",
+            _REMOTE_MANIFEST_URL,
+        )
+    except Exception as e:
+        logger.warning(
+            "ack-tag manifest fetch failed (%s): %s — falling back to baked snapshot",
+            _REMOTE_MANIFEST_URL, e,
+        )
     return _load_baked()
 
 

--- a/cekura-mcp-server/skill_gate.py
+++ b/cekura-mcp-server/skill_gate.py
@@ -6,10 +6,10 @@ them: the quality-critical write tools accept an OPTIONAL ``skill_ack`` argument
 whose value is a short verification tag carried inside each design playbook.
 Presenting the tag is direct evidence the playbook is in the model's context.
 
-Two families and their write-tool sets mirror the server-side design gate; keep
-them in sync by hand (families change rarely). This is a quality nudge, not a
-security boundary: the tag is copyable from a public repo, so the point is to
-raise the bar for honest clients, not to be uncircumventable.
+Two families each pair a set of quality-critical write tools with the design
+playbooks that cover them. This is a quality nudge, not a security boundary: the
+tag is copyable from a public repo, so the point is to raise the bar for honest
+clients, not to be uncircumventable.
 
 Rollout ladder (env ``CEKURA_SKILL_GATE_MODE``):
 
@@ -36,7 +36,7 @@ import httpx
 
 logger = logging.getLogger(__name__)
 
-# ── Families (mirror of the server-side design gate) ─────────────────────────
+# ── Families (gated write tools ↔ their design playbooks) ────────────────────
 # One entry per gated tool-family. ``skill_slugs`` are skill-backed playbooks the
 # server can deliver via ``cekura_load_skill``; ``command_slugs`` are slash-command
 # playbooks that ship only inside the installed plugin. Tags from either satisfy
@@ -95,8 +95,8 @@ _FAMILIES = (
     ),
 )
 
-# Every tool the gate can act on. Read/list/run and server-side generation tools
-# are intentionally absent — the model does not author their payload content.
+# Every tool the gate can act on. Read/list/run and generation tools are
+# intentionally absent — the model does not author their payload content.
 GATED_TOOLS = frozenset().union(*(f["write_tools"] for f in _FAMILIES))
 
 # Every slug that can carry a recognized tag.

--- a/cekura-mcp-server/skill_gate.py
+++ b/cekura-mcp-server/skill_gate.py
@@ -216,9 +216,12 @@ def _deny_text(family, tool_name):
         "Ask the user whether to use the Cekura design skills here, then act on their answer:\n"
         "  • Yes (recommended): tell the user to install or update the Cekura skills so future "
         "sessions are skill-guided automatically (https://docs.cekura.ai/mcp/overview), AND — to "
-        f"complete THIS call now — call {family['load_hint']}, then retry this call with the "
-        "returned verification tag as `skill_ack`.\n"
-        f'  • No, proceed without the skills: retry this call with skill_ack="{OVERRIDE_ACK}".\n\n'
+        f"complete THIS call now — call {family['load_hint']}, then retry with the returned "
+        "verification tag as `skill_ack`. Reuse that tag as `skill_ack` on every subsequent "
+        "authoring call this session so you are not asked again.\n"
+        f'  • No, proceed without the skills: retry this call with skill_ack="{OVERRIDE_ACK}", and '
+        f'pass skill_ack="{OVERRIDE_ACK}" on every subsequent authoring call this session too — '
+        "otherwise you will be prompted again on each one.\n\n"
         "Do not proceed until the user has chosen."
     )
 

--- a/cekura-mcp-server/skill_gate.py
+++ b/cekura-mcp-server/skill_gate.py
@@ -14,7 +14,7 @@ raise the bar for honest clients, not to be uncircumventable.
 Rollout ladder (env ``CEKURA_SKILL_GATE_MODE``):
 
 * ``off``     — inert. No schema change; no evaluation. (``skill_ack`` is still
-  stripped from tool args by the caller so it never reaches the backend.)
+  stripped from tool args so it never reaches the backend.)
 * ``shadow``  — log-only. Emits ``skill_gate_blocked`` when a gated write lacks a
   valid ack, but the call proceeds unchanged.
 * ``warn``    — the call proceeds and a short nudge is appended to the response.
@@ -29,62 +29,79 @@ Everything fails OPEN: any unexpected error should leave the write allowed.
 """
 
 import json
+import logging
 import os
 
 import httpx
 
+logger = logging.getLogger(__name__)
+
 # ── Families (mirror of the server-side design gate) ─────────────────────────
+# One entry per gated tool-family. ``skill_slugs`` are skill-backed playbooks the
+# server can deliver via ``cekura_load_skill``; ``command_slugs`` are slash-command
+# playbooks that ship only inside the installed plugin. Tags from either satisfy
+# the family's gate.
 
-EVAL_DESIGN_TOOLS = frozenset({
-    "scenarios_create",
-    "scenarios_bulk_update",
-    "scenarios_partial_update",
-    "scenarios_create_from_transcript",
-    "scenarios_create_from_transcript_bg",
-    "scenarios_update_scenario_with_transcript_create",
-    "test_profiles_create",
-    "test_profiles_partial_update",
-})
-EVAL_DESIGN_SLUGS = frozenset({
-    "cekura-eval-design",
-    "manual-create-update-eval",
-    "autogen-eval",
-    "cekura-generate-scenarios",
-    "cekura-self-improving-agent",
-    "cekura-infra-test-suite",
-})
 
-METRIC_DESIGN_TOOLS = frozenset({
-    "metrics_create",
-    "metrics_bulk_create",
-    "metrics_partial_update",
-})
-METRIC_DESIGN_SLUGS = frozenset({
-    "cekura-metric-design",
-    "create-metric",
-    "improve-metric",
-    "cekura-metric-improvement",
-    "cekura-predefined-metrics",
-})
+def _family(name, write_tools, skill_slugs, command_slugs, load_hint):
+    return {
+        "name": name,
+        "write_tools": frozenset(write_tools),
+        "skill_slugs": frozenset(skill_slugs),
+        "slugs": frozenset(skill_slugs) | frozenset(command_slugs),
+        "load_hint": load_hint,
+    }
+
 
 _FAMILIES = (
-    {
-        "name": "eval-design",
-        "write_tools": EVAL_DESIGN_TOOLS,
-        "slugs": EVAL_DESIGN_SLUGS,
-        "load_hint": 'cekura_load_skill(skill_name="cekura-eval-design")',
-    },
-    {
-        "name": "metric-design",
-        "write_tools": METRIC_DESIGN_TOOLS,
-        "slugs": METRIC_DESIGN_SLUGS,
-        "load_hint": 'cekura_load_skill(skill_name="cekura-metric-design")',
-    },
+    _family(
+        "eval-design",
+        write_tools={
+            "scenarios_create",
+            "scenarios_bulk_update",
+            "scenarios_partial_update",
+            "scenarios_create_from_transcript",
+            "scenarios_create_from_transcript_bg",
+            "scenarios_update_scenario_with_transcript_create",
+            "test_profiles_create",
+            "test_profiles_partial_update",
+        },
+        skill_slugs={
+            "cekura-eval-design",
+            "cekura-generate-scenarios",
+            "cekura-self-improving-agent",
+            "cekura-infra-test-suite",
+        },
+        command_slugs={"manual-create-update-eval", "autogen-eval"},
+        load_hint='cekura_load_skill(skill_name="cekura-eval-design")',
+    ),
+    _family(
+        "metric-design",
+        write_tools={
+            "metrics_create",
+            "metrics_bulk_create",
+            "metrics_partial_update",
+        },
+        skill_slugs={
+            "cekura-metric-design",
+            "cekura-metric-improvement",
+            "cekura-predefined-metrics",
+        },
+        command_slugs={"create-metric", "improve-metric"},
+        load_hint='cekura_load_skill(skill_name="cekura-metric-design")',
+    ),
 )
 
 # Every tool the gate can act on. Read/list/run and server-side generation tools
 # are intentionally absent — the model does not author their payload content.
-GATED_TOOLS = frozenset(EVAL_DESIGN_TOOLS | METRIC_DESIGN_TOOLS)
+GATED_TOOLS = frozenset().union(*(f["write_tools"] for f in _FAMILIES))
+
+# Every slug that can carry a recognized tag.
+ALL_FAMILY_SLUGS = frozenset().union(*(f["slugs"] for f in _FAMILIES))
+
+# Slugs `cekura_load_skill` can deliver (skill-backed; command playbooks exist
+# only in the installed plugin).
+LOADABLE_SKILLS = tuple(sorted(frozenset().union(*(f["skill_slugs"] for f in _FAMILIES))))
 
 # Sentinel a caller passes as `skill_ack` to proceed without the skills, AFTER the
 # user has explicitly chosen to (enforce/strict only). Recorded as an override.
@@ -100,6 +117,7 @@ _REMOTE_MANIFEST_URL = os.environ.get(
 
 _manifest = {}          # slug -> [tags]
 _manifest_source = "unloaded"
+_family_tags = {}       # family name -> frozenset of every recognized tag
 
 
 def _parse_manifest(data):
@@ -114,19 +132,26 @@ def _parse_manifest(data):
     return out
 
 
+def _rebuild_family_tags():
+    """Precompute each family's recognized-tag set; the manifest only changes at
+    load time, so `evaluate` does a plain membership test per call."""
+    global _family_tags
+    _family_tags = {
+        f["name"]: frozenset(tag for slug in f["slugs"] for tag in _manifest.get(slug, []))
+        for f in _FAMILIES
+    }
+
+
 def set_manifest(mapping):
     """Directly set the in-memory manifest (used by tests)."""
     global _manifest, _manifest_source
     _manifest = _parse_manifest(mapping)
     _manifest_source = "explicit"
+    _rebuild_family_tags()
 
 
 def get_manifest():
     return dict(_manifest)
-
-
-def manifest_source():
-    return _manifest_source
 
 
 def _load_baked():
@@ -138,6 +163,7 @@ def _load_baked():
     except Exception:
         _manifest = {}
         _manifest_source = "empty"
+    _rebuild_family_tags()
     return _manifest_source
 
 
@@ -157,6 +183,7 @@ async def load_manifest(client_factory=httpx.AsyncClient):
             if parsed:
                 _manifest = parsed
                 _manifest_source = "remote"
+                _rebuild_family_tags()
                 return _manifest_source
     except Exception:
         pass
@@ -176,23 +203,15 @@ def _family_for_tool(tool_name):
     return None
 
 
-def _recognized_tags(family):
-    tags = set()
-    for slug in family["slugs"]:
-        tags.update(_manifest.get(slug, []))
-    return tags
-
-
 # ── Decision ─────────────────────────────────────────────────────────────────
 
 
 class GateDecision:
-    __slots__ = ("action", "family", "tool", "ack_present", "ack_valid", "reason", "nudge")
+    __slots__ = ("action", "family", "ack_present", "ack_valid", "reason", "nudge")
 
-    def __init__(self, action, family, tool, ack_present, ack_valid, reason, nudge=None):
-        self.action = action          # "allow" | "shadow_block" | "warn"
+    def __init__(self, action, family, ack_present, ack_valid, reason, nudge=None):
+        self.action = action          # "allow" | "shadow_block" | "warn" | "deny"
         self.family = family          # family name or None
-        self.tool = tool
         self.ack_present = ack_present
         self.ack_valid = ack_valid
         self.reason = reason
@@ -227,32 +246,102 @@ def evaluate(tool_name, skill_ack, mode, is_sandbox=False):
     ack_present = bool(skill_ack)
     family = _family_for_tool(tool_name)
     if family is None:
-        return GateDecision("allow", None, tool_name, ack_present, False, "not_gated")
+        return GateDecision("allow", None, ack_present, False, "not_gated")
     if mode == "off":
-        return GateDecision("allow", family["name"], tool_name, ack_present, False, "mode_off")
+        return GateDecision("allow", family["name"], ack_present, False, "mode_off")
     if is_sandbox:
-        return GateDecision("allow", family["name"], tool_name, ack_present, False, "sandbox_bypass")
+        return GateDecision("allow", family["name"], ack_present, False, "sandbox_bypass")
 
     # Explicit user override: proceed without skills (blocking modes only).
     if skill_ack == OVERRIDE_ACK and mode in ("enforce", "strict"):
-        return GateDecision("allow", family["name"], tool_name, ack_present, False, "user_override")
+        return GateDecision("allow", family["name"], ack_present, False, "user_override")
 
-    ack_valid = ack_present and skill_ack in _recognized_tags(family)
+    ack_valid = ack_present and skill_ack in _family_tags.get(family["name"], frozenset())
     if ack_valid:
-        return GateDecision("allow", family["name"], tool_name, True, True, "ack_ok")
+        return GateDecision("allow", family["name"], True, True, "ack_ok")
 
     if mode == "shadow":
-        return GateDecision("shadow_block", family["name"], tool_name, ack_present, False, "would_block")
+        return GateDecision("shadow_block", family["name"], ack_present, False, "would_block")
     if mode in ("enforce", "strict"):
         # Hold the write; the model must ask the user (install/load or proceed).
         return GateDecision(
-            "deny", family["name"], tool_name, ack_present, False, "deny",
+            "deny", family["name"], ack_present, False, "deny",
             nudge=_deny_text(family, tool_name),
         )
     # warn -> proceed with a nudge
     return GateDecision(
-        "warn", family["name"], tool_name, ack_present, False, "warn", nudge=_nudge_text(family)
+        "warn", family["name"], ack_present, False, "warn", nudge=_nudge_text(family)
     )
+
+
+# ── Handler-side application ─────────────────────────────────────────────────
+
+# decision.reason -> (log event, blocked flag). Allows with reason
+# mode_off/not_gated log nothing. `blocked` None means the event doesn't carry
+# the ack_present/blocked pair.
+_GATE_LOG_EVENTS = {
+    "deny": ("skill_gate_blocked", True),
+    "would_block": ("skill_gate_blocked", False),
+    "warn": ("skill_gate_blocked", False),
+    "user_override": ("skill_gate_user_override", None),
+    "sandbox_bypass": ("skill_gate_sandbox_bypass", None),
+    "ack_ok": ("skill_gate_ack_ok", None),
+}
+
+
+def _log_decision(decision, mode, tool_name, call_id, client_id, cred_hash_fn):
+    entry = _GATE_LOG_EVENTS.get(decision.reason)
+    if entry is None:
+        return
+    event, blocked = entry
+    payload = {
+        "event": event,
+        "tool": tool_name,
+        "family": decision.family,
+        "call_id": call_id,
+    }
+    if event != "skill_gate_sandbox_bypass":
+        payload["mode"] = mode
+    if event in ("skill_gate_blocked", "skill_gate_user_override"):
+        payload["client_id"] = client_id
+        payload["cred_hash"] = cred_hash_fn()
+    if blocked is not None:
+        payload["ack_present"] = decision.ack_present
+        payload["blocked"] = blocked
+    logger.info(json.dumps(payload))
+
+
+def apply_gate(tool_name, arguments, mode, *, is_sandbox=False, client_id=None,
+               call_id=None, cred_hash_fn=lambda: None):
+    """The complete handler-side gate step for one tool call.
+
+    Returns ``(deny_text, nudge)``: ``deny_text`` set means the write must NOT
+    be executed (enforce/strict deny); ``nudge`` set means proceed and append it
+    to the response (warn).
+
+    Always strips ``skill_ack`` from ``arguments`` in place — in EVERY mode,
+    including ``off`` — so the backend request stays byte-identical to a call
+    that never carried it. Evaluation and logging run only for gated tools with
+    the gate on; any internal error fails open (write allowed).
+    """
+    skill_ack = None
+    if arguments and "skill_ack" in arguments:
+        skill_ack = arguments.pop("skill_ack")
+
+    if mode == "off" or tool_name not in GATED_TOOLS:
+        return None, None
+
+    try:
+        decision = evaluate(tool_name, skill_ack, mode, is_sandbox=is_sandbox)
+        _log_decision(decision, mode, tool_name, call_id, client_id, cred_hash_fn)
+        if decision.action == "deny":
+            return decision.nudge, None
+        if decision.action == "warn":
+            return None, decision.nudge
+        return None, None
+    except Exception:
+        logger.exception("skill_gate_error tool=%s (failing open)", tool_name)
+        return None, None
 
 
 # ── Schema injection ─────────────────────────────────────────────────────────

--- a/cekura-mcp-server/skill_gate.py
+++ b/cekura-mcp-server/skill_gate.py
@@ -43,13 +43,14 @@ logger = logging.getLogger(__name__)
 # the family's gate.
 
 
-def _family(name, write_tools, skill_slugs, command_slugs, load_hint):
+def _family(name, write_tools, skill_slugs, command_slugs, load_hint, write_hint):
     return {
         "name": name,
         "write_tools": frozenset(write_tools),
         "skill_slugs": frozenset(skill_slugs),
         "slugs": frozenset(skill_slugs) | frozenset(command_slugs),
         "load_hint": load_hint,
+        "write_hint": write_hint,
     }
 
 
@@ -74,6 +75,7 @@ _FAMILIES = (
         },
         command_slugs={"manual-create-update-eval", "autogen-eval"},
         load_hint='cekura_load_skill(skill_name="cekura-eval-design")',
+        write_hint="scenario / test-profile write calls (`scenarios_*`, `test_profiles_*`)",
     ),
     _family(
         "metric-design",
@@ -89,6 +91,7 @@ _FAMILIES = (
         },
         command_slugs={"create-metric", "improve-metric"},
         load_hint='cekura_load_skill(skill_name="cekura-metric-design")',
+        write_hint="metric write calls (`metrics_create`, `metrics_bulk_create`, `metrics_partial_update`)",
     ),
 )
 
@@ -118,6 +121,7 @@ _REMOTE_MANIFEST_URL = os.environ.get(
 _manifest = {}          # slug -> [tags]
 _manifest_source = "unloaded"
 _family_tags = {}       # family name -> frozenset of every recognized tag
+_all_tags = frozenset() # every recognized tag across all families
 
 
 def _parse_manifest(data):
@@ -135,11 +139,12 @@ def _parse_manifest(data):
 def _rebuild_family_tags():
     """Precompute each family's recognized-tag set; the manifest only changes at
     load time, so `evaluate` does a plain membership test per call."""
-    global _family_tags
+    global _family_tags, _all_tags
     _family_tags = {
         f["name"]: frozenset(tag for slug in f["slugs"] for tag in _manifest.get(slug, []))
         for f in _FAMILIES
     }
+    _all_tags = frozenset().union(*_family_tags.values()) if _family_tags else frozenset()
 
 
 def set_manifest(mapping):
@@ -203,6 +208,15 @@ def current_tag_for_slug(slug):
     return tags[-1] if tags else None
 
 
+def ack_hint_for_slug(slug, subject="this value"):
+    """Threading hint for a tag delivered for `slug`, scoped to its family's
+    write tools so the model doesn't reuse the tag across families."""
+    for family in _FAMILIES:
+        if slug in family["slugs"]:
+            return f"Pass {subject} as `skill_ack` on {family['write_hint']} in this session."
+    return f"Pass {subject} as `skill_ack` on gated authoring calls in this session."
+
+
 def _family_for_tool(tool_name):
     for family in _FAMILIES:
         if tool_name in family["write_tools"]:
@@ -240,11 +254,13 @@ def _deny_text(family, tool_name):
         "playbook loaded, which isn't loaded here. This write was NOT executed.\n\n"
         "Ask the user, then:\n"
         "  • Use the skills (recommended): suggest they install or update the Cekura skills "
-        f"(https://docs.cekura.ai/mcp/overview), call {family['load_hint']}, and pass the "
+        "(https://docs.cekura.ai/mcp/overview) — or, if already installed, invoke the matching "
+        f"Cekura skill/command. Either way, call {family['load_hint']} now and pass the "
         "returned tag as `skill_ack` on this and every subsequent write call.\n"
         f'  • Proceed without: pass skill_ack="{OVERRIDE_ACK}" on this and every subsequent '
         "write call.\n\n"
-        "Do not proceed until the user has chosen."
+        "Do not proceed until the user has chosen. If they already chose earlier in this "
+        "conversation, keep that choice and continue without asking again."
     )
 
 
@@ -266,6 +282,12 @@ def evaluate(tool_name, skill_ack, mode, is_sandbox=False):
     ack_valid = ack_present and skill_ack in _family_tags.get(family["name"], frozenset())
     if ack_valid:
         return GateDecision("allow", family["name"], True, True, "ack_ok")
+
+    # A recognized tag from another family still proves a Cekura playbook is in
+    # context (skills are installed/loaded) — allow, but log the mismatch so the
+    # cross-family rate is visible.
+    if ack_present and skill_ack in _all_tags:
+        return GateDecision("allow", family["name"], True, False, "ack_wrong_family")
 
     if mode == "shadow":
         return GateDecision("shadow_block", family["name"], ack_present, False, "would_block")
@@ -293,6 +315,7 @@ _GATE_LOG_EVENTS = {
     "user_override": ("skill_gate_user_override", None),
     "sandbox_bypass": ("skill_gate_sandbox_bypass", None),
     "ack_ok": ("skill_gate_ack_ok", None),
+    "ack_wrong_family": ("skill_gate_ack_wrong_family", None),
 }
 
 

--- a/cekura-mcp-server/skill_gate.py
+++ b/cekura-mcp-server/skill_gate.py
@@ -215,8 +215,9 @@ def _deny_text(family, tool_name):
         "Ask the user, then:\n"
         "  • Use the skills (recommended): suggest they install or update the Cekura skills "
         f"(https://docs.cekura.ai/mcp/overview), call {family['load_hint']}, and pass the "
-        "returned tag as `skill_ack` on write calls.\n"
-        f'  • Proceed without: pass skill_ack="{OVERRIDE_ACK}" on write calls.\n\n'
+        "returned tag as `skill_ack` on this and every subsequent write call.\n"
+        f'  • Proceed without: pass skill_ack="{OVERRIDE_ACK}" on this and every subsequent '
+        "write call.\n\n"
         "Do not proceed until the user has chosen."
     )
 

--- a/cekura-mcp-server/skill_gate.py
+++ b/cekura-mcp-server/skill_gate.py
@@ -1,0 +1,290 @@
+"""Client-cooperative skill gate for quality-critical authoring tools.
+
+The Cekura design playbooks (scenario / test-profile / metric authoring) produce
+markedly better results than raw create calls. This gate steers callers toward
+them: the quality-critical write tools accept an OPTIONAL ``skill_ack`` argument
+whose value is a short verification tag carried inside each design playbook.
+Presenting the tag is direct evidence the playbook is in the model's context.
+
+Two families and their write-tool sets mirror the server-side design gate; keep
+them in sync by hand (families change rarely). This is a quality nudge, not a
+security boundary: the tag is copyable from a public repo, so the point is to
+raise the bar for honest clients, not to be uncircumventable.
+
+Rollout ladder (env ``CEKURA_SKILL_GATE_MODE``):
+
+* ``off``     — inert. No schema change; no evaluation. (``skill_ack`` is still
+  stripped from tool args by the caller so it never reaches the backend.)
+* ``shadow``  — log-only. Emits ``skill_gate_blocked`` when a gated write lacks a
+  valid ack, but the call proceeds unchanged.
+* ``warn``    — the call proceeds and a short nudge is appended to the response.
+* ``enforce`` — the write is HELD (denied) when no valid ack is present; the deny
+  instructs the model to ask the user to install/load the skills OR to explicitly
+  proceed without them (by retrying with ``skill_ack="proceed-without-skill"``).
+  A caller that already threaded a valid tag passes silently, unaffected.
+* ``strict``  — currently uses ``enforce`` behavior; strict-specific hardening
+  (tag redaction) is deferred.
+
+Everything fails OPEN: any unexpected error should leave the write allowed.
+"""
+
+import json
+import os
+
+import httpx
+
+# ── Families (mirror of the server-side design gate) ─────────────────────────
+
+EVAL_DESIGN_TOOLS = frozenset({
+    "scenarios_create",
+    "scenarios_bulk_update",
+    "scenarios_partial_update",
+    "scenarios_create_from_transcript",
+    "scenarios_create_from_transcript_bg",
+    "scenarios_update_scenario_with_transcript_create",
+    "test_profiles_create",
+    "test_profiles_partial_update",
+})
+EVAL_DESIGN_SLUGS = frozenset({
+    "cekura-eval-design",
+    "manual-create-update-eval",
+    "autogen-eval",
+    "cekura-generate-scenarios",
+    "cekura-self-improving-agent",
+    "cekura-infra-test-suite",
+})
+
+METRIC_DESIGN_TOOLS = frozenset({
+    "metrics_create",
+    "metrics_bulk_create",
+    "metrics_partial_update",
+})
+METRIC_DESIGN_SLUGS = frozenset({
+    "cekura-metric-design",
+    "create-metric",
+    "improve-metric",
+    "cekura-metric-improvement",
+    "cekura-predefined-metrics",
+})
+
+_FAMILIES = (
+    {
+        "name": "eval-design",
+        "write_tools": EVAL_DESIGN_TOOLS,
+        "slugs": EVAL_DESIGN_SLUGS,
+        "load_hint": 'cekura_load_skill(skill_name="cekura-eval-design")',
+    },
+    {
+        "name": "metric-design",
+        "write_tools": METRIC_DESIGN_TOOLS,
+        "slugs": METRIC_DESIGN_SLUGS,
+        "load_hint": 'cekura_load_skill(skill_name="cekura-metric-design")',
+    },
+)
+
+# Every tool the gate can act on. Read/list/run and server-side generation tools
+# are intentionally absent — the model does not author their payload content.
+GATED_TOOLS = frozenset(EVAL_DESIGN_TOOLS | METRIC_DESIGN_TOOLS)
+
+# Sentinel a caller passes as `skill_ack` to proceed without the skills, AFTER the
+# user has explicitly chosen to (enforce/strict only). Recorded as an override.
+OVERRIDE_ACK = "proceed-without-skill"
+
+# ── Tag manifest (append-only; historical tags stay valid forever) ───────────
+
+_BAKED_MANIFEST_PATH = os.path.join(os.path.dirname(__file__), "ack_tags.snapshot.json")
+_REMOTE_MANIFEST_URL = os.environ.get(
+    "CEKURA_ACK_TAGS_URL",
+    "https://raw.githubusercontent.com/cekura-ai/cekura-skills/main/cekura/ack-tags.json",
+)
+
+_manifest = {}          # slug -> [tags]
+_manifest_source = "unloaded"
+
+
+def _parse_manifest(data):
+    if not isinstance(data, dict):
+        return {}
+    out = {}
+    for key, value in data.items():
+        if key.startswith("_"):
+            continue
+        if isinstance(value, list):
+            out[key] = [t for t in value if isinstance(t, str)]
+    return out
+
+
+def set_manifest(mapping):
+    """Directly set the in-memory manifest (used by tests)."""
+    global _manifest, _manifest_source
+    _manifest = _parse_manifest(mapping)
+    _manifest_source = "explicit"
+
+
+def get_manifest():
+    return dict(_manifest)
+
+
+def manifest_source():
+    return _manifest_source
+
+
+def _load_baked():
+    global _manifest, _manifest_source
+    try:
+        with open(_BAKED_MANIFEST_PATH) as fh:
+            _manifest = _parse_manifest(json.load(fh))
+            _manifest_source = "baked"
+    except Exception:
+        _manifest = {}
+        _manifest_source = "empty"
+    return _manifest_source
+
+
+async def load_manifest(client_factory=httpx.AsyncClient):
+    """Populate the manifest once at startup: try the public cekura-skills copy,
+    fall back to the baked snapshot. Returns the source used.
+
+    The manifest is append-only, so the remote copy is always a superset of any
+    installed plugin's tags — fetching it never invalidates a stale plugin.
+    """
+    global _manifest, _manifest_source
+    try:
+        async with client_factory(timeout=httpx.Timeout(5.0, connect=2.0)) as client:
+            resp = await client.get(_REMOTE_MANIFEST_URL)
+            resp.raise_for_status()
+            parsed = _parse_manifest(resp.json())
+            if parsed:
+                _manifest = parsed
+                _manifest_source = "remote"
+                return _manifest_source
+    except Exception:
+        pass
+    return _load_baked()
+
+
+def current_tag_for_slug(slug):
+    """Latest (last-appended) tag for a slug, or None."""
+    tags = _manifest.get((slug or "").strip())
+    return tags[-1] if tags else None
+
+
+def _family_for_tool(tool_name):
+    for family in _FAMILIES:
+        if tool_name in family["write_tools"]:
+            return family
+    return None
+
+
+def _recognized_tags(family):
+    tags = set()
+    for slug in family["slugs"]:
+        tags.update(_manifest.get(slug, []))
+    return tags
+
+
+# ── Decision ─────────────────────────────────────────────────────────────────
+
+
+class GateDecision:
+    __slots__ = ("action", "family", "tool", "ack_present", "ack_valid", "reason", "nudge")
+
+    def __init__(self, action, family, tool, ack_present, ack_valid, reason, nudge=None):
+        self.action = action          # "allow" | "shadow_block" | "warn"
+        self.family = family          # family name or None
+        self.tool = tool
+        self.ack_present = ack_present
+        self.ack_valid = ack_valid
+        self.reason = reason
+        self.nudge = nudge
+
+
+def _nudge_text(family):
+    return (
+        "\n\n[cekura skills] For much better results, install or update the Cekura skills: "
+        "https://docs.cekura.ai/mcp/overview (one-time setup; makes every future session "
+        f"skill-guided). To load this playbook just for now instead, call {family['load_hint']} "
+        "and pass its verification tag as `skill_ack`. Proceeding without it."
+    )
+
+
+def _deny_text(family, tool_name):
+    return (
+        f"[cekura skills] '{tool_name}' produces much better results with the Cekura "
+        f"{family['name']} playbook loaded, which isn't loaded in this session. This "
+        "write was NOT executed.\n\n"
+        "Ask the user whether to use the Cekura design skills here, then act on their answer:\n"
+        "  • Yes (recommended): tell the user to install or update the Cekura skills so future "
+        "sessions are skill-guided automatically (https://docs.cekura.ai/mcp/overview), AND — to "
+        f"complete THIS call now — call {family['load_hint']}, then retry this call with the "
+        "returned verification tag as `skill_ack`.\n"
+        f'  • No, proceed without the skills: retry this call with skill_ack="{OVERRIDE_ACK}".\n\n'
+        "Do not proceed until the user has chosen."
+    )
+
+
+def evaluate(tool_name, skill_ack, mode, is_sandbox=False):
+    """Pure gate decision for one tool call. Does not raise on ordinary inputs."""
+    ack_present = bool(skill_ack)
+    family = _family_for_tool(tool_name)
+    if family is None:
+        return GateDecision("allow", None, tool_name, ack_present, False, "not_gated")
+    if mode == "off":
+        return GateDecision("allow", family["name"], tool_name, ack_present, False, "mode_off")
+    if is_sandbox:
+        return GateDecision("allow", family["name"], tool_name, ack_present, False, "sandbox_bypass")
+
+    # Explicit user override: proceed without skills (blocking modes only).
+    if skill_ack == OVERRIDE_ACK and mode in ("enforce", "strict"):
+        return GateDecision("allow", family["name"], tool_name, ack_present, False, "user_override")
+
+    ack_valid = ack_present and skill_ack in _recognized_tags(family)
+    if ack_valid:
+        return GateDecision("allow", family["name"], tool_name, True, True, "ack_ok")
+
+    if mode == "shadow":
+        return GateDecision("shadow_block", family["name"], tool_name, ack_present, False, "would_block")
+    if mode in ("enforce", "strict"):
+        # Hold the write; the model must ask the user (install/load or proceed).
+        return GateDecision(
+            "deny", family["name"], tool_name, ack_present, False, "deny",
+            nudge=_deny_text(family, tool_name),
+        )
+    # warn -> proceed with a nudge
+    return GateDecision(
+        "warn", family["name"], tool_name, ack_present, False, "warn", nudge=_nudge_text(family)
+    )
+
+
+# ── Schema injection ─────────────────────────────────────────────────────────
+
+_SKILL_ACK_PROPERTY = {
+    "type": "string",
+    "description": (
+        "Optional. If a Cekura design skill or command is loaded, pass its verification "
+        "tag here (shown in the skill as `ack:<slug>:<code>`, or returned by "
+        "cekura_load_skill). It confirms the design playbook is in context. Leave unset "
+        "if you are not working from a Cekura skill."
+    ),
+}
+
+
+def maybe_inject_skill_ack(tool_name, input_schema, mode):
+    """Add the optional ``skill_ack`` property to a gated tool's input schema.
+
+    No-op when the gate is ``off`` (so the default deploy makes zero schema
+    change), for non-gated tools, or when the property already exists. Never
+    added to ``required`` — callers that omit it are unaffected.
+    """
+    if mode == "off" or tool_name not in GATED_TOOLS:
+        return input_schema
+    if not isinstance(input_schema, dict):
+        return input_schema
+    props = input_schema.get("properties")
+    if not isinstance(props, dict) or "skill_ack" in props:
+        return input_schema
+    new_props = dict(props)
+    new_props["skill_ack"] = dict(_SKILL_ACK_PROPERTY)
+    new_schema = dict(input_schema)
+    new_schema["properties"] = new_props
+    return new_schema

--- a/cekura-mcp-server/skill_gate.py
+++ b/cekura-mcp-server/skill_gate.py
@@ -210,18 +210,13 @@ def _nudge_text(family):
 
 def _deny_text(family, tool_name):
     return (
-        f"[cekura skills] '{tool_name}' produces much better results with the Cekura "
-        f"{family['name']} playbook loaded, which isn't loaded in this session. This "
-        "write was NOT executed.\n\n"
-        "Ask the user whether to use the Cekura design skills here, then act on their answer:\n"
-        "  • Yes (recommended): tell the user to install or update the Cekura skills so future "
-        "sessions are skill-guided automatically (https://docs.cekura.ai/mcp/overview), AND — to "
-        f"complete THIS call now — call {family['load_hint']}, then retry with the returned "
-        "verification tag as `skill_ack`. Reuse that tag as `skill_ack` on every subsequent "
-        "authoring call this session so you are not asked again.\n"
-        f'  • No, proceed without the skills: retry this call with skill_ack="{OVERRIDE_ACK}", and '
-        f'pass skill_ack="{OVERRIDE_ACK}" on every subsequent authoring call this session too — '
-        "otherwise you will be prompted again on each one.\n\n"
+        f"[cekura skills] '{tool_name}' works much better with the Cekura {family['name']} "
+        "playbook loaded, which isn't loaded here. This write was NOT executed.\n\n"
+        "Ask the user, then:\n"
+        "  • Use the skills (recommended): suggest they install or update the Cekura skills "
+        f"(https://docs.cekura.ai/mcp/overview), call {family['load_hint']}, and pass the "
+        "returned tag as `skill_ack` on write calls.\n"
+        f'  • Proceed without: pass skill_ack="{OVERRIDE_ACK}" on write calls.\n\n'
         "Do not proceed until the user has chosen."
     )
 

--- a/cekura-mcp-server/tests/test_skill_gate.py
+++ b/cekura-mcp-server/tests/test_skill_gate.py
@@ -128,8 +128,8 @@ class TestEvaluate:
         assert "docs.cekura.ai/mcp/overview" in d.nudge
         assert 'skill_ack="proceed-without-skill"' in d.nudge
         assert "NOT executed" in d.nudge
-        # both recovery paths must tell the model to reuse the value on later calls
-        assert "subsequent" in d.nudge
+        # both recovery paths must tell the model to pass the value on write calls
+        assert "on write calls" in d.nudge
 
     def test_sandbox_bypass(self):
         d = skill_gate.evaluate("scenarios_create", None, "enforce", is_sandbox=True)

--- a/cekura-mcp-server/tests/test_skill_gate.py
+++ b/cekura-mcp-server/tests/test_skill_gate.py
@@ -5,6 +5,8 @@ schema injection, the append-only manifest + baked fallback, and the hard
 no-regression invariant: `skill_ack` is stripped before dispatch so it never
 reaches the backend.
 """
+import json
+import logging
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
@@ -250,6 +252,71 @@ class TestApplyGate:
     def test_none_arguments_tolerated(self):
         deny, nudge = skill_gate.apply_gate("scenarios_create", None, "enforce")
         assert deny is not None  # gated, no ack -> deny; and no crash on None args
+
+
+# ── log-event contract (Datadog dashboards key off these exact shapes) ───────
+
+class TestGateLogEvents:
+    def _events(self, caplog):
+        out = []
+        for record in caplog.records:
+            msg = record.getMessage()
+            if msg.startswith("{"):
+                out.append(json.loads(msg))
+        return out
+
+    def _run(self, caplog, tool, args, mode, **kw):
+        kw.setdefault("client_id", "test-client/1.0")
+        kw.setdefault("call_id", "call_test123")
+        kw.setdefault("cred_hash_fn", lambda: "cafecafecafecafe")
+        with caplog.at_level(logging.INFO, logger="skill_gate"):
+            skill_gate.apply_gate(tool, args, mode, **kw)
+        return self._events(caplog)
+
+    def test_deny_event_shape(self, caplog):
+        (e,) = self._run(caplog, "metrics_create", {}, "enforce")
+        assert e == {
+            "event": "skill_gate_blocked",
+            "tool": "metrics_create",
+            "family": "metric-design",
+            "call_id": "call_test123",
+            "mode": "enforce",
+            "client_id": "test-client/1.0",
+            "cred_hash": "cafecafecafecafe",
+            "ack_present": False,
+            "blocked": True,
+        }
+
+    def test_shadow_event_shape(self, caplog):
+        (e,) = self._run(caplog, "scenarios_create", {"skill_ack": "junk"}, "shadow")
+        assert e["event"] == "skill_gate_blocked"
+        assert e["blocked"] is False and e["ack_present"] is True
+        assert e["mode"] == "shadow" and e["family"] == "eval-design"
+
+    def test_override_event_shape(self, caplog):
+        (e,) = self._run(
+            caplog, "scenarios_create", {"skill_ack": skill_gate.OVERRIDE_ACK}, "enforce"
+        )
+        assert e["event"] == "skill_gate_user_override"
+        assert e["client_id"] == "test-client/1.0" and e["cred_hash"] == "cafecafecafecafe"
+        # override events do not carry the ack_present/blocked pair
+        assert "ack_present" not in e and "blocked" not in e
+
+    def test_ack_ok_event_shape(self, caplog):
+        (e,) = self._run(caplog, "scenarios_create", {"skill_ack": VALID_TAG}, "warn")
+        assert e["event"] == "skill_gate_ack_ok" and e["mode"] == "warn"
+        # thread-rate signal is anonymous: no identity fields
+        assert "client_id" not in e and "cred_hash" not in e
+
+    def test_sandbox_event_shape(self, caplog):
+        (e,) = self._run(caplog, "scenarios_create", {}, "enforce", is_sandbox=True)
+        assert e["event"] == "skill_gate_sandbox_bypass"
+        assert "mode" not in e  # bypass is mode-independent
+
+    def test_off_and_non_gated_log_nothing(self, caplog):
+        assert self._run(caplog, "metrics_create", {}, "off") == []
+        caplog.clear()
+        assert self._run(caplog, "scenarios_list", {}, "enforce") == []
 
 
 # ── no-regression: skill_ack never reaches the backend ───────────────────────

--- a/cekura-mcp-server/tests/test_skill_gate.py
+++ b/cekura-mcp-server/tests/test_skill_gate.py
@@ -186,8 +186,70 @@ class TestManifest:
         m = skill_gate.get_manifest()
         assert len(m) == 11
         # every family slug in the code table is present in the shipped snapshot
-        for slug in (skill_gate.EVAL_DESIGN_SLUGS | skill_gate.METRIC_DESIGN_SLUGS):
+        for slug in skill_gate.ALL_FAMILY_SLUGS:
             assert slug in m
+
+    def test_loadable_skills_derived_from_families(self):
+        # loadable = the skill-backed subset of the family slugs (commands ship
+        # only inside the plugin and have no SKILL.md to deliver)
+        assert set(skill_gate.LOADABLE_SKILLS) <= skill_gate.ALL_FAMILY_SLUGS
+        assert len(skill_gate.LOADABLE_SKILLS) == 7
+
+
+# ── apply_gate: the complete handler-side step ───────────────────────────────
+
+class TestApplyGate:
+    def test_off_mode_still_strips(self):
+        args = {"name": "x", "skill_ack": VALID_TAG}
+        deny, nudge = skill_gate.apply_gate("scenarios_create", args, "off")
+        assert deny is None and nudge is None
+        assert "skill_ack" not in args
+
+    def test_non_gated_tool_strips_and_allows_even_in_enforce(self):
+        args = {"query": "q", "skill_ack": "whatever"}
+        deny, nudge = skill_gate.apply_gate("scenarios_list", args, "enforce")
+        assert deny is None and nudge is None
+        assert "skill_ack" not in args
+
+    def test_enforce_denies_without_ack(self):
+        args = {"name": "x"}
+        deny, nudge = skill_gate.apply_gate("metrics_create", args, "enforce")
+        assert deny is not None and "NOT executed" in deny
+        assert nudge is None
+        assert args == {"name": "x"}  # other args untouched
+
+    def test_enforce_allows_valid_ack(self):
+        args = {"name": "x", "skill_ack": VALID_TAG}
+        deny, nudge = skill_gate.apply_gate("scenarios_create", args, "enforce")
+        assert deny is None and nudge is None
+        assert "skill_ack" not in args
+
+    def test_enforce_allows_user_override(self):
+        args = {"name": "x", "skill_ack": skill_gate.OVERRIDE_ACK}
+        deny, nudge = skill_gate.apply_gate("scenarios_create", args, "enforce")
+        assert deny is None and nudge is None
+
+    def test_warn_returns_nudge_and_proceeds(self):
+        deny, nudge = skill_gate.apply_gate("metrics_create", {}, "warn")
+        assert deny is None
+        assert nudge and "cekura_load_skill" in nudge
+
+    def test_sandbox_bypasses_enforce(self):
+        deny, nudge = skill_gate.apply_gate("scenarios_create", {}, "enforce", is_sandbox=True)
+        assert deny is None and nudge is None
+
+    def test_fails_open_on_internal_error(self, monkeypatch):
+        def boom(*a, **k):
+            raise RuntimeError("boom")
+        monkeypatch.setattr(skill_gate, "evaluate", boom)
+        args = {"name": "x", "skill_ack": "junk"}
+        deny, nudge = skill_gate.apply_gate("scenarios_create", args, "enforce")
+        assert deny is None and nudge is None  # write proceeds
+        assert "skill_ack" not in args         # strip happened before the failure
+
+    def test_none_arguments_tolerated(self):
+        deny, nudge = skill_gate.apply_gate("scenarios_create", None, "enforce")
+        assert deny is not None  # gated, no ack -> deny; and no crash on None args
 
 
 # ── no-regression: skill_ack never reaches the backend ───────────────────────
@@ -196,7 +258,7 @@ class TestSkillAckStripped:
     def test_stripped_before_object_body_dispatch(self):
         op = FakeOp(path="/scenarios/", request_body=JSON_OBJECT_BODY)
         args = {"name": "x", "project": 5, "skill_ack": VALID_TAG}
-        args.pop("skill_ack", None)  # mirrors call_tool_with_dynamic
+        skill_gate.apply_gate("scenarios_create", args, "warn")
         path, query, body = _dispatch_args(op, args)
         assert "skill_ack" not in (body or {})
         assert "skill_ack" not in query
@@ -206,13 +268,13 @@ class TestSkillAckStripped:
         # metrics_bulk_create: top-level array body via `items`
         op = FakeOp(path="/metrics/bulk/", request_body=JSON_ARRAY_BODY)
         args = {"items": [{"name": "m1"}], "skill_ack": METRIC_TAG}
-        args.pop("skill_ack", None)
+        skill_gate.apply_gate("metrics_bulk_create", args, "shadow")
         path, query, body = _dispatch_args(op, args)
         assert body == [{"name": "m1"}]  # bare array, no skill_ack anywhere
 
     def test_stripped_when_no_body_routes_to_query(self):
         op = FakeOp(path="/scenarios/", parameters=[{"name": "project_id", "in": "query"}])
         args = {"project_id": 5, "skill_ack": VALID_TAG}
-        args.pop("skill_ack", None)
+        skill_gate.apply_gate("scenarios_create", args, "off")
         path, query, body = _dispatch_args(op, args)
         assert "skill_ack" not in query and query == {"project_id": 5}

--- a/cekura-mcp-server/tests/test_skill_gate.py
+++ b/cekura-mcp-server/tests/test_skill_gate.py
@@ -96,10 +96,13 @@ class TestEvaluate:
         d = skill_gate.evaluate("scenarios_create", "ack:manual-create-update-eval:5m4p7c", "enforce")
         assert d.action == "allow" and d.ack_valid is True
 
-    def test_wrong_family_ack_does_not_satisfy(self):
-        # a metric-family tag must NOT satisfy an eval-family write
-        d = skill_gate.evaluate("scenarios_create", METRIC_TAG, "warn")
-        assert d.action == "warn" and d.ack_valid is False
+    def test_wrong_family_ack_allows_but_is_flagged(self):
+        # a recognized tag from another family still proves a playbook is in
+        # context: allow (never deny an installed user), but mark the mismatch
+        for mode in ("warn", "enforce", "shadow"):
+            d = skill_gate.evaluate("scenarios_create", METRIC_TAG, mode)
+            assert d.action == "allow" and d.reason == "ack_wrong_family"
+            assert d.ack_valid is False and d.nudge is None
 
     def test_unknown_ack_shadow_would_block(self):
         d = skill_gate.evaluate("metrics_create", "ack:bogus:zzzzzz", "shadow")
@@ -132,6 +135,10 @@ class TestEvaluate:
         assert "NOT executed" in d.nudge
         # both recovery paths must tell the model to keep passing the value on later calls
         assert "subsequent write call" in d.nudge
+        # already-installed users get a recovery path that doesn't say "install"
+        assert "already installed" in d.nudge
+        # a choice made earlier in the conversation must not trigger a re-ask
+        assert "without asking again" in d.nudge
 
     def test_sandbox_bypass(self):
         d = skill_gate.evaluate("scenarios_create", None, "enforce", is_sandbox=True)
@@ -306,6 +313,12 @@ class TestGateLogEvents:
         (e,) = self._run(caplog, "scenarios_create", {"skill_ack": VALID_TAG}, "warn")
         assert e["event"] == "skill_gate_ack_ok" and e["mode"] == "warn"
         # thread-rate signal is anonymous: no identity fields
+        assert "client_id" not in e and "cred_hash" not in e
+
+    def test_wrong_family_event_shape(self, caplog):
+        (e,) = self._run(caplog, "scenarios_create", {"skill_ack": METRIC_TAG}, "enforce")
+        assert e["event"] == "skill_gate_ack_wrong_family"
+        assert e["family"] == "eval-design" and e["mode"] == "enforce"
         assert "client_id" not in e and "cred_hash" not in e
 
     def test_sandbox_event_shape(self, caplog):

--- a/cekura-mcp-server/tests/test_skill_gate.py
+++ b/cekura-mcp-server/tests/test_skill_gate.py
@@ -128,6 +128,8 @@ class TestEvaluate:
         assert "docs.cekura.ai/mcp/overview" in d.nudge
         assert 'skill_ack="proceed-without-skill"' in d.nudge
         assert "NOT executed" in d.nudge
+        # both recovery paths must tell the model to reuse the value on later calls
+        assert "subsequent" in d.nudge
 
     def test_sandbox_bypass(self):
         d = skill_gate.evaluate("scenarios_create", None, "enforce", is_sandbox=True)

--- a/cekura-mcp-server/tests/test_skill_gate.py
+++ b/cekura-mcp-server/tests/test_skill_gate.py
@@ -1,0 +1,216 @@
+"""Tests for the client-cooperative skill gate (through the `warn` mode).
+
+Covers the family/tool table, the mode-by-mode decision, sandbox bypass,
+schema injection, the append-only manifest + baked fallback, and the hard
+no-regression invariant: `skill_ack` is stripped before dispatch so it never
+reaches the backend.
+"""
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+import skill_gate
+from openapi_mcp_server import _dispatch_args
+
+
+# ── fixtures / helpers ───────────────────────────────────────────────────────
+
+VALID_TAG = "ack:cekura-eval-design:7k3m4q"
+METRIC_TAG = "ack:cekura-metric-design:6n2q5r"
+
+
+@pytest.fixture(autouse=True)
+def _manifest():
+    """Give every test a known manifest; restore nothing (each test sets its own)."""
+    skill_gate.set_manifest({
+        "cekura-eval-design": [VALID_TAG],
+        "manual-create-update-eval": ["ack:manual-create-update-eval:5m4p7c"],
+        "cekura-metric-design": [METRIC_TAG],
+    })
+    yield
+
+
+@dataclass
+class FakeOp:
+    path: str
+    parameters: Optional[List[Dict[str, Any]]] = None
+    request_body: Optional[Dict[str, Any]] = None
+
+
+JSON_OBJECT_BODY = {"content": {"application/json": {"schema": {"$ref": "#/x"}}}}
+JSON_ARRAY_BODY = {"content": {"application/json": {"schema": {"type": "array", "items": {"type": "object"}}}}}
+
+
+# ── family / tool table ──────────────────────────────────────────────────────
+
+class TestFamilyTable:
+    def test_exactly_eleven_gated_tools(self):
+        assert len(skill_gate.GATED_TOOLS) == 11
+
+    def test_every_gated_tool_maps_to_a_family(self):
+        for tool in skill_gate.GATED_TOOLS:
+            assert skill_gate._family_for_tool(tool) is not None
+
+    def test_generation_and_read_tools_are_not_gated(self):
+        for tool in (
+            "metrics_generate",
+            "scenarios_generate_bg",
+            "scenarios_agent_create",
+            "metric_failure_mode_insights_generate_scenario_create",
+            "predefined_metrics_copy_create",
+            "scenarios_list",
+            "metrics_retrieve",
+        ):
+            assert tool not in skill_gate.GATED_TOOLS
+
+
+# ── decision by mode ─────────────────────────────────────────────────────────
+
+class TestEvaluate:
+    def test_non_gated_tool_always_allowed(self):
+        d = skill_gate.evaluate("scenarios_list", None, "warn")
+        assert d.action == "allow" and d.reason == "not_gated"
+
+    def test_off_is_inert_even_for_gated_tool(self):
+        d = skill_gate.evaluate("scenarios_create", None, "off")
+        assert d.action == "allow" and d.reason == "mode_off"
+
+    def test_shadow_missing_ack_would_block(self):
+        d = skill_gate.evaluate("scenarios_create", None, "shadow")
+        assert d.action == "shadow_block" and d.family == "eval-design"
+
+    def test_warn_missing_ack_proceeds_with_nudge(self):
+        d = skill_gate.evaluate("scenarios_create", None, "warn")
+        assert d.action == "warn"
+        assert d.nudge and "cekura_load_skill" in d.nudge
+
+    def test_valid_ack_allows(self):
+        d = skill_gate.evaluate("scenarios_create", VALID_TAG, "warn")
+        assert d.action == "allow" and d.ack_valid is True
+
+    def test_ack_from_sibling_family_member_allows(self):
+        # a command tag in the same family satisfies the write
+        d = skill_gate.evaluate("scenarios_create", "ack:manual-create-update-eval:5m4p7c", "enforce")
+        assert d.action == "allow" and d.ack_valid is True
+
+    def test_wrong_family_ack_does_not_satisfy(self):
+        # a metric-family tag must NOT satisfy an eval-family write
+        d = skill_gate.evaluate("scenarios_create", METRIC_TAG, "warn")
+        assert d.action == "warn" and d.ack_valid is False
+
+    def test_unknown_ack_shadow_would_block(self):
+        d = skill_gate.evaluate("metrics_create", "ack:bogus:zzzzzz", "shadow")
+        assert d.action == "shadow_block"
+
+    def test_enforce_and_strict_deny_without_ack(self):
+        for mode in ("enforce", "strict"):
+            d = skill_gate.evaluate("metrics_create", None, mode)
+            assert d.action == "deny"
+
+    def test_enforce_valid_ack_allows(self):
+        d = skill_gate.evaluate("scenarios_create", VALID_TAG, "enforce")
+        assert d.action == "allow" and d.ack_valid is True
+
+    def test_enforce_user_override_allows(self):
+        d = skill_gate.evaluate("scenarios_create", skill_gate.OVERRIDE_ACK, "enforce")
+        assert d.action == "allow" and d.reason == "user_override"
+
+    def test_override_sentinel_is_not_special_outside_blocking_modes(self):
+        # the override only applies in enforce/strict; in warn everything proceeds
+        d = skill_gate.evaluate("scenarios_create", skill_gate.OVERRIDE_ACK, "warn")
+        assert d.action == "warn" and d.reason == "warn"
+
+    def test_deny_text_offers_both_paths(self):
+        d = skill_gate.evaluate("metrics_create", None, "enforce")
+        assert "Ask the user" in d.nudge
+        assert "cekura_load_skill" in d.nudge
+        assert "docs.cekura.ai/mcp/overview" in d.nudge
+        assert 'skill_ack="proceed-without-skill"' in d.nudge
+        assert "NOT executed" in d.nudge
+
+    def test_sandbox_bypass(self):
+        d = skill_gate.evaluate("scenarios_create", None, "enforce", is_sandbox=True)
+        assert d.action == "allow" and d.reason == "sandbox_bypass"
+
+    def test_does_not_raise_on_odd_input(self):
+        # fail-open safety: pure function must not raise on empty manifest / junk
+        skill_gate.set_manifest({})
+        assert skill_gate.evaluate("scenarios_create", "", "warn").action == "warn"
+        assert skill_gate.evaluate("not_a_tool", None, "warn").action == "allow"
+
+
+# ── schema injection ─────────────────────────────────────────────────────────
+
+class TestInjection:
+    def _schema(self):
+        return {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]}
+
+    def test_off_injects_nothing(self):
+        out = skill_gate.maybe_inject_skill_ack("scenarios_create", self._schema(), "off")
+        assert "skill_ack" not in out["properties"]
+
+    def test_warn_injects_optional_skill_ack(self):
+        original = self._schema()
+        out = skill_gate.maybe_inject_skill_ack("scenarios_create", original, "warn")
+        assert out["properties"]["skill_ack"]["type"] == "string"
+        assert "skill_ack" not in out.get("required", [])
+        # original object is not mutated
+        assert "skill_ack" not in original["properties"]
+
+    def test_non_gated_tool_not_injected(self):
+        out = skill_gate.maybe_inject_skill_ack("aiagents_create", self._schema(), "warn")
+        assert "skill_ack" not in out["properties"]
+
+    def test_idempotent(self):
+        once = skill_gate.maybe_inject_skill_ack("metrics_create", self._schema(), "warn")
+        twice = skill_gate.maybe_inject_skill_ack("metrics_create", once, "warn")
+        assert list(twice["properties"]).count("skill_ack") == 1
+
+
+# ── manifest ─────────────────────────────────────────────────────────────────
+
+class TestManifest:
+    def test_current_tag_is_last_appended(self):
+        skill_gate.set_manifest({"cekura-eval-design": ["ack:cekura-eval-design:old111", VALID_TAG]})
+        assert skill_gate.current_tag_for_slug("cekura-eval-design") == VALID_TAG
+
+    def test_current_tag_unknown_slug(self):
+        assert skill_gate.current_tag_for_slug("nope") is None
+
+    def test_baked_snapshot_loads(self):
+        source = skill_gate._load_baked()
+        assert source == "baked"
+        m = skill_gate.get_manifest()
+        assert len(m) == 11
+        # every family slug in the code table is present in the shipped snapshot
+        for slug in (skill_gate.EVAL_DESIGN_SLUGS | skill_gate.METRIC_DESIGN_SLUGS):
+            assert slug in m
+
+
+# ── no-regression: skill_ack never reaches the backend ───────────────────────
+
+class TestSkillAckStripped:
+    def test_stripped_before_object_body_dispatch(self):
+        op = FakeOp(path="/scenarios/", request_body=JSON_OBJECT_BODY)
+        args = {"name": "x", "project": 5, "skill_ack": VALID_TAG}
+        args.pop("skill_ack", None)  # mirrors call_tool_with_dynamic
+        path, query, body = _dispatch_args(op, args)
+        assert "skill_ack" not in (body or {})
+        assert "skill_ack" not in query
+        assert body == {"name": "x", "project": 5}
+
+    def test_stripped_before_array_body_dispatch(self):
+        # metrics_bulk_create: top-level array body via `items`
+        op = FakeOp(path="/metrics/bulk/", request_body=JSON_ARRAY_BODY)
+        args = {"items": [{"name": "m1"}], "skill_ack": METRIC_TAG}
+        args.pop("skill_ack", None)
+        path, query, body = _dispatch_args(op, args)
+        assert body == [{"name": "m1"}]  # bare array, no skill_ack anywhere
+
+    def test_stripped_when_no_body_routes_to_query(self):
+        op = FakeOp(path="/scenarios/", parameters=[{"name": "project_id", "in": "query"}])
+        args = {"project_id": 5, "skill_ack": VALID_TAG}
+        args.pop("skill_ack", None)
+        path, query, body = _dispatch_args(op, args)
+        assert "skill_ack" not in query and query == {"project_id": 5}

--- a/cekura-mcp-server/tests/test_skill_gate.py
+++ b/cekura-mcp-server/tests/test_skill_gate.py
@@ -128,8 +128,8 @@ class TestEvaluate:
         assert "docs.cekura.ai/mcp/overview" in d.nudge
         assert 'skill_ack="proceed-without-skill"' in d.nudge
         assert "NOT executed" in d.nudge
-        # both recovery paths must tell the model to pass the value on write calls
-        assert "on write calls" in d.nudge
+        # both recovery paths must tell the model to keep passing the value on later calls
+        assert "subsequent write call" in d.nudge
 
     def test_sandbox_bypass(self):
         d = skill_gate.evaluate("scenarios_create", None, "enforce", is_sandbox=True)


### PR DESCRIPTION
## What

A client-cooperative **skill gate** on the MCP server's quality-critical authoring tools, plus a server-delivered playbook tool and joinable telemetry. **Ships gated at `mode=off` — zero behavior change on deploy.** Companion PRs: `cekura-skills` (tags + manifest) and `vocera.backend` (activation endpoint).

## Rollout ladder — `CEKURA_SKILL_GATE_MODE`

| Mode | Behavior |
|---|---|
| `off` (default) | Inert — no schema change, no evaluation. |
| `shadow` | Log-only: would-block volume + thread-rate (`skill_gate_ack_ok` / `skill_gate_blocked`). |
| `warn` | Write proceeds; appends an install-first nudge. |
| `enforce` | **Holds** a gated write with no valid ack; the deny asks the user (via the model) to install/update the skills + load the playbook now, or proceed via `skill_ack="proceed-without-skill"` (logged `skill_gate_user_override`). |
| `strict` | Currently uses `enforce` behavior (tag-redaction hardening deferred). |

## Changes

- **`skill_gate.py`** — family↔tool table (mirror of the server-side design gate: 8 eval-design + 3 metric-design write tools), append-only tag manifest (remote fetch with baked `ack_tags.snapshot.json` fallback), and `evaluate()`. Fails **open** on any error.
- **`openapi_mcp_server.py`**:
  - `skill_ack` is **stripped before dispatch in every mode** → the backend request body stays byte-identical; the optional `skill_ack` property is injected on the 11 gated tools **only when `mode != off`**.
  - **`cekura_load_skill(skill_name)`** — server-delivered playbook + tag for any client.
  - **`cekura_skill_started`** extended with `verification_tag` / `plugin_version` / `skill_version`: fire-and-forget activation forward, migration grace (hands old installs the current tag), and an update nudge for the pre-tagging signature.
  - Sandbox traffic (`X-Cekura-Conversation-Id`) is exempt.
- Auth flows (CredentialMiddleware, OAuth routes, token endpoints) **untouched** — the gate runs inside `call_tool`, after auth.

## No-regression posture

Default `off` is fully inert (verified: no `skill_ack` in any tool schema, gate never evaluates). `skill_ack` never reaches the backend. `enforce` fails open and is intended to be flipped only after `shadow` shows installed traffic reliably threads the ack.

## Tests

- `tests/test_skill_gate.py` — **28 pass** (mode decisions, override, deny text, sandbox bypass, manifest fallback, and the hard invariant that `skill_ack` is never forwarded).
- Full suite: **104 passed, 6 failed**. The 6 failures are **pre-existing** (proven: they reproduce on the base branch with these changes stashed) in `test_config.py` and `test_tool_generator.py` — files untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Merge order / rollout requirements

- **This PR is safe to merge and deploy anytime** — the gate defaults to `off` (fully inert: no schema change, no evaluation; `skill_ack` is stripped if ever sent).
- **Before flipping any non-`off` mode**: cekura-skills PR #96 must be merged **and shipped as a plugin release**. Until then the remote tag manifest 404s (the baked snapshot fallback carries the same tags, and startup now WARNs when an enforcing mode runs on the fallback) and `cekura_load_skill` serves un-tagged playbooks from main (the tag still rides the response's `verification_tag` field, so recovery works).
- **Before `enforce`**: run `shadow` and confirm thread-rate (installed traffic reliably passes `skill_ack`) — see the plan's go/no-go metrics.
