### PR TITLE
[Auto] Sync docs for backend PR #10226

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -40880,7 +40880,7 @@
         "/test_framework/v2/aiagents/{id}/auto-fetch/": {
             "post": {
                 "operationId": "aiagents-auto-fetch-create",
-                "description": "Re-fetch the full agent configuration from its connected provider (Retell, VAPI, ElevenLabs, Synthflow): system prompt, call settings, phone number, tools with mock data, dynamic variables and knowledge base files. Returns a `progress_id`; poll `auto-fetch-progress/` for staged status.",
+                "description": "Re-fetch the full agent configuration from its connected provider (Retell, VAPI, ElevenLabs, Synthflow, Bland): system prompt, call settings, phone number, tools with mock data, dynamic variables and knowledge base files. Returns a `progress_id`; poll `auto-fetch-progress/` for staged status.",
                 "summary": "Auto-fetch the agent configuration from its provider",
                 "parameters": [
                     {
@@ -40928,7 +40928,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "aiagents-auto-fetch-create",
-                        "description": "Re-fetch the full agent configuration from its connected provider (Retell, VAPI, ElevenLabs, Synthflow): system prompt, call settings, phone number, tools with mock data, dynamic variables and knowledge base files. Returns a `progress_id`; poll `auto-fetch-progress/` for staged status."
+                        "description": "Re-fetch the full agent configuration from its connected provider (Retell, VAPI, ElevenLabs, Synthflow, Bland): system prompt, call settings, phone number, tools with mock data, dynamic variables and knowledge base files. Returns a `progress_id`; poll `auto-fetch-progress/` for staged status."
                     }
                 }
             }
@@ -56407,7 +56407,7 @@
                         "type": "string",
                         "x-spec-enum-id": "adeb892ced4d9eb0",
                         "default": "",
-                        "description": "\nService provider for the AI assistant functionality. Valid values (live enum):\n\n- `self_hosted` — websocket or observation-only; no api_key needed. Use `websocket_url` + `websocket_headers` for text-mode runs.\n- `vapi` — requires `vapi_api_key`; optional `assistant_id`, `vapi_data.public_key`.\n- `retell` — requires `retell_api_key` AND `chat_assistant_id` (used for voice too).\n- `bland` — requires `bland_api_key` AND `chat_assistant_id` (Bland calls this `pathway_id`); `bland_data.encrypted_key` for Twilio.\n- `livekit` — requires `livekit_api_key` + `livekit_data.api_secret` + `livekit_data.url`.\n- `elevenlabs` — requires `elevenlabs_api_key`.\n- `agentforce` — requires `agentforce_client_secret` + `agentforce_data`.\n- `amazon_connect` — requires `amazon_connect_data` with `snippet_id` and `connect_host`; optional `amazon_connect_security_token` and `region`.\n- `cisco` — Cisco Webex.\n- `vocera` — Cekura-hosted.\n- `sms` / `whatsapp` — text-only channels; use `chat_assistant_id`.\n- `\"\"` (empty) — unset; agent is not runnable until a provider is configured.\n\nNote: the serializer also exposes `pipecat_*`, `synthflow_*`, `koreai_*`, `genesys_*`, `custom_provider_*` fields, but those provider values are not currently selectable in this enum.\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `elevenlabs` - Elevenlabs\n* `vocera` - Vocera\n* `sms` - Sms\n* `whatsapp` - Whatsapp\n* `self_hosted` - Self Hosted\n* `agentforce` - Agentforce\n* `cisco` - Cisco\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `synthflow` - Synthflow\n* `agora` - Agora\n* `koreai` - Koreai\n* `genesys` - Genesys\n* `amazon_connect` - Amazon Connect\n* `telnyx` - Telnyx"
+                        "description": "\nService provider for the AI assistant functionality. Valid values (live enum):\n\n- `self_hosted` — websocket or observation-only; no api_key needed. Use `websocket_url` + `websocket_headers` for text-mode runs.\n- `vapi` — requires `vapi_api_key`; optional `assistant_id`, `vapi_data.public_key`.\n- `retell` — requires `retell_api_key` AND `chat_assistant_id` (used for voice too).\n- `bland` — requires `bland_api_key`; `assistant_id` is the Bland persona_id (voice), `chat_assistant_id` the pathway_id (text); `bland_data.encrypted_key` for Twilio.\n- `livekit` — requires `livekit_api_key` + `livekit_data.api_secret` + `livekit_data.url`.\n- `elevenlabs` — requires `elevenlabs_api_key`.\n- `agentforce` — requires `agentforce_client_secret` + `agentforce_data`.\n- `amazon_connect` — requires `amazon_connect_data` with `snippet_id` and `connect_host`; optional `amazon_connect_security_token` and `region`.\n- `cisco` — Cisco Webex.\n- `vocera` — Cekura-hosted.\n- `sms` / `whatsapp` — text-only channels; use `chat_assistant_id`.\n- `\"\"` (empty) — unset; agent is not runnable until a provider is configured.\n\nNote: the serializer also exposes `pipecat_*`, `synthflow_*`, `koreai_*`, `genesys_*`, `custom_provider_*` fields, but those provider values are not currently selectable in this enum.\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `elevenlabs` - Elevenlabs\n* `vocera` - Vocera\n* `sms` - Sms\n* `whatsapp` - Whatsapp\n* `self_hosted` - Self Hosted\n* `agentforce` - Agentforce\n* `cisco` - Cisco\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `synthflow` - Synthflow\n* `agora` - Agora\n* `koreai` - Koreai\n* `genesys` - Genesys\n* `amazon_connect` - Amazon Connect\n* `telnyx` - Telnyx"
                     },
                     "vapi_api_key": {
                         "type": "string",
@@ -56443,7 +56443,7 @@
                     "bland_api_key": {
                         "type": "string",
                         "writeOnly": true,
-                        "description": "\nAPI key for Bland service provider. Required when `assistant_provider=\"bland\"` (along with `chat_assistant_id`, which Bland calls `pathway_id`).\nExample: `\"bland_api_key_123\"`\n"
+                        "description": "\nAPI key for Bland service provider. Required when `assistant_provider=\"bland\"`. Pair with `assistant_id` (Bland persona_id) for voice, or `chat_assistant_id` (Bland pathway_id) for text-mode runs.\nExample: `\"bland_api_key_123\"`\n"
                     },
                     "bland_api_key_configured": {
                         "type": "string",
@@ -59995,6 +59995,10 @@
                         "type": "integer",
                         "readOnly": true
                     },
+                    "project": {
+                        "type": "integer",
+                        "description": "\nProject that will own the personality. Optional when using a project-scoped API key\n(it is inferred from the key); required otherwise.\nExample: `1`\n"
+                    },
                     "name": {
                         "type": "string",
                         "description": "\nName of the personality\nExample: `\"Customer Service\"`\n",
@@ -60686,6 +60690,14 @@
                         "x-spec-enum-id": "128862fca689ae44",
                         "readOnly": true
                     },
+                    "focus": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "focus_fallback": {
+                        "type": "boolean",
+                        "readOnly": true
+                    },
                     "failure_modes": {
                         "type": "string",
                         "readOnly": true
@@ -60732,7 +60744,13 @@
                         "type": "integer",
                         "maximum": 1000,
                         "minimum": 10,
-                        "default": 200
+                        "default": 500
+                    },
+                    "focus": {
+                        "type": "string",
+                        "default": "",
+                        "description": "Optional research focus, stored and passed to the audit verbatim. If it cannot be understood, the audit falls back to a full audit.",
+                        "maxLength": 2000
                     }
                 },
                 "required": [
@@ -66393,6 +66411,10 @@
                         "type": "integer",
                         "readOnly": true
                     },
