### PR TITLE
[Auto] Sync docs for backend PR #10342

### DIFF
--- a/api-reference/observability/delete-failure-category.mdx
+++ b/api-reference/observability/delete-failure-category.mdx
@@ -1,0 +1,6 @@
+---
+title: Delete Failure Category
+description: "Remove one persistent failure category and all of its stored call assignments. Future calls are classified only against the remaining categories. Scope with `project` and `metric_id`. ⚠ Cannot be undone."
+openapi: delete /observability/v1/metric-failure-mode-insights/categories/{category_slug}/delete/
+slug: delete-failure-category
+---

--- a/api-reference/observability/delete-metric-failure-mode-insight-category.mdx
+++ b/api-reference/observability/delete-metric-failure-mode-insight-category.mdx
@@ -1,0 +1,6 @@
+---
+title: Delete Metric Failure Mode Insight Category
+description: "Remove one persistent failure category and all of its stored call assignments. Future calls are classified only against the remaining categories. Scope with `project` and `metric_id`. ⚠ Cannot be undone."
+openapi: delete /observability/v1/metric-failure-mode-insights/categories/{category_slug}/delete/
+slug: delete-metric-failure-mode-insight-category
+---

--- a/api-reference/observability/list-failure-category-calls.mdx
+++ b/api-reference/observability/list-failure-category-calls.mdx
@@ -1,0 +1,6 @@
+---
+title: List Failure Category Calls
+description: "Return all call-log ids assigned to one persistent failure category, newest first. Use the same date bounds as the category list to expand the examples shown for the selected range. The accumulator retains at most 500 calls per metric."
+openapi: get /observability/v1/metric-failure-mode-insights/categories/{category_slug}/calls/
+slug: list-failure-category-calls
+---

--- a/api-reference/observability/list-metric-failure-mode-insight-category-calls.mdx
+++ b/api-reference/observability/list-metric-failure-mode-insight-category-calls.mdx
@@ -1,0 +1,6 @@
+---
+title: List Metric Failure Mode Insight Category Calls
+description: "Return all call-log ids assigned to one persistent failure category, newest first. Use the same date bounds as the category list to expand the examples shown for the selected range. The accumulator retains at most 500 calls per metric."
+openapi: get /observability/v1/metric-failure-mode-insights/categories/{category_slug}/calls/
+slug: list-metric-failure-mode-insight-category-calls
+---

--- a/api-reference/subscriptions/add-payg-pack.mdx
+++ b/api-reference/subscriptions/add-payg-pack.mdx
@@ -1,0 +1,6 @@
+---
+title: Add Pay-As-You-Go Pack
+description: "Start the free pay-as-you-go plan for an organization."
+openapi: post /subscriptions/packs/add_payg_pack/
+slug: add-payg-pack
+---

--- a/api-reference/subscriptions/restart-seat-billing.mdx
+++ b/api-reference/subscriptions/restart-seat-billing.mdx
@@ -1,0 +1,6 @@
+---
+title: Restart Seat Billing
+description: "Recreate the seat subscription of a perpetual (free base) plan after its"
+openapi: post /subscriptions/subscriptions/{id}/restart-seat-billing/
+slug: restart-seat-billing
+---

--- a/api-reference/subscriptions/setup-payment-method.mdx
+++ b/api-reference/subscriptions/setup-payment-method.mdx
@@ -1,0 +1,6 @@
+---
+title: Setup Payment Method
+description: "Start a Stripe setup-mode checkout to save a payment method for the"
+openapi: post /subscriptions/subscriptions/{id}/setup-payment-method/
+slug: setup-payment-method
+---

--- a/api-reference/subscriptions/switch-to-payg.mdx
+++ b/api-reference/subscriptions/switch-to-payg.mdx
@@ -1,0 +1,6 @@
+---
+title: Switch to Pay-As-You-Go
+description: "Switch a legacy Stripe-managed self-serve plan (the old developer plan"
+openapi: post /subscriptions/packs/switch_to_payg/
+slug: switch-to-payg
+---

--- a/cekura-mcp-server/mcp_tools.json
+++ b/cekura-mcp-server/mcp_tools.json
@@ -145,5 +145,8 @@
   },
   "metrics_simplify_prompt_progress_retrieve": {
     "description_suffix": "Async — initiated by metrics_simplify_prompt_create. Poll until status is completed or failed."
+  },
+  "metric_failure_mode_insights_categories_delete_destroy": {
+    "description_suffix": "After deletion, `metric_failure_mode_insights_categories_fix_metric_create` can no longer target the removed category."
   }
 }

--- a/mint.json
+++ b/mint.json
@@ -430,11 +430,7 @@
             "api-reference/user/get-userorganizations",
             "api-reference/organization/get-billing-info",
             "api-reference/test_framework/get-payment-history",
-            "api-reference/user/list-organizations",
-            "api-reference/subscriptions/add-payg-pack",
-            "api-reference/subscriptions/switch-to-payg",
-            "api-reference/subscriptions/restart-seat-billing",
-            "api-reference/subscriptions/setup-payment-method"
+            "api-reference/user/list-organizations"
           ]
         },
         {
@@ -501,8 +497,8 @@
             "api-reference/observability/list-agent-improvement-sessions",
             "api-reference/observability/create-agent-improvement-session",
             "api-reference/observability/get-agent-improvement-session",
-            "api-reference/observability/list-failure-category-calls",
-            "api-reference/observability/delete-failure-category"
+            "api-reference/observability/list-metric-failure-mode-insight-category-calls",
+            "api-reference/observability/delete-metric-failure-mode-insight-category"
           ]
         }
       ]

--- a/mint.json
+++ b/mint.json
@@ -430,7 +430,11 @@
             "api-reference/user/get-userorganizations",
             "api-reference/organization/get-billing-info",
             "api-reference/test_framework/get-payment-history",
-            "api-reference/user/list-organizations"
+            "api-reference/user/list-organizations",
+            "api-reference/subscriptions/add-payg-pack",
+            "api-reference/subscriptions/switch-to-payg",
+            "api-reference/subscriptions/restart-seat-billing",
+            "api-reference/subscriptions/setup-payment-method"
           ]
         },
         {
@@ -496,7 +500,9 @@
             "api-reference/observability/add-metric-failure-mode-insight-category-example-calls-to-labs",
             "api-reference/observability/list-agent-improvement-sessions",
             "api-reference/observability/create-agent-improvement-session",
-            "api-reference/observability/get-agent-improvement-session"
+            "api-reference/observability/get-agent-improvement-session",
+            "api-reference/observability/list-failure-category-calls",
+            "api-reference/observability/delete-failure-category"
           ]
         }
       ]

