### PR TITLE
Document Humanness predefined metric

### DIFF
--- a/documentation/key-concepts/metrics/pre-defined-metrics.mdx
+++ b/documentation/key-concepts/metrics/pre-defined-metrics.mdx
@@ -364,7 +364,7 @@ These metrics evaluate the audio and speech characteristics of the Main Agent.
   <Accordion title="Humanness">
     **Result**: Score (1-5) | **Cost**: 0.3 credits per minute
 
-    Evaluates whether the Main Agent's isolated voice sounds human. A multimodal LLM considers articulation and word joins, prosody and semantic emphasis, rhythm and fluency, voice quality and acoustic artifacts, cross-turn variation, and conversational adaptation. No single feature such as pitch, cadence, breathing, or polish determines the score, and response latency is not considered. Proposed 5/5 ratings receive a second, stricter audio review.
+    Evaluates whether the Main Agent's voice sounds human. A multimodal LLM receives the full call recording and uses the speaker-labelled transcript to identify and judge only the Main Agent's turns. It considers voice quality, articulation, prosody, rhythm, fluency, and natural variation holistically; no single feature such as pitch, cadence, breathing, polish, or response latency determines the score.
 
     **Requirements**: Audio recording.
 

--- a/documentation/key-concepts/metrics/pre-defined-metrics.mdx
+++ b/documentation/key-concepts/metrics/pre-defined-metrics.mdx
@@ -350,7 +350,7 @@ These metrics evaluate the audio and speech characteristics of the Main Agent.
   </Accordion>
 
   <Accordion title="Gibberish Detection (Beta)">
-    **Result**: True/False | **Cost**: 0.2 credits per minute
+    **Result**: True/False | **Cost**: 0.3 credits per minute
 
     Detects nonsensical or garbled speech from the Main Agent. A multimodal LLM analyzes the Main Agent's audio to identify unintelligible segments, nonsense sounds, or garbled speech.
 
@@ -362,18 +362,18 @@ These metrics evaluate the audio and speech characteristics of the Main Agent.
   </Accordion>
 
   <Accordion title="Humanness">
-    **Result**: Score (1-5) | **Cost**: 0.2 credits per minute
+    **Result**: Score (1-5) | **Cost**: 0.3 credits per minute
 
-    Evaluates how naturally human the Main Agent sounds. A multimodal LLM analyzes prosody, cadence, fluency, and conversational delivery while ignoring the Testing Agent and the factual content of the response.
+    Evaluates how naturally human the Main Agent sounds. A multimodal LLM analyzes prosody, pitch variation, cadence, fluency, conversational delivery, and recurring response-latency patterns while ignoring the Testing Agent and the factual content of the response.
 
     **Requirements**: Audio recording.
 
     **Interpretation**:
-    - **5**: Convincingly human throughout; ordinary human variation and isolated imperfections are allowed
-    - **4**: Convincingly human overall, but with recurring mild synthetic cues
-    - **3**: Mixed; noticeable stretches of mechanical or awkward delivery
-    - **2**: Frequently artificial, with multiple delivery problems
-    - **1**: Strongly robotic or synthetic throughout
+    - **5**: Indistinguishable from natural live human speech throughout
+    - **4**: Highly human-like, but subtle recurring synthetic or agentic timing cues remain
+    - **3**: Polished and intelligible, but recognizably synthetic in several places
+    - **2**: Frequently artificial, with strong recurring defects
+    - **1**: Pervasively robotic or clearly synthesized
   </Accordion>
 
   <Accordion title="Letterwise Pronunciation">

--- a/documentation/key-concepts/metrics/pre-defined-metrics.mdx
+++ b/documentation/key-concepts/metrics/pre-defined-metrics.mdx
@@ -364,13 +364,13 @@ These metrics evaluate the audio and speech characteristics of the Main Agent.
   <Accordion title="Humanness">
     **Result**: Score (1-5) | **Cost**: 0.3 credits per minute
 
-    Evaluates how naturally human the Main Agent sounds. A multimodal LLM analyzes prosody, pitch variation, cadence, fluency, conversational delivery, and recurring response-latency patterns while ignoring the Testing Agent and the factual content of the response.
+    Evaluates whether the Main Agent's isolated voice sounds human. A multimodal LLM considers articulation and word joins, prosody and semantic emphasis, rhythm and fluency, voice quality and acoustic artifacts, cross-turn variation, and conversational adaptation. No single feature such as pitch, cadence, breathing, or polish determines the score, and response latency is not considered. Proposed 5/5 ratings receive a second, stricter audio review.
 
     **Requirements**: Audio recording.
 
     **Interpretation**:
     - **5**: Indistinguishable from natural live human speech throughout
-    - **4**: Highly human-like, but subtle recurring synthetic or agentic timing cues remain
+    - **4**: Highly human-like or genuinely ambiguous, but subtle recurring voice-synthesis cues remain
     - **3**: Polished and intelligible, but recognizably synthetic in several places
     - **2**: Frequently artificial, with strong recurring defects
     - **1**: Pervasively robotic or clearly synthesized

--- a/documentation/key-concepts/metrics/pre-defined-metrics.mdx
+++ b/documentation/key-concepts/metrics/pre-defined-metrics.mdx
@@ -369,8 +369,8 @@ These metrics evaluate the audio and speech characteristics of the Main Agent.
     **Requirements**: Audio recording.
 
     **Interpretation**:
-    - **5**: Consistently natural, fluid, and context-responsive
-    - **4**: Mostly natural, with minor synthetic or stiff moments
+    - **5**: Convincingly human throughout; ordinary human variation and isolated imperfections are allowed
+    - **4**: Convincingly human overall, but with recurring mild synthetic cues
     - **3**: Mixed; noticeable stretches of mechanical or awkward delivery
     - **2**: Frequently artificial, with multiple delivery problems
     - **1**: Strongly robotic or synthetic throughout

--- a/documentation/key-concepts/metrics/pre-defined-metrics.mdx
+++ b/documentation/key-concepts/metrics/pre-defined-metrics.mdx
@@ -361,6 +361,21 @@ These metrics evaluate the audio and speech characteristics of the Main Agent.
     - **False**: Gibberish or garbled speech detected
   </Accordion>
 
+  <Accordion title="Humanness">
+    **Result**: Score (1-5) | **Cost**: 0.2 credits per minute
+
+    Evaluates how naturally human the Main Agent sounds. A multimodal LLM analyzes prosody, cadence, fluency, and conversational delivery while ignoring the Testing Agent and the factual content of the response.
+
+    **Requirements**: Audio recording.
+
+    **Interpretation**:
+    - **5**: Consistently natural, fluid, and context-responsive
+    - **4**: Mostly natural, with minor synthetic or stiff moments
+    - **3**: Mixed; noticeable stretches of mechanical or awkward delivery
+    - **2**: Frequently artificial, with multiple delivery problems
+    - **1**: Strongly robotic or synthetic throughout
+  </Accordion>
+
   <Accordion title="Letterwise Pronunciation">
     **Result**: True/False | **Cost**: 0.2 credits per call
 


### PR DESCRIPTION
## Summary
- Document Humanness as a 1-5 audio metric priced at 0.3 credits per minute.
- Explain that one multimodal evaluation receives the full call recording and speaker-labelled transcript, then judges only the Main Agent voice.
- Document the balanced acoustic criteria and 1-5 interpretation.

## Notes
- Backend implementation: cekura-ai/vocera.backend#10374