+                    "project": {
+                        "type": "integer",
+                        "description": "\nProject that will own the personality. Optional when using a project-scoped API key\n(it is inferred from the key); required otherwise.\nExample: `1`\n"
+                    },
                     "name": {
                         "type": "string",
                         "description": "\nName of the personality\nExample: `\"Customer Service\"`\n",
@@ -69647,7 +69669,7 @@
                         "type": "string",
                         "x-spec-enum-id": "adeb892ced4d9eb0",
                         "default": "",
-                        "description": "\nService provider for the AI assistant functionality. Valid values (live enum):\n\n- `self_hosted` — websocket or observation-only; no api_key needed. Use `websocket_url` + `websocket_headers` for text-mode runs.\n- `vapi` — requires `vapi_api_key`; optional `assistant_id`, `vapi_data.public_key`.\n- `retell` — requires `retell_api_key` AND `chat_assistant_id` (used for voice too).\n- `bland` — requires `bland_api_key` AND `chat_assistant_id` (Bland calls this `pathway_id`); `bland_data.encrypted_key` for Twilio.\n- `livekit` — requires `livekit_api_key` + `livekit_data.api_secret` + `livekit_data.url`.\n- `elevenlabs` — requires `elevenlabs_api_key`.\n- `agentforce` — requires `agentforce_client_secret` + `agentforce_data`.\n- `amazon_connect` — requires `amazon_connect_data` with `snippet_id` and `connect_host`; optional `amazon_connect_security_token` and `region`.\n- `cisco` — Cisco Webex.\n- `vocera` — Cekura-hosted.\n- `sms` / `whatsapp` — text-only channels; use `chat_assistant_id`.\n- `\"\"` (empty) — unset; agent is not runnable until a provider is configured.\n\nNote: the serializer also exposes `pipecat_*`, `synthflow_*`, `koreai_*`, `genesys_*`, `custom_provider_*` fields, but those provider values are not currently selectable in this enum.\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `elevenlabs` - Elevenlabs\n* `vocera` - Vocera\n* `sms` - Sms\n* `whatsapp` - Whatsapp\n* `self_hosted` - Self Hosted\n* `agentforce` - Agentforce\n* `cisco` - Cisco\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `synthflow` - Synthflow\n* `agora` - Agora\n* `koreai` - Koreai\n* `genesys` - Genesys\n* `amazon_connect` - Amazon Connect\n* `telnyx` - Telnyx"
+                        "description": "\nService provider for the AI assistant functionality. Valid values (live enum):\n\n- `self_hosted` — websocket or observation-only; no api_key needed. Use `websocket_url` + `websocket_headers` for text-mode runs.\n- `vapi` — requires `vapi_api_key`; optional `assistant_id`, `vapi_data.public_key`.\n- `retell` — requires `retell_api_key` AND `chat_assistant_id` (used for voice too).\n- `bland` — requires `bland_api_key`; `assistant_id` is the Bland persona_id (voice), `chat_assistant_id` the pathway_id (text); `bland_data.encrypted_key` for Twilio.\n- `livekit` — requires `livekit_api_key` + `livekit_data.api_secret` + `livekit_data.url`.\n- `elevenlabs` — requires `elevenlabs_api_key`.\n- `agentforce` — requires `agentforce_client_secret` + `agentforce_data`.\n- `amazon_connect` — requires `amazon_connect_data` with `snippet_id` and `connect_host`; optional `amazon_connect_security_token` and `region`.\n- `cisco` — Cisco Webex.\n- `vocera` — Cekura-hosted.\n- `sms` / `whatsapp` — text-only channels; use `chat_assistant_id`.\n- `\"\"` (empty) — unset; agent is not runnable until a provider is configured.\n\nNote: the serializer also exposes `pipecat_*`, `synthflow_*`, `koreai_*`, `genesys_*`, `custom_provider_*` fields, but those provider values are not currently selectable in this enum.\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `elevenlabs` - Elevenlabs\n* `vocera` - Vocera\n* `sms` - Sms\n* `whatsapp` - Whatsapp\n* `self_hosted` - Self Hosted\n* `agentforce` - Agentforce\n* `cisco` - Cisco\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `synthflow` - Synthflow\n* `agora` - Agora\n* `koreai` - Koreai\n* `genesys` - Genesys\n* `amazon_connect` - Amazon Connect\n* `telnyx` - Telnyx"
                     },
                     "vapi_api_key": {
                         "type": "string",
@@ -69683,7 +69705,7 @@
                     "bland_api_key": {
                         "type": "string",
                         "writeOnly": true,
-                        "description": "\nAPI key for Bland service provider. Required when `assistant_provider=\"bland\"` (along with `chat_assistant_id`, which Bland calls `pathway_id`).\nExample: `\"bland_api_key_123\"`\n"
+                        "description": "\nAPI key for Bland service provider. Required when `assistant_provider=\"bland\"`. Pair with `assistant_id` (Bland persona_id) for voice, or `chat_assistant_id` (Bland pathway_id) for text-mode runs.\nExample: `\"bland_api_key_123\"`\n"
                     },
                     "bland_api_key_configured": {
                         "type": "string",
@@ -76964,7 +76986,7 @@
                         "type": "string",
                         "x-spec-enum-id": "adeb892ced4d9eb0",
                         "default": "",
-                        "description": "\nService provider for the AI assistant functionality. Valid values (live enum):\n\n- `self_hosted` — websocket or observation-only; no api_key needed. Use `websocket_url` + `websocket_headers` for text-mode runs.\n- `vapi` — requires `vapi_api_key`; optional `assistant_id`, `vapi_data.public_key`.\n- `retell` — requires `retell_api_key` AND `chat_assistant_id` (used for voice too).\n- `bland` — requires `bland_api_key` AND `chat_assistant_id` (Bland calls this `pathway_id`); `bland_data.encrypted_key` for Twilio.\n- `livekit` — requires `livekit_api_key` + `livekit_data.api_secret` + `livekit_data.url`.\n- `elevenlabs` — requires `elevenlabs_api_key`.\n- `agentforce` — requires `agentforce_client_secret` + `agentforce_data`.\n- `amazon_connect` — requires `amazon_connect_data` with `snippet_id` and `connect_host`; optional `amazon_connect_security_token` and `region`.\n- `cisco` — Cisco Webex.\n- `vocera` — Cekura-hosted.\n- `sms` / `whatsapp` — text-only channels; use `chat_assistant_id`.\n- `\"\"` (empty) — unset; agent is not runnable until a provider is configured.\n\nNote: the serializer also exposes `pipecat_*`, `synthflow_*`, `koreai_*`, `genesys_*`, `custom_provider_*` fields, but those provider values are not currently selectable in this enum.\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `elevenlabs` - Elevenlabs\n* `vocera` - Vocera\n* `sms` - Sms\n* `whatsapp` - Whatsapp\n* `self_hosted` - Self Hosted\n* `agentforce` - Agentforce\n* `cisco` - Cisco\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `synthflow` - Synthflow\n* `agora` - Agora\n* `koreai` - Koreai\n* `genesys` - Genesys\n* `amazon_connect` - Amazon Connect\n* `telnyx` - Telnyx"
+                        "description": "\nService provider for the AI assistant functionality. Valid values (live enum):\n\n- `self_hosted` — websocket or observation-only; no api_key needed. Use `websocket_url` + `websocket_headers` for text-mode runs.\n- `vapi` — requires `vapi_api_key`; optional `assistant_id`, `vapi_data.public_key`.\n- `retell` — requires `retell_api_key` AND `chat_assistant_id` (used for voice too).\n- `bland` — requires `bland_api_key`; `assistant_id` is the Bland persona_id (voice), `chat_assistant_id` the pathway_id (text); `bland_data.encrypted_key` for Twilio.\n- `livekit` — requires `livekit_api_key` + `livekit_data.api_secret` + `livekit_data.url`.\n- `elevenlabs` — requires `elevenlabs_api_key`.\n- `agentforce` — requires `agentforce_client_secret` + `agentforce_data`.\n- `amazon_connect` — requires `amazon_connect_data` with `snippet_id` and `connect_host`; optional `amazon_connect_security_token` and `region`.\n- `cisco` — Cisco Webex.\n- `vocera` — Cekura-hosted.\n- `sms` / `whatsapp` — text-only channels; use `chat_assistant_id`.\n- `\"\"` (empty) — unset; agent is not runnable until a provider is configured.\n\nNote: the serializer also exposes `pipecat_*`, `synthflow_*`, `koreai_*`, `genesys_*`, `custom_provider_*` fields, but those provider values are not currently selectable in this enum.\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `elevenlabs` - Elevenlabs\n* `vocera` - Vocera\n* `sms` - Sms\n* `whatsapp` - Whatsapp\n* `self_hosted` - Self Hosted\n* `agentforce` - Agentforce\n* `cisco` - Cisco\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `synthflow` - Synthflow\n* `agora` - Agora\n* `koreai` - Koreai\n* `genesys` - Genesys\n* `amazon_connect` - Amazon Connect\n* `telnyx` - Telnyx"
                     },
                     "vapi_api_key": {
                         "type": "string",
@@ -77000,7 +77022,7 @@
                     "bland_api_key": {
                         "type": "string",
                         "writeOnly": true,
-                        "description": "\nAPI key for Bland service provider. Required when `assistant_provider=\"bland\"` (along with `chat_assistant_id`, which Bland calls `pathway_id`).\nExample: `\"bland_api_key_123\"`\n"
+                        "description": "\nAPI key for Bland service provider. Required when `assistant_provider=\"bland\"`. Pair with `assistant_id` (Bland persona_id) for voice, or `chat_assistant_id` (Bland pathway_id) for text-mode runs.\nExample: `\"bland_api_key_123\"`\n"
                     },
                     "bland_api_key_configured": {
                         "type": "string",


### PR DESCRIPTION
Auto-generated docs sync for backend PR [#10226](https://github.com/cekura-ai/vocera.backend/pull/10226).

Reviewers: @dileep-chagam

## Summary

**Spec/overlay:** 2 Bucket A ops (exposed → exposed with schema/description changes): personalities_create gained a `project` field with updated help_text; aiagents_auto_fetch_create description added Bland to the provider list. No transport-quirk signals fired — no overlay additions. Spec-only refresh.

**Conceptual docs:** No edits — the PR fixes personality creation via API key/MCP (was always 403) by making the `project` field optional and adding server-side inference from the key scope. No existing docs page misrepresents the post-PR behavior: the concept page describes personalities without referencing the API creation flow, the dashboard guide covers UI-only creation (incomplete but not wrong), and the MCP overview does not enumerate this tool specifically.

## Changes

- `openapi.json` — regenerate_from_backend

---
*Auto-generated from backend PR #10226.*

<!-- mcp-sync:file-hashes -->
```json
{}
```
<!-- /mcp-sync:file-hashes -->