### PR TITLE
Document quick vs detailed metric build modes and the voice-recording toggle

### DIFF
--- a/documentation/key-concepts/metrics/build-with-ai.mdx
+++ b/documentation/key-concepts/metrics/build-with-ai.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Build a Metric with AI"
-description: "Refine an LLM Judge or Python metric with an AI agent that runs it on your real calls and runs, fixes clear edge cases itself, and asks you only when a decision is genuinely ambiguous"
+description: "Refine an LLM Judge or Python metric with an AI agent that uses real calls and runs when available, fixes clear edge cases itself, and asks you only when a decision is genuinely ambiguous"
 sidebarTitle: "Build with AI"
 icon: "wand-magic-sparkles"
 iconType: "solid"
@@ -20,7 +20,9 @@ When you click **Improve** on a metric's definition, an AI agent:
 1. Cleans up your definition and gives it a quick check. If the intent is
    unclear or the definition has an obvious gap, it asks you a short question
    **up front** — before spending a run on calls it can't yet judge meaningfully.
-2. Runs the definition against a sample of the agent's real **calls and runs**.
+2. Runs the definition against a sample of the agent's real **calls and runs**
+   when enough transcript history is available. For a new agent with fewer than
+   10 transcripts, it refines the definition directly instead.
 3. Reviews the predictions and finds edge cases — early hang-ups, partial
    completions, off-topic calls, caller-vs-agent fault, voicemail, transfers,
    and so on.
@@ -100,7 +102,8 @@ production, so what you review is what you ship.
 ### Credits
 
 A build runs your metric against the sampled calls and runs, and consumes credits
-for each pass, priced the same way the metric optimizer is:
+for each pass, priced the same way the metric optimizer is. Builds with fewer
+than 10 transcripts skip this evaluation pass and do not consume evaluation credits:
 
 - **LLM Judge metrics** — and Python metrics that call `evaluate_llm_judge_metric`
   — are charged at the **LLM-judge** per-evaluation rate.

--- a/documentation/key-concepts/metrics/build-with-ai.mdx
+++ b/documentation/key-concepts/metrics/build-with-ai.mdx
@@ -78,9 +78,12 @@ the agent has them.
     switches to the full form if you'd rather configure everything yourself.)
   </Step>
   <Step title="Describe what to measure">
-    Pick the agent, choose **LLM Judge** or **Python code**, and describe the
-    metric in plain language — what should pass, what should fail, anything the
-    verdict depends on.
+    Pick the agent and describe the metric in plain language — what should
+    pass, what should fail, anything the verdict depends on. Quick Mode builds
+    it as a **Python metric** (deterministic and cheap to evaluate, calling the
+    LLM judge inline only where a language judgment is genuinely needed) and
+    infers the verdict shape — pass/fail, rating, number, or categories — from
+    your description.
   </Step>
   <Step title="Generate">
     Click **Generate Metric**. You're taken back to the metrics list while the
@@ -146,10 +149,10 @@ from the code and the agent's description rather than from predictions. Either
 way it stays valid, runnable Python in the same style as what you wrote.
 
 <Tip>
-You don't have to start from code. Pick **Python code** in Quick Mode — or
-describe the metric in **plain English** in the Python editor — and the builder
-turns it into a working Python metric on the first pass, then refines it from
-there.
+You don't have to start from code. Quick Mode always works this way — plain
+English in, working Python out — and the same applies in the Python editor:
+describe the metric in **plain English** and the builder turns it into runnable
+code on the first pass, then refines it from there.
 </Tip>
 
 Everything the builder produces is the exact code the metric will run in

--- a/documentation/key-concepts/metrics/build-with-ai.mdx
+++ b/documentation/key-concepts/metrics/build-with-ai.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Build a Metric with AI"
-description: "Refine an LLM Judge or Python metric with an AI agent that uses real calls and runs when available, fixes clear edge cases itself, and asks you only when a decision is genuinely ambiguous"
+description: "Refine an LLM Judge or Python metric with an AI agent — quickly from your description, or against your real calls and runs — that fixes clear edge cases itself and asks you only when a decision is genuinely ambiguous"
 sidebarTitle: "Build with AI"
 icon: "wand-magic-sparkles"
 iconType: "solid"
