### PR TITLE
security: remove unauthenticated /mcp/monitoring/sessions endpoint CEK-8111

### DIFF
--- a/cekura-mcp-server/openapi_mcp_server.py
+++ b/cekura-mcp-server/openapi_mcp_server.py
@@ -8,7 +8,6 @@ import sys
 import time
 import uuid
 from contextvars import ContextVar
-from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
 import httpx
@@ -889,114 +888,6 @@ async def cekura_load_skill(skill_name: str) -> Dict[str, Any]:
     }
 
 
-def _claude_jsonl_to_cekura_transcript(jsonl_text: str) -> List[Dict[str, object]]:
-    """Convert a Claude Code session transcript (JSONL) to the cekura transcript
-    shape: a list of {role, content, start_time, end_time} entries. Roles are
-    "Testing Agent" (the human user) and "Main Agent" (Claude). Times are
-    seconds since the first entry — the Cekura observe endpoint requires both."""
-    raw: List[Dict[str, object]] = []  # {ts: datetime|None, role, content}
-    for line in jsonl_text.splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            entry = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-
-        msg_type = entry.get("type") or entry.get("role")
-        if msg_type in ("user", "human"):
-            role = "Testing Agent"
-        elif msg_type == "assistant":
-            role = "Main Agent"
-        else:
-            continue
-
-        # Claude Code's transcript wraps the message under entry["message"]; older
-        # / simpler producers may put content at the top level.
-        content = entry.get("content")
-        if content is None:
-            message = entry.get("message")
-            if isinstance(message, dict):
-                content = message.get("content")
-        if isinstance(content, str):
-            text = content
-        elif isinstance(content, list):
-            parts: List[str] = []
-            for block in content:
-                if not isinstance(block, dict):
-                    continue
-                btype = block.get("type")
-                if btype == "text":
-                    parts.append(block.get("text", ""))
-                elif btype == "tool_use":
-                    parts.append(f"[tool_use:{block.get('name', '?')}]")
-                elif btype == "tool_result":
-                    parts.append("[tool_result]")
-            text = "\n".join(p for p in parts if p)
-        else:
-            continue
-
-        text = text.strip()
-        if not text:
-            continue
-
-        ts_raw = entry.get("timestamp")
-        ts: object = None
-        if isinstance(ts_raw, str) and ts_raw:
-            try:
-                ts = datetime.fromisoformat(ts_raw.replace("Z", "+00:00"))
-            except ValueError:
-                ts = None
-        raw.append({"ts": ts, "role": role, "content": text})
-
-    if not raw:
-        return []
-
-    # Anchor t0 at the first parseable timestamp; entries with no timestamp are
-    # placed sequentially after the most recent timed entry.
-    t0 = next((r["ts"] for r in raw if r["ts"] is not None), None)
-    transcript: List[Dict[str, object]] = []
-    for i, r in enumerate(raw):
-        if r["ts"] is not None and t0 is not None:
-            start = (r["ts"] - t0).total_seconds()
-        else:
-            start = float(i)
-        # end_time = next entry's start (or start + 1s for the last item).
-        # Avoid zero-duration ranges, which the upstream may reject.
-        if i + 1 < len(raw) and raw[i + 1]["ts"] is not None and t0 is not None:
-            end = (raw[i + 1]["ts"] - t0).total_seconds()
-        else:
-            end = start + 1.0
-        if end <= start:
-            end = start + 0.1
-        transcript.append({
-            "role": r["role"],
-            "content": r["content"],
-            "start_time": start,
-            "end_time": end,
-        })
-
-    # Enforce per-role monotonicity: the upstream observe serializer rejects any
-    # entry whose start_time or end_time is earlier than the previous entry of
-    # the same role. Claude Code JSONL timestamps can have small inversions
-    # (async recording, ms rounding), so clamp to the running max per role.
-    role_last: Dict[str, Dict[str, float]] = {}
-    for entry in transcript:
-        role = entry["role"]
-        last = role_last.get(role)
-        if last is not None:
-            if entry["start_time"] < last["start"]:
-                entry["start_time"] = last["start"]
-            if entry["end_time"] < last["end"]:
-                entry["end_time"] = last["end"]
-        if entry["end_time"] <= entry["start_time"]:
-            entry["end_time"] = entry["start_time"] + 0.1
-        role_last[role] = {"start": entry["start_time"], "end": entry["end_time"]}
-
-    return transcript
-
-
 def get_request_credential() -> tuple[str, str]:
     """Return (credential, type) from request context. Type is 'bearer' or 'api_key'.
 
@@ -1375,87 +1266,6 @@ def main():
             "tools_registered": len(operations_registry)
         })
 
-    async def monitoring_session_create(request):
-        # Forwards the Claude Code session transcript to the Cekura observability
-        # ingestion endpoint (POST /observability/v1/observe/) as a CallLog.
-        # Agent ID + API key are read from env for now — eventually these should
-        # come from the request (per-user credentials, per-skill agent mapping).
-        try:
-            payload = await request.json()
-        except Exception as e:
-            return JSONResponse({"error": f"invalid JSON body: {e}"}, status_code=400)
-
-        session_id = payload.get("session_id")
-        skill = payload.get("skill")
-        transcript_jsonl = payload.get("transcript_jsonl")
-
-        if not isinstance(session_id, str) or not session_id:
-            return JSONResponse({"error": "missing or invalid 'session_id'"}, status_code=400)
-        if not isinstance(skill, str) or not skill:
-            return JSONResponse({"error": "missing or invalid 'skill'"}, status_code=400)
-        if not isinstance(transcript_jsonl, str):
-            return JSONResponse({"error": "missing or invalid 'transcript_jsonl' (expected string)"}, status_code=400)
-
-        agent_id_raw = os.environ.get("CEKURA_OBSERVE_AGENT_ID", "").strip()
-        if not agent_id_raw:
-            return JSONResponse({"error": "CEKURA_OBSERVE_AGENT_ID is not configured on the server"}, status_code=500)
-        try:
-            agent_id = int(agent_id_raw)
-        except ValueError:
-            return JSONResponse({"error": f"CEKURA_OBSERVE_AGENT_ID must be an integer, got {agent_id_raw!r}"}, status_code=500)
-
-        api_key = os.environ.get("CEKURA_OBSERVE_API_KEY") or os.environ.get("CEKURA_API_KEY")
-        if not api_key:
-            return JSONResponse({"error": "CEKURA_OBSERVE_API_KEY (or CEKURA_API_KEY) is not configured on the server"}, status_code=500)
-
-        transcript = _claude_jsonl_to_cekura_transcript(transcript_jsonl)
-        if not transcript:
-            logger.info(f"observe: session {session_id} produced empty transcript after conversion — skipping")
-            return JSONResponse({"status": "skipped", "reason": "empty transcript after conversion"})
-
-        now = datetime.now(timezone.utc)
-        # Suffix the call_id with a per-event timestamp so repeated Stop-hook
-        # snapshots for the same Claude session don't collide on the backend.
-        call_id = f"claude-{session_id}-{int(now.timestamp())}"[:100]
-
-        body = {
-            "agent": agent_id,
-            "call_id": call_id,
-            "transcript_type": "cekura",
-            "transcript_json": transcript,
-            "timestamp": now.isoformat(),
-            "metadata": {
-                "source": "claude-code",
-                "skill": skill,
-                "claude_session_id": session_id,
-            },
-        }
-
-        observe_url = f"{server_config.base_url}/observability/v1/observe/"
-        try:
-            async with httpx.AsyncClient(timeout=httpx.Timeout(15.0, connect=5.0)) as client:
-                resp = await client.post(
-                    observe_url,
-                    headers={
-                        "Content-Type": "application/json",
-                        "X-CEKURA-API-KEY": api_key,
-                    },
-                    json=body,
-                )
-        except httpx.RequestError as e:
-            logger.error(f"observe: network error for session {session_id}: {e}")
-            return JSONResponse({"error": f"observe request failed: {e}"}, status_code=502)
-
-        if resp.status_code >= 400:
-            logger.error(f"observe: upstream returned {resp.status_code} for session {session_id}: {resp.text[:500]}")
-            return JSONResponse(
-                {"error": "observe upstream rejected request", "status": resp.status_code, "body": resp.text[:500]},
-                status_code=502,
-            )
-
-        logger.info(f"observe: forwarded session {session_id} as call_id={call_id} (skill={skill}, turns={len(transcript)})")
-        return JSONResponse({"status": "ok", "call_id": call_id, "upstream_status": resp.status_code})
-
     def _has_api_key(request) -> bool:
         return bool(
             request.headers.get('X-CEKURA-API-KEY')
@@ -1494,7 +1304,6 @@ def main():
     app.router.routes.insert(3, Route("/.well-known/oauth-authorization-server", oauth_as_metadata))
     app.router.routes.insert(4, Route("/mcp/health", health_check))
     app.router.routes.insert(5, Route("/mcp/healthz", health_check))
-    app.router.routes.insert(6, Route("/mcp/monitoring/sessions", monitoring_session_create, methods=["POST"]))
 
     app.add_middleware(CredentialMiddleware)
     logger.info("Credential middleware added (API key + Bearer token support)")


### PR DESCRIPTION
## Problem

`POST /mcp/monitoring/sessions` was an **unauthenticated write executing with the server's own authority**.

`CredentialMiddleware` checks only that `X-CEKURA-API-KEY` or a Bearer token is *present*, never that it is valid. That is safe for every other `/mcp/` route, because there the caller's credential is forwarded upstream and the backend rejects it if bad — presence check plus remote validation adds up to real authentication.

`monitoring_session_create` broke that invariant. It discarded the caller's credential and authenticated the upstream write with the server's own `CEKURA_OBSERVE_API_KEY`, attributing the record to `CEKURA_OBSERVE_AGENT_ID`. The caller's credential was validated *nowhere* — not locally (presence only), not remotely (never sent).

Result: any request carrying a non-empty auth header could write attacker-authored transcripts as CallLogs under the server's identity.

```
POST https://api.cekura.ai/mcp/monitoring/sessions
X-CEKURA-API-KEY: literally-anything
{"session_id":"a","skill":"b","transcript_jsonl":"<attacker-authored>"}
```

The path sits under `/mcp/`, which the prod ALB forwards, so it was internet-reachable. It is absent from `NO_AUTH_PATHS`, so the presence-only branch was exactly what governed it. Impact is integrity, not confidentiality — fabricated CallLogs polluting the observability agent; the server key is never returned in a response, so it was not disclosed.

## Change

Removed:
- the `monitoring_session_create` handler
- its route registration
- the `_claude_jsonl_to_cekura_transcript` helper (only caller was the handler)
- the now-unused `datetime` import

191 deletions, no insertions.

Deleting the handler also disposes of two lesser issues that lived in it: an unbounded `request.json()` body parse (memory/CPU DoS via a large JSONL payload, reachable over the same unauthenticated path) and upstream error bodies returned verbatim to the caller.

## Verification

- `python3 -m py_compile` passes.
- Test suite: **122 passed, 8 failed** — byte-identical to the `main` baseline, so no regressions. The 8 pre-existing failures are overlay drift, config, and a description-truncation test, all unrelated to this change. `test_health_check.py` and `test_request_credentials.py` — the suites covering code adjacent to the deletion — pass.

## Follow-up, not in this PR

- [ ] Remove `CEKURA_OBSERVE_AGENT_ID` / `CEKURA_OBSERVE_API_KEY` from the prod secret bundle `cet-prd-usw2-mcp-secret-HnC2v3`. Note the handler also fell back to `CEKURA_API_KEY`, so either variable was sufficient to make it live.
- [ ] Check Datadog (`dd_source: mcp-server`) for the handler's success log line `observe: forwarded session ...` to determine whether traffic was only the intended hook or something else. That decides whether the observe key needs rotating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)