### PR TITLE
[CEK-8008] docs(livekit): bump SDK pin to 1.5.1

### DIFF
--- a/documentation/integrations/livekit/tracing.mdx
+++ b/documentation/integrations/livekit/tracing.mdx
@@ -37,7 +37,7 @@ export const livekitPrompt = [
   "- Note: track_session takes an additional agent parameter (the Agent instance) so it can inject mock tools.",
   "",
   "Common setup for both (Python):",
-  "1. Install the SDK: pip install cekura[livekit]==1.2.0",
+  "1. Install the SDK: pip install cekura[livekit]==1.5.1",
   "2. Import LiveKitTracer: from cekura.livekit import LiveKitTracer",
   "3. Initialize the tracer (outside the entrypoint function):",
   "   cekura = LiveKitTracer(",
@@ -210,7 +210,7 @@ Use this setup in your test agents while running simulation calls from the Cekur
 <Tab title="Python">
 
 ```bash
-pip install cekura[livekit]==1.2.0
+pip install cekura[livekit]==1.5.1
 ```
 
 </Tab>
@@ -352,7 +352,7 @@ Use this setup in your production agents for monitoring live calls with audio re
 <Tab title="Python">
 
 ```bash
-pip install cekura[livekit]==1.2.0
+pip install cekura[livekit]==1.5.1
 ```
 
 </Tab>


### PR DESCRIPTION
Bump pinned Python SDK from 1.2.0 → 1.5.1 (fixes text-mode crash on livekit-agents>=1.6). Companion: cekura-ai/cekura-python#21.