@@ -15,14 +15,43 @@ rounds of trial and error — write a definition, preview it on some calls,
 notice a case it gets wrong, tighten the wording, repeat. **Build with AI**
 collapses that loop into a single conversation.
 
-When you click **Improve** on a metric's definition, an AI agent:
+When you click **Improve** on a metric's definition, you pick a **build mode** and
+an AI agent refines the metric for you.
+
+<Note>
+Build with AI works for both **LLM Judge** metrics (it refines the natural-language
+description) and **Python** metrics (it makes surgical edits to your code — see
+below). You commit the final metric yourself; nothing is saved until you click
+**Use this metric** and then **Create**/**Update**.
+</Note>
+
+### Build modes
+
+<CardGroup cols={2}>
+  <Card title="Quick" icon="bolt">
+    **The default.** Refines the metric straight from your description, the
+    agent's own description, and anything you've told it so far. No sample of
+    calls is run, so there are no evaluation credits to spend and it finishes in
+    **1–2 minutes**. Best for a first draft, or a small wording change.
+  </Card>
+  <Card title="Detailed" icon="magnifying-glass-chart">
+    Runs the draft metric against a sample of your agent's **real calls and
+    runs** first, then refines it against what it actually predicted. Slower
+    (**5–12 minutes**) and it spends evaluation credits, but it is the only mode
+    that can find edge cases you haven't thought of.
+  </Card>
+</CardGroup>
+
+Pick **Detailed** when a metric matters and you want it grounded in real
+transcripts. Pick **Quick** when you want a clean first draft fast, then run a
+Detailed build later once you're happy with the wording.
+
+### What a Detailed build does
 
 1. Cleans up your definition and gives it a quick check. If the intent is
    unclear or the definition has an obvious gap, it asks you a short question
    **up front** — before spending a run on calls it can't yet judge meaningfully.
-2. Runs the definition against a sample of the agent's real **calls and runs**
-   when enough transcript history is available. For a new agent with fewer than
-   10 transcripts, it refines the definition directly instead.
+2. Runs the definition against a sample of the agent's real **calls and runs**.
 3. Reviews the predictions and finds edge cases — early hang-ups, partial
    completions, off-topic calls, caller-vs-agent fault, voicemail, transfers,
    and so on.
@@ -31,11 +60,16 @@ When you click **Improve** on a metric's definition, an AI agent:
    (for example, "should a partial completion count as PASS?").
 5. Proposes a refined definition for you to review and apply.
 
+A Quick build does steps 4 and 5 only — it reasons about the definition itself
+rather than about predictions, and still asks you a question if the metric can't
+be pinned down safely without one.
+
 <Note>
-Build with AI works for both **LLM Judge** metrics (it refines the natural-language
-description) and **Python** metrics (it makes surgical edits to your code — see
-below). You commit the final metric yourself; nothing is saved until you click
-**Use this metric** and then **Create**/**Update**.
+**Not enough history?** A Detailed build needs at least 10 calls or runs to
+sample. A brand-new agent doesn't have them, so the build runs as a Quick one
+instead of stalling on an empty sample — it says so in the chat, and no
+evaluation credits are spent. Your **Detailed** choice is remembered, so a later
+build uses real transcripts once the agent has them.
 </Note>
 
 ### Starting a build
@@ -48,15 +82,15 @@ below). You commit the final metric yourself; nothing is saved until you click
   </Step>
   <Step title="Click Improve">
     The **Improve** button sits next to the Description (LLM Judge) or the Custom
-    Code editor (Python). Pick the agent whose calls and runs the builder should
-    sample from.
+    Code editor (Python). Pick the agent to build against, then choose
+    **Quick** or **Detailed**.
   </Step>
   <Step title="Chat with the builder">
