### PR TITLE
[Auto] Sync docs for backend PR #10141

### DIFF
--- a/api-reference/test_framework/metric-reviews-process-feedbacks-answer.mdx
+++ b/api-reference/test_framework/metric-reviews-process-feedbacks-answer.mdx
@@ -1,0 +1,6 @@
+---
+title: Process Feedbacks Answer
+description: "Answer the questions a running metric optimization is paused on. Answers are keyed by question id; use {\"action\": \"skip\"} to skip one."
+openapi: post /test_framework/metric-reviews/process_feedbacks_answer/
+slug: metric-reviews-process-feedbacks-answer
+---

--- a/documentation/key-concepts/evaluators/test-profile.mdx
+++ b/documentation/key-concepts/evaluators/test-profile.mdx
@@ -27,7 +27,7 @@ Test profiles are essential when your AI agent needs to:
 ### Common Use Cases
 
 | Scenario | Required Information | Example |
-|----------|---------------------|---------|
+|----------|---------------------|---------|  
 | Healthcare Appointment | Name, DOB, Phone Number | "I'm calling to cancel my appointment" |
 | Banking Support | Name, Account Number, DOB, Address | "I need help with my account" |
 | E-commerce Returns | Name, Order Number, Email | "I want to return an order" |
@@ -131,6 +131,10 @@ Sectioned example:
 <Tip>
 **Why split?** Persona PII like `customer_name` shouldn't be sent to the agent under test as a dynamic variable unless your agent registered it. Conversely, dynamic-variable values your production code expects shouldn't leak into the testing agent's persona prompt. The split keeps each side honest.
 </Tip>
+
+<Note>
+**Custom SIP and WebSocket headers:** Keys in `main_agent_variables` starting with `X-` are also sent as custom SIP headers (for SIP runs) or connection headers (for WebSocket runs) to the agent under test. For example, `"X-Tenant-ID": "tenant-123"` becomes a `X-Tenant-ID` header on the connection. Reserved system headers (`X-Run-Id`, `X-Scenario-Id`, `X-Result-Id`) are always set by Cekura and cannot be overridden. See the [SIP integration guide](/documentation/integrations/sip-integration) for details.
+</Note>
 
 <Note>
 **Both sections are optional.** Set only the ones you need:

--- a/documentation/key-concepts/evaluators/test-profile.mdx
+++ b/documentation/key-concepts/evaluators/test-profile.mdx
@@ -27,7 +27,7 @@ Test profiles are essential when your AI agent needs to:
 ### Common Use Cases
 
 | Scenario | Required Information | Example |
-|----------|---------------------|---------|  
+|----------|---------------------|---------|
 | Healthcare Appointment | Name, DOB, Phone Number | "I'm calling to cancel my appointment" |
 | Banking Support | Name, Account Number, DOB, Address | "I need help with my account" |
 | E-commerce Returns | Name, Order Number, Email | "I want to return an order" |
@@ -133,15 +133,44 @@ Sectioned example:
 </Tip>
 
 <Note>
-**Custom SIP and WebSocket headers:** Keys in `main_agent_variables` starting with `X-` are also sent as custom SIP headers (for SIP runs) or connection headers (for WebSocket runs) to the agent under test. For example, `"X-Tenant-ID": "tenant-123"` becomes a `X-Tenant-ID` header on the connection. Reserved system headers (`X-Run-Id`, `X-Scenario-Id`, `X-Result-Id`) are always set by Cekura and cannot be overridden. See the [SIP integration guide](/documentation/integrations/sip-integration) for details.
-</Note>
-
-<Note>
 **Both sections are optional.** Set only the ones you need:
 - If your agent has no registered [dynamic variables](/documentation/key-concepts/evaluators/dynamic-variables), omit `main_agent_variables` (or leave it `{}`) — there's nothing for it to deliver. Put persona/context for the simulated caller in `testing_agent_variables` only.
 - If you only need to send dynamic-variable values and don't need to brief the simulated caller separately, populate `main_agent_variables` and leave `testing_agent_variables` empty (or omit it).
 - Both empty / both missing is also valid — the profile then has no information payload but can still be attached to a scenario for naming purposes.
 </Note>