--- a/openapi.json
+++ b/openapi.json
@@ -2431,7 +2431,7 @@
         "/observability/v1/agent-improvement-sessions/": {
             "get": {
                 "operationId": "agent-improvement-sessions-list",
-                "description": "Create + poll \"Improve Agent\" sessions launched from the Insights page.\n\n``create`` resolves the target agent from the selected insights' example\ncall logs, validates it is a VAPI / ElevenLabs agent with a configured\nprovider key, then opens a Claude Agent SDK session (product-chat sandbox\nruntime) seeded to run generate-scenarios → self-improving-agent. Returns\nthe new session row.\n\n``retrieve`` / ``list`` are the poll surface: retrieve syncs the row's\ncoarse status from the underlying sandbox run before returning, so the\nfrontend just polls ``GET /agent-improvement-sessions/<id>/?project=<id>``.",
+                "description": "Create + poll \"Improve Agent\" sessions from Insights or evaluators.\n\n``create`` resolves the target agent from Insight call logs, simulation\nruns, or selected evaluator scenarios. It validates a VAPI / ElevenLabs\nprovider key and opens a Claude Agent SDK session in the product-chat\nsandbox. Call-log sessions generate evaluators first; run and scenario\nsessions reuse their existing evaluator scenarios directly.\n\n``retrieve`` / ``list`` are the poll surface: retrieve syncs the row's\ncoarse status from the underlying sandbox run before returning, so the\nfrontend just polls ``GET /agent-improvement-sessions/<id>/?project=<id>``.",
                 "tags": [
                     "observability"
                 ],
@@ -2458,7 +2458,7 @@
             },
             "post": {
                 "operationId": "agent-improvement-sessions-create",
-                "description": "Create + poll \"Improve Agent\" sessions launched from the Insights page.\n\n``create`` resolves the target agent from the selected insights' example\ncall logs, validates it is a VAPI / ElevenLabs agent with a configured\nprovider key, then opens a Claude Agent SDK session (product-chat sandbox\nruntime) seeded to run generate-scenarios → self-improving-agent. Returns\nthe new session row.\n\n``retrieve`` / ``list`` are the poll surface: retrieve syncs the row's\ncoarse status from the underlying sandbox run before returning, so the\nfrontend just polls ``GET /agent-improvement-sessions/<id>/?project=<id>``.",
+                "description": "Create + poll \"Improve Agent\" sessions from Insights or evaluators.\n\n``create`` resolves the target agent from Insight call logs, simulation\nruns, or selected evaluator scenarios. It validates a VAPI / ElevenLabs\nprovider key and opens a Claude Agent SDK session in the product-chat\nsandbox. Call-log sessions generate evaluators first; run and scenario\nsessions reuse their existing evaluator scenarios directly.\n\n``retrieve`` / ``list`` are the poll surface: retrieve syncs the row's\ncoarse status from the underlying sandbox run before returning, so the\nfrontend just polls ``GET /agent-improvement-sessions/<id>/?project=<id>``.",
                 "tags": [
                     "observability"
                 ],
@@ -2503,7 +2503,7 @@
         "/observability/v1/agent-improvement-sessions/{id}/": {
             "get": {
                 "operationId": "agent-improvement-sessions-retrieve",
-                "description": "Create + poll \"Improve Agent\" sessions launched from the Insights page.\n\n``create`` resolves the target agent from the selected insights' example\ncall logs, validates it is a VAPI / ElevenLabs agent with a configured\nprovider key, then opens a Claude Agent SDK session (product-chat sandbox\nruntime) seeded to run generate-scenarios → self-improving-agent. Returns\nthe new session row.\n\n``retrieve`` / ``list`` are the poll surface: retrieve syncs the row's\ncoarse status from the underlying sandbox run before returning, so the\nfrontend just polls ``GET /agent-improvement-sessions/<id>/?project=<id>``.",
+                "description": "Create + poll \"Improve Agent\" sessions from Insights or evaluators.\n\n``create`` resolves the target agent from Insight call logs, simulation\nruns, or selected evaluator scenarios. It validates a VAPI / ElevenLabs\nprovider key and opens a Claude Agent SDK session in the product-chat\nsandbox. Call-log sessions generate evaluators first; run and scenario\nsessions reuse their existing evaluator scenarios directly.\n\n``retrieve`` / ``list`` are the poll surface: retrieve syncs the row's\ncoarse status from the underlying sandbox run before returning, so the\nfrontend just polls ``GET /agent-improvement-sessions/<id>/?project=<id>``.",
                 "parameters": [
                     {
                         "in": "path",
@@ -7064,6 +7064,116 @@
                 ]
             }
         },
+        "/observability/v1/metric-failure-mode-insights/categories/{category_slug}/calls/": {
+            "get": {
+                "operationId": "metric-failure-mode-insights-categories-calls-retrieve",
+                "description": "Return all call-log ids assigned to one persistent failure category, newest first. Use the same date bounds as the category list to expand the examples shown for the selected range. The accumulator retains at most 500 calls per metric.",
+                "summary": "List every call in one failure category",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "category_slug",
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^[^/]+$"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "project",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "metric_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "date_from",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "date_to",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    }
+                ],
+                "tags": [
+                    "observability"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FailureCategoryCallsResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/observability/v1/metric-failure-mode-insights/categories/{category_slug}/delete/": {
+            "delete": {
+                "operationId": "metric-failure-mode-insights-categories-delete-destroy",
+                "description": "Remove one persistent failure category and all of its stored call assignments. Future calls are classified only against the remaining categories. Scope with `project` and `metric_id`. ⚠ Cannot be undone.",
+                "summary": "Delete an accumulating failure category",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "category_slug",
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^[^/]+$"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "observability"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No response body"
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mcp-destructive": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "metric-failure-mode-insights-categories-delete-destroy",
+                        "description": "Remove one persistent failure category and all of its stored call assignments. Future calls are classified only against the remaining categories. Scope with `project` and `metric_id`. ⚠ Cannot be undone."
+                    }
+                }
+            }
+        },
         "/observability/v1/metric-failure-mode-insights/categories/{category_slug}/fix-metric/": {
             "post": {
                 "operationId": "metric-failure-mode-insights-categories-fix-metric-create",
@@ -10867,6 +10977,52 @@
                 "description": "Subscriptions packs add pack"
             }
         },
+        "/subscriptions/packs/add_payg_pack/": {
+            "post": {
+                "operationId": "subscriptions-packs-add-payg-pack-create",
+                "description": "Start the free pay-as-you-go plan for an organization.\n\nThe plan never expires: the first pack.free_members_count member(s) are free\nand only additional members are billed through Stripe. Eligible signups\n(business email whose domain hasn't used a plan before, org's first plan)\nalso receive the pack's one-time complimentary credits in the never-expiring\nbalance. Orgs whose previous plan expired or was cancelled can activate too,\nwith 0 complimentary credits. Requires a verified phone number.",
+                "tags": [
+                    "subscriptions"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Pack"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Pack"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Pack"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Pack"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/subscriptions/packs/check-trial-eligibility/": {
             "get": {
                 "operationId": "subscriptions-packs-check-trial-eligibility-retrieve",
@@ -10874,6 +11030,52 @@
                 "tags": [
                     "subscriptions"
                 ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Pack"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/subscriptions/packs/switch_to_payg/": {
+            "post": {
+                "operationId": "subscriptions-packs-switch-to-payg-create",
+                "description": "Switch a legacy Stripe-managed self-serve plan (the old developer plan\nwith recurring monthly credits) to the free first-user-free\npay-as-you-go plan. Admin-only, opt-in from the billing page.\n\nWhat it does: cancels the old Stripe subscription immediately (unpaid\ninvoices voided), moves the Stripe customer/card to the org, keeps the\nremaining credit balance until its normal expiry, and creates a seat\nsubscription for members beyond the free seats that starts billing only\nwhen the already-paid period ends. No complimentary credits.",
+                "tags": [
+                    "subscriptions"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Pack"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Pack"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Pack"
+                            }
+                        }
+                    },
+                    "required": true
+                },
                 "security": [
                     {
                         "api_key": []
@@ -11195,6 +11397,116 @@
                     }
                 },
                 "description": "Subscriptions subscriptions renew"
+            }
+        },
+        "/subscriptions/subscriptions/{id}/restart-seat-billing/": {
+            "post": {
+                "operationId": "subscriptions-subscriptions-restart-seat-billing-create",
+                "description": "Recreate the seat subscription of a perpetual (free base) plan after its\npaid seats ended (voluntary cancellation completed, or payment failure\nafter dunning). One click when a card is on file: charges immediately\nfor the current billable seats and lifts the overdue member block —\nno dependency on the setup-checkout webhook.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "subscriptions"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Subscription"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Subscription"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Subscription"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Subscription"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/subscriptions/subscriptions/{id}/setup-payment-method/": {
+            "post": {
+                "operationId": "subscriptions-subscriptions-setup-payment-method-create",
+                "description": "Start a Stripe setup-mode checkout to save a payment method for the\norganization. Used by plans without a Stripe subscription (e.g. the free\npay-as-you-go plan) before top-ups, auto-refill, or adding paid members.\nThe checkout.session.completed webhook makes the card the customer default.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "subscriptions"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Subscription"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Subscription"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Subscription"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Subscription"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
             }
         },
         "/subscriptions/subscriptions/{id}/update_payment_method/": {
@@ -17756,7 +18068,7 @@
             },
             "patch": {
                 "operationId": "metrics-v1-external-partial-update",
-                "description": "Partially update a metric. Same field shape as create — see `metrics_create` for details.\n\n**Note:** `project` and `agent` are read-only once set — you cannot move a metric between projects/agents after creation. To relocate, create a new metric and delete the old one.",
+                "description": "Partially update a metric. Same field shape as create — see `metrics_create` for details.\n\n**Note:** `project`, `agent`, and `audio_enabled` are read-only once set. To change `audio_enabled` on an existing metric, create a new metric with the desired setting and delete the old one.",
                 "summary": "Update a metric (partial)",
                 "parameters": [
                     {
@@ -19494,7 +19806,7 @@
             },
             "patch": {
                 "operationId": "metrics-v1-partial-update",
-                "description": "Partially update a metric. Same field shape as create — see `metrics_create` for details.\n\n**Note:** `project` and `agent` are read-only once set — you cannot move a metric between projects/agents after creation. To relocate, create a new metric and delete the old one.",
+                "description": "Partially update a metric. Same field shape as create — see `metrics_create` for details.\n\n**Note:** `project`, `agent`, and `audio_enabled` are read-only once set. To change `audio_enabled` on an existing metric, create a new metric with the desired setting and delete the old one.",
                 "summary": "Update a metric (partial)",
                 "parameters": [
                     {
@@ -24376,7 +24688,7 @@
         "/test_framework/v1/results-external/{id}/regenerate_ai_summary/": {
             "post": {
                 "operationId": "results-v1-external-regenerate-ai-summary-create",
-                "description": "Queue a background job that regenerates the structured AI summary (what_happened / why_it_happened / how_to_fix) and recommended next steps for this result, based on its current failure clusters. The new summary appears on the next `results_retrieve` call once the job finishes.",
+                "description": "Queue a background job that regenerates the structured AI summary (what_happened / why_it_happened / how_to_fix), recommended next steps, and the workflow coverage for this result, based on its current runs. The new values appear on the next `results_retrieve` call once the job finishes.",
                 "summary": "Regenerate the AI summary for a result",
                 "parameters": [
                     {
@@ -25468,7 +25780,7 @@
         "/test_framework/v1/results/{id}/regenerate_ai_summary/": {
             "post": {
                 "operationId": "results-v1-regenerate-ai-summary-create",
-                "description": "Queue a background job that regenerates the structured AI summary (what_happened / why_it_happened / how_to_fix) and recommended next steps for this result, based on its current failure clusters. The new summary appears on the next `results_retrieve` call once the job finishes.",
+                "description": "Queue a background job that regenerates the structured AI summary (what_happened / why_it_happened / how_to_fix), recommended next steps, and the workflow coverage for this result, based on its current runs. The new values appear on the next `results_retrieve` call once the job finishes.",
                 "summary": "Regenerate the AI summary for a result",
                 "parameters": [
                     {
@@ -28679,7 +28991,7 @@
             },
             "post": {
                 "operationId": "scenarios-create",
-                "description": "scenarios_create: Create a test scenario (evaluator) that simulates a caller interacting with your agent. Required: `name`, `instructions` or program (see modes), and an `agent` or `project` to attach to.\n\n**Two modes — pick one via `scenario_type`:**\n\n- `instruction` (default, simplest) — put plain-text caller instructions in the `instructions` field. The simulated caller uses an LLM to paraphrase your instructions during the call.\n\n- `conditional_actions` — deterministic, rule-based caller. Provide the structured `conditional_actions` object. Use either `conditional_actions` or `instructions` — not both.\n\n**Common companion fields:**\n- `personality` (required) — caller voice/personality ID. Browse via `GET /personalities/`.\n- `metrics` — list of metric IDs to evaluate after each run.\n- `tags` — for grouping and later selection via `run_scenarios?tags=[...]`.\n- `folder_path` — e.g. `\"Sales.Inbound\"` for folder organization.\n- `test_profile` — a test profile ID providing caller metadata (order_id, user_email, etc.).\n\n**Creating from a real call transcript:** if you want an evaluator that replays a past production call, use `POST /test_framework/v1/scenarios/create_scenario_from_transcript/` instead — it derives a `conditional_actions` scenario automatically.\n\n**To run evaluators after creating:** call `run_scenarios` (voice), `run_scenarios_text`, `run_scenarios_with_websockets`, or `run_scenarios_pipecat` with the scenario ID(s) returned here.",
+                "description": "scenarios_create: Create a test scenario (evaluator) that simulates a caller interacting with your agent. Required: `name`, `instructions` or program (see modes), and an `agent` or `project` to attach to.\n\n**Two modes — pick one via `scenario_type`:**\n\n- `instruction` (default, simplest) — put plain-text caller instructions in the `instructions` field. The simulated caller uses an LLM to paraphrase your instructions during the call.\n\n- `conditional_actions` — deterministic, rule-based caller. Provide the structured `conditional_actions` object. Use either `conditional_actions` or `instructions` — not both.\n\n**Common companion fields:**\n- `personality` (required) — caller voice/personality ID. Browse via `GET /personalities/`.\n- `metrics` — list of metric IDs to evaluate after each run.\n- `tags` — for grouping and later selection via `run_scenarios?tags=[...]`.\n- `folder_path` — e.g. `\"Sales.Inbound\"` for folder organization.\n- `test_profile` — a test profile ID providing caller metadata (order_id, user_email, etc.).\n\n**To run evaluators after creating:** call `run_scenarios` (voice), `run_scenarios_text`, `run_scenarios_with_websockets`, or `run_scenarios_pipecat` with the scenario ID(s) returned here.",
                 "summary": "Create an evaluator (scenario)",
                 "tags": [
                     "Scenarios"
@@ -28803,7 +29115,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-create",
-                        "description": "scenarios_create: Create a test scenario (evaluator) that simulates a caller interacting with your agent. Required: `name`, `instructions` or program (see modes), and an `agent` or `project` to attach to.\n\n**Two modes — pick one via `scenario_type`:**\n\n- `instruction` (default, simplest) — put plain-text caller instructions in the `instructions` field. The simulated caller uses an LLM to paraphrase your instructions during the call.\n\n- `conditional_actions` — deterministic, rule-based caller. Provide the structured `conditional_actions` object. Use either `conditional_actions` or `instructions` — not both.\n\n**Common companion fields:**\n- `personality` (required) — caller voice/personality ID. Browse via `GET /personalities/`.\n- `metrics` — list of metric IDs to evaluate after each run.\n- `tags` — for grouping and later selection via `run_scenarios?tags=[...]`.\n- `folder_path` — e.g. `\"Sales.Inbound\"` for folder organization.\n- `test_profile` — a test profile ID providing caller metadata (order_id, user_email, etc.).\n\n**Creating from a real call transcript:** if you want an evaluator that replays a past production call, use `POST /test_framework/v1/scenarios/create_scenario_from_transcript/` instead — it derives a `conditional_actions` scenario automatically.\n\n**To run evaluators after creating:** call `run_scenarios` (voice), `run_scenarios_text`, `run_scenarios_with_websockets`, or `run_scenarios_pipecat` with the scenario ID(s) returned here."
+                        "description": "scenarios_create: Create a test scenario (evaluator) that simulates a caller interacting with your agent. Required: `name`, `instructions` or program (see modes), and an `agent` or `project` to attach to.\n\n**Two modes — pick one via `scenario_type`:**\n\n- `instruction` (default, simplest) — put plain-text caller instructions in the `instructions` field. The simulated caller uses an LLM to paraphrase your instructions during the call.\n\n- `conditional_actions` — deterministic, rule-based caller. Provide the structured `conditional_actions` object. Use either `conditional_actions` or `instructions` — not both.\n\n**Common companion fields:**\n- `personality` (required) — caller voice/personality ID. Browse via `GET /personalities/`.\n- `metrics` — list of metric IDs to evaluate after each run.\n- `tags` — for grouping and later selection via `run_scenarios?tags=[...]`.\n- `folder_path` — e.g. `\"Sales.Inbound\"` for folder organization.\n- `test_profile` — a test profile ID providing caller metadata (order_id, user_email, etc.).\n\n**To run evaluators after creating:** call `run_scenarios` (voice), `run_scenarios_text`, `run_scenarios_with_websockets`, or `run_scenarios_pipecat` with the scenario ID(s) returned here."
                     }
                 }
             }
@@ -28914,7 +29226,7 @@
             },
             "post": {
                 "operationId": "scenarios-external-create",
-                "description": "scenarios_create: Create a test scenario (evaluator) that simulates a caller interacting with your agent. Required: `name`, `instructions` or program (see modes), and an `agent` or `project` to attach to.\n\n**Two modes — pick one via `scenario_type`:**\n\n- `instruction` (default, simplest) — put plain-text caller instructions in the `instructions` field. The simulated caller uses an LLM to paraphrase your instructions during the call.\n\n- `conditional_actions` — deterministic, rule-based caller. Provide the structured `conditional_actions` object. Use either `conditional_actions` or `instructions` — not both.\n\n**Common companion fields:**\n- `personality` (required) — caller voice/personality ID. Browse via `GET /personalities/`.\n- `metrics` — list of metric IDs to evaluate after each run.\n- `tags` — for grouping and later selection via `run_scenarios?tags=[...]`.\n- `folder_path` — e.g. `\"Sales.Inbound\"` for folder organization.\n- `test_profile` — a test profile ID providing caller metadata (order_id, user_email, etc.).\n\n**Creating from a real call transcript:** if you want an evaluator that replays a past production call, use `POST /test_framework/v1/scenarios/create_scenario_from_transcript/` instead — it derives a `conditional_actions` scenario automatically.\n\n**To run evaluators after creating:** call `run_scenarios` (voice), `run_scenarios_text`, `run_scenarios_with_websockets`, or `run_scenarios_pipecat` with the scenario ID(s) returned here.",
+                "description": "scenarios_create: Create a test scenario (evaluator) that simulates a caller interacting with your agent. Required: `name`, `instructions` or program (see modes), and an `agent` or `project` to attach to.\n\n**Two modes — pick one via `scenario_type`:**\n\n- `instruction` (default, simplest) — put plain-text caller instructions in the `instructions` field. The simulated caller uses an LLM to paraphrase your instructions during the call.\n\n- `conditional_actions` — deterministic, rule-based caller. Provide the structured `conditional_actions` object. Use either `conditional_actions` or `instructions` — not both.\n\n**Common companion fields:**\n- `personality` (required) — caller voice/personality ID. Browse via `GET /personalities/`.\n- `metrics` — list of metric IDs to evaluate after each run.\n- `tags` — for grouping and later selection via `run_scenarios?tags=[...]`.\n- `folder_path` — e.g. `\"Sales.Inbound\"` for folder organization.\n- `test_profile` — a test profile ID providing caller metadata (order_id, user_email, etc.).\n\n**To run evaluators after creating:** call `run_scenarios` (voice), `run_scenarios_text`, `run_scenarios_with_websockets`, or `run_scenarios_pipecat` with the scenario ID(s) returned here.",
                 "summary": "Create an evaluator (scenario)",
                 "tags": [
                     "Scenarios"
@@ -30304,52 +30616,6 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/ScenarioFolder"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
-        },
-        "/test_framework/v1/scenarios-external/create_scenario_from_transcript/": {
-            "post": {
-                "operationId": "scenarios-external-create-scenario-from-transcript-create",
-                "description": "Create a test scenario from a call transcript",
-                "tags": [
-                    "test_framework"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Scenario"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Scenario"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Scenario"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Scenario"
                                 }
                             }
                         },
@@ -34354,7 +34620,7 @@
         "/test_framework/v1/scenarios-external/scenario-agent/": {
             "post": {
                 "operationId": "scenarios-agent-create",
-                "description": "Improve evaluators using AI by providing natural language feedback.\n\n**How it works:**\n1. Send evaluator IDs and your improvement request\n2. AI analyzes and suggests improvements\n3. Review suggestions and apply with `apply_changes=true`\n\n**`scenarios` field:** pass a list of integer IDs `[101, 102]`, a single integer `101`, or the string `\"all\"` to improve all scenarios for the agent. Do not pass IDs as a JSON-stringified list — pass them as a native array.\n\n**Applying large change sets:** when using `apply_changes: true` with many scenarios, the `updated_scenarios` payload may be large. If you receive an unexpected error, split the apply into smaller batches of 3–5 scenarios at a time.\n\n**Response:** Returns `progress_id` for polling status at /scenario-agent-progress/\n\n**Multi-turn improvements:** Use the `context` field to maintain conversation history across requests.",
+                "description": "Create or improve evaluator scenarios using AI by providing natural-language feedback. This tool changes evaluator scenarios only; it does not change an AI agent's prompt, configuration, tools, or provider settings. For a request such as `improve agent <id>`, use the `cekura:cekura-self-improving-agent` skill instead.\n\n**How it works:**\n1. Send evaluator IDs and your improvement request\n2. AI analyzes and suggests improvements\n3. Review suggestions and apply with `apply_changes=true`\n\n**`scenarios` field:** pass a list of integer IDs `[101, 102]`, a single integer `101`, or the string `\"all\"` to improve all scenarios for the agent. Do not pass IDs as a JSON-stringified list — pass them as a native array.\n\n**Applying large change sets:** when using `apply_changes: true` with many scenarios, the `updated_scenarios` payload may be large. If you receive an unexpected error, split the apply into smaller batches of 3–5 scenarios at a time.\n\n**Response:** Returns `progress_id` for polling status at /scenario-agent-progress/\n\n**Multi-turn improvements:** Use the `context` field to maintain conversation history across requests.",
                 "tags": [
                     "test_framework"
                 ],
@@ -35832,52 +36098,6 @@
                         "enabled": true,
                         "name": "scenarios-folder-create",
                         "description": "Scenarios folder"
-                    }
-                }
-            }
-        },
-        "/test_framework/v1/scenarios/create_scenario_from_transcript/": {
-            "post": {
-                "operationId": "scenarios-create-scenario-from-transcript-create",
-                "description": "Create a test scenario from a call transcript",
-                "tags": [
-                    "test_framework"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Scenario"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Scenario"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Scenario"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Scenario"
-                                }
-                            }
-                        },
-                        "description": ""
                     }
                 }
             }
@@ -40109,7 +40329,7 @@
         "/test_framework/v1/scenarios/scenario-agent/": {
             "post": {
                 "operationId": "scenarios-agent-create_2",
-                "description": "Improve evaluators using AI by providing natural language feedback.\n\n**How it works:**\n1. Send evaluator IDs and your improvement request\n2. AI analyzes and suggests improvements\n3. Review suggestions and apply with `apply_changes=true`\n\n**`scenarios` field:** pass a list of integer IDs `[101, 102]`, a single integer `101`, or the string `\"all\"` to improve all scenarios for the agent. Do not pass IDs as a JSON-stringified list — pass them as a native array.\n\n**Applying large change sets:** when using `apply_changes: true` with many scenarios, the `updated_scenarios` payload may be large. If you receive an unexpected error, split the apply into smaller batches of 3–5 scenarios at a time.\n\n**Response:** Returns `progress_id` for polling status at /scenario-agent-progress/\n\n**Multi-turn improvements:** Use the `context` field to maintain conversation history across requests.",
+                "description": "Create or improve evaluator scenarios using AI by providing natural-language feedback. This tool changes evaluator scenarios only; it does not change an AI agent's prompt, configuration, tools, or provider settings. For a request such as `improve agent <id>`, use the `cekura:cekura-self-improving-agent` skill instead.\n\n**How it works:**\n1. Send evaluator IDs and your improvement request\n2. AI analyzes and suggests improvements\n3. Review suggestions and apply with `apply_changes=true`\n\n**`scenarios` field:** pass a list of integer IDs `[101, 102]`, a single integer `101`, or the string `\"all\"` to improve all scenarios for the agent. Do not pass IDs as a JSON-stringified list — pass them as a native array.\n\n**Applying large change sets:** when using `apply_changes: true` with many scenarios, the `updated_scenarios` payload may be large. If you receive an unexpected error, split the apply into smaller batches of 3–5 scenarios at a time.\n\n**Response:** Returns `progress_id` for polling status at /scenario-agent-progress/\n\n**Multi-turn improvements:** Use the `context` field to maintain conversation history across requests.",
                 "tags": [
                     "test_framework"
                 ],
@@ -40172,7 +40392,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-agent-create",
-                        "description": "Improve evaluators using AI by providing natural language feedback.\n\n**How it works:**\n1. Send evaluator IDs and your improvement request\n2. AI analyzes and suggests improvements\n3. Review suggestions and apply with `apply_changes=true`\n\n**`scenarios` field:** pass a list of integer IDs `[101, 102]`, a single integer `101`, or the string `\"all\"` to improve all scenarios for the agent. Do not pass IDs as a JSON-stringified list — pass them as a native array.\n\n**Applying large change sets:** when using `apply_changes: true` with many scenarios, the `updated_scenarios` payload may be large. If you receive an unexpected error, split the apply into smaller batches of 3–5 scenarios at a time.\n\n**Response:** Returns `progress_id` for polling status at /scenario-agent-progress/\n\n**Multi-turn improvements:** Use the `context` field to maintain conversation history across requests."
+                        "description": "Create or improve evaluator scenarios using AI by providing natural-language feedback. This tool changes evaluator scenarios only; it does not change an AI agent's prompt, configuration, tools, or provider settings. For a request such as `improve agent <id>`, use the `cekura:cekura-self-improving-agent` skill instead.\n\n**How it works:**\n1. Send evaluator IDs and your improvement request\n2. AI analyzes and suggests improvements\n3. Review suggestions and apply with `apply_changes=true`\n\n**`scenarios` field:** pass a list of integer IDs `[101, 102]`, a single integer `101`, or the string `\"all\"` to improve all scenarios for the agent. Do not pass IDs as a JSON-stringified list — pass them as a native array.\n\n**Applying large change sets:** when using `apply_changes: true` with many scenarios, the `updated_scenarios` payload may be large. If you receive an unexpected error, split the apply into smaller batches of 3–5 scenarios at a time.\n\n**Response:** Returns `progress_id` for polling status at /scenario-agent-progress/\n\n**Multi-turn improvements:** Use the `context` field to maintain conversation history across requests."
                     }
                 }
             }
@@ -46436,7 +46656,7 @@
         "/test_framework/v2/results/{id}/regenerate_ai_summary/": {
             "post": {
                 "operationId": "results-regenerate-ai-summary-create",
-                "description": "Queue a background job that regenerates the structured AI summary (what_happened / why_it_happened / how_to_fix) and recommended next steps for this result, based on its current failure clusters. The new summary appears on the next `results_retrieve` call once the job finishes.",
+                "description": "Queue a background job that regenerates the structured AI summary (what_happened / why_it_happened / how_to_fix), recommended next steps, and the workflow coverage for this result, based on its current runs. The new values appear on the next `results_retrieve` call once the job finishes.",
                 "summary": "Regenerate the AI summary for a result",
                 "parameters": [
                     {
@@ -48187,7 +48407,7 @@
             },
             "post": {
                 "operationId": "test-framework-v2-scenarios-create",
-                "description": "scenarios_create: Create a test scenario (evaluator) that simulates a caller interacting with your agent. Required: `name`, `instructions` or program (see modes), and an `agent` or `project` to attach to.\n\n**Two modes — pick one via `scenario_type`:**\n\n- `instruction` (default, simplest) — put plain-text caller instructions in the `instructions` field. The simulated caller uses an LLM to paraphrase your instructions during the call.\n\n- `conditional_actions` — deterministic, rule-based caller. Provide the structured `conditional_actions` object. Use either `conditional_actions` or `instructions` — not both.\n\n**Common companion fields:**\n- `personality` (required) — caller voice/personality ID. Browse via `GET /personalities/`.\n- `metrics` — list of metric IDs to evaluate after each run.\n- `tags` — for grouping and later selection via `run_scenarios?tags=[...]`.\n- `folder_path` — e.g. `\"Sales.Inbound\"` for folder organization.\n- `test_profile` — a test profile ID providing caller metadata (order_id, user_email, etc.).\n\n**Creating from a real call transcript:** if you want an evaluator that replays a past production call, use `POST /test_framework/v1/scenarios/create_scenario_from_transcript/` instead — it derives a `conditional_actions` scenario automatically.\n\n**To run evaluators after creating:** call `run_scenarios` (voice), `run_scenarios_text`, `run_scenarios_with_websockets`, or `run_scenarios_pipecat` with the scenario ID(s) returned here.",
+                "description": "scenarios_create: Create a test scenario (evaluator) that simulates a caller interacting with your agent. Required: `name`, `instructions` or program (see modes), and an `agent` or `project` to attach to.\n\n**Two modes — pick one via `scenario_type`:**\n\n- `instruction` (default, simplest) — put plain-text caller instructions in the `instructions` field. The simulated caller uses an LLM to paraphrase your instructions during the call.\n\n- `conditional_actions` — deterministic, rule-based caller. Provide the structured `conditional_actions` object. Use either `conditional_actions` or `instructions` — not both.\n\n**Common companion fields:**\n- `personality` (required) — caller voice/personality ID. Browse via `GET /personalities/`.\n- `metrics` — list of metric IDs to evaluate after each run.\n- `tags` — for grouping and later selection via `run_scenarios?tags=[...]`.\n- `folder_path` — e.g. `\"Sales.Inbound\"` for folder organization.\n- `test_profile` — a test profile ID providing caller metadata (order_id, user_email, etc.).\n\n**To run evaluators after creating:** call `run_scenarios` (voice), `run_scenarios_text`, `run_scenarios_with_websockets`, or `run_scenarios_pipecat` with the scenario ID(s) returned here.",
                 "summary": "Create an evaluator (scenario)",
                 "tags": [
                     "Scenarios"
@@ -49577,52 +49797,6 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/ScenarioFolder"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
-        },
-        "/test_framework/v2/scenarios/create_scenario_from_transcript/": {
-            "post": {
-                "operationId": "test-framework-v2-scenarios-create-scenario-from-transcript-crea",
-                "description": "Scenarios create scenario from transcript crea",
-                "tags": [
-                    "test_framework"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ScenarioSerializerV2"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ScenarioSerializerV2"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ScenarioSerializerV2"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ScenarioSerializerV2"
                                 }
                             }
                         },
@@ -53627,7 +53801,7 @@
         "/test_framework/v2/scenarios/scenario-agent/": {
             "post": {
                 "operationId": "scenarios-agent-create_3",
-                "description": "Improve evaluators using AI by providing natural language feedback.\n\n**How it works:**\n1. Send evaluator IDs and your improvement request\n2. AI analyzes and suggests improvements\n3. Review suggestions and apply with `apply_changes=true`\n\n**`scenarios` field:** pass a list of integer IDs `[101, 102]`, a single integer `101`, or the string `\"all\"` to improve all scenarios for the agent. Do not pass IDs as a JSON-stringified list — pass them as a native array.\n\n**Applying large change sets:** when using `apply_changes: true` with many scenarios, the `updated_scenarios` payload may be large. If you receive an unexpected error, split the apply into smaller batches of 3–5 scenarios at a time.\n\n**Response:** Returns `progress_id` for polling status at /scenario-agent-progress/\n\n**Multi-turn improvements:** Use the `context` field to maintain conversation history across requests.",
+                "description": "Create or improve evaluator scenarios using AI by providing natural-language feedback. This tool changes evaluator scenarios only; it does not change an AI agent's prompt, configuration, tools, or provider settings. For a request such as `improve agent <id>`, use the `cekura:cekura-self-improving-agent` skill instead.\n\n**How it works:**\n1. Send evaluator IDs and your improvement request\n2. AI analyzes and suggests improvements\n3. Review suggestions and apply with `apply_changes=true`\n\n**`scenarios` field:** pass a list of integer IDs `[101, 102]`, a single integer `101`, or the string `\"all\"` to improve all scenarios for the agent. Do not pass IDs as a JSON-stringified list — pass them as a native array.\n\n**Applying large change sets:** when using `apply_changes: true` with many scenarios, the `updated_scenarios` payload may be large. If you receive an unexpected error, split the apply into smaller batches of 3–5 scenarios at a time.\n\n**Response:** Returns `progress_id` for polling status at /scenario-agent-progress/\n\n**Multi-turn improvements:** Use the `context` field to maintain conversation history across requests.",
                 "tags": [
                     "test_framework"
                 ],
@@ -58139,174 +58313,6 @@
                 },
                 "description": "List user v2 organizations"
             }
-        },
-        "/test_framework/v1/runs-external/{id}/run_expected_outcome/": {
-            "post": {
-                "operationId": "runs-v1-external-run-expected-outcome-create",
-                "description": "Runs v1 run expected outcome",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "A unique integer value identifying this run.",
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "test_framework"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Run"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Run"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Run"
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Run"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
-        },
-        "/test_framework/v1/runs/{id}/run_expected_outcome/": {
-            "post": {
-                "operationId": "runs-v1-run-expected-outcome-create",
-                "description": "Runs v1 run expected outcome",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "A unique integer value identifying this run.",
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "test_framework"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Run"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Run"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Run"
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Run"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
-        },
-        "/test_framework/v2/runs/{id}/run_expected_outcome/": {
-            "post": {
-                "operationId": "runs-run-expected-outcome-create",
-                "description": "Runs run expected outcome",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "A unique integer value identifying this run.",
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "test_framework"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Run"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Run"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Run"
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Run"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
         }
     },
     "components": {
@@ -59427,8 +59433,7 @@
                     },
                     "mock_tools_enabled": {
                         "type": "boolean",
-                        "readOnly": true,
-                        "description": "Whether mock-tool mode is currently active on the provider. Default false."
+                        "description": "Whether mock tools should be selected by default when configuring a run."
                     },
                     "mock_tools_provider": {
                         "type": [
@@ -59670,10 +59675,27 @@
                         "type": "string",
                         "readOnly": true
                     },
+                    "source": {
+                        "enum": [
+                            "call_log",
+                            "scenario",
+                            "run"
+                        ],
+                        "type": "string",
+                        "description": "* `call_log` - Call Log\n* `scenario` - Scenario\n* `run` - Run",
+                        "x-spec-enum-id": "7a464211ef729f6c",
+                        "readOnly": true
+                    },
                     "insights": {
                         "readOnly": true
                     },
                     "call_log_ids": {
+                        "readOnly": true
+                    },
+                    "run_ids": {
+                        "readOnly": true
+                    },
+                    "scenario_ids": {
                         "readOnly": true
                     },
                     "status": {
@@ -59705,6 +59727,42 @@
                         "readOnly": true
                     },
                     "error_message": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "summary_json": {
+                        "readOnly": true
+                    },
+                    "slack_notification_status": {
+                        "enum": [
+                            "not_attempted",
+                            "sending",
+                            "sent",
+                            "skipped_no_channel",
+                            "failed"
+                        ],
+                        "type": "string",
+                        "description": "* `not_attempted` - Not Attempted\n* `sending` - Sending\n* `sent` - Sent\n* `skipped_no_channel` - Skipped No Channel\n* `failed` - Failed",
+                        "x-spec-enum-id": "f90ffa468a33b565",
+                        "readOnly": true
+                    },
+                    "routed_to": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "slack_channel_id": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "slack_message_ts": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "slack_message_text": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "slack_error": {
                         "type": "string",
                         "readOnly": true
                     },
@@ -59760,6 +59818,15 @@
                     },
                     "served_via": {
                         "$ref": "#/components/schemas/AgentMockToolServedVia"
+                    },
+                    "mcp_server": {
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "MCP server this tool was fetched from, as {name, key}. Null for standalone tools. Server-managed — ignored on writes."
                     }
                 },
                 "required": [
@@ -61341,6 +61408,7 @@
             },
             "CallLogDetail": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -61532,6 +61600,7 @@
             },
             "CallLogList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -62781,6 +62850,7 @@
             },
             "Dashboard": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -62912,6 +62982,7 @@
             },
             "DashboardList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -63488,6 +63559,24 @@
                     "explanation",
                     "outcome_alignments",
                     "score"
+                ]
+            },
+            "FailureCategoryCallsResponse": {
+                "type": "object",
+                "properties": {
+                    "count": {
+                        "type": "integer"
+                    },
+                    "call_log_ids": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "required": [
+                    "call_log_ids",
+                    "count"
                 ]
             },
             "GenerateClarifyAnswer": {
@@ -65767,6 +65856,7 @@
             },
             "MetricList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -66025,6 +66115,7 @@
             },
             "MetricListSerializerV2": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -67509,6 +67600,18 @@
                         "minimum": -2147483648,
                         "description": "Data retention period in days. Leave blank to skip archival for this plan."
                     },
+                    "free_members_count": {
+                        "type": "integer",
+                        "maximum": 2147483647,
+                        "minimum": -2147483648,
+                        "description": "Number of members included for free (e.g. 1 = first user free). <b>Only applies to self-serve billing.</b> Self-serve packs with free members never expire: the base plan is free and only the seats beyond this count are billed through Stripe."
+                    },
+                    "one_time_credits": {
+                        "type": "string",
+                        "format": "decimal",
+                        "pattern": "^-?\\d{0,8}(?:\\.\\d{0,2})?$",
+                        "description": "One-time complimentary credits granted when the pack is provisioned. Added to the never-expiring extra balance; they do not recur."
+                    },
                     "created_at": {
                         "type": "string",
                         "format": "date-time",
@@ -67695,6 +67798,18 @@
                     "extra_member_price": {
                         "type": "string",
                         "readOnly": true
+                    },
+                    "free_members_count": {
+                        "type": "integer",
+                        "maximum": 2147483647,
+                        "minimum": -2147483648,
+                        "description": "Number of members included for free (e.g. 1 = first user free). <b>Only applies to self-serve billing.</b> Self-serve packs with free members never expire: the base plan is free and only the seats beyond this count are billed through Stripe."
+                    },
+                    "one_time_credits": {
+                        "type": "string",
+                        "format": "decimal",
+                        "pattern": "^-?\\d{0,8}(?:\\.\\d{0,2})?$",
+                        "description": "One-time complimentary credits granted when the pack is provisioned. Added to the never-expiring extra balance; they do not recur."
                     }
                 },
                 "required": [
@@ -68586,6 +68701,7 @@
             },
             "PatchedCallLogDetail": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -69018,6 +69134,7 @@
             },
             "PatchedDashboard": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -70879,6 +70996,16 @@
                         "readOnly": true,
                         "description": "\nLLM-suggested next steps to fix the issues found in this result, ordered by impact.\nExample:\n```json\n[\n    {\"title\": \"Seed test profile in production\", \"description\": \"Unblocks 6 runs; ~5 min.\"},\n    {\"title\": \"Tighten competitor guardrail\", \"description\": \"1 prompt edit; review drift run.\"}\n]\n```\n"
                     },
+                    "path_coverage": {
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "readOnly": true,
+                        "description": "\nWorkflow-coverage summary for this result: which of the agent's critical paths the\nruns exercised, and which they missed.\nExample:\n```json\n{\n    \"coverage_pct\": 66.7,\n    \"total_paths\": 3,\n    \"covered_paths\": [\"Book appointment\", \"Reschedule appointment\"],\n    \"uncovered_paths\": [\"Cancel appointment\"],\n    \"generated_at\": \"2026-07-14T12:00:00Z\"\n}\n```\n"
+                    },
                     "performance_metrics": {
                         "type": "string",
                         "readOnly": true,
@@ -71443,8 +71570,7 @@
                     },
                     "mock_tools_enabled": {
                         "type": "boolean",
-                        "readOnly": true,
-                        "description": "Whether mock-tool mode is currently active on the provider. Default false."
+                        "description": "Whether mock tools should be selected by default when configuring a run."
                     },
                     "mock_tools_provider": {
                         "type": [
@@ -71773,6 +71899,7 @@
             },
             "PatchedSchemaPostScenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "agent": {
                         "type": [
@@ -72556,7 +72683,12 @@
                     "served_via": {
                         "type": "string",
                         "readOnly": true,
-                        "description": "How this tool is accessed at runtime. `{'type': 'direct'}` for standalone tools; `{'type': 'mcp', 'mock_index': N, 'url': '.../mcp/N/'}` for MCP sub-tools."
+                        "description": "How this tool is accessed at runtime. `{'type': 'direct'}` for standalone tools; `{'type': 'mcp', 'mock_index': N, 'url': '.../mcp/N/', 'server_name': ...}` for MCP sub-tools."
+                    },
+                    "mcp_server": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "MCP server this tool was fetched from, as `{'name', 'key'}`. Null for standalone (non-MCP) tools. Server-managed — ignored on writes."
                     }
                 }
             },
@@ -74669,6 +74801,16 @@
                         "readOnly": true,
                         "description": "\nLLM-suggested next steps to fix the issues found in this result, ordered by impact.\nExample:\n```json\n[\n    {\"title\": \"Seed test profile in production\", \"description\": \"Unblocks 6 runs; ~5 min.\"},\n    {\"title\": \"Tighten competitor guardrail\", \"description\": \"1 prompt edit; review drift run.\"}\n]\n```\n"
                     },
+                    "path_coverage": {
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "readOnly": true,
+                        "description": "\nWorkflow-coverage summary for this result: which of the agent's critical paths the\nruns exercised, and which they missed.\nExample:\n```json\n{\n    \"coverage_pct\": 66.7,\n    \"total_paths\": 3,\n    \"covered_paths\": [\"Book appointment\", \"Reschedule appointment\"],\n    \"uncovered_paths\": [\"Cancel appointment\"],\n    \"generated_at\": \"2026-07-14T12:00:00Z\"\n}\n```\n"
+                    },
                     "performance_metrics": {
                         "type": "string",
                         "readOnly": true,
@@ -75070,6 +75212,7 @@
             },
             "RunList": {
                 "type": "object",
+                "description": "Adds outbound dial-window fields read from cekura_metadata.",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -75363,7 +75506,7 @@
                         "items": {
                             "type": "string"
                         },
-                        "description": "Names of mock tools to activate for this run. Omit (or send null) to mock every tool configured on the agent; send an empty list to mock none so every tool keeps its original endpoint; send specific names to mock only those."
+                        "description": "Names of mock tools to activate for this run. Omit (or send null) to mock every tool configured on the agent; send an empty list to mock none so every tool keeps its original endpoint; send specific names to mock only those. Tools that belong to an MCP server should be selected via the MCP server's name or key, which mocks all of that server's tools as one unit. Legacy MCP sub-tool names are accepted as aliases for the whole parent MCP."
                     },
                     "livekit_data": {
                         "allOf": [
@@ -75687,7 +75830,7 @@
                         "items": {
                             "type": "string"
                         },
-                        "description": "Names of mock tools to activate for this run. Omit (or send null) to mock every tool configured on the agent; send an empty list to mock none so every tool keeps its original endpoint; send specific names to mock only those."
+                        "description": "Names of mock tools to activate for this run. Omit (or send null) to mock every tool configured on the agent; send an empty list to mock none so every tool keeps its original endpoint; send specific names to mock only those. Tools that belong to an MCP server should be selected via the MCP server's name or key, which mocks all of that server's tools as one unit. Legacy MCP sub-tool names are accepted as aliases for the whole parent MCP."
                     }
                 },
                 "required": [
@@ -75713,6 +75856,7 @@
             },
             "Scenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -75988,12 +76132,12 @@
             },
             "ScenarioAgentRequest": {
                 "type": "object",
-                "description": "Improve evaluators using AI by providing natural language feedback.\n\nProvide evaluator IDs and your improvement request, and the AI will suggest changes.",
+                "description": "Create or improve evaluator scenarios using AI by providing natural-language\nfeedback. This endpoint does not improve the target AI agent itself.\n\nProvide evaluator IDs and your improvement request, and the AI will suggest changes.",
                 "properties": {
                     "user_message": {
                         "type": "string",
                         "default": "",
-                        "description": "Your improvement request (e.g., 'Make instructions more detailed')"
+                        "description": "Evaluator-scenario request (e.g., 'Make these scenario instructions more detailed'). Do not use for agent prompt/config improvements."
                     },
                     "agent_id": {
                         "type": [
@@ -76609,6 +76753,7 @@
             },
             "ScenarioList": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -76828,6 +76973,7 @@
             },
             "ScenarioSerializerV2": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -77731,8 +77877,7 @@
                     },
                     "mock_tools_enabled": {
                         "type": "boolean",
-                        "readOnly": true,
-                        "description": "Whether mock-tool mode is currently active on the provider. Default false."
+                        "description": "Whether mock tools should be selected by default when configuring a run."
                     },
                     "mock_tools_provider": {
                         "type": [
@@ -78303,6 +78448,7 @@
             },
             "SchemaPostRunScenarios": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "agent_id": {
                         "type": "integer",
@@ -79057,6 +79203,7 @@
             },
             "SchemaPostScenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "agent": {
                         "type": [
@@ -79206,6 +79353,7 @@
             },
             "SchemaScenario": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -80199,6 +80347,19 @@
                         "type": "string",
                         "readOnly": true
                     },
+                    "has_payment_method": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "seat_payment_overdue_since": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "date-time",
+                        "readOnly": true,
+                        "description": "When a renewal payment for this perpetual plan's seat subscription first failed. Once older than SUBSCRIPTION_GRACE_PERIOD_DAYS, billable members other than the free-plan owner are blocked at the API level until the payment is fixed. Cleared when a seat invoice is paid."
+                    },
                     "last_payment_at": {
                         "type": "string",
                         "format": "date-time",
@@ -80656,7 +80817,12 @@
                     "served_via": {
                         "type": "string",
                         "readOnly": true,
-                        "description": "How this tool is accessed at runtime. `{'type': 'direct'}` for standalone tools; `{'type': 'mcp', 'mock_index': N, 'url': '.../mcp/N/'}` for MCP sub-tools."
+                        "description": "How this tool is accessed at runtime. `{'type': 'direct'}` for standalone tools; `{'type': 'mcp', 'mock_index': N, 'url': '.../mcp/N/', 'server_name': ...}` for MCP sub-tools."
+                    },
+                    "mcp_server": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "MCP server this tool was fetched from, as `{'name', 'key'}`. Null for standalone (non-MCP) tools. Server-managed — ignored on writes."
                     }
                 },
                 "required": [


### PR DESCRIPTION
Auto-generated docs sync for backend PR [#10342](https://github.com/cekura-ai/vocera.backend/pull/10342).

Reviewers: @dileep-chagam, @lavish-cekura

## Summary

**Spec/overlay:** 1 newly exposed op (metric_failure_mode_insights_categories_delete_destroy, Bucket B-new). 1 modified exposed op (scenarios_agent_create, Bucket A — description clarified to disambiguate from agent-improvement). No overlay patches needed — no transport-quirk signal fired for the new op and existing scenarios_agent_create overlay left intact per D2 precedence. 1 SDK/CLI follow-up for the new exposure.

**Conceptual docs:** No edits — PR only clarifies internal descriptions and help_text on the scenario-agent endpoint to disambiguate from the agent-improvement flow. No user-visible API behavior changed (no new fields, no response shape change, no behavioral difference). Existing docs remain accurate.

## Changes

- `openapi.json` — regenerate_from_backend

## SDK / CLI parity follow-ups

- `metric_failure_mode_insights_categories_delete_destroy` (DELETE `/observability/v1/metric-failure-mode-insights/categories/{category_slug}/delete/`) — add

---
*Auto-generated from backend PR #10342.*

<!-- mcp-sync:file-hashes -->
```json
{}
```
<!-- /mcp-sync:file-hashes -->