-    The builder works through your calls and runs and either asks a clarifying
-    question or presents a refined definition. Answer questions by selecting an
-    option (the recommended default is marked) or typing your own guidance. You
-    can also message the builder at any time — for example, "make it stricter
-    about confirming the appointment time."
+    The builder either asks a clarifying question or presents a refined
+    definition. Answer questions by selecting an option (the recommended default
+    is marked) or typing your own guidance. You can also message the builder at
+    any time — for example, "make it stricter about confirming the appointment
+    time."
   </Step>
   <Step title="Review and apply">
     When it's done, the builder shows a diff of the proposed definition against
@@ -67,8 +101,9 @@ below). You commit the final metric yourself; nothing is saved until you click
 
 ### Working in the background
 
-A build runs an AI agent over dozens of real calls and runs, so it typically
-takes **a few minutes** (usually 4–6). You don't have to wait on it:
+A Quick build usually takes **1–2 minutes**. A Detailed build runs an AI agent
+over dozens of real calls and runs, so it typically takes **5–12 minutes** —
+longer for a multi-turn Python build. Either way, you don't have to wait on it:
 
 - **Minimize** the chat and it keeps running as a small card in the corner.
 - The card **follows you across the platform** — open another metric, inspect
@@ -77,23 +112,23 @@ takes **a few minutes** (usually 4–6). You don't have to wait on it:
 - Reopen the card any time to see progress, answer a question, or apply the
   result.
 
-The card shows the current step and elapsed time so you always know where the
-build is.
+The card shows the current step, the elapsed time, and the typical range for the
+mode you're running, so you always know where the build is.
 
 ### Python metrics
 
 For a Python metric the builder works in **code**. Before it runs anything, it
 cleans up your starting point — fixing syntax errors and obvious bugs — so a
-rough first draft doesn't stall the build. From there it runs your code on the
-sampled calls and runs and makes the smallest change that fixes each case it
-gets wrong, keeping it valid, runnable Python in the same style as what you
-wrote.
+rough first draft doesn't stall the build. A Detailed build then runs your code
+on the sampled calls and runs and makes the smallest change that fixes each case
+it gets wrong; a Quick build makes the same kind of surgical edits, reasoning
+from the code and the agent's description rather than from predictions. Either
+way it stays valid, runnable Python in the same style as what you wrote.
 
 <Tip>
 You don't have to start from code. Describe the metric in **plain English** in
 the Python editor and the builder turns it into a working Python metric on the
-first pass — then refines it against your real calls and runs like any other
-build.
+first pass — in both modes — then refines it from there.
 </Tip>
 
 Everything the builder produces is the exact code the metric will run in
@@ -101,23 +136,32 @@ production, so what you review is what you ship.
 
 ### Credits
 
-A build runs your metric against the sampled calls and runs, and consumes credits
-for each pass, priced the same way the metric optimizer is. Builds with fewer
-than 10 transcripts skip this evaluation pass and do not consume evaluation credits:
+What a build costs depends entirely on the mode.
+
+**Quick builds** run no evaluation pass, so there is nothing to meter per call.
+They are charged a small **flat amount once per build**, however many
+clarification rounds it takes. A build that fails is not charged.
+
+**Detailed builds** run your metric against the sampled calls and runs and
+consume credits for each pass, priced the same way the metric optimizer is:
 
 - **LLM Judge metrics** — and Python metrics that call `evaluate_llm_judge_metric`
   — are charged at the **LLM-judge** per-evaluation rate.
