### PR TITLE
Document turn-normalized transcription scoring

### DIFF
--- a/documentation/key-concepts/metrics/pre-defined-metrics.mdx
+++ b/documentation/key-concepts/metrics/pre-defined-metrics.mdx
@@ -103,9 +103,13 @@ These metrics evaluate whether your agent provides correct and consistent inform
     | Verbs | **0.5** |
     | Everything else (articles, pronouns, fillers, prepositions…) | **0** toward the weighted count — treated as a *minor variation* (see below) |
 
-    The same distinct significant word mistranscribed multiple times is only counted once. This POS-weighted approach works across common languages including Spanish. The weighted error count maps to a base score:
+    The same distinct significant word mistranscribed multiple times is only counted once. This POS-weighted approach works across common languages including Spanish. For Runs/Simulations, the weighted error count is normalized to **10 non-empty Testing Agent turns** before it maps to a base score:
 
-    | Base score | Weighted errors |
+    ```
+    Weighted errors per 10 turns = weighted errors / Testing Agent turns × 10
+    ```
+
+    | Base score | Weighted errors per 10 Testing Agent turns |
     | --- | --- |
     | 100% | 0 |
     | 80% | 1–3 |


### PR DESCRIPTION
## Summary
- document weighted transcription errors per 10 non-empty Testing Agent turns
- clarify the existing score thresholds use the normalized error count