### PR TITLE
docs(ca-functions): add auto_run:false on-demand variant to Example 5

### DIFF
--- a/documentation/key-concepts/evaluators/conditional-actions.mdx
+++ b/documentation/key-concepts/evaluators/conditional-actions.mdx
@@ -1121,6 +1121,23 @@ One `auto_run` function feeding both flows: condition 1 drops a fetched value in
 
 If the API call fails, the declared `default`s take over: condition 1 speaks "It's under unknown." and the testing agent in condition 2 is told the lookup failed rather than inventing a status.
 
+**On-demand variant (`auto_run: false`):** to run the lookup only at a specific point in the flow instead of at call start, turn off `auto_run` and invoke it with a tag — the function completes before the rest of the action is spoken:
+
+```json
+"functions": [
+  { "name": "lookup", "type": "rest_api", "auto_run": false,
+    "config": { "method": "GET", "url": "https://api.example.com/orders/{{test_profile.order_id}}",
+      "response_mapping": { "customer": { "path": "$.customer_name", "default": "unknown" } } } }
+],
+"conditions": [
+  { "id": 1, "condition": "The agent asks for the name on the order",
+    "action": "One moment. <function name=\"lookup\"/> It's under {{function.lookup.customer}}.",
+    "type": "standard", "fixed_message": true }
+]
+```
+
+Nothing runs at call start; the request fires the moment condition 1 executes, and the same fixed/non-fixed usage rules apply from there.
+
 ## Best Practices
 
 <CardGroup cols={2}>


### PR DESCRIPTION
Follow-up to #776 (merged before this landed). Example 5 covered `auto_run: true` end-to-end but the `false` case was only explained in pieces (field docs, decision table, chaining snippet) — never assembled into a copy-paste example.

Adds an **On-demand variant (`auto_run: false`)** block to Example 5: the same lookup with `auto_run: false`, invoked mid-flow via the `<function/>` tag in the action, with the two behavioral notes (nothing runs at call start; the function completes before the rest of the action is spoken). Both flag values now have complete examples on the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)