-- **Python metrics that judge audio** (calling `evaluate_llm_judge_metric` with
-  `audio=True`) are charged at the **audio** per-minute rate times each call's
-  duration. A time window (`audio_start_time`/`audio_end_time`) changes what the
-  judge listens to, not the charge.
+- **LLM Judge metrics with voice recording enabled**, and Python metrics that
+  judge audio (calling `evaluate_llm_judge_metric` with `audio=True`), are
+  charged at the **audio** per-minute rate times each call's duration. A time
+  window (`audio_start_time`/`audio_end_time`) changes what the judge listens to,
+  not the charge.
 - **Pure Python metrics** are charged at the **custom-code** per-evaluation rate.
 
 The cost of a pass is roughly the number of sampled items (≈50) times that rate.
 A pass runs only when the metric definition actually changed, so answering a
 clarifying question or sending a note that doesn't alter the metric won't
-re-charge. Minimizing the chat doesn't stop the build; if you don't want to spend
-more credits, **Stop** it.
+re-charge. A Detailed build that falls back to Quick for lack of history is
+charged as a Quick build.
+
+Minimizing the chat doesn't stop the build; if you don't want to spend more
+credits, **Stop** it. Your current rates are on the **Billing** page.
 
 ## Related Documentation
 

--- a/documentation/key-concepts/metrics/build-with-ai.mdx
+++ b/documentation/key-concepts/metrics/build-with-ai.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Build a Metric with AI"
-description: "Refine an LLM Judge or Python metric with an AI agent — quickly from your description, or against your real calls and runs — that fixes clear edge cases itself and asks you only when a decision is genuinely ambiguous"
+description: "Generate a metric from a plain-language description, or refine an LLM Judge or Python metric against your real calls and runs — the AI fixes clear edge cases itself and asks you only when a decision is genuinely ambiguous"
 sidebarTitle: "Build with AI"
 icon: "wand-magic-sparkles"
 iconType: "solid"
@@ -13,40 +13,36 @@ import { CopyPageButton } from "/snippets/copy-page-button.mdx";
 Writing a metric that behaves exactly the way you intend usually takes a few
 rounds of trial and error — write a definition, preview it on some calls,
 notice a case it gets wrong, tighten the wording, repeat. **Build with AI**
-collapses that loop into a single conversation.
-
-When you click **Improve** on a metric's definition, you pick a **build mode** and
-an AI agent refines the metric for you.
-
-<Note>
-Build with AI works for both **LLM Judge** metrics (it refines the natural-language
-description) and **Python** metrics (it makes surgical edits to your code — see
-below). You commit the final metric yourself; nothing is saved until you click
-**Use this metric** and then **Create**/**Update**.
-</Note>
-
-### Build modes
+collapses that loop, from two places:
 
 <CardGroup cols={2}>
-  <Card title="Quick" icon="bolt">
-    **The default.** Refines the metric straight from your description, the
-    agent's own description, and anything you've told it so far. No sample of
-    calls is run, so there are no evaluation credits to spend and it finishes in
-    **1–2 minutes**. Best for a first draft, or a small wording change.
+  <Card title="Quick Mode" icon="bolt">
+    **The default view of the Create Metric page.** Pick an agent, describe
+    what to measure, and click **Generate Metric** — the AI drafts the metric
+    from your description and the agent's context and **saves it for you**,
+    usually in **1–2 minutes**. No form to fill, no evaluation credits spent.
   </Card>
-  <Card title="Detailed" icon="magnifying-glass-chart">
-    Runs the draft metric against a sample of your agent's **real calls and
-    runs** first, then refines it against what it actually predicted. Slower
-    (**5–12 minutes**) and it spends evaluation credits, but it is the only mode
-    that can find edge cases you haven't thought of.
+  <Card title="Improve (detailed build)" icon="magnifying-glass-chart">
+    The **Improve** button next to a metric's definition runs the draft against
+    a sample of your agent's **real calls and runs** first, then refines it in
+    a conversation. Slower (**5–12 minutes**) and it spends evaluation credits,
+    but it is the only path that can find edge cases you haven't thought of.
   </Card>
 </CardGroup>
 
-Pick **Detailed** when a metric matters and you want it grounded in real
-transcripts. Pick **Quick** when you want a clean first draft fast, then run a
-Detailed build later once you're happy with the wording.
+<Note>
+Both paths work for **LLM Judge** metrics (refining the natural-language
+description) and **Python** metrics (writing and surgically editing code — see
+below). Quick Mode saves the metric itself and links you to it when it's done;
+an **Improve** build commits nothing until you click **Use this metric** and
+then **Create**/**Update**.
+</Note>
 
