### PR TITLE
Deploy ElevenLabs MCP as a standalone ECS service

### DIFF
--- a/.github/workflows/deploy-elevenlabs-mcp.yml
+++ b/.github/workflows/deploy-elevenlabs-mcp.yml
@@ -1,0 +1,148 @@
+name: Deploy ElevenLabs MCP Server (PROD)
+
+# Builds the ElevenLabs MCP wrapper and deploys one Fargate task in the
+# existing prod us-west-2 ECS cluster. The service is exposed through its
+# dedicated ALB host, elevenlabs-mcp.cekura.ai, so it does not conflict with
+# the existing /mcp rule for the Cekura MCP server.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'elevenlabs-mcp/**'
+      - '.github/workflows/deploy-elevenlabs-mcp.yml'
+
+env:
+  AWS_REGION: us-west-2
+  ECR_REPOSITORY: cekura/elevenlabs-mcp
+  ECS_CLUSTER: cet-prd-usw2-cekura-ecs-cluster
+  ECS_SERVICE: cet-prd-usw2-elevenlabs-mcp-ecs-service
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: deploy-elevenlabs-mcp-prod
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      image-tag: ${{ steps.construct-tag.outputs.image-tag }}
+      registry: ${{ steps.login-ecr.outputs.registry }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          version: latest
+
+      - name: Configure AWS credentials (shared services for ECR push)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN_SHARED }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Construct Docker image tag
+        id: construct-tag
+        run: |
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          BRANCH_NAME=${GITHUB_REF_NAME//\//-}
+          IMAGE_TAG="${BRANCH_NAME}-${SHORT_SHA}"
+          echo "image-tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push image to ECR
+        uses: docker/build-push-action@v6
+        with:
+          context: ./elevenlabs-mcp
+          file: ./elevenlabs-mcp/Dockerfile
+          push: true
+          tags: ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ steps.construct-tag.outputs.image-tag }}
+          cache-from: |
+            type=gha,scope=elevenlabs-mcp-${{ github.ref_name }}
+            type=gha,scope=elevenlabs-mcp-main
+          cache-to: type=gha,mode=max,scope=elevenlabs-mcp-${{ github.ref_name }}
+
+  deploy:
+    name: deploy
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (workload account for ECS deploy)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN_PROD }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Render + register task definition
+        id: register
+        run: |
+          sed "s|<IMAGE_TAG>|${{ needs.build.outputs.image-tag }}|g" \
+            elevenlabs-mcp/deployment/ecs/prod-usw2/elevenlabs-mcp-task-def.json \
+            > /tmp/elevenlabs-mcp-task-def.rendered.json
+          TASK_DEF_ARN=$(aws ecs register-task-definition \
+            --cli-input-json file:///tmp/elevenlabs-mcp-task-def.rendered.json \
+            --query 'taskDefinition.taskDefinitionArn' --output text)
+          echo "task-def-arn=$TASK_DEF_ARN" >> "$GITHUB_OUTPUT"
+
+      - name: Update ECS service
+        run: |
+          aws ecs update-service \
+            --cluster "$ECS_CLUSTER" \
+            --service "$ECS_SERVICE" \
+            --task-definition "${{ steps.register.outputs.task-def-arn }}" \
+            --desired-count 1 \
+            --force-new-deployment \
+            --query 'service.[serviceName,taskDefinition,desiredCount]' --output text
+
+      - name: Wait for service stable
+        run: |
+          aws ecs wait services-stable --cluster "$ECS_CLUSTER" --services "$ECS_SERVICE"
+          echo "✅ Service stable"
+
+  notify:
+    needs: [build, deploy]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Compose message
+        id: collect
+        run: |
+          IMAGE_TAG="${{ needs.build.outputs.image-tag }}"
+          if [ "${{ needs.build.result }}" != "success" ]; then
+            echo "message=*❌ elevenlabs-mcp build failed for prod!* (tag: ${IMAGE_TAG:-n/a})" >> "$GITHUB_OUTPUT"
+          elif [ "${{ needs.deploy.result }}" = "success" ]; then
+            echo "message=*✅ elevenlabs-mcp deployed to prod* (tag: ${IMAGE_TAG})" >> "$GITHUB_OUTPUT"
+          else
+            DD_LINK="https://us5.datadoghq.com/logs?query=env%3Aprod%20version%3A${IMAGE_TAG}%20service%3Aelevenlabs-mcp"
+            echo "message=*❌ elevenlabs-mcp deploy to prod failed* (tag: ${IMAGE_TAG}) - <${DD_LINK}|Datadog logs>" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Notify Slack
+        if: vars.SLACK_DEPLOYMENTS_CHANNEL != ''
+        env:
+          SLACK_TOKEN: ${{ secrets.SLACK_BOT_BEARER_TOKEN }}
+          SLACK_CHANNEL: ${{ vars.SLACK_DEPLOYMENTS_CHANNEL }}
+          MESSAGE: ${{ steps.collect.outputs.message }}
+        run: |
+          if [ -z "$SLACK_TOKEN" ] || [ -z "$SLACK_CHANNEL" ]; then
+            echo "(Slack creds missing — skipping notification)"
+            exit 0
+          fi
+          curl -sS -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer $SLACK_TOKEN" \
+            -H 'Content-Type: application/json; charset=utf-8' \
+            -d "$(jq -n --arg ch "$SLACK_CHANNEL" --arg msg "$MESSAGE" '{channel:$ch,text:$msg}')" \
+            | jq '{ok,error}'