+
+### Custom Headers for SIP and WebSocket Runs
+
+For [SIP](/documentation/integrations/sip-integration) and [WebSocket](/documentation/integrations/websocket-chirp) runs, keys in `main_agent_variables` that start with `X-` are additionally sent as custom headers during connection setup:
+
+- **SIP runs**: sent as custom SIP headers in the INVITE request
+- **WebSocket runs**: sent as custom HTTP headers during the WebSocket upgrade
+
+This is the only way to pass custom headers to your agent for these connection types. Reserved system headers (`X-Run-Id`, `X-Scenario-Id`, `X-Result-Id`) are always set by Cekura and cannot be overridden.
+
+**Example:**
+
+```json
+{
+  "main_agent_variables": {
+    "X-Auth-Token": "abc123xyz",
+    "X-Customer-Tier": "premium",
+    "user_id": "U-42"
+  },
+  "testing_agent_variables": {
+    "customer_name": "Jane Smith"
+  }
+}
+```
+
+In this example:
+- `X-Auth-Token` and `X-Customer-Tier` are sent as custom headers (SIP or WebSocket)
+- `user_id` is sent as a dynamic variable to the agent
+- `customer_name` stays on the testing agent and is NOT sent over the wire
+
+<Tip>
+Use custom headers to pass authentication tokens, routing metadata, or infrastructure flags to your SIP or WebSocket endpoint. See the [SIP integration guide](/documentation/integrations/sip-integration#user-defined-custom-headers) and [WebSocket integration guide](/documentation/integrations/websocket-chirp#custom-connection-headers) for full details.
+</Tip>
 
 ## Using Test Profile Variables in Instructions
 

--- a/mint.json
+++ b/mint.json
@@ -288,7 +288,8 @@
             "api-reference/test_framework/post-test_frameworkmetrics-run_reviews",
             "api-reference/test_framework/metric-run-reviews-progress",
             "api-reference/test_framework/metric-review-process-feedbacks",
-            "api-reference/test_framework/metric-review-process-feedbacks-progress"
+            "api-reference/test_framework/metric-review-process-feedbacks-progress",
+            "api-reference/test_framework/metric-reviews-process-feedbacks-answer"
           ]
         },
         {

--- a/openapi.json
+++ b/openapi.json
@@ -11767,6 +11767,45 @@
                 }
             }
         },
