### PR TITLE
docs: document RTVI client_message conditional actions

### DIFF
--- a/documentation/key-concepts/evaluators/conditional-actions.mdx
+++ b/documentation/key-concepts/evaluators/conditional-actions.mdx
@@ -550,6 +550,38 @@ Use `<silence>` when you want the conversation to feel natural and allow the mai
     - `text`: SMS message content to send (required)
   </Accordion>
 
+  <Accordion title="<client_message> - Send an RTVI Client Message" icon="code">
+    Send an app-level [RTVI](https://github.com/rtvi-ai) client message to a
+    Pipecat agent under test. Use this when the customer's app would send an
+    event such as opening a form, submitting data, or requesting session
+    arguments during the conversation.
+
+    ```json
+    {
+      "id": 2,
+      "type": "standard",
+      "condition": "The agent asks for the job number",
+      "action": "<client_message t=\"get_session_args\" d='{\"job_number\":\"JB-42\"}' />",
+      "fixed_message": true
+    }
+    ```
+
+    The tag is silent: any text before or after it is spoken separately. Client
+    messages are sent in the order they appear in the action.
+
+    **Attributes:**
+    - `t`: App-defined RTVI message type (required). Use the exact type your
+      agent expects; Cekura does not invent or validate application-specific types.
+    - `d`: Optional app-defined payload. JSON is decoded before it is sent. Use
+      single quotes around the attribute when the JSON contains double quotes,
+      as in the example above.
+
+    <Warning>
+    This tag is available for Pipecat agents that receive RTVI client messages.
+    It requires `fixed_message: true`, like all tags in conditional actions.
+    </Warning>
+  </Accordion>
+
   <Accordion title="<interruption> - Interrupt After Timeout" icon="hand">
     Interrupt the main agent after a specified time and deliver the message.
 


### PR DESCRIPTION
## Summary

Document the RTVI client-message capability added by pipecat-cloud-agents PR #790.

- Add <client_message> to the Conditional Actions supported-tags documentation.
- Show a complete Pipecat/RTVI example with an app-defined type and JSON payload.
- Explain fixed_message, silent dispatch, attribute quoting, and Pipecat RTVI scope.

Related: https://github.com/cekura-ai/pipecat-cloud-agents/pull/790

The backend validation companion is in cekura-ai/vocera.backend#10550.