--- a/.github/workflows/deploy-elevenlabs-mcp.yml
+++ b/.github/workflows/deploy-elevenlabs-mcp.yml
@@ -2,7 +2,7 @@ name: Deploy ElevenLabs MCP Server (PROD)
 
 # Builds the ElevenLabs MCP wrapper and deploys one Fargate task in the
 # existing prod us-west-2 ECS cluster. The service is exposed through its
-# dedicated ALB host, elevenlabs-mcp.cekura.ai, so it does not conflict with
+# dedicated ALB host, elevenlabs.cekura.ai, so it does not conflict with
 # the existing /mcp rule for the Cekura MCP server.
 
 on:

--- a/elevenlabs-mcp/README.md
+++ b/elevenlabs-mcp/README.md
@@ -25,38 +25,38 @@ The production deployment is a separate one-task Fargate service in the existing
 - Task definition: `deployment/ecs/prod-usw2/elevenlabs-mcp-task-def.json`
 
 The `Deploy ElevenLabs MCP Server (PROD)` workflow builds and deploys the
-service whenever `elevenlabs-mcp/**` changes on `main`. Create the ECS service,
-target group, listener rule, DNS record, secret, and IAM permission once before
-the first workflow run.
+service whenever `elevenlabs-mcp/**` changes on `main`. The task reuses the
+existing Cekura MCP task role and secret, so no new secret or IAM role is
+needed.
 
-1. Create the Secrets Manager secret named
-   `cet-prd-usw2-elevenlabs-mcp-secret` in `us-west-2`. Store these values in
-   its JSON value:
+Add these namespaced values to the existing
+`cet-prd-usw2-mcp-secret` JSON in `us-west-2`:
 
    ```text
-   OAUTH_TOKEN_SECRET=<same value used by the Cekura backend>
-   MCP_SERVER_URL=https://ELEVENLABS_MCP_HOST/mcp
-   MCP_ISSUER_URL=<backend OAUTH_AUDIENCE>
-   CEKURA_OAUTH_AUDIENCE=<backend OAUTH_AUDIENCE>
+   ELEVENLABS_MCP_OAUTH_TOKEN_SECRET=<same value used by the Cekura backend>
+   ELEVENLABS_MCP_SERVER_URL=https://ELEVENLABS_MCP_HOST/mcp
+   ELEVENLABS_MCP_ISSUER_URL=https://api.cekura.ai
+   ELEVENLABS_MCP_CEKURA_OAUTH_AUDIENCE=https://api.cekura.ai
    ```
 
-   Production uses `https://api.cekura.ai` as its OAuth audience. Stage must use its stage backend URL.
+Production uses `https://api.cekura.ai` as its OAuth audience. Stage must use
+its stage backend URL. Keep these names prefixed so they cannot overwrite
+configuration used by the existing Cekura MCP container when both services
+read the same secret.
 