+        "/test_framework/metric-reviews/process_feedbacks_answer/": {
+            "post": {
+                "operationId": "metric-reviews-process-feedbacks-answer",
+                "description": "Answer the questions a running metric optimization is paused on. Answers are keyed by question id; use {\"action\": \"skip\"} to skip one.",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricReviewInline"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricReviewInline"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricReviewInline"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Answers recorded; the paused optimization resumes"
+                    }
+                }
+            }
+        },
         "/test_framework/metric-reviews/process_feedbacks_cancel/": {
             "post": {
                 "operationId": "test-framework-metric-reviews-process-feedbacks-cancel-create",
@@ -32204,7 +32243,7 @@
         "/test_framework/v1/scenarios-external/run_scenarios_sip/": {
             "post": {
                 "operationId": "scenarios-run-sip",
-                "description": "SIP VOICE RUN (direct SIP): Execute evaluators against an agent over a direct SIP connection (orchestrated by Cekura's SIP voice service). The agent must have a SIP endpoint configured (`telephony.sip_uri` on the v2 agent).\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone calls via Cekura's standard voice path\n- `scenarios_run_vapi_webrtc` / `_retell_webrtc` — provider-managed WebRTC\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
+                "description": "SIP VOICE RUN (direct SIP): Execute evaluators against an agent over a direct SIP connection (orchestrated by Cekura's SIP voice service). The agent must have a SIP endpoint configured (`telephony.sip_uri` on the v2 agent).\n\n**Custom SIP headers:** to send custom headers to the agent, attach a test profile whose `main_agent_variables` contain `X-` prefixed keys (pass its ID in `test_profile_ids`) — headers cannot be set on the agent or in this request.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone calls via Cekura's standard voice path\n- `scenarios_run_vapi_webrtc` / `_retell_webrtc` — provider-managed WebRTC\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
                 "summary": "Run evaluators over a direct SIP connection",
                 "tags": [
                     "Evaluators"
@@ -37513,7 +37552,7 @@
         "/test_framework/v1/scenarios/run_scenarios_sip/": {
             "post": {
                 "operationId": "scenarios-run-sip_2",
-                "description": "SIP VOICE RUN (direct SIP): Execute evaluators against an agent over a direct SIP connection (orchestrated by Cekura's SIP voice service). The agent must have a SIP endpoint configured (`telephony.sip_uri` on the v2 agent).\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone calls via Cekura's standard voice path\n- `scenarios_run_vapi_webrtc` / `_retell_webrtc` — provider-managed WebRTC\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
+                "description": "SIP VOICE RUN (direct SIP): Execute evaluators against an agent over a direct SIP connection (orchestrated by Cekura's SIP voice service). The agent must have a SIP endpoint configured (`telephony.sip_uri` on the v2 agent).\n\n**Custom SIP headers:** to send custom headers to the agent, attach a test profile whose `main_agent_variables` contain `X-` prefixed keys (pass its ID in `test_profile_ids`) — headers cannot be set on the agent or in this request.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone calls via Cekura's standard voice path\n- `scenarios_run_vapi_webrtc` / `_retell_webrtc` — provider-managed WebRTC\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
                 "summary": "Run evaluators over a direct SIP connection",
                 "tags": [
                     "Evaluators"
@@ -37718,7 +37757,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-run-sip",
-                        "description": "SIP VOICE RUN (direct SIP): Execute evaluators against an agent over a direct SIP connection (orchestrated by Cekura's SIP voice service). The agent must have a SIP endpoint configured (`telephony.sip_uri` on the v2 agent).\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone calls via Cekura's standard voice path\n- `scenarios_run_vapi_webrtc` / `_retell_webrtc` — provider-managed WebRTC\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)"
+                        "description": "SIP VOICE RUN (direct SIP): Execute evaluators against an agent over a direct SIP connection (orchestrated by Cekura's SIP voice service). The agent must have a SIP endpoint configured (`telephony.sip_uri` on the v2 agent).\n\n**Custom SIP headers:** to send custom headers to the agent, attach a test profile whose `main_agent_variables` contain `X-` prefixed keys (pass its ID in `test_profile_ids`) — headers cannot be set on the agent or in this request.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone calls via Cekura's standard voice path\n- `scenarios_run_vapi_webrtc` / `_retell_webrtc` — provider-managed WebRTC\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)"
                     }
                 }
             }
@@ -50426,7 +50465,7 @@
         "/test_framework/v2/scenarios/run_scenarios_sip/": {
             "post": {
                 "operationId": "scenarios-run-sip_3",
-                "description": "SIP VOICE RUN (direct SIP): Execute evaluators against an agent over a direct SIP connection (orchestrated by Cekura's SIP voice service). The agent must have a SIP endpoint configured (`telephony.sip_uri` on the v2 agent).\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone calls via Cekura's standard voice path\n- `scenarios_run_vapi_webrtc` / `_retell_webrtc` — provider-managed WebRTC\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
+                "description": "SIP VOICE RUN (direct SIP): Execute evaluators against an agent over a direct SIP connection (orchestrated by Cekura's SIP voice service). The agent must have a SIP endpoint configured (`telephony.sip_uri` on the v2 agent).\n\n**Custom SIP headers:** to send custom headers to the agent, attach a test profile whose `main_agent_variables` contain `X-` prefixed keys (pass its ID in `test_profile_ids`) — headers cannot be set on the agent or in this request.\n\n**Cost:** voice-simulation rate per run.\n**Run-count math:** total runs = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`.\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `scenarios_run_voice` — phone calls via Cekura's standard voice path\n- `scenarios_run_vapi_webrtc` / `_retell_webrtc` — provider-managed WebRTC\n- `scenarios_run_livekit_v2` — LiveKit (project credentials, v2)",
                 "summary": "Run evaluators over a direct SIP connection",
                 "tags": [
                     "Evaluators"
@@ -52519,7 +52558,7 @@
         "/user/oauth/register/": {
             "post": {
                 "operationId": "user-oauth-register-create",
-                "description": "Minimal RFC 7591 Dynamic Client Registration. The OAuth flow here is a\npublic client / PKCE design — we don't actually persist or validate\nclient_ids (OAuthAuthorizeView ignores client_id entirely). This endpoint\nexists only because Claude.ai's MCP connector refuses to start the auth\nflow without a `registration_endpoint` in the metadata. We echo the\nrequest fields back with a synthetic client_id.",
+                "description": "Minimal RFC 7591 Dynamic Client Registration for the public-client / PKCE\nflow. Registration is persisted only so the consent page can recognize a\nknown client from a trusted redirect scheme among its registered\nredirect_uris (e.g. Cursor's cursor://) when the authorize request's\nredirect_uri matches one registered under the same client_id — client_id is\nstill not a credential and grants nothing by itself.",
                 "tags": [
                     "user"
                 ],
@@ -56589,7 +56628,7 @@
                         "maxLength": 255
                     },
                     "information": {
-                        "description": "\nVariables for the test profile, split by which agent receives them.\n```json\n{\n    \"main_agent_variables\": {\"user_id\": \"U-123\"},\n    \"testing_agent_variables\": {\"user_name\": \"John Doe\", \"user_email\": \"john.doe@example.com\"}\n}\n```\n`main_agent_variables` are sent to the agent under test as dynamic variables. `testing_agent_variables` shape the simulated caller's persona. A legacy flat dict (no section keys) is accepted for backward compatibility and is sent to both agents.\n"
+                        "description": "\nVariables for the test profile, split by which agent receives them.\n```json\n{\n    \"main_agent_variables\": {\"user_id\": \"U-123\"},\n    \"testing_agent_variables\": {\"user_name\": \"John Doe\", \"user_email\": \"john.doe@example.com\"}\n}\n```\n`main_agent_variables` are sent to the agent under test as dynamic variables. `testing_agent_variables` shape the simulated caller's persona. A legacy flat dict (no section keys) is accepted for backward compatibility and is sent to both agents.\n\nKeys in `main_agent_variables` starting with `X-` are additionally sent as custom SIP headers (SIP runs) or connection headers (WebSocket runs) to the agent under test. For SIP runs this is the only way to pass custom headers; `X-Run-Id`, `X-Scenario-Id`, and `X-Result-Id` are reserved and always set by Cekura.\n"
                     },
                     "created_by": {
                         "type": "integer",
@@ -56648,7 +56687,7 @@
                         "maxLength": 255
                     },
                     "information": {
-                        "description": "\nVariables for the test profile, split by which agent receives them.\n```json\n{\n    \"main_agent_variables\": {\"user_id\": \"U-123\"},\n    \"testing_agent_variables\": {\"user_name\": \"John Doe\", \"user_email\": \"john.doe@example.com\"}\n}\n```\n`main_agent_variables` are sent to the agent under test as dynamic variables. `testing_agent_variables` shape the simulated caller's persona. A legacy flat dict (no section keys) is accepted for backward compatibility and is sent to both agents.\n"
+                        "description": "\nVariables for the test profile, split by which agent receives them.\n```json\n{\n    \"main_agent_variables\": {\"user_id\": \"U-123\"},\n    \"testing_agent_variables\": {\"user_name\": \"John Doe\", \"user_email\": \"john.doe@example.com\"}\n}\n```\n`main_agent_variables` are sent to the agent under test as dynamic variables. `testing_agent_variables` shape the simulated caller's persona. A legacy flat dict (no section keys) is accepted for backward compatibility and is sent to both agents.\n\nKeys in `main_agent_variables` starting with `X-` are additionally sent as custom SIP headers (SIP runs) or connection headers (WebSocket runs) to the agent under test. For SIP runs this is the only way to pass custom headers; `X-Run-Id`, `X-Scenario-Id`, and `X-Result-Id` are reserved and always set by Cekura.\n"
                     },
                     "created_by": {
                         "type": "integer",
@@ -58525,6 +58564,7 @@
             },
             "CallLogDetail": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -58716,6 +58756,7 @@
             },
             "CallLogList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -59875,6 +59916,7 @@
             },
             "Dashboard": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -60006,6 +60048,7 @@
             },
             "DashboardList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -62785,21 +62828,23 @@
                         "enum": [
                             "openai",
                             "gemini",
-                            "dspy-gepa-gemini-flash"
+                            "dspy-gepa-gemini-flash",
+                            "deepseek-v4-flash"
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "627916df1920819a",
-                        "description": "LLM provider for this metric evaluation.\nExample: \n- `\"gemini\"`\n- `\"openai\"`\n\n\n* `openai` - OpenAI\n* `gemini` - Gemini\n* `dspy-gepa-gemini-flash` - Dspy Gepa Gemini Flash"
+                        "x-spec-enum-id": "6d1d2e77c71d1721",
+                        "description": "LLM provider for this metric evaluation.\nExample: \n- `\"gemini\"`\n- `\"openai\"`\n\n\n* `openai` - OpenAI\n* `gemini` - Gemini\n* `dspy-gepa-gemini-flash` - Dspy Gepa Gemini Flash\n* `deepseek-v4-flash` - DeepSeek V4 Flash"
                     },
                     "relevance_llm_provider": {
                         "enum": [
                             "openai",
                             "gemini",
-                            "dspy-gepa-gemini-flash"
+                            "dspy-gepa-gemini-flash",
+                            "deepseek-v4-flash"
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "627916df1920819a",
-                        "description": "LLM provider for this metric relevance.\nExample: \n- `\"gemini\"`\n- `\"openai\"`\n\n\n* `openai` - OpenAI\n* `gemini` - Gemini\n* `dspy-gepa-gemini-flash` - Dspy Gepa Gemini Flash"
+                        "x-spec-enum-id": "6d1d2e77c71d1721",
+                        "description": "LLM provider for this metric relevance.\nExample: \n- `\"gemini\"`\n- `\"openai\"`\n\n\n* `openai` - OpenAI\n* `gemini` - Gemini\n* `dspy-gepa-gemini-flash` - Dspy Gepa Gemini Flash\n* `deepseek-v4-flash` - DeepSeek V4 Flash"
                     },
                     "metric_description_variables": {
                         "description": "Dynamic variables for this metric evaluation using DSPy GEPA.\nExample: \n```json\n[\"customer_sentiment\", \"response_time\", \"issue_resolved\"]\n```\n"
@@ -62820,6 +62865,7 @@
             },
             "MetricList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -63078,6 +63124,7 @@
             },
             "MetricListSerializerV2": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -65576,6 +65623,7 @@
             },
             "PatchedCallLogDetail": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -66004,6 +66052,7 @@
             },
             "PatchedDashboard": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -68706,6 +68755,7 @@
             },
             "PatchedSchemaPostScenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "agent": {
                         "type": [
@@ -70695,6 +70745,21 @@
                         "type": "string",
                         "x-spec-enum-id": "b44700c0a6443b40",
                         "description": "Suggested metric type after optimization (custom_code if meta-harness produced code)\n\n* `basic` - Basic (Deprecated in favor of LLM Judge)\n* `custom_prompt` - Custom Prompt ( Deprecated in favor of LLM Judge)\n* `custom_code` - Custom Code\n* `llm_judge` - LLM Judge"
+                    },
+                    "feedback_edits": {
+                        "type": "array",
+                        "items": {},
+                        "description": "User-answer-driven feedback corrections applied to metric reviews during optimization"
+                    },
+                    "unauthorized_label_changes": {
+                        "type": "array",
+                        "items": {},
+                        "description": "Expected-value changes detected in the run that lacked explicit user approval"
+                    },
+                    "optimization_summary": {
+                        "type": "string",
+                        "default": "",
+                        "description": "Plain-language summary of what the optimized metric does, shown in the review dialog so the user can check intent without reading the code."
                     }
                 },
                 "required": [
@@ -71939,6 +72004,7 @@
             },
             "RunList": {
                 "type": "object",
+                "description": "Adds outbound dial-window fields read from cekura_metadata.",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -72449,6 +72515,7 @@
             },
             "Scenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -73345,6 +73412,7 @@
             },
             "ScenarioList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -73564,6 +73632,7 @@
             },
             "ScenarioSerializerV2": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -75038,6 +75107,7 @@
             },
             "SchemaPostRunScenarios": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "agent_id": {
                         "type": "integer",
@@ -75716,6 +75786,7 @@
             },
             "SchemaPostScenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "agent": {
                         "type": [
@@ -75865,6 +75936,7 @@
             },
             "SchemaScenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",


### PR DESCRIPTION
Auto-generated docs sync for backend PR [#10141](https://github.com/cekura-ai/vocera.backend/pull/10141).

Reviewers: @dileep-chagam

## Summary

**Spec/overlay:** Documentation-only update to test-profile X- header mechanism. 1 exposed operation (scenarios-run-sip_2) description refined. AIAgentTestProfile schema updated. No MCP overlay changes needed — no transport-quirk signals fired. Spec refresh only.

**Conceptual docs:** Updated documentation/key-concepts/evaluators/test-profile.mdx to document that X- prefixed keys in main_agent_variables are sent as custom SIP headers (SIP runs) or connection headers (WebSocket runs). Added a Note in the Profile Sections section to explain this behavior and link to the SIP integration guide.

## Changes

- `openapi.json` — regenerate_from_backend
- `documentation/key-concepts/evaluators/test-profile.mdx` — update

---
*Auto-generated from backend PR #10141.*

<!-- mcp-sync:file-hashes -->
```json
{
  "documentation/key-concepts/evaluators/test-profile.mdx": "5013e9bc2467556ab972a52dd61893c515f88ed067f1cba9145f3cb4a1618183"
}
```
<!-- /mcp-sync:file-hashes -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cekura-ai/docs/pull/762" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->