### PR TITLE
docs: custom provider outbound auto-call (trigger URL required)

### DIFF
--- a/documentation/guides/testing-agents/outbound-auto-call.mdx
+++ b/documentation/guides/testing-agents/outbound-auto-call.mdx
@@ -132,7 +132,7 @@ You can optionally configure a shared secret on your provider credentials. When 
 The secret is write-only — API responses expose only a `trigger_secret_configured` boolean, never the secret value itself.
 
 <Note>
-Your webhook endpoint must be publicly accessible (HTTPS), return a 2xx status code (200–299), and respond within 30 seconds.
+Your webhook endpoint must be publicly accessible (HTTPS), return a 2xx status code (200–299), and respond within 30 seconds. Cekura does not follow redirects, so configure the final URL rather than one that 3xx-redirects to it.
 </Note>
 
 <Info>
@@ -149,6 +149,9 @@ Your webhook should return:
   "call_id": "optional_provider_call_id"
 }
 ```
+
+The body is optional — `204 No Content` or a plain-text body works too. Cekura records
+`call_id` when the response is a JSON object containing one, and proceeds without it otherwise.
 
 ## Troubleshooting
 
@@ -173,6 +176,10 @@ Your webhook should return:
 
   <Accordion title="Custom Provider: Trigger URL Not Configured">
     Custom-hosted agents require a trigger URL to use auto outbound calls. Set `provider.credentials.config.trigger_url` in your agent configuration. Without it, enabling `auto_dial_outbound` is rejected by the API, and dispatch returns a "Trigger URL not configured" error.
+  </Accordion>
+
+  <Accordion title="Trigger URL Rejected">
+    The trigger URL is validated before each request. A "Trigger URL rejected" error means the URL is not usable: the scheme must be `http` or `https`, it must not embed credentials, and the host must resolve to a public address — anything internal, such as a private, loopback or link-local target, is refused.
   </Accordion>
 </AccordionGroup>
 


### PR DESCRIPTION
## What

Documents outbound auto-call support for the Custom (self-hosted) provider in `outbound-auto-call.mdx`:

- New "Custom Provider (Trigger URL Required)" section — no dial-out API, so auto-call always goes through the trigger URL webhook; trigger URL and phone number are mandatory.
- Webhook contract updated to match behavior: any 2xx accepted (JSON body optional, 204/plain-text fine).
- Troubleshooting entry for "Trigger URL not configured" run failures.

Companion to cekura-ai/vocera.backend#10551 and cekura-ai/vocera.frontend.product#3433 — merge after the backend PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)