-2. Grant the task role
-   `cet-prd-usw2-elevenlabs-mcp-task-iam-role` `secretsmanager:GetSecretValue`
-   on that secret. Use the existing prod ECS execution role and networking
-   configuration used by `mcp-server`.
-3. Create an HTTPS ALB target group for port `8080`, with `GET /mcp/health` as
+1. Create an HTTPS ALB target group for port `8080`, with `GET /mcp/health` as
    the health check. Allow inbound traffic to the task only from the ALB
    security group.
-4. Add an ALB host rule for `elevenlabs-mcp.cekura.ai` forwarding these paths
+2. Add an ALB host rule for `elevenlabs-mcp.cekura.ai` forwarding these paths
    to the target group:
    `/mcp*` and `/.well-known/oauth-protected-resource`.
    This dedicated host avoids conflicting with the existing `api.cekura.ai/mcp`
    rule used by the Cekura MCP server. Add an alias record for
    `elevenlabs-mcp.cekura.ai` to the ALB.
-5. Create the ECS service with the task definition above and desired count
-   `1`; subsequent image updates are handled by the workflow.
+3. Create the ECS service with the task definition above and desired count
+   `1`, using the existing MCP service's cluster, subnets, security groups,
+   execution role, and task role. Subsequent image updates are handled by the
+   workflow.
 
 The task stores no ElevenLabs API key.
 
@@ -96,7 +96,7 @@ On the first connection, Claude opens the Cekura OAuth login and consent page. A
 
 ## Security
 
-The server exposes the complete official ElevenLabs MCP tool set. It verifies Cekura OAuth tokens locally with the configured `OAUTH_TOKEN_SECRET`; it does not call the Cekura backend on MCP requests.
+The server exposes the complete official ElevenLabs MCP tool set. It verifies Cekura OAuth tokens locally with the configured `ELEVENLABS_MCP_OAUTH_TOKEN_SECRET`; it does not call the Cekura backend on MCP requests.
 
 OAuth access tokens remain valid until expiry, so disabling a user does not take effect here until the active token expires. Keep the OAuth access-token lifetime short.
 

--- a/elevenlabs-mcp/README.md
+++ b/elevenlabs-mcp/README.md
@@ -14,10 +14,24 @@ Streamable HTTP wrapper for the official `elevenlabs-mcp` package. It authentica
 
 ## Deployment
 
-1. Build this folder's Docker image and push it to ECR.
-2. Run it as a Fargate task behind an HTTPS ALB on port `8080`.
-3. Set `AWS_SECRET_NAME` on the task. Its task role needs `secretsmanager:GetSecretValue` for that secret.
-4. Store these values in the referenced Secrets Manager JSON:
+The production deployment is a separate one-task Fargate service in the existing
+`cet-prd-usw2-cekura-ecs-cluster`:
+
+- ECS family: `elevenlabs-mcp`
+- ECS service: `cet-prd-usw2-elevenlabs-mcp-ecs-service`
+- ECR repository: `cekura/elevenlabs-mcp`
+- Container/target-group port: `8080`
+- Desired count: `1`
+- Task definition: `deployment/ecs/prod-usw2/elevenlabs-mcp-task-def.json`
+
+The `Deploy ElevenLabs MCP Server (PROD)` workflow builds and deploys the
+service whenever `elevenlabs-mcp/**` changes on `main`. Create the ECS service,
+target group, listener rule, DNS record, secret, and IAM permission once before
+the first workflow run.
+
+1. Create the Secrets Manager secret named
+   `cet-prd-usw2-elevenlabs-mcp-secret` in `us-west-2`. Store these values in
+   its JSON value:
 
    ```text
    OAUTH_TOKEN_SECRET=<same value used by the Cekura backend>
@@ -28,8 +42,21 @@ Streamable HTTP wrapper for the official `elevenlabs-mcp` package. It authentica
 
    Production uses `https://api.cekura.ai` as its OAuth audience. Stage must use its stage backend URL.
 
