### PR TITLE
docs: document inline condition audio

### DIFF
--- a/documentation/key-concepts/evaluators/conditional-actions.mdx
+++ b/documentation/key-concepts/evaluators/conditional-actions.mdx
@@ -349,6 +349,8 @@ Conditional Actions supports a variety of special tags in the `action` field to 
 **Important**: Tags are only supported when `fixed_message` is set to `true`. They will not work with `fixed_message: false` (instruction-based actions).
 </Warning>
 
+Tags can be combined with text and other sibling tags. They run from left to right; do not nest tags inside one another. `<ivr>` and `<voicemail>` remain whole-action tags.
+
 ### Communication Tags
 
 <AccordionGroup>
@@ -827,19 +829,19 @@ Audio can only be attached to a **fixed-message** condition (`fixed_message: tru
 
 1. You upload an audio file to a specific condition (from the editor UI or the API).
 2. Cekura **transcribes it automatically** in the background — this is why a clip is briefly *processing* before it's ready to use.
-3. The condition's `action` is replaced with a managed reference tag — `<audio id="…"/>` — pointing at the uploaded clip. **You don't write this tag by hand**; attaching and removing audio manages it for you.
-4. On the call, when the condition fires, the testing agent plays the recording, and its transcript appears in the conversation transcript just like spoken text.
+3. Cekura inserts a managed `<audio id="…"/>` reference at the selected position in the action. **You don't write this tag by hand**; attaching, replacing, and removing audio manages it for you.
+4. When the condition fires, text, recordings, and tags run from left to right.
 
 <Warning>
-The transcript is **derived from the recording** and is read-only — you can't edit it, and it's never stored in the `action` (which holds only the `<audio>` reference tag).
+The transcript is **derived from the recording** and is read-only.
 </Warning>
 
 ### Attaching audio (UI)
 
-In the Conditional Actions editor, each fixed-message condition has an **Attach audio** control:
+In the Conditional Actions editor, each fixed-message condition has an **Attach audio at cursor** control:
 
-1. Click **Attach audio** and pick a file. A **Processing** badge appears while the clip transcribes.
-2. When it finishes, the condition shows the **read-only transcript** and an audio player. Use **Replace** to swap the clip or **Remove** to detach it (which restores the condition's original text action).
+1. Place the cursor where the recording should play, click **Attach audio at cursor**, and pick a file. You can attach more than one recording to the same action.
+2. When processing finishes, each recording shows its **read-only transcript** and an audio player. **Replace** or **Remove** affects only that recording; surrounding text and tags stay in place.
 3. While any attached clip is still processing (or has failed), **runs are blocked** for that scenario until it resolves — see [Statuses & run gating](#statuses-run-gating).
 
 ### Attaching audio (API)
@@ -853,6 +855,7 @@ Three endpoints on the scenario manage attached audio. The clip is uploaded as `
 curl -X POST "https://api.cekura.ai/test_framework/v1/scenarios/39001/condition-audio/" \
   -H "Authorization: Bearer $CEKURA_API_KEY" \
   -F "condition_id=2" \
+  -F 'action_template=Before the tone <audio /> <silence time="1s"/> continue' \
   -F "file=@greeting.mp3"
 # 202 Accepted — transcription runs in the background
 ```
@@ -893,6 +896,14 @@ The upload returns the clip's entry immediately with `status: "pending"`; poll t
   The audio file. Max **25 MB**; accepted formats: `wav`, `mp3`, `m4a`, `ogg`, `webm`, `flac`.
 </ParamField>
 
+<ParamField path="action_template" type="string">
+  The complete action with one `<audio />` marker where the new recording should be inserted. Existing managed audio tags must remain in the template.
+</ParamField>
+
+<ParamField path="replace_audio_id" type="string">
+  To replace one recording, pass its `audio_id` and put `<audio />` at that tag's position in `action_template`.
+</ParamField>
+
 ### Statuses & run gating
 
 Each attached clip moves through these statuses:
@@ -905,10 +916,6 @@ Each attached clip moves through these statuses:
 | `failed` | Transcription failed. Retry (re-upload) or remove the clip. |
 
 A scenario **cannot be run while any attached clip is not `ready`** — the run is rejected with a clear message (`"still transcribing — wait for it to finish"` for pending/processing, `"failed to transcribe — retry or remove it"` for failed).
-
-<Note>
-A scenario that already uses **generated audio samples** can't also use attached audio — the upload returns `409`. Pick one per scenario.
-</Note>
 
 ## Complete Examples
 
@@ -1473,10 +1480,7 @@ Chain `action_followup` conditions to deliver an exact sequence of messages acro
   <Accordion title="Attach audio option is missing on a condition" icon="microphone-slash">
     **Issue**: A condition has no way to attach a recording.
 
-    **Solutions**:
-    - Audio attaches only to **fixed-message** conditions — set `fixed_message: true` on the condition first.
-    - Save the scenario before attaching — uploads target a saved condition by its `id`.
-    - If the upload returns `409`, the scenario already uses generated audio samples; the two features are mutually exclusive per scenario.
+    **Solution**: Audio attaches only to **fixed-message** conditions. Set `fixed_message: true` on the condition first.
   </Accordion>
 </AccordionGroup>
 


### PR DESCRIPTION
## Summary
- document attaching multiple recordings at cursor position
- explain left-to-right sibling tag execution
- add action_template and replace_audio_id API fields
- keep the feature guide focused on user-facing behavior

## Verification
- stale single-audio and sole-content wording removed
- git diff --check