### PR TITLE
[Auto] Sync docs for backend PR #10359

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -13805,7 +13805,7 @@
         "/test_framework/v1/aiagents/": {
             "get": {
                 "operationId": "aiagents-v1-list",
-                "description": "aiagents_list: List AI voice agents in your account. Filter by `project_id` to scope to one project, or omit to list every agent the caller can access. Returns a paginated list of agent summaries (id, name, provider, contact number, created/updated timestamps).\n\nPerformance tip: passing `project_id` from your workspace context narrows the result. Try `page_size=20` first — you can paginate or raise the page size if you actually need more.",
+                "description": "aiagents_list: List AI voice agents in your account. Filter by `project_id` to scope to one project and by `inbound` to select inbound or outbound agents. Omit both filters to list every agent the caller can access. Returns a paginated list of agent summaries (id, name, provider, contact number, created/updated timestamps).\n\nPerformance tip: passing `project_id` from your workspace context narrows the result. Try `page_size=20` first — you can paginate or raise the page size if you actually need more.",
                 "summary": "List AI voice agents",
                 "parameters": [
                     {
@@ -13841,6 +13841,14 @@
                             "type": "string"
                         },
                         "description": "Search agents by name. A numeric value also matches the agent id."
+                    },
+                    {
+                        "in": "query",
+                        "name": "inbound",
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "description": "Filter agents by inbound or outbound direction."
                     }
                 ],
                 "tags": [
@@ -41844,6 +41852,14 @@
                             "type": "string"
                         },
                         "description": "Search agents by name. A numeric value also matches the agent id."
+                    },
+                    {
+                        "in": "query",
+                        "name": "inbound",
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "description": "Filter agents by inbound or outbound direction."
                     },
                     {
                         "name": "organization_id",


### PR DESCRIPTION
Auto-generated docs sync for backend PR [#10359](https://github.com/cekura-ai/vocera.backend/pull/10359).

Reviewers: @dileep-chagam, @atulcekura

## Summary

**Spec/overlay:** 1 exposed op updated (aiagents_list): new `inbound` query parameter added and description updated. Spec-only change — no overlay additions needed (no transport-quirk signals fired). No new exposures, retractions, or renames.

**Conceptual docs:** No edits — the PR adds an optional `inbound` query parameter to the agent list API endpoint. No conceptual docs page enumerates list-endpoint filters; existing pages describe agent setup workflows and concepts that remain accurate after this change. The new parameter is covered by the OpenAPI spec (API-reference workflow).

## Changes

- `openapi.json` — regenerate_from_backend

---
*Auto-generated from backend PR #10359.*

<!-- mcp-sync:file-hashes -->
```json
{}
```
<!-- /mcp-sync:file-hashes -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cekura-ai/docs/pull/795" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->