-5. Route `/mcp`, `/mcp/*`, and `/.well-known/oauth-protected-resource` to the task. Use `GET /mcp/health` as the target-group health check.
-6. Allow inbound traffic to the task only from the ALB security group.
+2. Grant the task role
+   `cet-prd-usw2-elevenlabs-mcp-task-iam-role` `secretsmanager:GetSecretValue`
+   on that secret. Use the existing prod ECS execution role and networking
+   configuration used by `mcp-server`.
+3. Create an HTTPS ALB target group for port `8080`, with `GET /mcp/health` as
+   the health check. Allow inbound traffic to the task only from the ALB
+   security group.
+4. Add an ALB host rule for `elevenlabs-mcp.cekura.ai` forwarding these paths
+   to the target group:
+   `/mcp*` and `/.well-known/oauth-protected-resource`.
+   This dedicated host avoids conflicting with the existing `api.cekura.ai/mcp`
+   rule used by the Cekura MCP server. Add an alias record for
+   `elevenlabs-mcp.cekura.ai` to the ALB.
+5. Create the ECS service with the task definition above and desired count
+   `1`; subsequent image updates are handled by the workflow.
 
 The task stores no ElevenLabs API key.
 

--- a/elevenlabs-mcp/README.md
+++ b/elevenlabs-mcp/README.md
@@ -34,7 +34,7 @@ Add these namespaced values to the existing
 
    ```text
    ELEVENLABS_MCP_OAUTH_TOKEN_SECRET=<same value used by the Cekura backend>
-   ELEVENLABS_MCP_SERVER_URL=https://ELEVENLABS_MCP_HOST/mcp
+   ELEVENLABS_MCP_SERVER_URL=https://elevenlabs.cekura.ai/mcp
    ELEVENLABS_MCP_ISSUER_URL=https://api.cekura.ai
    ELEVENLABS_MCP_CEKURA_OAUTH_AUDIENCE=https://api.cekura.ai
    ```
@@ -47,12 +47,12 @@ read the same secret.
 1. Create an HTTPS ALB target group for port `8080`, with `GET /mcp/health` as
    the health check. Allow inbound traffic to the task only from the ALB
    security group.
-2. Add an ALB host rule for `elevenlabs-mcp.cekura.ai` forwarding these paths
-   to the target group:
-   `/mcp*` and `/.well-known/oauth-protected-resource`.
+2. Add an ALB host rule for `elevenlabs.cekura.ai` forwarding traffic to the
+   target group. A host-only rule is sufficient because this uses a dedicated
+   hostname and the service handles `/mcp` and OAuth discovery routes itself.
    This dedicated host avoids conflicting with the existing `api.cekura.ai/mcp`
    rule used by the Cekura MCP server. Add an alias record for
-   `elevenlabs-mcp.cekura.ai` to the ALB.
+   `elevenlabs.cekura.ai` to the ALB.
 3. Create the ECS service with the task definition above and desired count
    `1`, using the existing MCP service's cluster, subnets, security groups,
    execution role, and task role. Subsequent image updates are handled by the
@@ -68,8 +68,8 @@ The client authenticates through Cekura OAuth and also sends its own ElevenLabs 
 
 ```bash
 codex mcp add elevenlabs \
-  --url https://ELEVENLABS_MCP_HOST/mcp \
-  --oauth-resource https://ELEVENLABS_MCP_HOST/mcp
+  --url https://elevenlabs.cekura.ai/mcp \
+  --oauth-resource https://elevenlabs.cekura.ai/mcp
 ```
 
 Add the ElevenLabs key to `~/.codex/config.toml`:
@@ -88,7 +88,7 @@ codex mcp login elevenlabs
 ### Claude Code
 
 ```bash
-claude mcp add --transport http elevenlabs https://ELEVENLABS_MCP_HOST/mcp \
+claude mcp add --transport http elevenlabs https://elevenlabs.cekura.ai/mcp \
   --header "xi-elevenlabs-api-key: YOUR_ELEVENLABS_API_KEY"
 ```
 

