### PR TITLE
[Auto] Sync docs for backend PR #10150

### DIFF
--- a/api-reference/user/list-organizations.mdx
+++ b/api-reference/user/list-organizations.mdx
@@ -1,0 +1,6 @@
+---
+title: List Organizations
+description: "List user v2 organizations"
+openapi: get /user/v2/organizations/
+slug: list-organizations
+---

--- a/mint.json
+++ b/mint.json
@@ -418,7 +418,8 @@
           "pages": [
             "api-reference/user/get-userorganizations",
             "api-reference/organization/get-billing-info",
-            "api-reference/test_framework/get-payment-history"
+            "api-reference/test_framework/get-payment-history",
+            "api-reference/user/list-organizations"
           ]
         },
         {

--- a/openapi.json
+++ b/openapi.json
@@ -52615,6 +52615,17 @@
         "/user/organizations/": {
             "get": {
                 "operationId": "user-organizations-list",
+                "parameters": [
+                    {
+                        "name": "search",
+                        "required": false,
+                        "in": "query",
+                        "description": "A search term.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
                 "tags": [
                     "user"
                 ],
@@ -55764,6 +55775,69 @@
                     }
                 },
                 "description": "Projects members"
+            }
+        },
+        "/user/v2/organizations/": {
+            "get": {
+                "operationId": "user-v2-organizations-list",
+                "parameters": [
+                    {
+                        "name": "search",
+                        "required": false,
+                        "in": "query",
+                        "description": "A search term.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "required": false,
+                        "in": "query",
+                        "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "tags": [
+                    "user"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedOrganizationList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "user-v2-organizations-list",
+                        "description": "List user v2 organizations"
+                    }
+                },
+                "description": "List user v2 organizations"
             }
         }
     },
@@ -61392,6 +61466,7 @@
             },
             "MembershipInline": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -64025,6 +64100,7 @@
             },
             "Organization": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -65230,6 +65306,37 @@
                         "type": "array",
                         "items": {
                             "$ref": "#/components/schemas/Notification"
+                        }
+                    }
+                }
+            },
+            "PaginatedOrganizationList": {
+                "type": "object",
+                "required": [
+                    "count",
+                    "results"
+                ],
+                "properties": {
+                    "count": {
+                        "type": "integer",
+                        "example": 123
+                    },
+                    "next": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "https://api.cekura.ai/example/v1/example-external/?page=4"
+                    },
+                    "previous": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "https://api.cekura.ai/example/v1/example-external/?page=3"
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Organization"
                         }
                     }
                 }
@@ -66810,6 +66917,7 @@
             },
             "PatchedOrganization": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -67351,6 +67459,11 @@
                             }
                         ],
                         "readOnly": true
+                    },
+                    "organization_id": {
+                        "type": "integer",
+                        "writeOnly": true,
+                        "description": "ID of the organization to create the project under. Required when authenticating as a user (you must be an admin of that organization); omit it when using an organization-scoped API key, where the organization is inferred from the key."
                     },
                     "outbound_timeout": {
                         "type": "integer",
@@ -70793,6 +70906,11 @@
                         ],
                         "readOnly": true
                     },
+                    "organization_id": {
+                        "type": "integer",
+                        "writeOnly": true,
+                        "description": "ID of the organization to create the project under. Required when authenticating as a user (you must be an admin of that organization); omit it when using an organization-scoped API key, where the organization is inferred from the key."
+                    },
                     "outbound_timeout": {
                         "type": "integer",
                         "description": "\nOutbound timeout in seconds\nExample: `300`\n"
@@ -71078,6 +71196,7 @@
             },
             "ProjectInline": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -77501,6 +77620,7 @@
             },
             "UserInline": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",


### PR DESCRIPTION
Auto-generated docs sync for backend PR [#10150](https://github.com/cekura-ai/vocera.backend/pull/10150).

Reviewers: @dileep-chagam

## Summary

**Spec/overlay:** Schema change on projects-create: organization_id field now exposed in the OpenAPI spec (previously excluded via @extend_schema_serializer). The field includes help_text clarifying when it's required (user/OAuth auth) vs. optional (org-scoped API key). No overlay needed — the spec-derived description is sufficient. Regenerating openapi.json only.

**Conceptual docs:** No conceptual docs edits — PR #10150 fixes a bug in project creation error handling and exposes the organization_id field in the OpenAPI schema. Project CRUD operations have no matching conceptual documentation page per the routing map (explicitly out of scope). The schema change (organization_id now visible with help_text) is handled by cekura-spec-update for the API reference, not conceptual docs.

## Changes

- `openapi.json` — regenerate_from_backend

---
*Auto-generated from backend PR #10150.*

<!-- mcp-sync:file-hashes -->
```json
{}
```
<!-- /mcp-sync:file-hashes -->