### PR TITLE
docs: custom functions in conditional actions (CEK-7663)

### DIFF
--- a/documentation/key-concepts/evaluators/conditional-actions.mdx
+++ b/documentation/key-concepts/evaluators/conditional-actions.mdx
@@ -663,13 +663,11 @@ Use `<silence>` when you want the conversation to feel natural and allow the mai
 
 ## Custom Functions
 
-Functions let the testing agent call an external API **mid-conversation** and use the response in its replies — for example, look up an order or account, then answer with the real status. Functions are generic (REST API is the currently supported type). Declare them once in a top-level `functions` array, then reference them from any condition's `action`.
-
-### Defining a function
+Functions let the testing agent fetch **live data from your systems during the call** and use it in what it says — look up an order, pull an account record, then respond with the real values instead of invented ones. Declare functions once in a top-level `functions` array (a sibling of `role` and `conditions`), then use them from any condition's `action`.
 
 ```json
 {
-  "role": "You are a customer checking an order",
+  "role": "You are a customer checking on an order",
   "functions": [
     {
       "name": "lookup_order",
@@ -679,9 +677,9 @@ Functions let the testing agent call an external API **mid-conversation** and us
         "method": "GET",
         "url": "https://api.example.com/orders/{{test_profile.order_id}}",
         "headers": { "Accept": "application/json" },
-        "timeout_seconds": 3,
+        "timeout_seconds": 5,
         "response_mapping": {
-          "order_status": { "path": "$.data.status", "default": "unknown" },
+          "status": { "path": "$.data.status", "default": "unknown" },
           "eta_days": "$.data.eta"
         }
       }
@@ -691,63 +689,151 @@ Functions let the testing agent call an external API **mid-conversation** and us
 }
 ```
 