-### What a Detailed build does
+Use **Improve** when a metric matters and you want it grounded in real
+transcripts. Use **Quick Mode** to get a clean, working metric fast, then run
+an Improve build later once the agent has call history worth testing against.
+
+### What a detailed (Improve) build does
 
 1. Cleans up your definition and gives it a quick check. If the intent is
    unclear or the definition has an obvious gap, it asks you a short question
@@ -60,19 +56,41 @@ Detailed build later once you're happy with the wording.
    (for example, "should a partial completion count as PASS?").
 5. Proposes a refined definition for you to review and apply.
 
-A Quick build does steps 4 and 5 only — it reasons about the definition itself
-rather than about predictions, and still asks you a question if the metric can't
-be pinned down safely without one.
+A Quick Mode build does steps 4 and 5 only — it reasons about the definition
+itself rather than about predictions, makes the most reasonable assumption when
+your description leaves a decision open (and lists what it assumed on the saved
+metric's summary), and only stops to ask when the metric genuinely can't be
+defined safely without you.
 
 <Note>
-**Not enough history?** A Detailed build needs at least 10 calls or runs to
-sample. A brand-new agent doesn't have them, so the build runs as a Quick one
+**Not enough history?** A detailed build needs at least 10 calls or runs to
+sample. A brand-new agent doesn't have them, so the build runs as a quick one
 instead of stalling on an empty sample — it says so in the chat, and no
-evaluation credits are spent. Your **Detailed** choice is remembered, so a later
-build uses real transcripts once the agent has them.
+evaluation credits are spent. A later Improve build uses real transcripts once
+the agent has them.
 </Note>
 
-### Starting a build
+### Quick Mode — generate a metric
+
+<Steps>
+  <Step title="Open Create Metric">
+    **Metrics → Create Metric** lands on Quick Mode. (The **Detail Mode** toggle
+    switches to the full form if you'd rather configure everything yourself.)
+  </Step>
+  <Step title="Describe what to measure">
+    Pick the agent, choose **LLM Judge** or **Python code**, and describe the
+    metric in plain language — what should pass, what should fail, anything the
+    verdict depends on.
+  </Step>
+  <Step title="Generate">
+    Click **Generate Metric**. You're taken back to the metrics list while the
+    build runs in the bottom-right progress card; when it finishes, the card
+    shows **Metric created** with a link straight to the saved metric — named,
+    typed, and enabled on the agent you picked.
+  </Step>
+</Steps>
+
+### Improve — refine against real calls
 
 <Steps>
   <Step title="Write a starting point">
@@ -82,8 +100,7 @@ build uses real transcripts once the agent has them.
   </Step>
   <Step title="Click Improve">
     The **Improve** button sits next to the Description (LLM Judge) or the Custom
-    Code editor (Python). Pick the agent to build against, then choose
-    **Quick** or **Detailed**.
+    Code editor (Python). Pick the agent to build against.
   </Step>
   <Step title="Chat with the builder">
     The builder either asks a clarifying question or presents a refined
@@ -101,16 +118,19 @@ build uses real transcripts once the agent has them.
 
 ### Working in the background
 
-A Quick build usually takes **1–2 minutes**. A Detailed build runs an AI agent
+A Quick Mode build usually takes **1–2 minutes** and runs in the corner card
+from the start — there is no chat to watch. A detailed build runs an AI agent
 over dozens of real calls and runs, so it typically takes **5–12 minutes** —
 longer for a multi-turn Python build. Either way, you don't have to wait on it:
 
-- **Minimize** the chat and it keeps running as a small card in the corner.
+- **Minimize** the builder chat and it keeps running as a small card in the
+  corner.
 - The card **follows you across the platform** — open another metric, inspect
   the example calls the builder linked, or check a run, and the build keeps
   going.
 - Reopen the card any time to see progress, answer a question, or apply the
-  result.
+  result — and a finished Quick Mode build's card links straight to the saved
+  metric.
 
 The card shows the current step, the elapsed time, and the typical range for the
 mode you're running, so you always know where the build is.
@@ -119,16 +139,17 @@ mode you're running, so you always know where the build is.
 
 For a Python metric the builder works in **code**. Before it runs anything, it
 cleans up your starting point — fixing syntax errors and obvious bugs — so a
-rough first draft doesn't stall the build. A Detailed build then runs your code
+rough first draft doesn't stall the build. An Improve build then runs your code
 on the sampled calls and runs and makes the smallest change that fixes each case
-it gets wrong; a Quick build makes the same kind of surgical edits, reasoning
+it gets wrong; a quick build makes the same kind of surgical edits, reasoning
 from the code and the agent's description rather than from predictions. Either
 way it stays valid, runnable Python in the same style as what you wrote.
 
 <Tip>
-You don't have to start from code. Describe the metric in **plain English** in
-the Python editor and the builder turns it into a working Python metric on the
-first pass — in both modes — then refines it from there.
+You don't have to start from code. Pick **Python code** in Quick Mode — or
+describe the metric in **plain English** in the Python editor — and the builder
+turns it into a working Python metric on the first pass, then refines it from
+there.
 </Tip>
 
 Everything the builder produces is the exact code the metric will run in
@@ -138,9 +159,10 @@ production, so what you review is what you ship.
 
 What a build costs depends entirely on the mode.
 
-**Quick builds** run no evaluation pass, so there is nothing to meter per call.
-They are charged a small **flat amount once per build**, however many
-clarification rounds it takes. A build that fails is not charged.
+**Quick builds** (Quick Mode, or an Improve build that fell back to quick) run
+no evaluation pass, so there is nothing to meter per call. They are charged a
+small **flat amount once per build**, however many clarification rounds it
+takes. A build that fails is not charged.
 
 **Detailed builds** run your metric against the sampled calls and runs and
 consume credits for each pass, priced the same way the metric optimizer is:
@@ -157,8 +179,7 @@ consume credits for each pass, priced the same way the metric optimizer is:
 The cost of a pass is roughly the number of sampled items (≈50) times that rate.
 A pass runs only when the metric definition actually changed, so answering a
 clarifying question or sending a note that doesn't alter the metric won't
-re-charge. A Detailed build that falls back to Quick for lack of history is
-charged as a Quick build.
+re-charge.
 
 Minimizing the chat doesn't stop the build; if you don't want to spend more
 credits, **Stop** it. Your current rates are on the **Billing** page.

--- a/documentation/key-concepts/metrics/llm-judge-metric.mdx
+++ b/documentation/key-concepts/metrics/llm-judge-metric.mdx
@@ -59,6 +59,12 @@ Check if the Main Agent ended the call only after all steps in
 {{metadata.instructions}} were completed by the Testing Agent.
 ```
 
+#### Use Voice Recording
+
+Off by default — the judge reads the transcript. Turn it on only for criteria the
+transcript cannot answer, such as tone, pace, silence, or voicemail detection. It
+costs extra; see [Audio Evaluation](#audio-evaluation).
+
 #### Set Triggers
 
 Define when the metric should run under the **Evaluation Trigger** section.
@@ -91,7 +97,40 @@ Before saving, validate your logic immediately within the builder.
 
 ## Audio Evaluation
 
-When calling LLM Judge metrics from Python code, you can set `audio=True` to have the judge analyze the actual voice recording instead of (or in addition to) the transcript text. This is useful for evaluating speech delivery, pacing, tone, and other audio properties that the transcript alone cannot capture.
+Some things cannot be judged from transcript text at all — tone, pace, empathy,
+talking over the caller, dead air, hold music, voicemail and answering-machine
+detection, pronunciation, or who is actually speaking. For these the judge has to
+listen to the **recording**, not read the transcript.
+
+### Enable voice recording on the metric
+
+Turn on **Use voice recording** — the toggle sits just above the Description on
+the metric form — and the judge analyzes the call's audio alongside the
+transcript. Write the description in terms of what to *listen* for:
+
+```
+Did the Main Agent speak at a steady, unhurried pace, without talking
+over the Testing Agent?
+```
+
+<Warning>
+Audio evaluation is billed **per minute of audio** on top of the standard
+per-call LLM-judge charge, so it costs meaningfully more than a transcript-only
+metric. Enable it only for criteria the transcript genuinely cannot answer. Your
+current rates are on the **Billing** page.
+</Warning>
+
+<Note>
+A metric with voice recording enabled analyzes the **whole call**. To judge only
+part of a call, you need a Python metric — see below. [Build with
+AI](/documentation/key-concepts/metrics/build-with-ai) will also turn this
+setting on by itself when your description names an audio-only phenomenon, and
+tell you it did.
+</Note>
+
+### From Python code
+
+When calling LLM Judge metrics from Python code, set `audio=True` to have the judge analyze the actual voice recording instead of (or in addition to) the transcript text. Python metrics can additionally window the audio to a time range:
 
 ```python
 response = evaluate_llm_judge_metric(
@@ -105,11 +144,14 @@ response = evaluate_llm_judge_metric(
 )
 ```
 
+A time window changes what the judge listens to, not the charge — the full call
+duration is billed either way.
+
 See [Python Metric — Audio-Based Analysis](/documentation/key-concepts/metrics/python-metric#audio-based-analysis) for the full pattern.
 
 ## Related Documentation
 
-- [Build a Metric with AI](/documentation/key-concepts/metrics/build-with-ai) - Refine this description with an AI agent that runs it on your real calls and runs
+- [Build a Metric with AI](/documentation/key-concepts/metrics/build-with-ai) - Refine this description with an AI agent, quickly or against your real calls and runs
 - [Metric Variables](/documentation/key-concepts/metrics/metric-variables) - Variables you can use in metric descriptions
 - [Creating Good Metrics](/documentation/guides/creating-good-metric) - Complete guide for building high-fidelity metrics
 - [Python Metric](/documentation/key-concepts/metrics/python-metric) - Write custom evaluation logic in Python, including audio-based evaluation


### PR DESCRIPTION
## Summary
The metric builder now asks users to pick **Quick** (default) or **Detailed** before starting. That supersedes the implicit "fewer than 10 transcripts" fallback this PR originally described, so the page is rewritten around the explicit choice.

Pairs with cekura-ai/vocera.backend#10610 and cekura-ai/vocera.frontend.product#3454.

## `build-with-ai`
- New **Build modes** section: what each mode does, what it costs, how long it takes.
- The numbered walkthrough is now labelled as the *Detailed* flow, with a note on what a Quick build does instead.
- The low-history fallback is kept, reframed as "a Detailed build runs as Quick", and notes the Detailed choice is remembered for later builds.
- **Credits** split by mode: Quick is a flat once-per-build charge and a failed build isn't charged; Detailed keeps the per-pass rates.
- Durations corrected — the page said "a few minutes (usually 4–6)" while the product shows 1–2 min for Quick and 5–12 min for Detailed.

## `llm-judge-metric`
- **Audio Evaluation** said audio was only reachable from Python code. Prose LLM Judge metrics now have a **Use voice recording** toggle, so the section leads with that.
- Warns that it bills per minute of audio on top of the per-call judge charge, and that only Python metrics can window audio to a time range.
- Notes that Build with AI can turn the setting on itself when the description names an audio-only phenomenon.

No rates are hardcoded — the docs point at the Billing page, since per-evaluation and per-minute rates are configurable per deployment.
