### PR TITLE
[Auto] Sync docs for backend PR #10363

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -13805,7 +13805,7 @@
         "/test_framework/v1/aiagents/": {
             "get": {
                 "operationId": "aiagents-v1-list",
-                "description": "aiagents_list: List AI voice agents in your account. Filter by `project_id` to scope to one project, or omit to list every agent the caller can access. Returns a paginated list of agent summaries (id, name, provider, contact number, created/updated timestamps).\n\nPerformance tip: passing `project_id` from your workspace context narrows the result. Try `page_size=20` first — you can paginate or raise the page size if you actually need more.",
+                "description": "aiagents_list: List AI voice agents in your account. Filter by `project_id` to scope to one project and by `inbound` to select inbound or outbound agents. Omit both filters to list every agent the caller can access. Returns a paginated list of agent summaries (id, name, provider, contact number, created/updated timestamps).\n\nPerformance tip: passing `project_id` from your workspace context narrows the result. Try `page_size=20` first — you can paginate or raise the page size if you actually need more.",
                 "summary": "List AI voice agents",
                 "parameters": [
                     {
@@ -13841,6 +13841,14 @@
                             "type": "string"
                         },
                         "description": "Search agents by name. A numeric value also matches the agent id."
+                    },
+                    {
+                        "in": "query",
+                        "name": "inbound",
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "description": "Filter agents by inbound or outbound direction."
                     }
                 ],
                 "tags": [
@@ -41844,6 +41852,14 @@
                             "type": "string"
                         },
                         "description": "Search agents by name. A numeric value also matches the agent id."
+                    },
+                    {
+                        "in": "query",
+                        "name": "inbound",
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "description": "Filter agents by inbound or outbound direction."
                     },
                     {
                         "name": "organization_id",


### PR DESCRIPTION
Auto-generated docs sync for backend PR [#10363](https://github.com/cekura-ai/vocera.backend/pull/10363).

Reviewers: @dileep-chagam, @atulcekura

## Summary

**Spec/overlay:** 1 exposed op updated (aiagents_list — new `inbound` boolean query parameter added). Spec-only change; no overlay patch needed (no transport-quirk signal fired). 1 non-exposed op also updated (aiagents-v1-list, v1 variant — description and parameter change).

**Conceptual docs:** No edits — the PR adds an optional `inbound` query parameter to the agent list endpoint. No conceptual docs page enumerates list-endpoint filters; existing pages describe agent setup and workflows at a concept level that remains accurate. The new parameter is covered by the API-reference workflow via the regenerated OpenAPI spec.

## Changes

- `openapi.json` — regenerate_from_backend

---
*Auto-generated from backend PR #10363.*

<!-- mcp-sync:file-hashes -->
```json
{}
```
<!-- /mcp-sync:file-hashes -->