### PR TITLE
[Auto] Sync docs for backend PR #10203

### DIFF
--- a/api-reference/observability/create-agent-improvement-session.mdx
+++ b/api-reference/observability/create-agent-improvement-session.mdx
@@ -1,0 +1,6 @@
+---
+title: Create Agent Improvement Session
+description: "Create + poll \"Improve Agent\" sessions launched from the Insights page."
+openapi: post /observability/v1/agent-improvement-sessions/
+slug: create-agent-improvement-session
+---

--- a/api-reference/observability/get-agent-improvement-session.mdx
+++ b/api-reference/observability/get-agent-improvement-session.mdx
@@ -1,0 +1,6 @@
+---
+title: Get Agent Improvement Session
+description: "Create + poll \"Improve Agent\" sessions launched from the Insights page."
+openapi: get /observability/v1/agent-improvement-sessions/{id}/
+slug: get-agent-improvement-session
+---

--- a/api-reference/observability/list-agent-improvement-sessions.mdx
+++ b/api-reference/observability/list-agent-improvement-sessions.mdx
@@ -1,0 +1,6 @@
+---
+title: List Agent Improvement Sessions
+description: "Create + poll \"Improve Agent\" sessions launched from the Insights page."
+openapi: get /observability/v1/agent-improvement-sessions/
+slug: list-agent-improvement-sessions
+---

--- a/mint.json
+++ b/mint.json
@@ -482,8 +482,8 @@
             "api-reference/observability/retrieve-deep-research-insights-pricing",
             "api-reference/observability/list-metric-failure-mode-insight-categories",
             "api-reference/observability/add-metric-failure-mode-insight-category-example-calls-to-labs",
-            "api-reference/observability/create-agent-improvement-session",
             "api-reference/observability/list-agent-improvement-sessions",
+            "api-reference/observability/create-agent-improvement-session",
             "api-reference/observability/get-agent-improvement-session"
           ]
         }

--- a/mint.json
+++ b/mint.json
@@ -481,7 +481,10 @@
             "api-reference/observability/get-metric-failure-mode-insights-available-dates",
             "api-reference/observability/retrieve-deep-research-insights-pricing",
             "api-reference/observability/list-metric-failure-mode-insight-categories",
-            "api-reference/observability/add-metric-failure-mode-insight-category-example-calls-to-labs"
+            "api-reference/observability/add-metric-failure-mode-insight-category-example-calls-to-labs",
+            "api-reference/observability/create-agent-improvement-session",
+            "api-reference/observability/list-agent-improvement-sessions",
+            "api-reference/observability/get-agent-improvement-session"
           ]
         }
       ]

--- a/openapi.json
+++ b/openapi.json
@@ -2428,6 +2428,115 @@
                 "description": "Notifications v1 push vapid public key"
             }
         },
