### PR TITLE
Clarify short-call transcription scoring

### DIFF
--- a/documentation/key-concepts/metrics/pre-defined-metrics.mdx
+++ b/documentation/key-concepts/metrics/pre-defined-metrics.mdx
@@ -103,13 +103,13 @@ These metrics evaluate whether your agent provides correct and consistent inform
     | Verbs | **0.5** |
     | Everything else (articles, pronouns, fillers, prepositions…) | **0** toward the weighted count — treated as a *minor variation* (see below) |
 
-    The same distinct significant word mistranscribed multiple times is only counted once. This POS-weighted approach works across common languages including Spanish. For Runs/Simulations, the weighted error count is normalized to **10 non-empty Testing Agent turns** before it maps to a base score:
+    The same distinct significant word mistranscribed multiple times is only counted once. This POS-weighted approach works across common languages including Spanish. For Runs/Simulations with **up to 10 non-empty Testing Agent turns**, the raw weighted error count maps directly to the base score. For longer runs, the count is normalized to a 10-turn baseline:
 
     ```
     Weighted errors per 10 turns = weighted errors / Testing Agent turns × 10
     ```
 
-    | Base score | Weighted errors per 10 Testing Agent turns |
+    | Base score | Weighted errors (raw for up to 10 turns; normalized for longer runs) |
     | --- | --- |
     | 100% | 0 |
     | 80% | 1–3 |


### PR DESCRIPTION
Clarifies that Transcription Accuracy uses raw weighted errors for runs with up to 10 Testing Agent turns and applies 10-turn normalization only to longer runs.