--- a/elevenlabs-mcp/deployment/ecs/prod-usw2/elevenlabs-mcp-task-def.json
+++ b/elevenlabs-mcp/deployment/ecs/prod-usw2/elevenlabs-mcp-task-def.json
@@ -1,0 +1,128 @@
+{
+  "containerDefinitions": [
+    {
+      "name": "elevenlabs-mcp",
+      "image": "212351099297.dkr.ecr.us-west-2.amazonaws.com/cekura/elevenlabs-mcp:<IMAGE_TAG>",
+      "cpu": 0,
+      "portMappings": [
+        {
+          "containerPort": 8080,
+          "hostPort": 8080,
+          "protocol": "tcp",
+          "name": "elevenlabs-mcp-8080-port",
+          "appProtocol": "http"
+        }
+      ],
+      "essential": true,
+      "environment": [
+        {
+          "name": "AWS_SECRET_NAME",
+          "value": "cet-prd-usw2-elevenlabs-mcp-secret"
+        },
+        {
+          "name": "MCP_SERVER_URL",
+          "value": "https://elevenlabs-mcp.cekura.ai/mcp"
+        },
+        {
+          "name": "MCP_ISSUER_URL",
+          "value": "https://api.cekura.ai"
+        },
+        {
+          "name": "CEKURA_OAUTH_AUDIENCE",
+          "value": "https://api.cekura.ai"
+        }
+      ],
+      "mountPoints": [],
+      "volumesFrom": [],
+      "logConfiguration": {
+        "logDriver": "awsfirelens",
+        "options": {
+          "dd_message_key": "log",
+          "provider": "ecs",
+          "dd_service": "elevenlabs-mcp",
+          "Host": "http-intake.logs.us5.datadoghq.com",
+          "TLS": "on",
+          "dd_source": "elevenlabs-mcp",
+          "dd_tags": "env:prod,version:<IMAGE_TAG>",
+          "Name": "datadog"
+        },
+        "secretOptions": [
+          {
+            "name": "apikey",
+            "valueFrom": "arn:aws:secretsmanager:us-west-2:593108103736:secret:cet-prd-usw2-datadog-api-key-secret-HSzirQ"
+          }
+        ]
+      },
+      "systemControls": []
+    },
+    {
+      "name": "log_router",
+      "image": "public.ecr.aws/aws-observability/aws-for-fluent-bit:stable",
+      "cpu": 0,
+      "memoryReservation": 51,
+      "portMappings": [],
+      "essential": false,
+      "environment": [],
+      "mountPoints": [],
+      "volumesFrom": [],
+      "user": "0",
+      "systemControls": [],
+      "firelensConfiguration": {
+        "type": "fluentbit",
+        "options": {
+          "enable-ecs-log-metadata": "true"
+        }
+      }
+    },
+    {
+      "name": "datadog-agent",
+      "image": "212351099297.dkr.ecr.us-west-2.amazonaws.com/datadog/agent:7.70.0",
+      "cpu": 0,
+      "portMappings": [],
+      "essential": false,
+      "environment": [
+        {
+          "name": "ECS_FARGATE",
+          "value": "true"
+        },
+        {
+          "name": "DD_APM_ENABLED",
+          "value": "true"
+        },
+        {
+          "name": "DD_TAGS",
+          "value": "service:elevenlabs-mcp env:prod version:<IMAGE_TAG>"
+        },
+        {
+          "name": "DD_SITE",
+          "value": "us5.datadoghq.com"
+        }
+      ],
+      "environmentFiles": [],
+      "mountPoints": [],
+      "secrets": [
+        {
+          "name": "DD_API_KEY",
+          "valueFrom": "arn:aws:secretsmanager:us-west-2:593108103736:secret:cet-prd-usw2-datadog-api-key-secret-HSzirQ"
+        }
+      ],
+      "systemControls": [],
+      "volumesFrom": []
+    }
+  ],
+  "family": "elevenlabs-mcp",
+  "taskRoleArn": "arn:aws:iam::593108103736:role/cet-prd-usw2-elevenlabs-mcp-task-iam-role",
+  "executionRoleArn": "arn:aws:iam::593108103736:role/cet-prd-usw2-backend-task-exec-iam-role",
+  "networkMode": "awsvpc",
+  "volumes": [],
+  "placementConstraints": [],
+  "runtimePlatform": {
+    "cpuArchitecture": "X86_64",
+    "operatingSystemFamily": "LINUX"
+  },
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "cpu": "1024",
+  "memory": "2048"
+}

--- a/elevenlabs-mcp/deployment/ecs/prod-usw2/elevenlabs-mcp-task-def.json
+++ b/elevenlabs-mcp/deployment/ecs/prod-usw2/elevenlabs-mcp-task-def.json
@@ -17,19 +17,7 @@
       "environment": [
         {
           "name": "AWS_SECRET_NAME",
-          "value": "cet-prd-usw2-elevenlabs-mcp-secret"
-        },
-        {
-          "name": "MCP_SERVER_URL",
-          "value": "https://elevenlabs-mcp.cekura.ai/mcp"
-        },
-        {
-          "name": "MCP_ISSUER_URL",
-          "value": "https://api.cekura.ai"
-        },
-        {
-          "name": "CEKURA_OAUTH_AUDIENCE",
-          "value": "https://api.cekura.ai"
+          "value": "arn:aws:secretsmanager:us-west-2:593108103736:secret:cet-prd-usw2-mcp-secret-HnC2v3"
         }
       ],
       "mountPoints": [],
