### PR TITLE
Remove knowledge_base scenario type from generate-evaluator API docs

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -75699,13 +75699,12 @@
                         "enum": [
                             "workflow",
                             "red_teaming_voice",
-                            "red_teaming_text",
-                            "knowledge_base"
+                            "red_teaming_text"
                         ],
                         "type": "string",
-                        "x-spec-enum-id": "4ef5c62a43e5fdd9",
+                        "x-spec-enum-id": "42aa0beee566f1ba",
                         "default": "workflow",
-                        "description": "Type of scenarios to generate: workflow (standard scenarios), red_teaming_voice (red teaming with voice-suitable prompts only), red_teaming_text (red teaming with all prompts), or knowledge_base (knowledge base scenarios)\n\n* `workflow` - workflow\n* `red_teaming_voice` - red_teaming_voice\n* `red_teaming_text` - red_teaming_text\n* `knowledge_base` - knowledge_base"
+                        "description": "Type of scenarios to generate: workflow (standard scenarios), red_teaming_voice (red teaming with voice-suitable prompts only), or red_teaming_text (red teaming with all prompts)\n\n* `workflow` - workflow\n* `red_teaming_voice` - red_teaming_voice\n* `red_teaming_text` - red_teaming_text"
                     },
                     "attack_type": {
                         "enum": [
@@ -75731,13 +75730,6 @@
                             "null"
                         ],
                         "description": "Custom expected outcome for the scenario. If not provided, a default is generated based on the attack type."
-                    },
-                    "knowledge_base": {
-                        "type": "array",
-                        "items": {
-                            "type": "integer"
-                        },
-                        "description": "List of Knowledge Base file IDs for the agent to reference during scenario generation"
                     },
                     "extra_instructions": {
                         "type": "string",


### PR DESCRIPTION
The Knowledge Base scenario type has been removed from the product, but the [generate-evaluator-bg API reference](https://docs.cekura.ai/api-reference/test_framework/generate-evaluator-bg) still shows it.

This removes from the `SchemaGenerateScenarios` request schema:
- the `knowledge_base` value in the `scenario_type` enum (and its mention in the description)
- the `knowledge_base` (KB file IDs) request field — the generate endpoint never consumed it

Surgical edit to `openapi.json` (a full regen from backend `main` would have clobbered ~1k lines of newer docs). The source serializer is updated to match in cekura-ai/vocera.backend#10240 so future regens stay consistent. The KB file upload/list endpoints are untouched — only the removed scenario *type* is dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)