+        "/observability/v1/agent-improvement-sessions/": {
+            "get": {
+                "operationId": "agent-improvement-sessions-list",
+                "description": "Create + poll \"Improve Agent\" sessions launched from the Insights page.\n\n``create`` resolves the target agent from the selected insights' example\ncall logs, validates it is a VAPI / ElevenLabs agent with a configured\nprovider key, then opens a Claude Agent SDK session (product-chat sandbox\nruntime) seeded to run generate-scenarios → self-improving-agent. Returns\nthe new session row.\n\n``retrieve`` / ``list`` are the poll surface: retrieve syncs the row's\ncoarse status from the underlying sandbox run before returning, so the\nfrontend just polls ``GET /agent-improvement-sessions/<id>/?project=<id>``.",
+                "tags": [
+                    "observability"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/AgentImprovementSession"
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "post": {
+                "operationId": "agent-improvement-sessions-create",
+                "description": "Create + poll \"Improve Agent\" sessions launched from the Insights page.\n\n``create`` resolves the target agent from the selected insights' example\ncall logs, validates it is a VAPI / ElevenLabs agent with a configured\nprovider key, then opens a Claude Agent SDK session (product-chat sandbox\nruntime) seeded to run generate-scenarios → self-improving-agent. Returns\nthe new session row.\n\n``retrieve`` / ``list`` are the poll surface: retrieve syncs the row's\ncoarse status from the underlying sandbox run before returning, so the\nfrontend just polls ``GET /agent-improvement-sessions/<id>/?project=<id>``.",
+                "tags": [
+                    "observability"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AgentImprovementSession"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AgentImprovementSession"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AgentImprovementSession"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AgentImprovementSession"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/observability/v1/agent-improvement-sessions/{id}/": {
+            "get": {
+                "operationId": "agent-improvement-sessions-retrieve",
+                "description": "Create + poll \"Improve Agent\" sessions launched from the Insights page.\n\n``create`` resolves the target agent from the selected insights' example\ncall logs, validates it is a VAPI / ElevenLabs agent with a configured\nprovider key, then opens a Claude Agent SDK session (product-chat sandbox\nruntime) seeded to run generate-scenarios → self-improving-agent. Returns\nthe new session row.\n\n``retrieve`` / ``list`` are the poll surface: retrieve syncs the row's\ncoarse status from the underlying sandbox run before returning, so the\nfrontend just polls ``GET /agent-improvement-sessions/<id>/?project=<id>``.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "A unique integer value identifying this agent improvement session.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "observability"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AgentImprovementSession"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/observability/v1/alerts/": {
             "get": {
                 "operationId": "alerts-list",
@@ -6047,8 +6156,7 @@
         "/observability/v1/deep-research-insights/": {
             "get": {
                 "operationId": "deep-research-insights-list",
-                "description": "Return project-level Deep Research audits, newest first. Each audit surfaces up to three cross-metric failure modes found across recent calls. Scope with `project`; pass `latest_only=true` for the most recent completed audit.",
-                "summary": "List Deep Research insights",
+                "description": "List deep research insights",
                 "tags": [
                     "observability"
                 ],
@@ -6071,33 +6179,13 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "deep-research-insights-list",
-                        "description": "Return project-level Deep Research audits, newest first. Each audit surfaces up to three cross-metric failure modes found across recent calls. Scope with `project`; pass `latest_only=true` for the most recent completed audit."
-                    }
-                },
-                "parameters": [
-                    {
-                        "name": "project",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `project` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    }
-                ]
+                }
             }
         },
         "/observability/v1/deep-research-insights/{id}/": {
             "get": {
                 "operationId": "deep-research-insights-retrieve",
-                "description": "Return a single Deep Research audit with its failure modes and status. Failure modes dismissed for the project are omitted.",
-                "summary": "Get one Deep Research insight",
+                "description": "Retrieve a deep research insight by ID",
                 "parameters": [
                     {
                         "in": "path",
@@ -6128,20 +6216,11 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "deep-research-insights-retrieve",
-                        "description": "Return a single Deep Research audit with its failure modes and status. Failure modes dismissed for the project are omitted."
-                    }
                 }
             },
             "delete": {
                 "operationId": "deep-research-insights-destroy",
-                "description": "Permanently delete one Deep Research audit. ⚠ Cannot be undone.",
-                "summary": "Delete a Deep Research insight",
+                "description": "Delete a deep research insight",
                 "parameters": [
                     {
                         "in": "path",
@@ -6164,15 +6243,6 @@
                 "responses": {
                     "204": {
                         "description": "No response body"
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mcp-destructive": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "deep-research-insights-destroy",
-                        "description": "Permanently delete one Deep Research audit. ⚠ Cannot be undone."
                     }
                 }
             }
@@ -16960,7 +17030,7 @@
         },
         "/test_framework/v1/metrics/": {
             "get": {
-                "operationId": "metrics-list",
+                "operationId": "metrics-v1-list",
                 "description": "\nmetrics_list: List quality metrics (LLM-judge prompts, custom code, or predefined metrics) used to evaluate AI voice agents. Filter by `agent_id` or `project_id` to scope results.\n\nFiltering behavior:\n- If only agent_id is provided: Returns metrics associated with that agent only\n- If only project_id is provided: Returns metrics associated with that project only\n- If both agent_id and project_id are provided: Returns metrics from both the agent and the project\n- If agents is provided: Returns metrics where any of the specified agents are in the M2M agents field\n- If slug is provided: Returns the metric with that specific slug\n\nPerformance tip: `agent_id` (when a specific agent is in context) or `project_id` will narrow the result. Orgs can accumulate hundreds of metrics so a filter usually helps.\n        ",
                 "summary": "List metrics",
                 "parameters": [
@@ -17136,7 +17206,7 @@
                 }
             },
             "post": {
-                "operationId": "metrics-create",
+                "operationId": "metrics-v1-create",
                 "description": "Create a quality metric for evaluating agent conversations.\n\n**Two supported types on create** (the `BASIC` and `CUSTOM_PROMPT` values are deprecated and rejected on create):\n\n- `llm_judge` — an LLM-as-judge metric. Put the evaluation criterion in `description`. Most common choice for qualitative scoring (politeness, compliance, resolution quality, etc.).\n\n- `custom_code` — Python code that receives the transcript and returns a score. Put the code in `custom_code`. Use for deterministic checks (regex matches, tool-call ordering, structured-field extraction, etc.).\n\n**Scope:** metrics must be created at the project level — pass `project` (project ID). Agent-level metrics are deprecated; if you pass `agent`, the server silently creates a project-level metric and returns a deprecation warning.\n\n**Evaluation control:** `observability_enabled` runs the metric on production calls (via CallLog); `simulation_enabled` runs it on test runs; `sampling_enabled` enables statistical sampling. `eval_type` picks the output shape (`bool`, `int`, `float`, `enum`, `string`); when `eval_type=\"enum\"`, also pass `enum_values`.\n\n**Triggering:** pass `trigger_type` + `evaluation_trigger_prompt` to gate the metric to only fire on specific call patterns (see the metric-triggers guide).",
                 "summary": "Create a metric",
                 "tags": [
@@ -17242,7 +17312,7 @@
         },
         "/test_framework/v1/metrics-external/": {
             "get": {
-                "operationId": "metrics-external-list",
+                "operationId": "metrics-v1-external-list",
                 "description": "\nmetrics_list: List quality metrics (LLM-judge prompts, custom code, or predefined metrics) used to evaluate AI voice agents. Filter by `agent_id` or `project_id` to scope results.\n\nFiltering behavior:\n- If only agent_id is provided: Returns metrics associated with that agent only\n- If only project_id is provided: Returns metrics associated with that project only\n- If both agent_id and project_id are provided: Returns metrics from both the agent and the project\n- If agents is provided: Returns metrics where any of the specified agents are in the M2M agents field\n- If slug is provided: Returns the metric with that specific slug\n\nPerformance tip: `agent_id` (when a specific agent is in context) or `project_id` will narrow the result. Orgs can accumulate hundreds of metrics so a filter usually helps.\n        ",
                 "summary": "List metrics",
                 "parameters": [
@@ -17418,7 +17488,7 @@
                 }
             },
             "post": {
-                "operationId": "metrics-external-create",
+                "operationId": "metrics-v1-external-create",
                 "description": "Create a quality metric for evaluating agent conversations.\n\n**Two supported types on create** (the `BASIC` and `CUSTOM_PROMPT` values are deprecated and rejected on create):\n\n- `llm_judge` — an LLM-as-judge metric. Put the evaluation criterion in `description`. Most common choice for qualitative scoring (politeness, compliance, resolution quality, etc.).\n\n- `custom_code` — Python code that receives the transcript and returns a score. Put the code in `custom_code`. Use for deterministic checks (regex matches, tool-call ordering, structured-field extraction, etc.).\n\n**Scope:** metrics must be created at the project level — pass `project` (project ID). Agent-level metrics are deprecated; if you pass `agent`, the server silently creates a project-level metric and returns a deprecation warning.\n\n**Evaluation control:** `observability_enabled` runs the metric on production calls (via CallLog); `simulation_enabled` runs it on test runs; `sampling_enabled` enables statistical sampling. `eval_type` picks the output shape (`bool`, `int`, `float`, `enum`, `string`); when `eval_type=\"enum\"`, also pass `enum_values`.\n\n**Triggering:** pass `trigger_type` + `evaluation_trigger_prompt` to gate the metric to only fire on specific call patterns (see the metric-triggers guide).",
                 "summary": "Create a metric",
                 "tags": [
@@ -17524,7 +17594,7 @@
         },
         "/test_framework/v1/metrics-external/{id}/": {
             "get": {
-                "operationId": "metrics-external-retrieve",
+                "operationId": "metrics-v1-external-retrieve",
                 "description": "Retrieve a specific metric by ID or slug.",
                 "parameters": [
                     {
@@ -17574,7 +17644,7 @@
                 }
             },
             "put": {
-                "operationId": "metrics-external-update",
+                "operationId": "metrics-v1-external-update",
                 "description": "Update a metric (full)",
                 "summary": "Update a metric (full)",
                 "parameters": [
@@ -17648,7 +17718,7 @@
                 }
             },
             "patch": {
-                "operationId": "metrics-external-partial-update",
+                "operationId": "metrics-v1-external-partial-update",
                 "description": "Partially update a metric. Same field shape as create — see `metrics_create` for details.\n\n**Note:** `project` and `agent` are read-only once set — you cannot move a metric between projects/agents after creation. To relocate, create a new metric and delete the old one.",
                 "summary": "Update a metric (partial)",
                 "parameters": [
@@ -17730,7 +17800,7 @@
                 }
             },
             "delete": {
-                "operationId": "metrics-external-destroy",
+                "operationId": "metrics-v1-external-destroy",
                 "description": "⚠ Irreversible. Deletes the metric and detaches it from all agents and evaluators. Dashboard widgets that displayed this metric are also removed.",
                 "summary": "Delete a metric",
                 "parameters": [
@@ -17776,8 +17846,8 @@
         },
         "/test_framework/v1/metrics-external/{id}/add_to_predefined_metrics/": {
             "post": {
-                "operationId": "metrics-external-add-to-predefined-metrics-create",
-                "description": "Metrics add to predefined metrics",
+                "operationId": "metrics-v1-external-add-to-predefined-metrics-create",
+                "description": "Metrics v1 add to predefined metrics",
                 "parameters": [
                     {
                         "in": "path",
@@ -17833,7 +17903,7 @@
         },
         "/test_framework/v1/metrics-external/{id}/apply_optimisation_proposal/": {
             "post": {
-                "operationId": "metrics-external-apply-optimisation-proposal-create",
+                "operationId": "metrics-v1-external-apply-optimisation-proposal-create",
                 "description": "Apply a pending optimisation proposal",
                 "summary": "Apply a pending optimisation proposal",
                 "parameters": [
@@ -17864,7 +17934,7 @@
         },
         "/test_framework/v1/metrics-external/{id}/dismiss_optimisation_proposal/": {
             "post": {
-                "operationId": "metrics-external-dismiss-optimisation-proposal-create",
+                "operationId": "metrics-v1-external-dismiss-optimisation-proposal-create",
                 "description": "Dismiss a pending optimisation proposal",
                 "summary": "Dismiss a pending optimisation proposal",
                 "parameters": [
@@ -17895,7 +17965,7 @@
         },
         "/test_framework/v1/metrics-external/{id}/evaluate_advance_metric/": {
             "post": {
-                "operationId": "metrics-external-evaluate-advance-metric-create",
+                "operationId": "metrics-v1-external-evaluate-advance-metric-create",
                 "description": "Evaluate an advance metric in the background.\n\nReturns a progress_id to poll for results.",
                 "parameters": [
                     {
@@ -17952,7 +18022,7 @@
         },
         "/test_framework/v1/metrics-external/{id}/evaluate_basic_metric/": {
             "post": {
-                "operationId": "metrics-external-evaluate-basic-metric-create",
+                "operationId": "metrics-v1-external-evaluate-basic-metric-create",
                 "description": "Evaluate a basic metric in the background.\n\nReturns a progress_id to poll for results.",
                 "parameters": [
                     {
@@ -18009,7 +18079,7 @@
         },
         "/test_framework/v1/metrics-external/{id}/evaluate_llm_judge_metric/": {
             "post": {
-                "operationId": "metrics-external-evaluate-llm-judge-metric-create",
+                "operationId": "metrics-v1-external-evaluate-llm-judge-metric-create",
                 "description": "Evaluate a metric using LLM Judge (DSPy) in the background.\n\nReturns a progress_id to poll for results.",
                 "parameters": [
                     {
@@ -18066,8 +18136,8 @@
         },
         "/test_framework/v1/metrics-external/{id}/history/": {
             "get": {
-                "operationId": "metrics-external-history-list",
-                "description": "Metrics history",
+                "operationId": "metrics-v1-external-history-list",
+                "description": "Metrics v1 history",
                 "parameters": [
                     {
                         "in": "path",
@@ -18117,8 +18187,8 @@
         },
         "/test_framework/v1/metrics-external/{id}/history/edit/": {
             "patch": {
-                "operationId": "metrics-external-history-edit-partial-update",
-                "description": "Metrics history edit",
+                "operationId": "metrics-v1-external-history-edit-partial-update",
+                "description": "Metrics v1 history edit",
                 "parameters": [
                     {
                         "in": "path",
@@ -18173,8 +18243,8 @@
         },
         "/test_framework/v1/metrics-external/{id}/restore/": {
             "post": {
-                "operationId": "metrics-external-restore-create",
-                "description": "Metrics restore",
+                "operationId": "metrics-v1-external-restore-create",
+                "description": "Metrics v1 restore",
                 "parameters": [
                     {
                         "in": "path",
@@ -18230,8 +18300,8 @@
         },
         "/test_framework/v1/metrics-external/{id}/run_reviews/": {
             "post": {
-                "operationId": "metrics-external-run-reviews-create",
-                "description": "Run metric reviews to identify improvement opportunities",
+                "operationId": "metrics-v1-external-run-reviews-create",
+                "description": "Metrics v1 run reviews",
                 "parameters": [
                     {
                         "in": "path",
@@ -18279,7 +18349,7 @@
         },
         "/test_framework/v1/metrics-external/{id}/variables/": {
             "post": {
-                "operationId": "metrics-external-variables-create",
+                "operationId": "metrics-v1-external-variables-create",
                 "description": "Get all variables and their values for a specific test_set and metric combination.\n\nURL Parameter:\n- pk: The metric_id\n\nRequest Body:\n- test_set_id (required): The ID of the test_set (datapoint)\n- metric_description_variables (required/optional): Array of variable names for description.\n  At least one of metric_description_variables or evaluation_trigger_variables must be provided.\n- evaluation_trigger_variables (required/optional): Array of variable names for trigger.\n  At least one of metric_description_variables or evaluation_trigger_variables must be provided.\n\nThis endpoint retrieves the variables and populates them with values from the test_set (datapoint).",
                 "parameters": [
                     {
@@ -18336,8 +18406,8 @@
         },
         "/test_framework/v1/metrics-external/basic_list/": {
             "get": {
-                "operationId": "metrics-external-basic-list-retrieve",
-                "description": "Metrics basic list",
+                "operationId": "metrics-v1-external-basic-list-retrieve",
+                "description": "Metrics v1 basic list",
                 "tags": [
                     "test_framework"
                 ],
@@ -18362,8 +18432,8 @@
         },
         "/test_framework/v1/metrics-external/bulk-toggle-settings/": {
             "post": {
-                "operationId": "metrics-external-bulk-toggle-settings-create",
-                "description": "Metrics bulk toggle settings",
+                "operationId": "metrics-v1-external-bulk-toggle-settings-create",
+                "description": "Metrics v1 bulk toggle settings",
                 "tags": [
                     "test_framework"
                 ],
@@ -18485,8 +18555,8 @@
         },
         "/test_framework/v1/metrics-external/bulk_manage_agents/": {
             "post": {
-                "operationId": "metrics-external-bulk-manage-agents-create",
-                "description": "Metrics bulk manage agents",
+                "operationId": "metrics-v1-external-bulk-manage-agents-create",
+                "description": "Metrics v1 bulk manage agents",
                 "tags": [
                     "test_framework"
                 ],
@@ -18531,8 +18601,8 @@
         },
         "/test_framework/v1/metrics-external/delete_metrics/": {
             "post": {
-                "operationId": "metrics-external-delete-metrics-create",
-                "description": "Metrics delete metrics",
+                "operationId": "metrics-v1-external-delete-metrics-create",
+                "description": "Metrics v1 delete metrics",
                 "tags": [
                     "test_framework"
                 ],
@@ -18577,7 +18647,7 @@
         },
         "/test_framework/v1/metrics-external/evaluate_metric_progress/": {
             "get": {
-                "operationId": "metrics-external-evaluate-metric-progress-retrieve",
+                "operationId": "metrics-v1-external-evaluate-metric-progress-retrieve",
                 "description": "Poll for metric evaluation progress.\n\nQuery params:\n    progress_id: The progress_id returned from evaluate_basic_metric or evaluate_advance_metric\n\nReturns:\n    State object with status, output, error, etc.",
                 "tags": [
                     "test_framework"
@@ -18603,8 +18673,8 @@
         },
         "/test_framework/v1/metrics-external/fetch_call_details/": {
             "get": {
-                "operationId": "metrics-external-fetch-call-details-retrieve",
-                "description": "Metrics fetch call details",
+                "operationId": "metrics-v1-external-fetch-call-details-retrieve",
+                "description": "Metrics v1 fetch call details",
                 "tags": [
                     "test_framework"
                 ],
@@ -18629,8 +18699,8 @@
         },
         "/test_framework/v1/metrics-external/generate_clean_description/": {
             "post": {
-                "operationId": "metrics-external-generate-clean-description-create",
-                "description": "Metrics generate clean description",
+                "operationId": "metrics-v1-external-generate-clean-description-create",
+                "description": "Metrics v1 generate clean description",
                 "tags": [
                     "test_framework"
                 ],
@@ -18675,7 +18745,7 @@
         },
         "/test_framework/v1/metrics-external/generate_clean_description_bg/": {
             "post": {
-                "operationId": "metrics-external-generate-clean-description-bg-create",
+                "operationId": "metrics-v1-external-generate-clean-description-bg-create",
                 "description": "Start async clean description generation",
                 "summary": "Start async clean description generation",
                 "tags": [
@@ -18722,7 +18792,7 @@
         },
         "/test_framework/v1/metrics-external/generate_clean_description_progress/": {
             "get": {
-                "operationId": "metrics-external-generate-clean-description-progress-retrieve",
+                "operationId": "metrics-v1-external-generate-clean-description-progress-retrieve",
                 "description": "Poll async clean description generation",
                 "summary": "Poll async clean description generation",
                 "parameters": [
@@ -18760,8 +18830,8 @@
         },
         "/test_framework/v1/metrics-external/generate_evaluation_trigger/": {
             "post": {
-                "operationId": "metrics-external-generate-evaluation-trigger-create",
-                "description": "Metrics generate evaluation trigger",
+                "operationId": "metrics-v1-external-generate-evaluation-trigger-create",
+                "description": "Metrics v1 generate evaluation trigger",
                 "tags": [
                     "test_framework"
                 ],
@@ -18869,8 +18939,8 @@
         },
         "/test_framework/v1/metrics-external/generate_metrics_progress/": {
             "get": {
-                "operationId": "metrics-external-generate-metrics-progress-retrieve",
-                "description": "Metrics generate metrics progress",
+                "operationId": "metrics-v1-external-generate-metrics-progress-retrieve",
+                "description": "Metrics v1 generate metrics progress",
                 "parameters": [
                     {
                         "in": "query",
@@ -18899,8 +18969,8 @@
         },
         "/test_framework/v1/metrics-external/preview/": {
             "post": {
-                "operationId": "metrics-external-preview-create",
-                "description": "Preview metric evaluation against sample transcripts",
+                "operationId": "metrics-v1-external-preview-create",
+                "description": "Metrics v1 preview",
                 "tags": [
                     "test_framework"
                 ],
@@ -19014,8 +19084,8 @@
         },
         "/test_framework/v1/metrics-external/save_result/": {
             "post": {
-                "operationId": "metrics-external-save-result-create",
-                "description": "Metrics save result",
+                "operationId": "metrics-v1-external-save-result-create",
+                "description": "Metrics v1 save result",
                 "tags": [
                     "test_framework"
                 ],
@@ -19060,8 +19130,8 @@
         },
         "/test_framework/v1/metrics-external/simplify_prompt/": {
             "post": {
-                "operationId": "metrics-external-simplify-prompt-create",
-                "description": "Metrics simplify prompt",
+                "operationId": "metrics-v1-external-simplify-prompt-create",
+                "description": "Metrics v1 simplify prompt",
                 "tags": [
                     "test_framework"
                 ],
@@ -19106,8 +19176,8 @@
         },
         "/test_framework/v1/metrics-external/simplify_prompt_progress/": {
             "get": {
-                "operationId": "metrics-external-simplify-prompt-progress-retrieve",
-                "description": "Metrics simplify prompt progress",
+                "operationId": "metrics-v1-external-simplify-prompt-progress-retrieve",
+                "description": "Metrics v1 simplify prompt progress",
                 "parameters": [
                     {
                         "in": "query",
@@ -19143,7 +19213,7 @@
         },
         "/test_framework/v1/metrics/{id}/": {
             "get": {
-                "operationId": "metrics-retrieve",
+                "operationId": "metrics-v1-retrieve",
                 "description": "Retrieve a specific metric by ID or slug.",
                 "parameters": [
                     {
@@ -19193,7 +19263,7 @@
                 }
             },
             "put": {
-                "operationId": "metrics-update",
+                "operationId": "metrics-v1-update",
                 "description": "Update a metric (full)",
                 "summary": "Update a metric (full)",
                 "parameters": [
@@ -19267,7 +19337,7 @@
                 }
             },
             "patch": {
-                "operationId": "metrics-partial-update",
+                "operationId": "metrics-v1-partial-update",
                 "description": "Partially update a metric. Same field shape as create — see `metrics_create` for details.\n\n**Note:** `project` and `agent` are read-only once set — you cannot move a metric between projects/agents after creation. To relocate, create a new metric and delete the old one.",
                 "summary": "Update a metric (partial)",
                 "parameters": [
@@ -19349,7 +19419,7 @@
                 }
             },
             "delete": {
-                "operationId": "metrics-destroy",
+                "operationId": "metrics-v1-destroy",
                 "description": "⚠ Irreversible. Deletes the metric and detaches it from all agents and evaluators. Dashboard widgets that displayed this metric are also removed.",
                 "summary": "Delete a metric",
                 "parameters": [
@@ -19395,8 +19465,8 @@
         },
         "/test_framework/v1/metrics/{id}/add_to_predefined_metrics/": {
             "post": {
-                "operationId": "metrics-add-to-predefined-metrics-create",
-                "description": "Metrics add to predefined metrics",
+                "operationId": "metrics-v1-add-to-predefined-metrics-create",
+                "description": "Metrics v1 add to predefined metrics",
                 "parameters": [
                     {
                         "in": "path",
@@ -19452,7 +19522,7 @@
         },
         "/test_framework/v1/metrics/{id}/apply_optimisation_proposal/": {
             "post": {
-                "operationId": "metrics-apply-optimisation-proposal-create",
+                "operationId": "metrics-v1-apply-optimisation-proposal-create",
                 "description": "Apply a pending optimisation proposal",
                 "summary": "Apply a pending optimisation proposal",
                 "parameters": [
@@ -19483,7 +19553,7 @@
         },
         "/test_framework/v1/metrics/{id}/dismiss_optimisation_proposal/": {
             "post": {
-                "operationId": "metrics-dismiss-optimisation-proposal-create",
+                "operationId": "metrics-v1-dismiss-optimisation-proposal-create",
                 "description": "Dismiss a pending optimisation proposal",
                 "summary": "Dismiss a pending optimisation proposal",
                 "parameters": [
@@ -19514,7 +19584,7 @@
         },
         "/test_framework/v1/metrics/{id}/evaluate_advance_metric/": {
             "post": {
-                "operationId": "metrics-evaluate-advance-metric-create",
+                "operationId": "metrics-v1-evaluate-advance-metric-create",
                 "description": "Evaluate an advance metric in the background.\n\nReturns a progress_id to poll for results.",
                 "parameters": [
                     {
@@ -19571,7 +19641,7 @@
         },
         "/test_framework/v1/metrics/{id}/evaluate_basic_metric/": {
             "post": {
-                "operationId": "metrics-evaluate-basic-metric-create",
+                "operationId": "metrics-v1-evaluate-basic-metric-create",
                 "description": "Evaluate a basic metric in the background.\n\nReturns a progress_id to poll for results.",
                 "parameters": [
                     {
@@ -19628,7 +19698,7 @@
         },
         "/test_framework/v1/metrics/{id}/evaluate_llm_judge_metric/": {
             "post": {
-                "operationId": "metrics-evaluate-llm-judge-metric-create",
+                "operationId": "metrics-v1-evaluate-llm-judge-metric-create",
                 "description": "Evaluate a metric using LLM Judge (DSPy) in the background.\n\nReturns a progress_id to poll for results.",
                 "parameters": [
                     {
@@ -19685,8 +19755,8 @@
         },
         "/test_framework/v1/metrics/{id}/history/": {
             "get": {
-                "operationId": "metrics-history-list",
-                "description": "Metrics history",
+                "operationId": "metrics-v1-history-list",
+                "description": "Metrics v1 history",
                 "parameters": [
                     {
                         "in": "path",
@@ -19736,8 +19806,8 @@
         },
         "/test_framework/v1/metrics/{id}/history/edit/": {
             "patch": {
-                "operationId": "metrics-history-edit-partial-update",
-                "description": "Metrics history edit",
+                "operationId": "metrics-v1-history-edit-partial-update",
+                "description": "Metrics v1 history edit",
                 "parameters": [
                     {
                         "in": "path",
@@ -19792,8 +19862,8 @@
         },
         "/test_framework/v1/metrics/{id}/restore/": {
             "post": {
-                "operationId": "metrics-restore-create",
-                "description": "Metrics restore",
+                "operationId": "metrics-v1-restore-create",
+                "description": "Metrics v1 restore",
                 "parameters": [
                     {
                         "in": "path",
@@ -19849,8 +19919,8 @@
         },
         "/test_framework/v1/metrics/{id}/run_reviews/": {
             "post": {
-                "operationId": "metrics-run-reviews-create",
-                "description": "Run metric reviews to identify improvement opportunities",
+                "operationId": "metrics-v1-run-reviews-create",
+                "description": "Metrics v1 run reviews",
                 "parameters": [
                     {
                         "in": "path",
@@ -19898,7 +19968,7 @@
         },
         "/test_framework/v1/metrics/{id}/variables/": {
             "post": {
-                "operationId": "metrics-variables-create",
+                "operationId": "metrics-v1-variables-create",
                 "description": "Get all variables and their values for a specific test_set and metric combination.\n\nURL Parameter:\n- pk: The metric_id\n\nRequest Body:\n- test_set_id (required): The ID of the test_set (datapoint)\n- metric_description_variables (required/optional): Array of variable names for description.\n  At least one of metric_description_variables or evaluation_trigger_variables must be provided.\n- evaluation_trigger_variables (required/optional): Array of variable names for trigger.\n  At least one of metric_description_variables or evaluation_trigger_variables must be provided.\n\nThis endpoint retrieves the variables and populates them with values from the test_set (datapoint).",
                 "parameters": [
                     {
@@ -19955,8 +20025,8 @@
         },
         "/test_framework/v1/metrics/basic_list/": {
             "get": {
-                "operationId": "metrics-basic-list-retrieve",
-                "description": "Metrics basic list",
+                "operationId": "metrics-v1-basic-list-retrieve",
+                "description": "Metrics v1 basic list",
                 "tags": [
                     "test_framework"
                 ],
@@ -19981,8 +20051,8 @@
         },
         "/test_framework/v1/metrics/bulk-toggle-settings/": {
             "post": {
-                "operationId": "metrics-bulk-toggle-settings-create",
-                "description": "Metrics bulk toggle settings",
+                "operationId": "metrics-v1-bulk-toggle-settings-create",
+                "description": "Metrics v1 bulk toggle settings",
                 "tags": [
                     "test_framework"
                 ],
@@ -20104,8 +20174,8 @@
         },
         "/test_framework/v1/metrics/bulk_manage_agents/": {
             "post": {
-                "operationId": "metrics-bulk-manage-agents-create",
-                "description": "Metrics bulk manage agents",
+                "operationId": "metrics-v1-bulk-manage-agents-create",
+                "description": "Metrics v1 bulk manage agents",
                 "tags": [
                     "test_framework"
                 ],
@@ -20150,8 +20220,8 @@
         },
         "/test_framework/v1/metrics/delete_metrics/": {
             "post": {
-                "operationId": "metrics-delete-metrics-create",
-                "description": "Metrics delete metrics",
+                "operationId": "metrics-v1-delete-metrics-create",
+                "description": "Metrics v1 delete metrics",
                 "tags": [
                     "test_framework"
                 ],
@@ -20196,7 +20266,7 @@
         },
         "/test_framework/v1/metrics/evaluate_metric_progress/": {
             "get": {
-                "operationId": "metrics-evaluate-metric-progress-retrieve",
+                "operationId": "metrics-v1-evaluate-metric-progress-retrieve",
                 "description": "Poll for metric evaluation progress.\n\nQuery params:\n    progress_id: The progress_id returned from evaluate_basic_metric or evaluate_advance_metric\n\nReturns:\n    State object with status, output, error, etc.",
                 "tags": [
                     "test_framework"
@@ -20222,8 +20292,8 @@
         },
         "/test_framework/v1/metrics/fetch_call_details/": {
             "get": {
-                "operationId": "metrics-fetch-call-details-retrieve",
-                "description": "Metrics fetch call details",
+                "operationId": "metrics-v1-fetch-call-details-retrieve",
+                "description": "Metrics v1 fetch call details",
                 "tags": [
                     "test_framework"
                 ],
@@ -20248,8 +20318,8 @@
         },
         "/test_framework/v1/metrics/generate_clean_description/": {
             "post": {
-                "operationId": "metrics-generate-clean-description-create",
-                "description": "Metrics generate clean description",
+                "operationId": "metrics-v1-generate-clean-description-create",
+                "description": "Metrics v1 generate clean description",
                 "tags": [
                     "test_framework"
                 ],
@@ -20294,7 +20364,7 @@
         },
         "/test_framework/v1/metrics/generate_clean_description_bg/": {
             "post": {
-                "operationId": "metrics-generate-clean-description-bg-create",
+                "operationId": "metrics-v1-generate-clean-description-bg-create",
                 "description": "Start async clean description generation",
                 "summary": "Start async clean description generation",
                 "tags": [
@@ -20341,7 +20411,7 @@
         },
         "/test_framework/v1/metrics/generate_clean_description_progress/": {
             "get": {
-                "operationId": "metrics-generate-clean-description-progress-retrieve",
+                "operationId": "metrics-v1-generate-clean-description-progress-retrieve",
                 "description": "Poll async clean description generation",
                 "summary": "Poll async clean description generation",
                 "parameters": [
@@ -20379,8 +20449,8 @@
         },
         "/test_framework/v1/metrics/generate_evaluation_trigger/": {
             "post": {
-                "operationId": "metrics-generate-evaluation-trigger-create",
-                "description": "Metrics generate evaluation trigger",
+                "operationId": "metrics-v1-generate-evaluation-trigger-create",
+                "description": "Metrics v1 generate evaluation trigger",
                 "tags": [
                     "test_framework"
                 ],
@@ -20488,8 +20558,8 @@
         },
         "/test_framework/v1/metrics/generate_metrics_progress/": {
             "get": {
-                "operationId": "metrics-generate-metrics-progress-retrieve",
-                "description": "Metrics generate metrics progress",
+                "operationId": "metrics-v1-generate-metrics-progress-retrieve",
+                "description": "Metrics v1 generate metrics progress",
                 "parameters": [
                     {
                         "in": "query",
@@ -20518,8 +20588,8 @@
         },
         "/test_framework/v1/metrics/preview/": {
             "post": {
-                "operationId": "metrics-preview-create",
-                "description": "Preview metric evaluation against sample transcripts",
+                "operationId": "metrics-v1-preview-create",
+                "description": "Metrics v1 preview",
                 "tags": [
                     "test_framework"
                 ],
@@ -20633,8 +20703,8 @@
         },
         "/test_framework/v1/metrics/save_result/": {
             "post": {
-                "operationId": "metrics-save-result-create",
-                "description": "Metrics save result",
+                "operationId": "metrics-v1-save-result-create",
+                "description": "Metrics v1 save result",
                 "tags": [
                     "test_framework"
                 ],
@@ -20679,8 +20749,8 @@
         },
         "/test_framework/v1/metrics/simplify_prompt/": {
             "post": {
-                "operationId": "metrics-simplify-prompt-create",
-                "description": "Metrics simplify prompt",
+                "operationId": "metrics-v1-simplify-prompt-create",
+                "description": "Metrics v1 simplify prompt",
                 "tags": [
                     "test_framework"
                 ],
@@ -20725,8 +20795,8 @@
         },
         "/test_framework/v1/metrics/simplify_prompt_progress/": {
             "get": {
-                "operationId": "metrics-simplify-prompt-progress-retrieve",
-                "description": "Metrics simplify prompt progress",
+                "operationId": "metrics-v1-simplify-prompt-progress-retrieve",
+                "description": "Metrics v1 simplify prompt progress",
                 "parameters": [
                     {
                         "in": "query",
@@ -24065,7 +24135,8 @@
         "/test_framework/v1/results-external/{id}/rerun/": {
             "post": {
                 "operationId": "results-external-rerun-create",
-                "description": "Re-run a test result evaluation",
+                "description": "Re-execute every scenario from a completed result against the same agent, creating a new result with a fresh set of runs. The connection mode (voice or text) and provider are inherited from the original runs. Consumes simulation credits (one run per scenario) and launches live calls, so the new result populates asynchronously.",
+                "summary": "Re-run the scenarios from a completed test result",
                 "parameters": [
                     {
                         "in": "path",
@@ -25156,7 +25227,8 @@
         "/test_framework/v1/results/{id}/rerun/": {
             "post": {
                 "operationId": "results-rerun-create",
-                "description": "Re-run a test result evaluation",
+                "description": "Re-execute every scenario from a completed result against the same agent, creating a new result with a fresh set of runs. The connection mode (voice or text) and provider are inherited from the original runs. Consumes simulation credits (one run per scenario) and launches live calls, so the new result populates asynchronously.",
+                "summary": "Re-run the scenarios from a completed test result",
                 "parameters": [
                     {
                         "in": "path",
@@ -41822,7 +41894,7 @@
         },
         "/test_framework/v2/metrics/": {
             "get": {
-                "operationId": "test-framework-v2-metrics-list",
+                "operationId": "metrics-list",
                 "description": "List quality metrics. Filter by `project_id` or `agent_id` to scope results.",
                 "summary": "List quality metrics",
                 "parameters": [
@@ -42000,13 +42072,13 @@
                 "x-mint": {
                     "mcp": {
                         "enabled": true,
-                        "name": "test-framework-v2-metrics-list",
+                        "name": "metrics-list",
                         "description": "List quality metrics. Filter by `project_id` or `agent_id` to scope results."
                     }
                 }
             },
             "post": {
-                "operationId": "test-framework-v2-metrics-create",
+                "operationId": "metrics-create",
                 "description": "Create a quality metric. `type` is `llm_judge` or `custom_code`. `eval_type` is one of `binary`, `continuous_qualitative`, `numeric`, `enum`. Set `add_to_rubric=true` to include the metric in the project's call-success rubric.",
                 "summary": "Create a metric",
                 "tags": [
@@ -42163,7 +42235,7 @@
                 "x-mint": {
                     "mcp": {
                         "enabled": true,
-                        "name": "test-framework-v2-metrics-create",
+                        "name": "metrics-create",
                         "description": "Create a quality metric. `type` is `llm_judge` or `custom_code`. `eval_type` is one of `binary`, `continuous_qualitative`, `numeric`, `enum`. Set `add_to_rubric=true` to include the metric in the project's call-success rubric."
                     }
                 }
@@ -42171,7 +42243,7 @@
         },
         "/test_framework/v2/metrics/{id}/": {
             "get": {
-                "operationId": "test-framework-v2-metrics-retrieve",
+                "operationId": "metrics-retrieve",
                 "description": "Fetch one metric by id.",
                 "summary": "Retrieve a metric",
                 "parameters": [
@@ -42224,13 +42296,13 @@
                 "x-mint": {
                     "mcp": {
                         "enabled": true,
-                        "name": "test-framework-v2-metrics-retrieve",
+                        "name": "metrics-retrieve",
                         "description": "Fetch one metric by id."
                     }
                 }
             },
             "put": {
-                "operationId": "test-framework-v2-metrics-update",
+                "operationId": "metrics-update",
                 "description": "Update a metric (full)",
                 "summary": "Update a metric (full)",
                 "parameters": [
@@ -42304,7 +42376,7 @@
                 }
             },
             "patch": {
-                "operationId": "test-framework-v2-metrics-partial-update",
+                "operationId": "metrics-partial-update",
                 "description": "Partially update a metric. Pass `add_to_rubric=true` to add the metric to the project's rubric, or `false` to remove it.",
                 "summary": "Update a metric (partial)",
                 "parameters": [
@@ -42403,13 +42475,13 @@
                 "x-mint": {
                     "mcp": {
                         "enabled": true,
-                        "name": "test-framework-v2-metrics-partial-update",
+                        "name": "metrics-partial-update",
                         "description": "Partially update a metric. Pass `add_to_rubric=true` to add the metric to the project's rubric, or `false` to remove it."
                     }
                 }
             },
             "delete": {
-                "operationId": "test-framework-v2-metrics-destroy",
+                "operationId": "metrics-destroy",
                 "description": "⚠ Irreversible. Deletes the metric and detaches it from all agents and evaluators. Dashboard widgets that displayed this metric are also removed.",
                 "summary": "Delete a metric",
                 "parameters": [
@@ -42455,7 +42527,7 @@
                 "x-mint": {
                     "mcp": {
                         "enabled": true,
-                        "name": "test-framework-v2-metrics-destroy",
+                        "name": "metrics-destroy",
                         "description": "⚠ Irreversible. Deletes the metric and detaches it from all agents and evaluators. Dashboard widgets that displayed this metric are also removed."
                     }
                 }
@@ -42463,7 +42535,7 @@
         },
         "/test_framework/v2/metrics/{id}/add_to_predefined_metrics/": {
             "post": {
-                "operationId": "test-framework-v2-metrics-add-to-predefined-metrics-create",
+                "operationId": "metrics-add-to-predefined-metrics-create",
                 "description": "Manage quality metrics for evaluating AI voice agent performance.\n\n`eval_type` values: `binary`, `continuous_qualitative`, `numeric`, `enum`.\n`add_to_rubric` (write-only) controls whether the metric contributes to\nthe project's call-success rubric.",
                 "parameters": [
                     {
@@ -42520,7 +42592,7 @@
         },
         "/test_framework/v2/metrics/{id}/apply_optimisation_proposal/": {
             "post": {
-                "operationId": "test-framework-v2-metrics-apply-optimisation-proposal-create",
+                "operationId": "metrics-apply-optimisation-proposal-create",
                 "description": "Apply a pending optimisation proposal",
                 "summary": "Apply a pending optimisation proposal",
                 "parameters": [
@@ -42551,7 +42623,7 @@
         },
         "/test_framework/v2/metrics/{id}/dismiss_optimisation_proposal/": {
             "post": {
-                "operationId": "test-framework-v2-metrics-dismiss-optimisation-proposal-create",
+                "operationId": "metrics-dismiss-optimisation-proposal-create",
                 "description": "Dismiss a pending optimisation proposal",
                 "summary": "Dismiss a pending optimisation proposal",
                 "parameters": [
@@ -42582,7 +42654,7 @@
         },
         "/test_framework/v2/metrics/{id}/evaluate_advance_metric/": {
             "post": {
-                "operationId": "test-framework-v2-metrics-evaluate-advance-metric-create",
+                "operationId": "metrics-evaluate-advance-metric-create",
                 "description": "Evaluate an advance metric in the background.\n\nReturns a progress_id to poll for results.",
                 "parameters": [
                     {
@@ -42639,7 +42711,7 @@
         },
         "/test_framework/v2/metrics/{id}/evaluate_basic_metric/": {
             "post": {
-                "operationId": "test-framework-v2-metrics-evaluate-basic-metric-create",
+                "operationId": "metrics-evaluate-basic-metric-create",
                 "description": "Evaluate a basic metric in the background.\n\nReturns a progress_id to poll for results.",
                 "parameters": [
                     {
@@ -42696,7 +42768,7 @@
         },
         "/test_framework/v2/metrics/{id}/evaluate_llm_judge_metric/": {
             "post": {
-                "operationId": "test-framework-v2-metrics-evaluate-llm-judge-metric-create",
+                "operationId": "metrics-evaluate-llm-judge-metric-create",
                 "description": "Evaluate a metric using LLM Judge (DSPy) in the background.\n\nReturns a progress_id to poll for results.",
                 "parameters": [
                     {
@@ -42753,7 +42825,7 @@
         },
         "/test_framework/v2/metrics/{id}/history/": {
             "get": {
-                "operationId": "test-framework-v2-metrics-history-list",
+                "operationId": "metrics-history-list",
                 "description": "Metrics history",
                 "parameters": [
                     {
@@ -42804,7 +42876,7 @@
         },
         "/test_framework/v2/metrics/{id}/history/edit/": {
             "patch": {
-                "operationId": "test-framework-v2-metrics-history-edit-partial-update",
+                "operationId": "metrics-history-edit-partial-update",
                 "description": "Metrics history edit",
                 "parameters": [
                     {
@@ -42860,7 +42932,7 @@
         },
         "/test_framework/v2/metrics/{id}/restore/": {
             "post": {
-                "operationId": "test-framework-v2-metrics-restore-create",
+                "operationId": "metrics-restore-create",
                 "description": "Metrics restore",
                 "parameters": [
                     {
@@ -42917,8 +42989,8 @@
         },
         "/test_framework/v2/metrics/{id}/run_reviews/": {
             "post": {
-                "operationId": "test-framework-v2-metrics-run-reviews-create",
-                "description": "Metrics run reviews",
+                "operationId": "metrics-run-reviews-create",
+                "description": "Run metric reviews to identify improvement opportunities",
                 "parameters": [
                     {
                         "in": "path",
@@ -42966,15 +43038,15 @@
                 "x-mint": {
                     "mcp": {
                         "enabled": true,
-                        "name": "test-framework-v2-metrics-run-reviews-create",
-                        "description": "Metrics run reviews"
+                        "name": "metrics-run-reviews-create",
+                        "description": "Run metric reviews to identify improvement opportunities"
                     }
                 }
             }
         },
         "/test_framework/v2/metrics/{id}/variables/": {
             "post": {
-                "operationId": "test-framework-v2-metrics-variables-create",
+                "operationId": "metrics-variables-create",
                 "description": "Get all variables and their values for a specific test_set and metric combination.\n\nURL Parameter:\n- pk: The metric_id\n\nRequest Body:\n- test_set_id (required): The ID of the test_set (datapoint)\n- metric_description_variables (required/optional): Array of variable names for description.\n  At least one of metric_description_variables or evaluation_trigger_variables must be provided.\n- evaluation_trigger_variables (required/optional): Array of variable names for trigger.\n  At least one of metric_description_variables or evaluation_trigger_variables must be provided.\n\nThis endpoint retrieves the variables and populates them with values from the test_set (datapoint).",
                 "parameters": [
                     {
@@ -43031,7 +43103,7 @@
         },
         "/test_framework/v2/metrics/basic_list/": {
             "get": {
-                "operationId": "test-framework-v2-metrics-basic-list-retrieve",
+                "operationId": "metrics-basic-list-retrieve",
                 "description": "Manage quality metrics for evaluating AI voice agent performance.\n\n`eval_type` values: `binary`, `continuous_qualitative`, `numeric`, `enum`.\n`add_to_rubric` (write-only) controls whether the metric contributes to\nthe project's call-success rubric.",
                 "tags": [
                     "test_framework"
@@ -43057,7 +43129,7 @@
         },
         "/test_framework/v2/metrics/bulk-toggle-settings/": {
             "post": {
-                "operationId": "test-framework-v2-metrics-bulk-toggle-settings-create",
+                "operationId": "metrics-bulk-toggle-settings-create",
                 "description": "Manage quality metrics for evaluating AI voice agent performance.\n\n`eval_type` values: `binary`, `continuous_qualitative`, `numeric`, `enum`.\n`add_to_rubric` (write-only) controls whether the metric contributes to\nthe project's call-success rubric.",
                 "tags": [
                     "test_framework"
@@ -43188,7 +43260,7 @@
         },
         "/test_framework/v2/metrics/bulk_manage_agents/": {
             "post": {
-                "operationId": "test-framework-v2-metrics-bulk-manage-agents-create",
+                "operationId": "metrics-bulk-manage-agents-create",
                 "description": "Metrics bulk manage agents",
                 "tags": [
                     "test_framework"
@@ -43234,7 +43306,7 @@
         },
         "/test_framework/v2/metrics/delete_metrics/": {
             "post": {
-                "operationId": "test-framework-v2-metrics-delete-metrics-create",
+                "operationId": "metrics-delete-metrics-create",
                 "description": "Manage quality metrics for evaluating AI voice agent performance.\n\n`eval_type` values: `binary`, `continuous_qualitative`, `numeric`, `enum`.\n`add_to_rubric` (write-only) controls whether the metric contributes to\nthe project's call-success rubric.",
                 "tags": [
                     "test_framework"
@@ -43280,7 +43352,7 @@
         },
         "/test_framework/v2/metrics/evaluate_metric_progress/": {
             "get": {
-                "operationId": "test-framework-v2-metrics-evaluate-metric-progress-retrieve",
+                "operationId": "metrics-evaluate-metric-progress-retrieve",
                 "description": "Poll for metric evaluation progress.\n\nQuery params:\n    progress_id: The progress_id returned from evaluate_basic_metric or evaluate_advance_metric\n\nReturns:\n    State object with status, output, error, etc.",
                 "tags": [
                     "test_framework"
@@ -43306,7 +43378,7 @@
         },
         "/test_framework/v2/metrics/fetch_call_details/": {
             "get": {
-                "operationId": "test-framework-v2-metrics-fetch-call-details-retrieve",
+                "operationId": "metrics-fetch-call-details-retrieve",
                 "description": "Metrics fetch call details",
                 "tags": [
                     "test_framework"
@@ -43332,7 +43404,7 @@
         },
         "/test_framework/v2/metrics/generate_clean_description/": {
             "post": {
-                "operationId": "test-framework-v2-metrics-generate-clean-description-create",
+                "operationId": "metrics-generate-clean-description-create",
                 "description": "Metrics generate clean description",
                 "tags": [
                     "test_framework"
@@ -43378,7 +43450,7 @@
                 "x-mint": {
                     "mcp": {
                         "enabled": true,
-                        "name": "test-framework-v2-metrics-generate-clean-description-create",
+                        "name": "metrics-generate-clean-description-create",
                         "description": "Metrics generate clean description"
                     }
                 }
@@ -43386,7 +43458,7 @@
         },
         "/test_framework/v2/metrics/generate_clean_description_bg/": {
             "post": {
-                "operationId": "test-framework-v2-metrics-generate-clean-description-bg-create",
+                "operationId": "metrics-generate-clean-description-bg-create",
                 "description": "Start async clean description generation",
                 "summary": "Start async clean description generation",
                 "tags": [
@@ -43433,7 +43505,7 @@
                 "x-mint": {
                     "mcp": {
                         "enabled": true,
-                        "name": "test-framework-v2-metrics-generate-clean-description-bg-create",
+                        "name": "metrics-generate-clean-description-bg-create",
                         "description": "Start async clean description generation"
                     }
                 }
@@ -43441,7 +43513,7 @@
         },
         "/test_framework/v2/metrics/generate_clean_description_progress/": {
             "get": {
-                "operationId": "test-framework-v2-metrics-generate-clean-description-progress-re",
+                "operationId": "metrics-generate-clean-description-progress-retrieve",
                 "description": "Poll async clean description generation",
                 "summary": "Poll async clean description generation",
                 "parameters": [
@@ -43506,7 +43578,7 @@
                 "x-mint": {
                     "mcp": {
                         "enabled": true,
-                        "name": "test-framework-v2-metrics-generate-clean-description-progress-re",
+                        "name": "metrics-generate-clean-description-progress-retrieve",
                         "description": "Poll async clean description generation"
                     }
                 }
@@ -43514,7 +43586,7 @@
         },
         "/test_framework/v2/metrics/generate_evaluation_trigger/": {
             "post": {
-                "operationId": "test-framework-v2-metrics-generate-evaluation-trigger-create",
+                "operationId": "metrics-generate-evaluation-trigger-create",
                 "description": "Metrics generate evaluation trigger",
                 "tags": [
                     "test_framework"
@@ -43560,7 +43632,7 @@
                 "x-mint": {
                     "mcp": {
                         "enabled": true,
-                        "name": "test-framework-v2-metrics-generate-evaluation-trigger-create",
+                        "name": "metrics-generate-evaluation-trigger-create",
                         "description": "Metrics generate evaluation trigger"
                     }
                 }
@@ -43639,7 +43711,7 @@
         },
         "/test_framework/v2/metrics/generate_metrics_progress/": {
             "get": {
-                "operationId": "test-framework-v2-metrics-generate-metrics-progress-retrieve",
+                "operationId": "metrics-generate-metrics-progress-retrieve",
                 "description": "Metrics generate metrics progress",
                 "parameters": [
                     {
@@ -43696,7 +43768,7 @@
                 "x-mint": {
                     "mcp": {
                         "enabled": true,
-                        "name": "test-framework-v2-metrics-generate-metrics-progress-retrieve",
+                        "name": "metrics-generate-metrics-progress-retrieve",
                         "description": "Metrics generate metrics progress"
                     }
                 }
@@ -43704,8 +43776,8 @@
         },
         "/test_framework/v2/metrics/preview/": {
             "post": {
-                "operationId": "test-framework-v2-metrics-preview-create",
-                "description": "Metrics preview",
+                "operationId": "metrics-preview-create",
+                "description": "Preview metric evaluation against sample transcripts",
                 "tags": [
                     "test_framework"
                 ],
@@ -43743,8 +43815,8 @@
                 "x-mint": {
                     "mcp": {
                         "enabled": true,
-                        "name": "test-framework-v2-metrics-preview-create",
-                        "description": "Metrics preview"
+                        "name": "metrics-preview-create",
+                        "description": "Preview metric evaluation against sample transcripts"
                     }
                 }
             }
@@ -43879,7 +43951,7 @@
         },
         "/test_framework/v2/metrics/save_result/": {
             "post": {
-                "operationId": "test-framework-v2-metrics-save-result-create",
+                "operationId": "metrics-save-result-create",
                 "description": "Metrics save result",
                 "tags": [
                     "test_framework"
@@ -43925,7 +43997,7 @@
         },
         "/test_framework/v2/metrics/simplify_prompt/": {
             "post": {
-                "operationId": "test-framework-v2-metrics-simplify-prompt-create",
+                "operationId": "metrics-simplify-prompt-create",
                 "description": "Metrics simplify prompt",
                 "tags": [
                     "test_framework"
@@ -43971,7 +44043,7 @@
                 "x-mint": {
                     "mcp": {
                         "enabled": true,
-                        "name": "test-framework-v2-metrics-simplify-prompt-create",
+                        "name": "metrics-simplify-prompt-create",
                         "description": "Metrics simplify prompt"
                     }
                 }
@@ -43979,7 +44051,7 @@
         },
         "/test_framework/v2/metrics/simplify_prompt_progress/": {
             "get": {
-                "operationId": "test-framework-v2-metrics-simplify-prompt-progress-retrieve",
+                "operationId": "metrics-simplify-prompt-progress-retrieve",
                 "description": "Metrics simplify prompt progress",
                 "parameters": [
                     {
@@ -44043,7 +44115,7 @@
                 "x-mint": {
                     "mcp": {
                         "enabled": true,
-                        "name": "test-framework-v2-metrics-simplify-prompt-progress-retrieve",
+                        "name": "metrics-simplify-prompt-progress-retrieve",
                         "description": "Metrics simplify prompt progress"
                     }
                 }
@@ -44944,7 +45016,8 @@
         "/test_framework/v2/results/{id}/rerun/": {
             "post": {
                 "operationId": "test-framework-v2-results-rerun-create",
-                "description": "Results rerun",
+                "description": "Re-execute every scenario from a completed result against the same agent, creating a new result with a fresh set of runs. The connection mode (voice or text) and provider are inherited from the original runs. Consumes simulation credits (one run per scenario) and launches live calls, so the new result populates asynchronously.",
+                "summary": "Re-run the scenarios from a completed test result",
                 "parameters": [
                     {
                         "in": "path",
@@ -44981,7 +45054,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "test-framework-v2-results-rerun-create",
-                        "description": "Results rerun"
+                        "description": "Re-execute every scenario from a completed result against the same agent, creating a new result with a fresh set of runs. The connection mode (voice or text) and provider are inherited from the original runs. Consumes simulation credits (one run per scenario) and launches live calls, so the new result populates asynchronously."
                     }
                 }
             }
@@ -51812,14 +51885,6 @@
                         },
                         "description": ""
                     }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "user-api-key-create",
-                        "description": "Create a new API key. When using API key authentication, only project-level API keys can be created."
-                    }
                 }
             }
         },
@@ -57411,6 +57476,79 @@
                     "name"
                 ]
             },
+            "AgentImprovementSession": {
+                "type": "object",
+                "description": "Read view of an Improve-Agent session — what the frontend polls to\ntrack progress. `provider_key` and other secrets are never serialized.",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "project": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "agent": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
+                        "readOnly": true
+                    },
+                    "provider": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "insights": {
+                        "readOnly": true
+                    },
+                    "call_log_ids": {
+                        "readOnly": true
+                    },
+                    "status": {
+                        "enum": [
+                            "pending",
+                            "running",
+                            "succeeded",
+                            "failed"
+                        ],
+                        "type": "string",
+                        "description": "* `pending` - Pending\n* `running` - Running\n* `succeeded` - Succeeded\n* `failed` - Failed",
+                        "x-spec-enum-id": "7a7ee2ea425ee5c6",
+                        "readOnly": true
+                    },
+                    "conversation_id": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "uuid",
+                        "readOnly": true
+                    },
+                    "message_id": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "uuid",
+                        "readOnly": true
+                    },
+                    "error_message": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    }
+                }
+            },
             "AgentKnowledgeBaseFileWrite": {
                 "type": "object",
                 "description": "One knowledge base file entry in the v2 agent write payload (request side of `knowledge_base_files`).",
@@ -61179,46 +61317,42 @@
                         "readOnly": true
                     },
                     "insight": {
-                        "type": "integer",
-                        "readOnly": true
+                        "type": "integer"
                     },
                     "project": {
-                        "type": "integer",
-                        "readOnly": true
+                        "type": "integer"
                     },
                     "agent": {
-                        "type": "integer",
-                        "readOnly": true
+                        "type": "integer"
                     },
                     "failure_mode_index": {
                         "type": "integer",
-                        "readOnly": true
+                        "maximum": 2147483647,
+                        "minimum": -2147483648
                     },
                     "failure_mode_title": {
                         "type": "string",
-                        "readOnly": true
+                        "maxLength": 255
                     },
                     "metric": {
                         "type": [
                             "integer",
                             "null"
-                        ],
-                        "readOnly": true
+                        ]
                     },
                     "predefined_metric": {
                         "type": [
                             "integer",
                             "null"
-                        ],
-                        "readOnly": true
+                        ]
                     },
                     "metric_name": {
                         "type": "string",
-                        "readOnly": true
+                        "maxLength": 255
                     },
                     "execution_mode": {
                         "type": "string",
-                        "readOnly": true
+                        "maxLength": 32
                     },
                     "status": {
                         "enum": [
@@ -61231,48 +61365,42 @@
                         ],
                         "type": "string",
                         "description": "* `pending` - Pending\n* `generating_scenario` - Generating Scenario\n* `running` - Running\n* `reproduced` - Reproduced\n* `exhausted` - Exhausted\n* `failed` - Failed",
-                        "x-spec-enum-id": "cd33c9bed092472e",
-                        "readOnly": true
+                        "x-spec-enum-id": "cd33c9bed092472e"
                     },
-                    "scenario_ids": {
-                        "readOnly": true
-                    },
+                    "scenario_ids": {},
                     "max_attempts": {
                         "type": "integer",
-                        "readOnly": true
+                        "maximum": 2147483647,
+                        "minimum": -2147483648
                     },
                     "attempts_made": {
                         "type": "integer",
-                        "readOnly": true
+                        "maximum": 2147483647,
+                        "minimum": -2147483648
                     },
                     "reproduced": {
-                        "type": "boolean",
-                        "readOnly": true
+                        "type": "boolean"
                     },
                     "current_result": {
                         "type": [
                             "integer",
                             "null"
-                        ],
-                        "readOnly": true
+                        ]
                     },
                     "reproducing_run": {
                         "type": [
                             "integer",
                             "null"
-                        ],
-                        "readOnly": true
+                        ]
                     },
                     "reproducing_result": {
                         "type": [
                             "integer",
                             "null"
-                        ],
-                        "readOnly": true
+                        ]
                     },
                     "error_message": {
-                        "type": "string",
-                        "readOnly": true
+                        "type": "string"
                     },
                     "created_at": {
                         "type": "string",
@@ -61284,7 +61412,13 @@
                         "format": "date-time",
                         "readOnly": true
                     }
-                }
+                },
+                "required": [
+                    "agent",
+                    "failure_mode_index",
+                    "insight",
+                    "project"
+                ]
             },
             "Invite": {
                 "type": "object",
@@ -72738,7 +72872,7 @@
                         "items": {
                             "type": "string"
                         },
-                        "description": "Names of mock tools to activate for this run. Omit or pass an empty list to mock every tool configured on the agent."
+                        "description": "Names of mock tools to activate for this run. Omit (or send null) to mock every tool configured on the agent; send an empty list to mock none so every tool keeps its original endpoint; send specific names to mock only those."
                     },
                     "livekit_data": {
                         "allOf": [
@@ -72863,7 +72997,7 @@
                         "items": {
                             "type": "string"
                         },
-                        "description": "Names of mock tools to activate for this run. Omit or pass an empty list to mock every tool configured on the agent."
+                        "description": "Names of mock tools to activate for this run. Omit (or send null) to mock every tool configured on the agent; send an empty list to mock none so every tool keeps its original endpoint; send specific names to mock only those."
                     }
                 },
                 "required": [
@@ -72906,7 +73040,7 @@
                         "items": {
                             "type": "string"
                         },
-                        "description": "Names of mock tools to activate for this run. Omit or pass an empty list to mock every tool configured on the agent."
+                        "description": "Names of mock tools to activate for this run. Omit (or send null) to mock every tool configured on the agent; send an empty list to mock none so every tool keeps its original endpoint; send specific names to mock only those."
                     }
                 },
                 "required": [
@@ -72945,7 +73079,7 @@
                         "items": {
                             "type": "string"
                         },
-                        "description": "Names of mock tools to activate for this run. Omit or pass an empty list to mock every tool configured on the agent."
+                        "description": "Names of mock tools to activate for this run. Omit (or send null) to mock every tool configured on the agent; send an empty list to mock none so every tool keeps its original endpoint; send specific names to mock only those."
                     }
                 },
                 "required": [
@@ -75652,7 +75786,7 @@
                         "items": {
                             "type": "string"
                         },
-                        "description": "\nNames of mock tools to activate for this run. Cekura swaps those tools' URLs to mock endpoints while the\nrun is active and restores the originals when it finishes. Omit or pass an empty list to mock every tool\nconfigured on the agent. Example: `[\"get_appointments\", \"cancel_booking\"]`\n"
+                        "description": "\nNames of mock tools to activate for this run. Cekura swaps those tools' URLs to mock endpoints while the\nrun is active and restores the originals when it finishes. Omit (or send null) to mock every tool\nconfigured on the agent; send an empty list to mock none so every tool keeps its original endpoint.\nExample: `[\"get_appointments\", \"cancel_booking\"]`\n"
                     }
                 }
             },
@@ -75763,7 +75897,7 @@
                         "items": {
                             "type": "string"
                         },
-                        "description": "\nNames of mock tools to activate for this run. Cekura swaps those tools' URLs to mock endpoints while the\nrun is active and restores the originals when it finishes. Omit or pass an empty list to mock every tool\nconfigured on the agent. Example: `[\"get_appointments\", \"cancel_booking\"]`\n"
+                        "description": "\nNames of mock tools to activate for this run. Cekura swaps those tools' URLs to mock endpoints while the\nrun is active and restores the originals when it finishes. Omit (or send null) to mock every tool\nconfigured on the agent; send an empty list to mock none so every tool keeps its original endpoint.\nExample: `[\"get_appointments\", \"cancel_booking\"]`\n"
                     },
                     "websocket_url": {
                         "type": "string",
@@ -75878,7 +76012,7 @@
                         "items": {
                             "type": "string"
                         },
-                        "description": "\nNames of mock tools to activate for this run. Cekura swaps those tools' URLs to mock endpoints while the\nrun is active and restores the originals when it finishes. Omit or pass an empty list to mock every tool\nconfigured on the agent. Example: `[\"get_appointments\", \"cancel_booking\"]`\n"
+                        "description": "\nNames of mock tools to activate for this run. Cekura swaps those tools' URLs to mock endpoints while the\nrun is active and restores the originals when it finishes. Omit (or send null) to mock every tool\nconfigured on the agent; send an empty list to mock none so every tool keeps its original endpoint.\nExample: `[\"get_appointments\", \"cancel_booking\"]`\n"
                     },
                     "elevenlabs_agent_id": {
                         "type": "string",
@@ -75917,7 +76051,7 @@
                         "items": {
                             "type": "string"
                         },
-                        "description": "Names of mock tools to activate for this run. Omit or pass an empty list to mock every tool configured on the agent."
+                        "description": "Names of mock tools to activate for this run. Omit (or send null) to mock every tool configured on the agent; send an empty list to mock none so every tool keeps its original endpoint; send specific names to mock only those."
                     }
                 },
                 "required": [
@@ -75977,7 +76111,7 @@
                         "items": {
                             "type": "string"
                         },
-                        "description": "Names of mock tools to activate for this run. Omit or pass an empty list to mock every tool configured on the agent."
+                        "description": "Names of mock tools to activate for this run. Omit (or send null) to mock every tool configured on the agent; send an empty list to mock none so every tool keeps its original endpoint; send specific names to mock only those."
                     },
                     "personality_id": {
                         "type": [
@@ -76120,7 +76254,7 @@
                         "items": {
                             "type": "string"
                         },
-                        "description": "\nNames of mock tools to activate for this run. Cekura swaps those tools' URLs to mock endpoints while the\nrun is active and restores the originals when it finishes. Omit or pass an empty list to mock every tool\nconfigured on the agent. Example: `[\"get_appointments\", \"cancel_booking\"]`\n"
+                        "description": "\nNames of mock tools to activate for this run. Cekura swaps those tools' URLs to mock endpoints while the\nrun is active and restores the originals when it finishes. Omit (or send null) to mock every tool\nconfigured on the agent; send an empty list to mock none so every tool keeps its original endpoint.\nExample: `[\"get_appointments\", \"cancel_booking\"]`\n"
                     },
                     "sip_endpoint": {
                         "type": "string",
@@ -76220,7 +76354,7 @@
                         "items": {
                             "type": "string"
                         },
-                        "description": "\nNames of mock tools to activate for this run. Cekura swaps those tools' URLs to mock endpoints while the\nrun is active and restores the originals when it finishes. Omit or pass an empty list to mock every tool\nconfigured on the agent. Example: `[\"get_appointments\", \"cancel_booking\"]`\n"
+                        "description": "\nNames of mock tools to activate for this run. Cekura swaps those tools' URLs to mock endpoints while the\nrun is active and restores the originals when it finishes. Omit (or send null) to mock every tool\nconfigured on the agent; send an empty list to mock none so every tool keeps its original endpoint.\nExample: `[\"get_appointments\", \"cancel_booking\"]`\n"
                     }
                 }
             },

--- a/openapi.json
+++ b/openapi.json
@@ -23182,7 +23182,7 @@
         },
         "/test_framework/v1/results/": {
             "get": {
-                "operationId": "results-list",
+                "operationId": "results-v1-list",
                 "description": "List test results.\n\nTo filter by status, use `results_retrieve(id=result_id)` and inspect `status` directly ('running', 'completed', 'failed') — there is no list-level status filter.\n\n**Result status:** a result marked `failed` indicates infrastructure failures (e.g. connection errors, websocket handshake failures), not metric evaluation failures. `success_runs_count` counts runs that reached terminal state regardless of connection errors. See `results_retrieve().failed_reasons` for the breakdown.\n\n**Scenarios filter note:** filtering by `scenarios` may return duplicate result rows when a result contains multiple runs of the same scenario — deduplicate by `result.id` if needed.\n\nAfter triggering a run, poll `results_retrieve(id=result_id)` until `status` is 'completed' or 'failed'. For outbound runs, each run's `outbound_dial_window_closes_at` shows the deadline by which your agent must dial in.",
                 "parameters": [
                     {
@@ -23259,7 +23259,7 @@
                 "deprecated": true
             },
             "post": {
-                "operationId": "results-create",
+                "operationId": "results-v1-create",
                 "description": "Create a new test result",
                 "tags": [
                     "test_framework"
@@ -23305,7 +23305,7 @@
         },
         "/test_framework/v1/results-external/": {
             "get": {
-                "operationId": "results-external-list",
+                "operationId": "results-v1-external-list",
                 "description": "List test results.\n\nTo filter by status, use `results_retrieve(id=result_id)` and inspect `status` directly ('running', 'completed', 'failed') — there is no list-level status filter.\n\n**Result status:** a result marked `failed` indicates infrastructure failures (e.g. connection errors, websocket handshake failures), not metric evaluation failures. `success_runs_count` counts runs that reached terminal state regardless of connection errors. See `results_retrieve().failed_reasons` for the breakdown.\n\n**Scenarios filter note:** filtering by `scenarios` may return duplicate result rows when a result contains multiple runs of the same scenario — deduplicate by `result.id` if needed.\n\nAfter triggering a run, poll `results_retrieve(id=result_id)` until `status` is 'completed' or 'failed'. For outbound runs, each run's `outbound_dial_window_closes_at` shows the deadline by which your agent must dial in.",
                 "parameters": [
                     {
@@ -23382,7 +23382,7 @@
                 "deprecated": true
             },
             "post": {
-                "operationId": "results-external-create",
+                "operationId": "results-v1-external-create",
                 "description": "Create a new test result",
                 "tags": [
                     "test_framework"
@@ -23428,7 +23428,7 @@
         },
         "/test_framework/v1/results-external/{id}/": {
             "get": {
-                "operationId": "results-external-retrieve",
+                "operationId": "results-v1-external-retrieve",
                 "description": "`success` indicates whether the run passed its quality evaluation. A run with `success=false` either failed to connect (check `error_message`) or failed an evaluation check (check `evaluation`). `success_rate` is the percentage of runs with `success=true`.\n\nThe `runs` field is a dict keyed by run ID string (e.g. `{\"86368\": {...}, \"86367\": {...}}`), not an array — unlike the list endpoint. Each run also has a `call_id` STRING field (the provider's call identifier) — that is a data field, NOT an endpoint ID; do not pass it where `run_id` is expected.",
                 "summary": "Retrieve a test result",
                 "parameters": [
@@ -23632,7 +23632,7 @@
                 "deprecated": true
             },
             "put": {
-                "operationId": "results-external-update",
+                "operationId": "results-v1-external-update",
                 "description": "Update a test result",
                 "parameters": [
                     {
@@ -23687,7 +23687,7 @@
                 }
             },
             "patch": {
-                "operationId": "results-external-partial-update",
+                "operationId": "results-v1-external-partial-update",
                 "description": "Update a test result",
                 "parameters": [
                     {
@@ -23741,7 +23741,7 @@
                 }
             },
             "delete": {
-                "operationId": "results-external-destroy",
+                "operationId": "results-v1-external-destroy",
                 "description": "Delete a test result",
                 "parameters": [
                     {
@@ -23771,7 +23771,7 @@
         },
         "/test_framework/v1/results-external/{id}/ask_about_failures/": {
             "post": {
-                "operationId": "results-external-ask-about-failures-create",
+                "operationId": "results-v1-external-ask-about-failures-create",
                 "description": "Query failed runs chatbot",
                 "summary": "Query failed runs chatbot",
                 "parameters": [
@@ -24043,8 +24043,8 @@
         },
         "/test_framework/v1/results-external/{id}/evaluate_metrics/": {
             "post": {
-                "operationId": "results-external-evaluate-metrics-create",
-                "description": "Evaluate metrics against result transcripts",
+                "operationId": "results-v1-external-evaluate-metrics-create",
+                "description": "Results v1 evaluate metrics",
                 "parameters": [
                     {
                         "in": "path",
@@ -24100,7 +24100,7 @@
         },
         "/test_framework/v1/results-external/{id}/regenerate_ai_summary/": {
             "post": {
-                "operationId": "results-external-regenerate-ai-summary-create",
+                "operationId": "results-v1-external-regenerate-ai-summary-create",
                 "description": "Queue a background job that regenerates the structured AI summary (what_happened / why_it_happened / how_to_fix) and recommended next steps for this result, based on its current failure clusters. The new summary appears on the next `results_retrieve` call once the job finishes.",
                 "summary": "Regenerate the AI summary for a result",
                 "parameters": [
@@ -24134,7 +24134,7 @@
         },
         "/test_framework/v1/results-external/{id}/rerun/": {
             "post": {
-                "operationId": "results-external-rerun-create",
+                "operationId": "results-v1-external-rerun-create",
                 "description": "Re-execute every scenario from a completed result against the same agent, creating a new result with a fresh set of runs. The connection mode (voice or text) and provider are inherited from the original runs. Consumes simulation credits (one run per scenario) and launches live calls, so the new result populates asynchronously.",
                 "summary": "Re-run the scenarios from a completed test result",
                 "parameters": [
@@ -24288,8 +24288,8 @@
         },
         "/test_framework/v1/results-external/bulk_export_progress/": {
             "get": {
-                "operationId": "results-external-bulk-export-progress-retrieve",
-                "description": "Results bulk export progress",
+                "operationId": "results-v1-external-bulk-export-progress-retrieve",
+                "description": "Results v1 bulk export progress",
                 "tags": [
                     "test_framework"
                 ],
@@ -24314,7 +24314,7 @@
         },
         "/test_framework/v1/results-external/bulk_export_result_runs/": {
             "get": {
-                "operationId": "results-external-bulk-export-result-runs-retrieve",
+                "operationId": "results-v1-external-bulk-export-result-runs-retrieve",
                 "description": "Bulk export results with progress tracking and file URL response.\nAccepts export_type in query params and applies the same filters as the queryset.",
                 "tags": [
                     "test_framework"
@@ -24340,8 +24340,8 @@
         },
         "/test_framework/v1/results-external/export_result_runs/": {
             "get": {
-                "operationId": "results-external-export-result-runs-retrieve",
-                "description": "Results export result runs",
+                "operationId": "results-v1-external-export-result-runs-retrieve",
+                "description": "Results v1 export result runs",
                 "tags": [
                     "test_framework"
                 ],
@@ -24366,8 +24366,8 @@
         },
         "/test_framework/v1/results-external/reports/": {
             "get": {
-                "operationId": "results-external-reports-retrieve",
-                "description": "Results reports",
+                "operationId": "results-v1-external-reports-retrieve",
+                "description": "Results v1 reports",
                 "tags": [
                     "test_framework"
                 ],
@@ -24392,7 +24392,7 @@
         },
         "/test_framework/v1/results-external/reports/ask-about-failures/": {
             "post": {
-                "operationId": "results-external-reports-ask-about-failures-create",
+                "operationId": "results-v1-external-reports-ask-about-failures-create",
                 "description": "Query failed runs chatbot for combined reports",
                 "summary": "Query failed runs chatbot for combined reports",
                 "tags": [
@@ -24448,8 +24448,8 @@
         },
         "/test_framework/v1/results-external/reports/share/": {
             "post": {
-                "operationId": "results-external-reports-share-create",
-                "description": "Results reports share",
+                "operationId": "results-v1-external-reports-share-create",
+                "description": "Results v1 reports share",
                 "tags": [
                     "test_framework"
                 ],
@@ -24494,8 +24494,8 @@
         },
         "/test_framework/v1/results-external/result_ids/": {
             "get": {
-                "operationId": "results-external-result-ids-retrieve",
-                "description": "Results result ids",
+                "operationId": "results-v1-external-result-ids-retrieve",
+                "description": "Results v1 result ids",
                 "tags": [
                     "test_framework"
                 ],
@@ -24520,7 +24520,7 @@
         },
         "/test_framework/v1/results/{id}/": {
             "get": {
-                "operationId": "results-retrieve",
+                "operationId": "results-v1-retrieve",
                 "description": "`success` indicates whether the run passed its quality evaluation. A run with `success=false` either failed to connect (check `error_message`) or failed an evaluation check (check `evaluation`). `success_rate` is the percentage of runs with `success=true`.\n\nThe `runs` field is a dict keyed by run ID string (e.g. `{\"86368\": {...}, \"86367\": {...}}`), not an array — unlike the list endpoint. Each run also has a `call_id` STRING field (the provider's call identifier) — that is a data field, NOT an endpoint ID; do not pass it where `run_id` is expected.",
                 "summary": "Retrieve a test result",
                 "parameters": [
@@ -24724,7 +24724,7 @@
                 "deprecated": true
             },
             "put": {
-                "operationId": "results-update",
+                "operationId": "results-v1-update",
                 "description": "Update a test result",
                 "parameters": [
                     {
@@ -24779,7 +24779,7 @@
                 }
             },
             "patch": {
-                "operationId": "results-partial-update",
+                "operationId": "results-v1-partial-update",
                 "description": "Update a test result",
                 "parameters": [
                     {
@@ -24833,7 +24833,7 @@
                 }
             },
             "delete": {
-                "operationId": "results-destroy",
+                "operationId": "results-v1-destroy",
                 "description": "Delete a test result",
                 "parameters": [
                     {
@@ -24863,7 +24863,7 @@
         },
         "/test_framework/v1/results/{id}/ask_about_failures/": {
             "post": {
-                "operationId": "results-ask-about-failures-create",
+                "operationId": "results-v1-ask-about-failures-create",
                 "description": "Query failed runs chatbot",
                 "summary": "Query failed runs chatbot",
                 "parameters": [
@@ -25135,8 +25135,8 @@
         },
         "/test_framework/v1/results/{id}/evaluate_metrics/": {
             "post": {
-                "operationId": "results-evaluate-metrics-create",
-                "description": "Evaluate metrics against result transcripts",
+                "operationId": "results-v1-evaluate-metrics-create",
+                "description": "Results v1 evaluate metrics",
                 "parameters": [
                     {
                         "in": "path",
@@ -25192,7 +25192,7 @@
         },
         "/test_framework/v1/results/{id}/regenerate_ai_summary/": {
             "post": {
-                "operationId": "results-regenerate-ai-summary-create",
+                "operationId": "results-v1-regenerate-ai-summary-create",
                 "description": "Queue a background job that regenerates the structured AI summary (what_happened / why_it_happened / how_to_fix) and recommended next steps for this result, based on its current failure clusters. The new summary appears on the next `results_retrieve` call once the job finishes.",
                 "summary": "Regenerate the AI summary for a result",
                 "parameters": [
@@ -25226,7 +25226,7 @@
         },
         "/test_framework/v1/results/{id}/rerun/": {
             "post": {
-                "operationId": "results-rerun-create",
+                "operationId": "results-v1-rerun-create",
                 "description": "Re-execute every scenario from a completed result against the same agent, creating a new result with a fresh set of runs. The connection mode (voice or text) and provider are inherited from the original runs. Consumes simulation credits (one run per scenario) and launches live calls, so the new result populates asynchronously.",
                 "summary": "Re-run the scenarios from a completed test result",
                 "parameters": [
@@ -25380,8 +25380,8 @@
         },
         "/test_framework/v1/results/bulk_export_progress/": {
             "get": {
-                "operationId": "results-bulk-export-progress-retrieve",
-                "description": "Results bulk export progress",
+                "operationId": "results-v1-bulk-export-progress-retrieve",
+                "description": "Results v1 bulk export progress",
                 "tags": [
                     "test_framework"
                 ],
@@ -25406,7 +25406,7 @@
         },
         "/test_framework/v1/results/bulk_export_result_runs/": {
             "get": {
-                "operationId": "results-bulk-export-result-runs-retrieve",
+                "operationId": "results-v1-bulk-export-result-runs-retrieve",
                 "description": "Bulk export results with progress tracking and file URL response.\nAccepts export_type in query params and applies the same filters as the queryset.",
                 "tags": [
                     "test_framework"
@@ -25432,8 +25432,8 @@
         },
         "/test_framework/v1/results/export_result_runs/": {
             "get": {
-                "operationId": "results-export-result-runs-retrieve",
-                "description": "Results export result runs",
+                "operationId": "results-v1-export-result-runs-retrieve",
+                "description": "Results v1 export result runs",
                 "tags": [
                     "test_framework"
                 ],
@@ -25458,8 +25458,8 @@
         },
         "/test_framework/v1/results/reports/": {
             "get": {
-                "operationId": "results-reports-retrieve",
-                "description": "Results reports",
+                "operationId": "results-v1-reports-retrieve",
+                "description": "Results v1 reports",
                 "tags": [
                     "test_framework"
                 ],
@@ -25484,7 +25484,7 @@
         },
         "/test_framework/v1/results/reports/ask-about-failures/": {
             "post": {
-                "operationId": "results-reports-ask-about-failures-create",
+                "operationId": "results-v1-reports-ask-about-failures-create",
                 "description": "Query failed runs chatbot for combined reports",
                 "summary": "Query failed runs chatbot for combined reports",
                 "tags": [
@@ -25540,8 +25540,8 @@
         },
         "/test_framework/v1/results/reports/share/": {
             "post": {
-                "operationId": "results-reports-share-create",
-                "description": "Results reports share",
+                "operationId": "results-v1-reports-share-create",
+                "description": "Results v1 reports share",
                 "tags": [
                     "test_framework"
                 ],
@@ -25586,8 +25586,8 @@
         },
         "/test_framework/v1/results/result_ids/": {
             "get": {
-                "operationId": "results-result-ids-retrieve",
-                "description": "Results result ids",
+                "operationId": "results-v1-result-ids-retrieve",
+                "description": "Results v1 result ids",
                 "tags": [
                     "test_framework"
                 ],
@@ -25612,7 +25612,7 @@
         },
         "/test_framework/v1/runs/": {
             "get": {
-                "operationId": "runs-list",
+                "operationId": "runs-v1-list",
                 "description": "List test runs",
                 "parameters": [
                     {
@@ -25978,7 +25978,7 @@
         },
         "/test_framework/v1/runs-external/": {
             "get": {
-                "operationId": "runs-external-list",
+                "operationId": "runs-v1-external-list",
                 "description": "List test runs",
                 "parameters": [
                     {
@@ -26344,7 +26344,7 @@
         },
         "/test_framework/v1/runs-external/{id}/": {
             "get": {
-                "operationId": "runs-external-retrieve",
+                "operationId": "runs-v1-external-retrieve",
                 "description": "Retrieve a test run by ID",
                 "parameters": [
                     {
@@ -26380,7 +26380,7 @@
                 "deprecated": true
             },
             "put": {
-                "operationId": "runs-external-update",
+                "operationId": "runs-v1-external-update",
                 "description": "Update a test run",
                 "parameters": [
                     {
@@ -26434,7 +26434,7 @@
                 }
             },
             "patch": {
-                "operationId": "runs-external-partial-update",
+                "operationId": "runs-v1-external-partial-update",
                 "description": "Update a test run",
                 "parameters": [
                     {
@@ -26488,7 +26488,7 @@
                 }
             },
             "delete": {
-                "operationId": "runs-external-destroy",
+                "operationId": "runs-v1-external-destroy",
                 "description": "Delete a test run",
                 "parameters": [
                     {
@@ -26564,8 +26564,8 @@
         },
         "/test_framework/v1/runs-external/{id}/get_listen_url/": {
             "get": {
-                "operationId": "runs-external-get-listen-url-retrieve",
-                "description": "Runs get listen url",
+                "operationId": "runs-v1-external-get-listen-url-retrieve",
+                "description": "Runs v1 get listen url",
                 "parameters": [
                     {
                         "in": "path",
@@ -26601,8 +26601,8 @@
         },
         "/test_framework/v1/runs-external/{id}/mark_critical_scenario_wrong/": {
             "post": {
-                "operationId": "runs-external-mark-critical-scenario-wrong-create",
-                "description": "Runs mark critical scenario wrong",
+                "operationId": "runs-v1-external-mark-critical-scenario-wrong-create",
+                "description": "Runs v1 mark critical scenario wrong",
                 "parameters": [
                     {
                         "in": "path",
@@ -26657,8 +26657,8 @@
         },
         "/test_framework/v1/runs-external/{id}/mark_expected_outcome_vote/": {
             "post": {
-                "operationId": "runs-external-mark-expected-outcome-vote-create",
-                "description": "Runs mark expected outcome vote",
+                "operationId": "runs-v1-external-mark-expected-outcome-vote-create",
+                "description": "Runs v1 mark expected outcome vote",
                 "parameters": [
                     {
                         "in": "path",
@@ -26713,7 +26713,7 @@
         },
         "/test_framework/v1/runs-external/{id}/mark_metric_vote/": {
             "post": {
-                "operationId": "runs-external-mark-metric-vote-create",
+                "operationId": "runs-v1-external-mark-metric-vote-create",
                 "description": "Record a thumbs-up or thumbs-down vote on a specific metric evaluation for this run and optionally provide an expected value and free-text feedback. Updates the metric evaluation and marks the run as reviewed.",
                 "summary": "Submit a metric vote for a run",
                 "parameters": [
@@ -26804,8 +26804,8 @@
         },
         "/test_framework/v1/runs-external/{id}/run_expected_outcome/": {
             "post": {
-                "operationId": "runs-external-run-expected-outcome-create",
-                "description": "Runs run expected outcome",
+                "operationId": "runs-v1-external-run-expected-outcome-create",
+                "description": "Runs v1 run expected outcome",
                 "parameters": [
                     {
                         "in": "path",
@@ -26860,8 +26860,8 @@
         },
         "/test_framework/v1/runs-external/{id}/run_expected_outcome_bg/": {
             "post": {
-                "operationId": "runs-external-run-expected-outcome-bg-create",
-                "description": "Runs run expected outcome bg",
+                "operationId": "runs-v1-external-run-expected-outcome-bg-create",
+                "description": "Runs v1 run expected outcome bg",
                 "parameters": [
                     {
                         "in": "path",
@@ -26916,8 +26916,8 @@
         },
         "/test_framework/v1/runs-external/{id}/unmark_critical_scenario_wrong/": {
             "post": {
-                "operationId": "runs-external-unmark-critical-scenario-wrong-create",
-                "description": "Runs unmark critical scenario wrong",
+                "operationId": "runs-v1-external-unmark-critical-scenario-wrong-create",
+                "description": "Runs v1 unmark critical scenario wrong",
                 "parameters": [
                     {
                         "in": "path",
@@ -26972,7 +26972,7 @@
         },
         "/test_framework/v1/runs-external/bulk/": {
             "get": {
-                "operationId": "runs-external-bulk-retrieve",
+                "operationId": "runs-v1-external-bulk-retrieve",
                 "description": "Retrieve multiple runs in a single request.\n\n`success: true` indicates the run passed its quality evaluation. A run with `success=false` either failed to connect (check `error_message`) or failed an evaluation check. For detailed outcomes check: `error_message`, `metadata.ended_reason`, and `evaluation.metrics[].result`.",
                 "parameters": [
                     {
@@ -27013,8 +27013,8 @@
         },
         "/test_framework/v1/runs-external/run_expected_outcome_progress/": {
             "get": {
-                "operationId": "runs-external-run-expected-outcome-progress-retrieve",
-                "description": "Runs run expected outcome progress",
+                "operationId": "runs-v1-external-run-expected-outcome-progress-retrieve",
+                "description": "Runs v1 run expected outcome progress",
                 "tags": [
                     "test_framework"
                 ],
@@ -27039,7 +27039,7 @@
         },
         "/test_framework/v1/runs/{id}/": {
             "get": {
-                "operationId": "runs-retrieve",
+                "operationId": "runs-v1-retrieve",
                 "description": "Retrieve a test run by ID",
                 "parameters": [
                     {
@@ -27075,7 +27075,7 @@
                 "deprecated": true
             },
             "put": {
-                "operationId": "runs-update",
+                "operationId": "runs-v1-update",
                 "description": "Update a test run",
                 "parameters": [
                     {
@@ -27129,7 +27129,7 @@
                 }
             },
             "patch": {
-                "operationId": "runs-partial-update",
+                "operationId": "runs-v1-partial-update",
                 "description": "Update a test run",
                 "parameters": [
                     {
@@ -27183,7 +27183,7 @@
                 }
             },
             "delete": {
-                "operationId": "runs-destroy",
+                "operationId": "runs-v1-destroy",
                 "description": "Delete a test run",
                 "parameters": [
                     {
@@ -27259,8 +27259,8 @@
         },
         "/test_framework/v1/runs/{id}/get_listen_url/": {
             "get": {
-                "operationId": "runs-get-listen-url-retrieve",
-                "description": "Runs get listen url",
+                "operationId": "runs-v1-get-listen-url-retrieve",
+                "description": "Runs v1 get listen url",
                 "parameters": [
                     {
                         "in": "path",
@@ -27296,8 +27296,8 @@
         },
         "/test_framework/v1/runs/{id}/mark_critical_scenario_wrong/": {
             "post": {
-                "operationId": "runs-mark-critical-scenario-wrong-create",
-                "description": "Runs mark critical scenario wrong",
+                "operationId": "runs-v1-mark-critical-scenario-wrong-create",
+                "description": "Runs v1 mark critical scenario wrong",
                 "parameters": [
                     {
                         "in": "path",
@@ -27352,8 +27352,8 @@
         },
         "/test_framework/v1/runs/{id}/mark_expected_outcome_vote/": {
             "post": {
-                "operationId": "runs-mark-expected-outcome-vote-create",
-                "description": "Runs mark expected outcome vote",
+                "operationId": "runs-v1-mark-expected-outcome-vote-create",
+                "description": "Runs v1 mark expected outcome vote",
                 "parameters": [
                     {
                         "in": "path",
@@ -27408,7 +27408,7 @@
         },
         "/test_framework/v1/runs/{id}/mark_metric_vote/": {
             "post": {
-                "operationId": "runs-mark-metric-vote-create",
+                "operationId": "runs-v1-mark-metric-vote-create",
                 "description": "Record a thumbs-up or thumbs-down vote on a specific metric evaluation for this run and optionally provide an expected value and free-text feedback. Updates the metric evaluation and marks the run as reviewed.",
                 "summary": "Submit a metric vote for a run",
                 "parameters": [
@@ -27499,8 +27499,8 @@
         },
         "/test_framework/v1/runs/{id}/run_expected_outcome/": {
             "post": {
-                "operationId": "runs-run-expected-outcome-create",
-                "description": "Runs run expected outcome",
+                "operationId": "runs-v1-run-expected-outcome-create",
+                "description": "Runs v1 run expected outcome",
                 "parameters": [
                     {
                         "in": "path",
@@ -27555,8 +27555,8 @@
         },
         "/test_framework/v1/runs/{id}/run_expected_outcome_bg/": {
             "post": {
-                "operationId": "runs-run-expected-outcome-bg-create",
-                "description": "Runs run expected outcome bg",
+                "operationId": "runs-v1-run-expected-outcome-bg-create",
+                "description": "Runs v1 run expected outcome bg",
                 "parameters": [
                     {
                         "in": "path",
@@ -27611,7 +27611,7 @@
         },
         "/test_framework/v1/runs/{id}/trace/": {
             "get": {
-                "operationId": "runs-trace-retrieve",
+                "operationId": "runs-v1-trace-retrieve",
                 "description": "Proxy trace data from Grafana Tempo for a Run.",
                 "parameters": [
                     {
@@ -27640,8 +27640,8 @@
         },
         "/test_framework/v1/runs/{id}/unmark_critical_scenario_wrong/": {
             "post": {
-                "operationId": "runs-unmark-critical-scenario-wrong-create",
-                "description": "Runs unmark critical scenario wrong",
+                "operationId": "runs-v1-unmark-critical-scenario-wrong-create",
+                "description": "Runs v1 unmark critical scenario wrong",
                 "parameters": [
                     {
                         "in": "path",
@@ -27696,7 +27696,7 @@
         },
         "/test_framework/v1/runs/bulk/": {
             "get": {
-                "operationId": "runs-bulk-retrieve",
+                "operationId": "runs-v1-bulk-retrieve",
                 "description": "Retrieve multiple runs in a single request.\n\n`success: true` indicates the run passed its quality evaluation. A run with `success=false` either failed to connect (check `error_message`) or failed an evaluation check. For detailed outcomes check: `error_message`, `metadata.ended_reason`, and `evaluation.metrics[].result`.",
                 "parameters": [
                     {
@@ -27737,8 +27737,8 @@
         },
         "/test_framework/v1/runs/run_expected_outcome_progress/": {
             "get": {
-                "operationId": "runs-run-expected-outcome-progress-retrieve",
-                "description": "Runs run expected outcome progress",
+                "operationId": "runs-v1-run-expected-outcome-progress-retrieve",
+                "description": "Runs v1 run expected outcome progress",
                 "tags": [
                     "test_framework"
                 ],
@@ -44123,7 +44123,7 @@
         },
         "/test_framework/v2/results/": {
             "get": {
-                "operationId": "test-framework-v2-results-list",
+                "operationId": "results-list",
                 "description": "List test results.\n\nTo filter by status, use `results_retrieve(id=result_id)` and inspect `status` directly ('running', 'completed', 'failed') — there is no list-level status filter.\n\n**Result status:** a result marked `failed` indicates infrastructure failures (e.g. connection errors, websocket handshake failures), not metric evaluation failures. `success_runs_count` counts runs that reached terminal state regardless of connection errors. See `results_retrieve().failed_reasons` for the breakdown.\n\n**Scenarios filter note:** filtering by `scenarios` may return duplicate result rows when a result contains multiple runs of the same scenario — deduplicate by `result.id` if needed.\n\nAfter triggering a run, poll `results_retrieve(id=result_id)` until `status` is 'completed' or 'failed'. For outbound runs, each run's `outbound_dial_window_closes_at` shows the deadline by which your agent must dial in.",
                 "parameters": [
                     {
@@ -44210,13 +44210,13 @@
                 "x-mint": {
                     "mcp": {
                         "enabled": true,
-                        "name": "test-framework-v2-results-list",
+                        "name": "results-list",
                         "description": "List test results.\n\nTo filter by status, use `results_retrieve(id=result_id)` and inspect `status` directly ('running', 'completed', 'failed') — there is no list-level status filter.\n\n**Result status:** a result marked `failed` indicates infrastructure failures (e.g. connection errors, websocket handshake failures), not metric evaluation failures. `success_runs_count` counts runs that reached terminal state regardless of connection errors. See `results_retrieve().failed_reasons` for the breakdown.\n\n**Scenarios filter note:** filtering by `scenarios` may return duplicate result rows when a result contains multiple runs of the same scenario — deduplicate by `result.id` if needed.\n\nAfter triggering a run, poll `results_retrieve(id=result_id)` until `status` is 'completed' or 'failed'. For outbound runs, each run's `outbound_dial_window_closes_at` shows the deadline by which your agent must dial in."
                     }
                 }
             },
             "post": {
-                "operationId": "test-framework-v2-results-create",
+                "operationId": "results-create",
                 "description": "Create a new Results with the canonical binary wire format (eval_type `binary`,",
                 "tags": [
                     "test_framework"
@@ -44262,7 +44262,7 @@
         },
         "/test_framework/v2/results/{id}/": {
             "get": {
-                "operationId": "test-framework-v2-results-retrieve",
+                "operationId": "results-retrieve",
                 "description": "`success` indicates whether the run passed its quality evaluation. A run with `success=false` either failed to connect (check `error_message`) or failed an evaluation check (check `evaluation`). `success_rate` is the percentage of runs with `success=true`.\n\nThe `runs` field is a dict keyed by run ID string (e.g. `{\"86368\": {...}, \"86367\": {...}}`), not an array — unlike the list endpoint. Each run also has a `call_id` STRING field (the provider's call identifier) — that is a data field, NOT an endpoint ID; do not pass it where `run_id` is expected.",
                 "summary": "Retrieve a test result",
                 "parameters": [
@@ -44467,13 +44467,13 @@
                 "x-mint": {
                     "mcp": {
                         "enabled": true,
-                        "name": "test-framework-v2-results-retrieve",
+                        "name": "results-retrieve",
                         "description": "`success` indicates whether the run passed its quality evaluation. A run with `success=false` either failed to connect (check `error_message`) or failed an evaluation check (check `evaluation`). `success_rate` is the percentage of runs with `success=true`.\n\nThe `runs` field is a dict keyed by run ID string (e.g. `{\"86368\": {...}, \"86367\": {...}}`), not an array — unlike the list endpoint. Each run also has a `call_id` STRING field (the provider's call identifier) — that is a data field, NOT an endpoint ID; do not pass it where `run_id` is expected."
                     }
                 }
             },
             "put": {
-                "operationId": "test-framework-v2-results-update",
+                "operationId": "results-update",
                 "description": "Update a Results with the canonical binary wire format (eval_type `binary`,",
                 "parameters": [
                     {
@@ -44528,7 +44528,7 @@
                 }
             },
             "patch": {
-                "operationId": "test-framework-v2-results-partial-update",
+                "operationId": "results-partial-update",
                 "description": "Update a Results with the canonical binary wire format (eval_type `binary`,",
                 "parameters": [
                     {
@@ -44582,7 +44582,7 @@
                 }
             },
             "delete": {
-                "operationId": "test-framework-v2-results-destroy",
+                "operationId": "results-destroy",
                 "description": "Delete a Results with the canonical binary wire format (eval_type `binary`,",
                 "parameters": [
                     {
@@ -44612,7 +44612,7 @@
         },
         "/test_framework/v2/results/{id}/ask_about_failures/": {
             "post": {
-                "operationId": "test-framework-v2-results-ask-about-failures-create",
+                "operationId": "results-ask-about-failures-create",
                 "description": "Query failed runs chatbot",
                 "summary": "Query failed runs chatbot",
                 "parameters": [
@@ -44679,7 +44679,7 @@
                 "x-mint": {
                     "mcp": {
                         "enabled": true,
-                        "name": "test-framework-v2-results-ask-about-failures-create",
+                        "name": "results-ask-about-failures-create",
                         "description": "Query failed runs chatbot"
                     }
                 }
@@ -44916,8 +44916,8 @@
         },
         "/test_framework/v2/results/{id}/evaluate_metrics/": {
             "post": {
-                "operationId": "test-framework-v2-results-evaluate-metrics-create",
-                "description": "Results evaluate metrics",
+                "operationId": "results-evaluate-metrics-create",
+                "description": "Evaluate metrics against result transcripts",
                 "parameters": [
                     {
                         "in": "path",
@@ -44973,15 +44973,15 @@
                 "x-mint": {
                     "mcp": {
                         "enabled": true,
-                        "name": "test-framework-v2-results-evaluate-metrics-create",
-                        "description": "Results evaluate metrics"
+                        "name": "results-evaluate-metrics-create",
+                        "description": "Evaluate metrics against result transcripts"
                     }
                 }
             }
         },
         "/test_framework/v2/results/{id}/regenerate_ai_summary/": {
             "post": {
-                "operationId": "test-framework-v2-results-regenerate-ai-summary-create",
+                "operationId": "results-regenerate-ai-summary-create",
                 "description": "Queue a background job that regenerates the structured AI summary (what_happened / why_it_happened / how_to_fix) and recommended next steps for this result, based on its current failure clusters. The new summary appears on the next `results_retrieve` call once the job finishes.",
                 "summary": "Regenerate the AI summary for a result",
                 "parameters": [
@@ -45015,7 +45015,7 @@
         },
         "/test_framework/v2/results/{id}/rerun/": {
             "post": {
-                "operationId": "test-framework-v2-results-rerun-create",
+                "operationId": "results-rerun-create",
                 "description": "Re-execute every scenario from a completed result against the same agent, creating a new result with a fresh set of runs. The connection mode (voice or text) and provider are inherited from the original runs. Consumes simulation credits (one run per scenario) and launches live calls, so the new result populates asynchronously.",
                 "summary": "Re-run the scenarios from a completed test result",
                 "parameters": [
@@ -45053,7 +45053,7 @@
                 "x-mint": {
                     "mcp": {
                         "enabled": true,
-                        "name": "test-framework-v2-results-rerun-create",
+                        "name": "results-rerun-create",
                         "description": "Re-execute every scenario from a completed result against the same agent, creating a new result with a fresh set of runs. The connection mode (voice or text) and provider are inherited from the original runs. Consumes simulation credits (one run per scenario) and launches live calls, so the new result populates asynchronously."
                     }
                 }
@@ -45177,7 +45177,7 @@
         },
         "/test_framework/v2/results/bulk_export_progress/": {
             "get": {
-                "operationId": "test-framework-v2-results-bulk-export-progress-retrieve",
+                "operationId": "results-bulk-export-progress-retrieve",
                 "description": "Results bulk export progress",
                 "tags": [
                     "test_framework"
@@ -45203,7 +45203,7 @@
         },
         "/test_framework/v2/results/bulk_export_result_runs/": {
             "get": {
-                "operationId": "test-framework-v2-results-bulk-export-result-runs-retrieve",
+                "operationId": "results-bulk-export-result-runs-retrieve",
                 "description": "Bulk export results with progress tracking and file URL response.\nAccepts export_type in query params and applies the same filters as the queryset.",
                 "tags": [
                     "test_framework"
@@ -45229,7 +45229,7 @@
         },
         "/test_framework/v2/results/export_result_runs/": {
             "get": {
-                "operationId": "test-framework-v2-results-export-result-runs-retrieve",
+                "operationId": "results-export-result-runs-retrieve",
                 "description": "Results export result runs",
                 "tags": [
                     "test_framework"
@@ -45255,7 +45255,7 @@
         },
         "/test_framework/v2/results/reports/": {
             "get": {
-                "operationId": "test-framework-v2-results-reports-retrieve",
+                "operationId": "results-reports-retrieve",
                 "description": "Results reports",
                 "tags": [
                     "test_framework"
@@ -45281,7 +45281,7 @@
         },
         "/test_framework/v2/results/reports/ask-about-failures/": {
             "post": {
-                "operationId": "test-framework-v2-results-reports-ask-about-failures-create",
+                "operationId": "results-reports-ask-about-failures-create",
                 "description": "Query failed runs chatbot for combined reports",
                 "summary": "Query failed runs chatbot for combined reports",
                 "tags": [
@@ -45337,7 +45337,7 @@
         },
         "/test_framework/v2/results/reports/share/": {
             "post": {
-                "operationId": "test-framework-v2-results-reports-share-create",
+                "operationId": "results-reports-share-create",
                 "description": "Results reports share",
                 "tags": [
                     "test_framework"
@@ -45383,7 +45383,7 @@
         },
         "/test_framework/v2/results/result_ids/": {
             "get": {
-                "operationId": "test-framework-v2-results-result-ids-retrieve",
+                "operationId": "results-result-ids-retrieve",
                 "description": "Results result ids",
                 "tags": [
                     "test_framework"
@@ -45409,7 +45409,7 @@
         },
         "/test_framework/v2/runs/": {
             "get": {
-                "operationId": "test-framework-v2-runs-list",
+                "operationId": "runs-list",
                 "description": "List Runs with the canonical binary wire format (eval_type `binary`,",
                 "parameters": [
                     {
@@ -45774,7 +45774,7 @@
         },
         "/test_framework/v2/runs/{id}/": {
             "get": {
-                "operationId": "test-framework-v2-runs-retrieve",
+                "operationId": "runs-retrieve",
                 "description": "Retrieve a Runs with the canonical binary wire format (eval_type `binary`, by ID",
                 "parameters": [
                     {
@@ -45809,7 +45809,7 @@
                 }
             },
             "put": {
-                "operationId": "test-framework-v2-runs-update",
+                "operationId": "runs-update",
                 "description": "Update a Runs with the canonical binary wire format (eval_type `binary`,",
                 "parameters": [
                     {
@@ -45863,7 +45863,7 @@
                 }
             },
             "patch": {
-                "operationId": "test-framework-v2-runs-partial-update",
+                "operationId": "runs-partial-update",
                 "description": "Update a Runs with the canonical binary wire format (eval_type `binary`,",
                 "parameters": [
                     {
@@ -45917,7 +45917,7 @@
                 }
             },
             "delete": {
-                "operationId": "test-framework-v2-runs-destroy",
+                "operationId": "runs-destroy",
                 "description": "Delete a Runs with the canonical binary wire format (eval_type `binary`,",
                 "parameters": [
                     {
@@ -46001,7 +46001,7 @@
         },
         "/test_framework/v2/runs/{id}/get_listen_url/": {
             "get": {
-                "operationId": "test-framework-v2-runs-get-listen-url-retrieve",
+                "operationId": "runs-get-listen-url-retrieve",
                 "description": "Runs get listen url",
                 "parameters": [
                     {
@@ -46038,7 +46038,7 @@
         },
         "/test_framework/v2/runs/{id}/mark_critical_scenario_wrong/": {
             "post": {
-                "operationId": "test-framework-v2-runs-mark-critical-scenario-wrong-create",
+                "operationId": "runs-mark-critical-scenario-wrong-create",
                 "description": "Runs mark critical scenario wrong",
                 "parameters": [
                     {
@@ -46094,7 +46094,7 @@
         },
         "/test_framework/v2/runs/{id}/mark_expected_outcome_vote/": {
             "post": {
-                "operationId": "test-framework-v2-runs-mark-expected-outcome-vote-create",
+                "operationId": "runs-mark-expected-outcome-vote-create",
                 "description": "Runs mark expected outcome vote",
                 "parameters": [
                     {
@@ -46150,7 +46150,7 @@
         },
         "/test_framework/v2/runs/{id}/mark_metric_vote/": {
             "post": {
-                "operationId": "test-framework-v2-runs-mark-metric-vote-create",
+                "operationId": "runs-mark-metric-vote-create",
                 "description": "Record a thumbs-up or thumbs-down vote on a specific metric evaluation for this run and optionally provide an expected value and free-text feedback. Updates the metric evaluation and marks the run as reviewed.",
                 "summary": "Submit a metric vote for a run",
                 "parameters": [
@@ -46241,7 +46241,7 @@
                 "x-mint": {
                     "mcp": {
                         "enabled": true,
-                        "name": "test-framework-v2-runs-mark-metric-vote-create",
+                        "name": "runs-mark-metric-vote-create",
                         "description": "Record a thumbs-up or thumbs-down vote on a specific metric evaluation for this run and optionally provide an expected value and free-text feedback. Updates the metric evaluation and marks the run as reviewed."
                     }
                 }
@@ -46249,7 +46249,7 @@
         },
         "/test_framework/v2/runs/{id}/run_expected_outcome/": {
             "post": {
-                "operationId": "test-framework-v2-runs-run-expected-outcome-create",
+                "operationId": "runs-run-expected-outcome-create",
                 "description": "Runs run expected outcome",
                 "parameters": [
                     {
@@ -46305,7 +46305,7 @@
         },
         "/test_framework/v2/runs/{id}/run_expected_outcome_bg/": {
             "post": {
-                "operationId": "test-framework-v2-runs-run-expected-outcome-bg-create",
+                "operationId": "runs-run-expected-outcome-bg-create",
                 "description": "Runs run expected outcome bg",
                 "parameters": [
                     {
@@ -46361,7 +46361,7 @@
         },
         "/test_framework/v2/runs/{id}/unmark_critical_scenario_wrong/": {
             "post": {
-                "operationId": "test-framework-v2-runs-unmark-critical-scenario-wrong-create",
+                "operationId": "runs-unmark-critical-scenario-wrong-create",
                 "description": "Runs unmark critical scenario wrong",
                 "parameters": [
                     {
@@ -46417,7 +46417,7 @@
         },
         "/test_framework/v2/runs/bulk/": {
             "get": {
-                "operationId": "test-framework-v2-runs-bulk-retrieve",
+                "operationId": "runs-bulk-retrieve",
                 "description": "Retrieve multiple runs in a single request.\n\n`success: true` indicates the run passed its quality evaluation. A run with `success=false` either failed to connect (check `error_message`) or failed an evaluation check. For detailed outcomes check: `error_message`, `metadata.ended_reason`, and `evaluation.metrics[].result`.",
                 "parameters": [
                     {
@@ -46484,7 +46484,7 @@
                 "x-mint": {
                     "mcp": {
                         "enabled": true,
-                        "name": "test-framework-v2-runs-bulk-retrieve",
+                        "name": "runs-bulk-retrieve",
                         "description": "Retrieve multiple runs in a single request.\n\n`success: true` indicates the run passed its quality evaluation. A run with `success=false` either failed to connect (check `error_message`) or failed an evaluation check. For detailed outcomes check: `error_message`, `metadata.ended_reason`, and `evaluation.metrics[].result`."
                     }
                 }
@@ -46492,7 +46492,7 @@
         },
         "/test_framework/v2/runs/run_expected_outcome_progress/": {
             "get": {
-                "operationId": "test-framework-v2-runs-run-expected-outcome-progress-retrieve",
+                "operationId": "runs-run-expected-outcome-progress-retrieve",
                 "description": "Runs run expected outcome progress",
                 "tags": [
                     "test_framework"


### PR DESCRIPTION
Auto-generated docs sync for backend PR [#10203](https://github.com/cekura-ai/vocera.backend/pull/10203).

Reviewers: @dileep-chagam

## Summary

**Spec/overlay:** OperationId cleanup for v2 metrics/results/runs families. The PR updates the MCP operationId shortening hook to give v2 endpoints clean tool names (`metrics-*`, `results-*`, `runs-*`) and re-version the legacy v1 duplicates to `*-v1-*`. This affects 34 MCP-exposed operations across the three families. All renamed operations lack mcp_tools.json overlays (verified), so the renames cascade only to cekura-skills allowed-tools entries—no overlay patches needed. No SDK/CLI follow-up required because HTTP paths are unchanged.

**Conceptual docs:** No edits — internal operationId shortening fix restores correct tool names that docs already reference. Checked `mcp/auto-optimize-metrics.mdx` (references `metrics_partial_update`, `metrics_retrieve`, etc.) and `mcp/overview.mdx` — both already use correct names matching the post-fix spec.

## Changes

- `openapi.json` — regenerate_from_backend

## Operation renames — cascade targets

- **test-framework-v2-metrics-list** → **metrics-list**
  - cekura-ai/cekura-skills: cekura/commands/**/*.md (allowed-tools frontmatter entries)
- **test-framework-v2-metrics-create** → **metrics-create**
  - cekura-ai/cekura-skills: cekura/commands/**/*.md (allowed-tools frontmatter entries)
- **test-framework-v2-metrics-retrieve** → **metrics-retrieve**
  - cekura-ai/cekura-skills: cekura/commands/**/*.md (allowed-tools frontmatter entries)
- **test-framework-v2-metrics-update** → **metrics-update**
  - cekura-ai/cekura-skills: cekura/commands/**/*.md (allowed-tools frontmatter entries)
- **test-framework-v2-metrics-partial-update** → **metrics-partial-update**
  - cekura-ai/cekura-skills: cekura/commands/**/*.md (allowed-tools frontmatter entries)
- **test-framework-v2-metrics-destroy** → **metrics-destroy**
  - cekura-ai/cekura-skills: cekura/commands/**/*.md (allowed-tools frontmatter entries)
- **test-framework-v2-metrics-generate-clean-description-create** → **metrics-generate-clean-description-create**
  - cekura-ai/cekura-skills: cekura/commands/**/*.md (allowed-tools frontmatter entries)
- **test-framework-v2-metrics-generate-clean-description-bg-create** → **metrics-generate-clean-description-bg-create**
  - cekura-ai/cekura-skills: cekura/commands/**/*.md (allowed-tools frontmatter entries)
- **test-framework-v2-metrics-generate-clean-description-progress-re** → **metrics-generate-clean-description-progress-retrieve**
  - cekura-ai/cekura-skills: cekura/commands/**/*.md (allowed-tools frontmatter entries)
- **test-framework-v2-metrics-generate-evaluation-trigger-create** → **metrics-generate-evaluation-trigger-create**
  - cekura-ai/cekura-skills: cekura/commands/**/*.md (allowed-tools frontmatter entries)
- **test-framework-v2-metrics-generate-metrics-progress-retrieve** → **metrics-generate-metrics-progress-retrieve**
  - cekura-ai/cekura-skills: cekura/commands/**/*.md (allowed-tools frontmatter entries)
- **test-framework-v2-metrics-preview-create** → **metrics-preview-create**
  - cekura-ai/cekura-skills: cekura/commands/**/*.md (allowed-tools frontmatter entries)
- **test-framework-v2-metrics-run-reviews-create** → **metrics-run-reviews-create**
  - cekura-ai/cekura-skills: cekura/commands/**/*.md (allowed-tools frontmatter entries)
- **test-framework-v2-metrics-simplify-prompt-create** → **metrics-simplify-prompt-create**
  - cekura-ai/cekura-skills: cekura/commands/**/*.md (allowed-tools frontmatter entries)
- **test-framework-v2-metrics-simplify-prompt-progress-retrieve** → **metrics-simplify-prompt-progress-retrieve**
  - cekura-ai/cekura-skills: cekura/commands/**/*.md (allowed-tools frontmatter entries)
- **test-framework-v2-metrics-bulk-create** → **metrics-bulk-create**
  - cekura-ai/cekura-skills: cekura/commands/**/*.md (allowed-tools frontmatter entries)
- **test-framework-v2-metrics-generate** → **metrics-generate**
  - cekura-ai/cekura-skills: cekura/commands/**/*.md (allowed-tools frontmatter entries)
- **test-framework-v2-metrics-preview-progress** → **metrics-preview-progress**
  - cekura-ai/cekura-skills: cekura/commands/**/*.md (allowed-tools frontmatter entries)
- **test-framework-v2-metrics-run-reviews-progress** → **metrics-run-reviews-progress**
  - cekura-ai/cekura-skills: cekura/commands/**/*.md (allowed-tools frontmatter entries)
- **test-framework-v2-results-list** → **results-list**
  - cekura-ai/cekura-skills: cekura/commands/**/*.md (allowed-tools frontmatter entries)
- **test-framework-v2-results-create** → **results-create**
  - cekura-ai/cekura-skills: cekura/commands/**/*.md (allowed-tools frontmatter entries)
- **test-framework-v2-results-retrieve** → **results-retrieve**
  - cekura-ai/cekura-skills: cekura/commands/**/*.md (allowed-tools frontmatter entries)
- **test-framework-v2-results-update** → **results-update**
  - cekura-ai/cekura-skills: cekura/commands/**/*.md (allowed-tools frontmatter entries)
- **test-framework-v2-results-partial-update** → **results-partial-update**
  - cekura-ai/cekura-skills: cekura/commands/**/*.md (allowed-tools frontmatter entries)
- **test-framework-v2-results-destroy** → **results-destroy**
  - cekura-ai/cekura-skills: cekura/commands/**/*.md (allowed-tools frontmatter entries)
- **test-framework-v2-results-ask-about-failures-create** → **results-ask-about-failures-create**
  - cekura-ai/cekura-skills: cekura/commands/**/*.md (allowed-tools frontmatter entries)
- **test-framework-v2-results-evaluate-metrics-create** → **results-evaluate-metrics-create**
  - cekura-ai/cekura-skills: cekura/commands/**/*.md (allowed-tools frontmatter entries)
- **test-framework-v2-results-rerun-create** → **results-rerun-create**
  - cekura-ai/cekura-skills: cekura/commands/**/*.md (allowed-tools frontmatter entries)
- **test-framework-v2-runs-bulk-retrieve** → **runs-bulk-retrieve**
  - cekura-ai/cekura-skills: cekura/commands/**/*.md (allowed-tools frontmatter entries)
- **test-framework-v2-runs-mark-metric-vote-create** → **runs-mark-metric-vote-create**
  - cekura-ai/cekura-skills: cekura/commands/**/*.md (allowed-tools frontmatter entries)
- **test-framework-v2-runs-delete** → **delete-runs**
  - cekura-ai/cekura-skills: cekura/commands/**/*.md (allowed-tools frontmatter entries)

---
*Auto-generated from backend PR #10203.*

<!-- mcp-sync:file-hashes -->
```json
{}
```
<!-- /mcp-sync:file-hashes -->