### PR TITLE
MCP messaging: version-aware update routing + tighten install instructions

### DIFF
--- a/cekura-mcp-server/openapi_mcp_server.py
+++ b/cekura-mcp-server/openapi_mcp_server.py
@@ -105,10 +105,16 @@ transport_security = TransportSecuritySettings(
 # lead with the install path, then a skills-first working note. Additive and
 # spec-standard — clients that don't render instructions simply ignore it.
 MCP_INSTRUCTIONS = (
-    "Cekura MCP server. For the best results, install the Cekura plugin/skills — "
-    "they carry the playbooks that make authored scenarios, metrics, and "
-    "evaluators substantially higher quality. Setup: "
-    "https://docs.cekura.ai/mcp/overview\n\n"
+    "Cekura MCP server. These tools work best with the Cekura design skills/plugin "
+    "installed — they carry the playbooks that make authored scenarios, metrics, and "
+    "evaluators substantially higher quality.\n\n"
+    "IMPORTANT — tell the user, do not just note it silently: if you do NOT have a "
+    "Cekura design skill or command loaded in this session and the user asks you to "
+    "create or edit scenarios, metrics, or test profiles, then before or alongside "
+    "your first such action, say to the user in your reply that installing the Cekura "
+    "plugin (one-time) will make results substantially better, and share this link: "
+    "https://docs.cekura.ai/mcp/overview . Say this once per session, not on every "
+    "call. You may still proceed (optionally via cekura_load_skill) if they decline.\n\n"
     "Working with Cekura: prefer the skills/commands when designing evaluators and "
     "metrics; retrieve the target agent first (aiagents_retrieve) to pick the "
     "right run connection; treat scenario/metric authoring as skill-guided work "

--- a/cekura-mcp-server/openapi_mcp_server.py
+++ b/cekura-mcp-server/openapi_mcp_server.py
@@ -627,13 +627,33 @@ def _latest_plugin_version() -> str:
     return os.environ.get("CEKURA_LATEST_PLUGIN_VERSION", "0.9.0")
 
 
-def _update_command_for_client() -> str:
-    # Match the documented update paths (mcp/skills.mdx). Only Claude Code has a
-    # first-class slash command; everyone else is routed to the docs update
-    # section, which carries the per-client (npx / marketplace) instructions.
+# /upgrade-skills only moves the installed version pin from this version on
+# (earlier releases silently no-op); older installs must uninstall + reinstall.
+_UPGRADE_SKILLS_MIN_VERSION = "0.8.1"
+
+
+def _upgrade_skills_reliable(current_version) -> bool:
+    if not current_version:
+        return False
+    try:
+        return _parse_version(current_version) >= _parse_version(_UPGRADE_SKILLS_MIN_VERSION)
+    except Exception:
+        return False
+
+
+def _update_command_for_client(current_version=None) -> str:
+    # Match the documented update paths (mcp/skills.mdx). Claude Code can
+    # self-upgrade via /upgrade-skills, but only from _UPGRADE_SKILLS_MIN_VERSION
+    # on; older or unknown installs are routed to reinstall, which always works.
+    # Everyone else goes to the docs update section (per-client instructions).
     client = (_resolve_client_identifier() or "").lower()
     if "claude" in client:
-        return "run /upgrade-skills (docs: https://docs.cekura.ai/mcp/skills#update)"
+        if _upgrade_skills_reliable(current_version):
+            return "run /upgrade-skills (docs: https://docs.cekura.ai/mcp/skills#update)"
+        return (
+            "uninstall and reinstall the plugin — older versions can't self-upgrade: "
+            "https://docs.cekura.ai/mcp/skills#reinstall-claude-code-plugin"
+        )
     return "https://docs.cekura.ai/mcp/skills#update"
 
 
@@ -764,8 +784,8 @@ async def cekura_skill_started(
             if not plugin_version:
                 response["update_recommended"] = True
                 response["update_hint"] = (
-                    "Your Cekura skills look outdated (no verification tag). Update them "
-                    f"for the best experience: {_update_command_for_client()}."
+                    "Your Cekura skills look outdated (no verification tag). To get the "
+                    f"current version, {_update_command_for_client(plugin_version)}."
                 )
 
     # Freshness nudge — recommendation only, never blocks anything.
@@ -774,7 +794,7 @@ async def cekura_skill_started(
         response["status"] = "update_available"
         response["current_version"] = plugin_version
         response["latest_version"] = latest
-        response["update_command"] = _update_command_for_client()
+        response["update_command"] = _update_command_for_client(plugin_version)
         response["docs_url"] = "https://docs.cekura.ai/mcp/overview"
 
     return response

--- a/cekura-mcp-server/openapi_mcp_server.py
+++ b/cekura-mcp-server/openapi_mcp_server.py
@@ -100,25 +100,22 @@ transport_security = TransportSecuritySettings(
 # Stateless: every request is self-contained, so restarts/redeploys and
 # horizontal scaling don't invalidate client sessions, and per-request
 # credentials always apply (no session-task contextvar snapshots).
-# Server instructions surfaced in the MCP `initialize` response. Install-first:
-# most quality gaps come from clients that skipped the Cekura plugin/skills, so
-# lead with the install path, then a skills-first working note. Additive and
-# spec-standard — clients that don't render instructions simply ignore it.
+# Server instructions surfaced in the MCP `initialize` response. Install-first
+# and deliberately high-level: nudge toward installing the Cekura skills/plugin,
+# no tool names or mechanism. Additive and spec-standard — clients that don't
+# render instructions simply ignore it.
 MCP_INSTRUCTIONS = (
-    "Cekura MCP server. These tools work best with the Cekura design skills/plugin "
-    "installed — they carry the playbooks that make authored scenarios, metrics, and "
-    "evaluators substantially higher quality.\n\n"
-    "IMPORTANT — tell the user, do not just note it silently: if you do NOT have a "
-    "Cekura design skill or command loaded in this session and the user asks you to "
-    "create or edit scenarios, metrics, or test profiles, then before or alongside "
-    "your first such action, say to the user in your reply that installing the Cekura "
-    "plugin (one-time) will make results substantially better, and share this link: "
+    "Cekura MCP server. These tools produce substantially higher-quality results "
+    "when the Cekura design skills/plugin are installed — they carry the authoring "
+    "playbooks for scenarios, metrics, and evaluators.\n\n"
+    "IMPORTANT — tell the user, do not just note it silently: if the Cekura design "
+    "skills are not installed in this session and the user asks you to create or edit "
+    "scenarios, metrics, or test profiles, then before or alongside your first such "
+    "action, tell the user in your reply that a one-time Cekura plugin install will "
+    "make results substantially better, and share this link: "
     "https://docs.cekura.ai/mcp/overview . Say this once per session, not on every "
-    "call. You may still proceed (optionally via cekura_load_skill) if they decline.\n\n"
-    "Working with Cekura: prefer the skills/commands when designing evaluators and "
-    "metrics; retrieve the target agent first (aiagents_retrieve) to pick the "
-    "right run connection; treat scenario/metric authoring as skill-guided work "
-    "rather than raw create calls."
+    "call; you may still proceed if they decline.\n\n"
+    "Treat scenario and metric authoring as skill-guided work, not raw create calls."
 )
 
 mcp = FastMCP(

--- a/cekura-mcp-server/tests/test_skill_gate.py
+++ b/cekura-mcp-server/tests/test_skill_gate.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, List, Optional
 import pytest
 
 import skill_gate
-from openapi_mcp_server import _dispatch_args
+from openapi_mcp_server import _dispatch_args, _upgrade_skills_reliable
 
 
 # ── fixtures / helpers ───────────────────────────────────────────────────────
@@ -89,6 +89,18 @@ class TestEvaluate:
         # the nudge must instruct the model to surface the install path to the user
         assert "docs.cekura.ai/mcp/overview" in d.nudge
         assert "user" in d.nudge
+
+    def test_upgrade_skills_reliable_threshold(self):
+        # /upgrade-skills reliably moves the version pin only from 0.8.1 on;
+        # older or unknown versions must reinstall instead.
+        assert _upgrade_skills_reliable("0.8.1") is True
+        assert _upgrade_skills_reliable("0.9.0") is True
+        assert _upgrade_skills_reliable("1.0.0") is True
+        assert _upgrade_skills_reliable("0.8.0") is False
+        assert _upgrade_skills_reliable("0.4.2") is False
+        assert _upgrade_skills_reliable("0.1.1") is False
+        assert _upgrade_skills_reliable(None) is False
+        assert _upgrade_skills_reliable("") is False
 
     def test_valid_ack_allows(self):
         d = skill_gate.evaluate("scenarios_create", VALID_TAG, "warn")

--- a/cekura-mcp-server/tests/test_skill_gate.py
+++ b/cekura-mcp-server/tests/test_skill_gate.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, List, Optional
 import pytest
 
 import skill_gate
-from openapi_mcp_server import _dispatch_args, _upgrade_skills_reliable
+from openapi_mcp_server import _dispatch_args, _upgrade_skills_reliable, MCP_INSTRUCTIONS
 
 
 # ── fixtures / helpers ───────────────────────────────────────────────────────
@@ -89,6 +89,13 @@ class TestEvaluate:
         # the nudge must instruct the model to surface the install path to the user
         assert "docs.cekura.ai/mcp/overview" in d.nudge
         assert "user" in d.nudge
+
+    def test_initialize_instructions_direct_the_model_to_tell_the_user(self):
+        # the session-start instructions must push the model to surface the
+        # install path to the user, not just note it, and carry the docs link
+        assert "tell the user" in MCP_INSTRUCTIONS.lower()
+        assert "docs.cekura.ai/mcp/overview" in MCP_INSTRUCTIONS
+        assert "once per session" in MCP_INSTRUCTIONS.lower()
 
     def test_upgrade_skills_reliable_threshold(self):
         # /upgrade-skills reliably moves the version pin only from 0.8.1 on;

--- a/cekura-mcp-server/tests/test_skill_gate.py
+++ b/cekura-mcp-server/tests/test_skill_gate.py
@@ -97,6 +97,12 @@ class TestEvaluate:
         assert "docs.cekura.ai/mcp/overview" in MCP_INSTRUCTIONS
         assert "once per session" in MCP_INSTRUCTIONS.lower()
 
+    def test_initialize_instructions_name_no_tools_or_mechanism(self):
+        # instructions stay high-level: no tool names, no gate mechanism leaked
+        for token in ("cekura_load_skill", "aiagents_retrieve", "skill_ack",
+                      "metrics_create", "scenarios_create", "proceed-without-skill"):
+            assert token not in MCP_INSTRUCTIONS, f"instructions should not mention {token}"
+
     def test_upgrade_skills_reliable_threshold(self):
         # /upgrade-skills reliably moves the version pin only from 0.8.1 on;
         # older or unknown versions must reinstall instead.


### PR DESCRIPTION
Follow-up to #757 (which merged only the warn-nudge change). These two commits were pushed to that branch *after* it merged, so they were stranded — this PR lands them on `main`.

## 1. Version-aware update guidance (reinstall for pre-0.8.1)
`/upgrade-skills` only moves the installed version pin from **v0.8.1** on — the fix (`04d46db`) + the session-start auto-update hook (`a440372`) shipped in 0.8.1; **0.8.0 and earlier silently no-op**, so telling those users to run it does nothing. `_update_command_for_client(current_version)` is now version-aware:
- Claude Code **≥ 0.8.1** → `run /upgrade-skills`
- Claude Code **< 0.8.1 or unknown version** → uninstall + reinstall (`/mcp/skills#reinstall-claude-code-plugin`) — always works
- other clients → docs update section (unchanged)

Applied at both call sites (migration-grace `update_hint`; freshness-nudge `update_command`). Threshold is the named constant `_UPGRADE_SKILLS_MIN_VERSION = "0.8.1"`.

## 2. Tighten `initialize` instructions to surface install to the user
`MCP_INSTRUCTIONS` (seen at session start, every mode incl. off/shadow) was declarative. Added a conditional, once-per-session directive: when authoring scenarios/metrics/test-profiles **without** a Cekura skill loaded, the model must tell the user (in its reply) that installing the plugin makes results substantially better, with the docs link. Conditioned on "no skill loaded" (won't pitch installed/read-only users) and "once per session" (no repeat).

## Behavior / safety
Messaging only. `off`/`shadow`/`enforce`, evaluation, `skill_ack` stripping, and fail-open untouched.

## Tests
`tests/test_skill_gate.py`: **47 passed**. Added `test_upgrade_skills_reliable_threshold` (locks the 0.8.1 boundary) and `test_initialize_instructions_direct_the_model_to_tell_the_user`.

## Rollout
Merge + redeploy the MCP server. Still `warn`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)