-| Field | Notes |
-|-------|-------|
-| `name` | Unique; letters, digits, `_`, `-` (≤64 chars). Used in tags/placeholders. |
-| `type` | `rest_api` (only type today). |
-| `auto_run` | Optional, **defaults to `true`**. When on, the function runs once at the start of the call so its values are ready for every condition. Set `false` to run it only on demand via a tag. |
-| `config.method` | `GET` or `POST`. |
-| `config.url` | Supports `{{test_profile.*}}` substitution. Must be publicly reachable — internal/loopback addresses are blocked. |
-| `config.headers` / `config.body` | Optional. `body` (POST only) is JSON or raw text. |
-| `config.timeout_seconds` | 1–30 (default 3). On timeout or failure, the declared `default`s are used — the call never breaks the conversation. |
-| `config.response_mapping` | Maps output names to values in the JSON response (see [Response mapping](#response-mapping-jsonpath)). |
+### Function fields
 
-### Referencing a function
+<ParamField path="name" type="string" required>
+  Unique name used in tags and placeholders. Letters, digits, `_`, `-`; up to 64 characters.
+</ParamField>
 
-There are two ways to use a function from a condition's `action`:
+<ParamField path="type" type="string" required>
+  The function type. Currently `rest_api` — an HTTP call to your API.
+</ParamField>
 
-- **`<function name="lookup_order"/>`** — the *invoking tag*. Runs the function when the condition fires. Allowed on any non-first `standard` or `action_followup` condition (fixed or non-fixed). Not allowed on the First Message (id 0). Not needed when `auto_run` is on.
-- **`{{function.lookup_order.order_status}}`** — a *value reference*. Renders one mapped output into the spoken text. Only valid in a **fixed message** (`fixed_message: true`).
+<ParamField path="auto_run" type="boolean" default="true">
+  When `true` (the default), the function runs once automatically at the start of the call, in the background — its values are ready before the conversation needs them. Set `false` to run the function only when a condition invokes it with a `<function>` tag.
+</ParamField>
 
-**Fixed vs non-fixed actions:**
-- **Fixed message** — the placeholder is substituted into the exact text: `"Your order is {{function.lookup_order.order_status}}."` → "Your order is shipped."
-- **Non-fixed action** — the reply is model-generated. The model is given the function's result (your named outputs plus the raw JSON) and answers from it, so no placeholder is needed: `"Tell the customer their order status."`
+<ParamField path="config.method" type="string" default="GET">
+  `GET` or `POST`.
+</ParamField>
+
+<ParamField path="config.url" type="string" required>
+  The endpoint to call. Supports `{{test_profile.*}}` substitution. Must be an `http(s)` URL that is **publicly reachable** — internal and loopback addresses are refused at call time.
+</ParamField>
+
+<ParamField path="config.headers" type="object">
+  Request headers, e.g. `{ "Authorization": "Bearer ..." }`. Values must be strings or numbers.
+</ParamField>
+
+<ParamField path="config.query_params" type="object">
+  Query parameters appended to the URL. Values must be strings or numbers.
+</ParamField>
+
+<ParamField path="config.body" type="object | array | string">
+  Request body (`POST` only). Objects and arrays are sent as JSON; strings are sent as-is.
+</ParamField>
+
+<ParamField path="config.timeout_seconds" type="number" default="10">
+  Between 1 and 30 seconds. Keep it short — a slow endpoint delays the turn that's waiting on it.
+</ParamField>
+
+<ParamField path="config.response_mapping" type="object">
+  Names the values you want out of the JSON response — see [Response mapping](#response-mapping-jsonpath) below.
+</ParamField>
+
+### When a function runs
+
+| Trigger | Runs | Choose it when |
+|---------|------|----------------|
+| `auto_run: true` (default) | Once, at the start of the call, in the background | The data will be needed at some point in the call — it's fetched before any turn waits on it |
+| `<function name="lookup_order"/>` tag in an action | The moment that condition fires | The call must happen at a specific point in the flow (e.g. only after the agent asks), or you need to **re-fetch** — a tag always makes a fresh request |
+
+The tag is allowed on any condition except the First Message (`id: 0`), on both `standard` and `action_followup` conditions, fixed or non-fixed.
+
+### Using the response
+
+Two ways to get fetched values into the testing agent's replies:
+
+- **Value placeholder — `{{function.lookup_order.status}}`** (fixed messages only). Substitutes one mapped output into the exact spoken text:
+
+  ```json
+  { "id": 2, "condition": 1, "action": "My order shows as {{function.lookup_order.status}}.", "type": "action_followup", "fixed_message": true }
+  ```
+
+- **Non-fixed actions — no placeholder needed.** When `fixed_message` is `false`, the testing agent is automatically given the function's results (your named outputs plus the response) and phrases its reply from them:
+
+  ```json
+  { "id": 2, "condition": 1, "action": "Ask about the order and mention its real status.", "type": "action_followup", "fixed_message": false }
+  ```
 
 <Note>
-A single fixed action can both trigger and use a value — put the tag **before** the reference: `Let me check. <function name="lookup_order"/> It is {{function.lookup_order.order_status}}.`
+A single fixed action can both invoke and use a function — put the tag **before** the placeholder. The function completes before the text is spoken:
+
+`"Let me check. <function name=\"lookup_order\"/> It shows as {{function.lookup_order.status}}."`
 </Note>
 
 ### Response mapping (JSONPath)
 
-Each `response_mapping` entry points a short output name at a value in the JSON response, using a **minimal JSONPath**:
+Each `response_mapping` entry gives a short output name to a value in the JSON response. An entry is either a path string, or an object with `path` and a `default`:
+
+```json
+"response_mapping": {
+  "status": "$.data.status",
+  "eta_days": { "path": "$.data.eta", "default": "a few" }
+}
+```
 
 | Syntax | Meaning |
 |--------|---------|
 | `$.data.status` | Nested key |
-| `$.items[0]` | Array index (negative allowed) |
-| `$.meta["order-id"]` | Bracket key |
+| `$.items[0].sku` | Array index (negative indexes allowed) |
+| `$.meta["order-id"]` | Bracket notation for keys with special characters |
 
-Wildcards, filters, and recursion are **not** supported. If a path isn't found, the entry's `default` is used (or, with no default, a `{{function.*}}` placeholder is left as-is rather than breaking the reply).
+Wildcards, filters, and recursive descent are **not** supported — point each output at one exact value.
 
-### Example
+### Chaining functions
+
+A function's `config` can reference an earlier function's outputs, so one call can feed the next — for example, look up a customer, then verify with the fetched name:
+
+```json
+"functions": [
+  { "name": "lookup", "type": "rest_api",
+    "config": { "method": "GET", "url": "https://api.example.com/orders/ORD-1",
+      "response_mapping": { "customer": "$.customer_name" } } },
+  { "name": "verify", "type": "rest_api", "auto_run": false,
+    "config": { "method": "GET",
+      "url": "https://api.example.com/verify?name={{function.lookup.customer}}",
+      "response_mapping": { "verified": "$.ok" } } }
+]
+```
+
+Make sure the referenced function has already run — via `auto_run` or a tag on an earlier condition.
+
+### If the call fails
+
+A failed function never breaks the conversation. On a timeout, an error response, or an unreachable URL:
+
+- Mapped outputs fall back to their declared `default`.
+- A placeholder with **no** default is spoken as-is (`"...status is {{function.lookup_order.status}}"`) — declare defaults for anything a fixed message references.
+- On non-fixed actions, the testing agent is told the lookup failed, so it doesn't invent values.
+
+### Rules
+
+- Function `name`s must be unique; `<function>` tags and `{{function.*}}` placeholders must reference a declared function.
+- Placeholders require `fixed_message: true`, and the key must be an output declared in that function's `response_mapping`.
+- Neither tags nor placeholders may appear on the First Message (`id: 0`) — use `auto_run` and reference the values from a later condition.
+
+### Complete example
 
 ```json
 {
-  "role": "You are a customer",
+  "role": "You are a customer checking on an order",
   "functions": [
     { "name": "lookup", "type": "rest_api", "auto_run": true,
       "config": { "method": "GET", "url": "https://api.example.com/orders/{{test_profile.order_id}}",
-        "response_mapping": { "status": "$.status", "customer": "$.customer_name" } } }
+        "response_mapping": {
+          "status": { "path": "$.status", "default": "unknown" },
+          "customer": { "path": "$.customer_name", "default": "unknown" } } } }
   ],
   "conditions": [
     { "id": 0, "condition": "FIRST_MESSAGE", "action": "Hi, I'd like to check my order.", "type": "standard", "fixed_message": true },
-    { "id": 1, "condition": 0, "action": "Your name is {{function.lookup.customer}}.", "type": "action_followup", "fixed_message": true },
-    { "id": 2, "condition": 1, "action": "Tell the customer their order status in one friendly sentence.", "type": "action_followup", "fixed_message": false }
+    { "id": 1, "condition": "The agent asks for the name on the order", "action": "It's under {{function.lookup.customer}}.", "type": "standard", "fixed_message": true },
+    { "id": 2, "condition": 1, "action": "Ask whether the order status they see matches yours, mentioning the real status.", "type": "action_followup", "fixed_message": false }
   ]
 }
 ```
 
-`lookup` runs at the start of the call (`auto_run`); condition 1 speaks the fetched customer name verbatim, and condition 2 lets the model phrase the status naturally from the response.
+`lookup` runs in the background as the call starts. Condition 1 speaks the fetched customer name verbatim; condition 2 lets the testing agent phrase the status naturally from the same response.
 
 ## Complete Examples
 

--- a/documentation/key-concepts/evaluators/conditional-actions.mdx
+++ b/documentation/key-concepts/evaluators/conditional-actions.mdx
@@ -661,6 +661,94 @@ Use `<silence>` when you want the conversation to feel natural and allow the mai
   </Accordion>
 </AccordionGroup>
 
+## Custom Functions
+
+Functions let the testing agent call an external API **mid-conversation** and use the response in its replies — for example, look up an order or account, then answer with the real status. Functions are generic (REST API is the currently supported type). Declare them once in a top-level `functions` array, then reference them from any condition's `action`.
+
+### Defining a function
+
+```json
+{
+  "role": "You are a customer checking an order",
+  "functions": [
+    {
+      "name": "lookup_order",
+      "type": "rest_api",
+      "auto_run": true,
+      "config": {
+        "method": "GET",
+        "url": "https://api.example.com/orders/{{test_profile.order_id}}",
+        "headers": { "Accept": "application/json" },
+        "timeout_seconds": 3,
+        "response_mapping": {
+          "order_status": { "path": "$.data.status", "default": "unknown" },
+          "eta_days": "$.data.eta"
+        }
+      }
+    }
+  ],
+  "conditions": [ ... ]
+}
+```
+
+| Field | Notes |
+|-------|-------|
+| `name` | Unique; letters, digits, `_`, `-` (≤64 chars). Used in tags/placeholders. |
+| `type` | `rest_api` (only type today). |
+| `auto_run` | Optional, **defaults to `true`**. When on, the function runs once at the start of the call so its values are ready for every condition. Set `false` to run it only on demand via a tag. |
+| `config.method` | `GET` or `POST`. |
+| `config.url` | Supports `{{test_profile.*}}` substitution. Must be publicly reachable — internal/loopback addresses are blocked. |
+| `config.headers` / `config.body` | Optional. `body` (POST only) is JSON or raw text. |
+| `config.timeout_seconds` | 1–30 (default 3). On timeout or failure, the declared `default`s are used — the call never breaks the conversation. |
+| `config.response_mapping` | Maps output names to values in the JSON response (see [Response mapping](#response-mapping-jsonpath)). |
+
+### Referencing a function
+
+There are two ways to use a function from a condition's `action`:
+
+- **`<function name="lookup_order"/>`** — the *invoking tag*. Runs the function when the condition fires. Allowed on any non-first `standard` or `action_followup` condition (fixed or non-fixed). Not allowed on the First Message (id 0). Not needed when `auto_run` is on.
+- **`{{function.lookup_order.order_status}}`** — a *value reference*. Renders one mapped output into the spoken text. Only valid in a **fixed message** (`fixed_message: true`).
+
+**Fixed vs non-fixed actions:**
+- **Fixed message** — the placeholder is substituted into the exact text: `"Your order is {{function.lookup_order.order_status}}."` → "Your order is shipped."
+- **Non-fixed action** — the reply is model-generated. The model is given the function's result (your named outputs plus the raw JSON) and answers from it, so no placeholder is needed: `"Tell the customer their order status."`
+
+<Note>
+A single fixed action can both trigger and use a value — put the tag **before** the reference: `Let me check. <function name="lookup_order"/> It is {{function.lookup_order.order_status}}.`
+</Note>
+
+### Response mapping (JSONPath)
+
+Each `response_mapping` entry points a short output name at a value in the JSON response, using a **minimal JSONPath**:
+
+| Syntax | Meaning |
+|--------|---------|
+| `$.data.status` | Nested key |
+| `$.items[0]` | Array index (negative allowed) |
+| `$.meta["order-id"]` | Bracket key |
+
+Wildcards, filters, and recursion are **not** supported. If a path isn't found, the entry's `default` is used (or, with no default, a `{{function.*}}` placeholder is left as-is rather than breaking the reply).
+
+### Example
+
+```json
+{
+  "role": "You are a customer",
+  "functions": [
+    { "name": "lookup", "type": "rest_api", "auto_run": true,
+      "config": { "method": "GET", "url": "https://api.example.com/orders/{{test_profile.order_id}}",
+        "response_mapping": { "status": "$.status", "customer": "$.customer_name" } } }
+  ],
+  "conditions": [
+    { "id": 0, "condition": "FIRST_MESSAGE", "action": "Hi, I'd like to check my order.", "type": "standard", "fixed_message": true },
+    { "id": 1, "condition": 0, "action": "Your name is {{function.lookup.customer}}.", "type": "action_followup", "fixed_message": true },
+    { "id": 2, "condition": 1, "action": "Tell the customer their order status in one friendly sentence.", "type": "action_followup", "fixed_message": false }
+  ]
+}
+```
+
+`lookup` runs at the start of the call (`auto_run`); condition 1 speaks the fetched customer name verbatim, and condition 2 lets the model phrase the status naturally from the response.
+
 ## Complete Examples
 
 ### Example 1: Appointment Cancellation


### PR DESCRIPTION
Documents the CEK-7663 custom-functions capability on the **Structured Tests** page (`conditional-actions.mdx`).

## What's added — a "Custom Functions" section
- **Defining a function**: the `functions[]` array, `rest_api` config (method/url/headers/body/timeout), `auto_run`, and `response_mapping`, with a field-reference table.
- **Referencing it**: the `<function name="…"/>` invoking tag vs the `{{function.<name>.<output>}}` value reference, where each is allowed.
- **Fixed vs non-fixed** behavior (placeholder substitution vs model answering from the result).
- **Response mapping** — the minimal JSONPath subset (dotted keys, array index, bracket keys; no wildcards/filters/recursion; `default` on miss).
- A worked example combining `auto_run`, a fixed placeholder, and a non-fixed reply.

Pairs with the implementation PRs: pipecat #558, backend #9349, frontend #3028.

🤖 Generated with [Claude Code](https://claude.com/claude-code)