### PR TITLE
[CEK-8094] docs(pipecat): require Cekura SDK 1.5.3

### DIFF
--- a/documentation/integrations/pipecat/tracing.mdx
+++ b/documentation/integrations/pipecat/tracing.mdx
@@ -35,7 +35,7 @@ export const pipecatPrompt = [
   "- Use cekura.track_pipeline() or cekura.track_and_create_task() — these capture transcripts only, no audio. This is what Cekura simulation calls use.",
   "",
   "Common setup for both:",
-  "1. Install the SDK: pip install \"cekura[pipecat]>=1.5.2\"",
+  "1. Install the SDK: pip install \"cekura[pipecat]>=1.5.3\"",
   "2. Import PipecatTracer: from cekura.pipecat import PipecatTracer",
   "3. Initialize the tracer:",
   "   cekura = PipecatTracer(",
@@ -164,7 +164,7 @@ Use this setup in your test agents while running simulation calls from the Cekur
 <Step title="Install the Cekura Python SDK">
 
 ```bash
-pip install "cekura[pipecat]>=1.5.2"
+pip install "cekura[pipecat]>=1.5.3"
 ```
 
 </Step>
@@ -292,7 +292,7 @@ Use this setup in your production agents for monitoring live calls with audio re
 <Step title="Install the Cekura Python SDK">
 
 ```bash
-pip install "cekura[pipecat]>=1.5.2"
+pip install "cekura[pipecat]>=1.5.3"
 ```
 
 </Step>


### PR DESCRIPTION
## Summary

Updates every Pipecat tracing installation snippet to require cekura[pipecat]>=1.5.3.

This is the first stable release containing support for Cekura trace export when a host application already owns the OpenTelemetry TracerProvider.

## Validation

Documentation-only change; verified the three installation snippets and whitespace checks.