@@ -111,7 +99,7 @@
     }
   ],
   "family": "elevenlabs-mcp",
-  "taskRoleArn": "arn:aws:iam::593108103736:role/cet-prd-usw2-elevenlabs-mcp-task-iam-role",
+  "taskRoleArn": "arn:aws:iam::593108103736:role/cet-prd-usw2-mcp-server-task-iam-role",
   "executionRoleArn": "arn:aws:iam::593108103736:role/cet-prd-usw2-backend-task-exec-iam-role",
   "networkMode": "awsvpc",
   "volumes": [],

--- a/elevenlabs-mcp/server.py
+++ b/elevenlabs-mcp/server.py
@@ -22,13 +22,19 @@ from starlette.routing import Route
 from elevenlabs_mcp import server as elevenlabs
 
 _request_key = contextvars.ContextVar("elevenlabs_api_key", default="")
-_oauth_secret = os.getenv("OAUTH_TOKEN_SECRET")
-_oauth_audience = os.getenv("CEKURA_OAUTH_AUDIENCE", "https://api.cekura.ai")
-_mcp_server_url = os.getenv("MCP_SERVER_URL", "http://localhost:8080/mcp").rstrip("/")
-_mcp_issuer_url = os.getenv("MCP_ISSUER_URL", "https://api.cekura.ai").rstrip("/")
+_oauth_secret = os.getenv("ELEVENLABS_MCP_OAUTH_TOKEN_SECRET")
+_oauth_audience = os.getenv(
+    "ELEVENLABS_MCP_CEKURA_OAUTH_AUDIENCE", "https://api.cekura.ai"
+)
+_mcp_server_url = os.getenv(
+    "ELEVENLABS_MCP_SERVER_URL", "http://localhost:8080/mcp"
+).rstrip("/")
+_mcp_issuer_url = os.getenv(
+    "ELEVENLABS_MCP_ISSUER_URL", "https://api.cekura.ai"
+).rstrip("/")
 
 if not _oauth_secret:
-    raise RuntimeError("OAUTH_TOKEN_SECRET is required")
+    raise RuntimeError("ELEVENLABS_MCP_OAUTH_TOKEN_SECRET is required")
 
 
 def _inject_key(request):


### PR DESCRIPTION
## Summary
- add a standalone `elevenlabs-mcp` Fargate task definition matching the existing Cekura MCP service shape
- add a production ECS build/register/deploy workflow
- reuse the existing Cekura MCP Secrets Manager secret and task IAM role
- document the one-time ECS, ALB, and DNS setup

## Runtime configuration
- ECS cluster: `cet-prd-usw2-cekura-ecs-cluster`
- ECS service: `cet-prd-usw2-elevenlabs-mcp-ecs-service`
- ECR repository: `cekura/elevenlabs-mcp`
- public URL: `https://elevenlabs.cekura.ai/mcp`
- desired count: 1

## Shared secret configuration
Add these namespaced keys to the existing `cet-prd-usw2-mcp-secret`:
- `ELEVENLABS_MCP_OAUTH_TOKEN_SECRET`
- `ELEVENLABS_MCP_SERVER_URL`
- `ELEVENLABS_MCP_ISSUER_URL`
- `ELEVENLABS_MCP_CEKURA_OAUTH_AUDIENCE`

The task reuses `cet-prd-usw2-mcp-server-task-iam-role`; no new secret or IAM role is required.

## One-time AWS prerequisites
- ECR repository (already created)
- port-8080 target group and health check at `/mcp/health`
- ALB host rule priority 45 for `elevenlabs.cekura.ai`, forwarding to the new target group
- Route 53 alias for `elevenlabs.cekura.ai`
- ECS service using the existing MCP cluster, subnets, security groups, execution role, and task role

## Validation
- task-definition JSON parsed successfully
- Python wrapper syntax compiled successfully
- workflow YAML parsed successfully
- workflow shell blocks passed `bash -n`

No AWS resources are created by this PR.