### PR TITLE
[Auto] Sync docs for backend PR #10551

### DIFF
--- a/api-reference/test_framework/fetch-external-scenarios-json-schema.mdx
+++ b/api-reference/test_framework/fetch-external-scenarios-json-schema.mdx
@@ -1,0 +1,6 @@
+---
+title: Fetch External Scenarios JSON Schema
+description: "Fetch the JSON Schema for test-suite spec files"
+openapi: get /test_framework/v1/scenarios-external/json_schema/
+slug: fetch-external-scenarios-json-schema
+---

--- a/api-reference/test_framework/fetch-scenarios-json-schema.mdx
+++ b/api-reference/test_framework/fetch-scenarios-json-schema.mdx
@@ -1,0 +1,6 @@
+---
+title: Fetch Scenarios JSON Schema
+description: "Fetch the JSON Schema for test-suite spec files"
+openapi: get /test_framework/v1/scenarios/json_schema/
+slug: fetch-scenarios-json-schema
+---

--- a/api-reference/test_framework/fetch-scenarios-v2-json-schema.mdx
+++ b/api-reference/test_framework/fetch-scenarios-v2-json-schema.mdx
@@ -1,0 +1,6 @@
+---
+title: Fetch Scenarios V2 JSON Schema
+description: "Fetch the JSON Schema for test-suite spec files"
+openapi: get /test_framework/v2/scenarios/json_schema/
+slug: fetch-scenarios-v2-json-schema
+---

--- a/api-reference/test_framework/run-external-scenarios-voice.mdx
+++ b/api-reference/test_framework/run-external-scenarios-voice.mdx
@@ -1,0 +1,6 @@
+---
+title: Run External Scenarios Voice
+description: "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing. Requires `telephony.phone_number` configured on the agent (any provider)."
+openapi: post /test_framework/v1/scenarios-external/run_scenarios_json/
+slug: run-external-scenarios-voice
+---

--- a/api-reference/test_framework/run-scenarios-v2-voice.mdx
+++ b/api-reference/test_framework/run-scenarios-v2-voice.mdx
@@ -1,0 +1,6 @@
+---
+title: Run Scenarios V2 Voice
+description: "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing. Requires `telephony.phone_number` configured on the agent (any provider)."
+openapi: post /test_framework/v2/scenarios/run_scenarios_json/
+slug: run-scenarios-v2-voice
+---

--- a/api-reference/test_framework/run-scenarios-voice.mdx
+++ b/api-reference/test_framework/run-scenarios-voice.mdx
@@ -1,0 +1,6 @@
+---
+title: Run Scenarios Voice
+description: "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing. Requires `telephony.phone_number` configured on the agent (any provider)."
+openapi: post /test_framework/v1/scenarios/run_scenarios_json/
+slug: run-scenarios-voice
+---

--- a/documentation/guides/testing-agents/outbound-auto-call.mdx
+++ b/documentation/guides/testing-agents/outbound-auto-call.mdx
@@ -27,7 +27,7 @@ Auto Outbound Call is an automated testing feature where Cekura automatically in
   </Step>
 
   <Step title="System Calls Automatically">
-    Cekura uses your voice provider (VAPI, Retell, ElevenLabs, Bland, or LiveKit) to initiate calls
+    Cekura uses your voice provider (VAPI, Retell, ElevenLabs, Bland, LiveKit, or Custom) to initiate calls
   </Step>
 
   <Step title="Review Results">
@@ -38,7 +38,7 @@ Auto Outbound Call is an automated testing feature where Cekura automatically in
 ## Prerequisites
 
 - **Outbound mode enabled**: Agent's `inbound` must be set to `false`
-- **Voice provider configured**: Valid credentials and required agent configuration for VAPI, Retell, ElevenLabs, Bland, or LiveKit
+- **Voice provider configured**: Valid credentials and required agent configuration for VAPI, Retell, ElevenLabs, Bland, LiveKit, or Custom
 - **Agent `contact_number` set to your outbound caller ID**: Cekura validates the caller ID (ANI) of every incoming outbound-test call against the agent's `contact_number` field. If the provider dials from `+15551234567`, the agent's `contact_number` must be exactly `+15551234567` in E.164 format. Set this in Agent settings or via the [Update Agent API](/api-reference/test_framework/update-agent-partial).
 - **Evaluators ready**: Created evaluators with valid phone numbers
 
@@ -70,6 +70,10 @@ For advanced use cases, you can configure a **Trigger URL** to receive webhook n
 **Advanced Feature**: When you configure a trigger URL, Cekura sends a webhook to your endpoint **instead of** automatically calling. You must handle the actual call initiation yourself.
 </Warning>
 
+<Note>
+**Custom provider:** For custom-hosted agents (provider type `custom`), the trigger URL is **required** — not optional. Custom agents have no provider dial-out API, so Cekura relies entirely on your trigger URL endpoint to initiate the call. Enable auto outbound and set `credentials.config.trigger_url` in your agent configuration.
+</Note>
+
 ### When to Use
 
 Use trigger URLs when you need to:
@@ -77,6 +81,7 @@ Use trigger URLs when you need to:
 - Schedule calls for specific times
 - Integrate with internal systems
 - Log or audit call requests
+- Use a custom-hosted agent with no provider API (trigger URL is the only option)
 
 ### How It Works
 
@@ -118,8 +123,12 @@ Cekura sends the following JSON payload to your trigger URL:
 - `to_number`: The evaluator's phone number (where to call)
 - `dynamic_variables`: Optional test profile data for dynamic prompting
 
+**Headers:**
+- `Content-Type: application/json`
+- `X-CEKURA-SECRET: <your_secret>` — included only when you have configured a `trigger_secret` in your agent's provider credentials. Use this header to verify requests originate from Cekura.
+
 <Note>
-Your webhook endpoint must be publicly accessible (HTTPS), return a 200 or 201 status code, and respond within 30 seconds.
+Your webhook endpoint must be publicly accessible (HTTPS), return a 2xx status code (any success status such as 200, 201, 202, or 204), and respond within 30 seconds.
 </Note>
 
 <Info>
@@ -136,6 +145,8 @@ Your webhook should return:
   "call_id": "optional_provider_call_id"
 }
 ```
+
+A non-JSON response body (e.g. plain text "OK") is also accepted as long as the HTTP status is 2xx.
 
 ## Troubleshooting
 
@@ -155,7 +166,7 @@ Your webhook should return:
   </Accordion>
 
   <Accordion title="Webhook Not Working">
-    Verify trigger URL is publicly accessible (HTTPS), returns 200/201 status, and no firewall is blocking requests.
+    Verify trigger URL is publicly accessible (HTTPS), returns a 2xx status, and no firewall is blocking requests.
   </Accordion>
 </AccordionGroup>
 
@@ -163,7 +174,7 @@ Your webhook should return:
 
 - **Monitor credits**: Track your provider account balance
 - **Valid numbers**: Use correct phone number format (+1XXXXXXXXXX)
-- **Secure webhooks**: Use HTTPS, validate requests, implement rate limiting
+- **Secure webhooks**: Use HTTPS, configure a `trigger_secret` for request verification, and implement rate limiting
 
 ---
 

--- a/documentation/guides/testing-agents/outbound-auto-call.mdx
+++ b/documentation/guides/testing-agents/outbound-auto-call.mdx
@@ -38,7 +38,7 @@ Auto Outbound Call is an automated testing feature where Cekura automatically in
 ## Prerequisites
 
 - **Outbound mode enabled**: Agent's `inbound` must be set to `false`
-- **Voice provider configured**: Valid credentials and required agent configuration for VAPI, Retell, ElevenLabs, Bland, LiveKit, or Custom
+- **Voice provider configured**: Valid credentials and required agent configuration for VAPI, Retell, ElevenLabs, Bland, LiveKit, or Custom (Custom requires a trigger URL instead of provider API credentials)
 - **Agent `contact_number` set to your outbound caller ID**: Cekura validates the caller ID (ANI) of every incoming outbound-test call against the agent's `contact_number` field. If the provider dials from `+15551234567`, the agent's `contact_number` must be exactly `+15551234567` in E.164 format. Set this in Agent settings or via the [Update Agent API](/api-reference/test_framework/update-agent-partial).
 - **Evaluators ready**: Created evaluators with valid phone numbers
 
@@ -66,13 +66,11 @@ Ensure your voice provider account has sufficient credits for making calls.
 
 For advanced use cases, you can configure a **Trigger URL** to receive webhook notifications instead of automatic calls. This lets you add custom logic before the call is made.
 
+For **Custom** provider agents, the trigger URL is mandatory — since there is no provider API for Cekura to call directly, your endpoint receives the call request and is responsible for making the agent dial the Cekura number.
+
 <Warning>
 **Advanced Feature**: When you configure a trigger URL, Cekura sends a webhook to your endpoint **instead of** automatically calling. You must handle the actual call initiation yourself.
 </Warning>
-
-<Note>
-**Custom provider:** For custom-hosted agents (provider type `custom`), the trigger URL is **required** — not optional. Custom agents have no provider dial-out API, so Cekura relies entirely on your trigger URL endpoint to initiate the call. Enable auto outbound and set `credentials.config.trigger_url` in your agent configuration.
-</Note>
 
 ### When to Use
 
@@ -81,7 +79,7 @@ Use trigger URLs when you need to:
 - Schedule calls for specific times
 - Integrate with internal systems
 - Log or audit call requests
-- Use a custom-hosted agent with no provider API (trigger URL is the only option)
+- Enable outbound auto-call for custom-hosted agents (required)
 
 ### How It Works
 
@@ -123,12 +121,18 @@ Cekura sends the following JSON payload to your trigger URL:
 - `to_number`: The evaluator's phone number (where to call)
 - `dynamic_variables`: Optional test profile data for dynamic prompting
 
-**Headers:**
+**Headers sent by Cekura:**
 - `Content-Type: application/json`
-- `X-CEKURA-SECRET: <your_secret>` — included only when you have configured a `trigger_secret` in your agent's provider credentials. Use this header to verify requests originate from Cekura.
+- `X-CEKURA-SECRET: <your_secret>` — included only when a trigger secret is configured (see below)
+
+### Trigger Secret
+
+You can optionally configure a shared secret on your provider credentials. When set, Cekura includes it as the `X-CEKURA-SECRET` header on every trigger URL request. Your endpoint can check this header to reject requests that did not originate from Cekura.
+
+The secret is write-only — API responses expose only a `trigger_secret_configured` boolean, never the secret value itself.
 
 <Note>
-Your webhook endpoint must be publicly accessible (HTTPS), return a 2xx status code (any success status such as 200, 201, 202, or 204), and respond within 30 seconds.
+Your webhook endpoint must be publicly accessible (HTTPS), return a 2xx status code (200–299), and respond within 30 seconds.
 </Note>
 
 <Info>
@@ -145,8 +149,6 @@ Your webhook should return:
   "call_id": "optional_provider_call_id"
 }
 ```
-
-A non-JSON response body (e.g. plain text "OK") is also accepted as long as the HTTP status is 2xx.
 
 ## Troubleshooting
 
@@ -166,7 +168,11 @@ A non-JSON response body (e.g. plain text "OK") is also accepted as long as the 
   </Accordion>
 
   <Accordion title="Webhook Not Working">
-    Verify trigger URL is publicly accessible (HTTPS), returns a 2xx status, and no firewall is blocking requests.
+    Verify trigger URL is publicly accessible (HTTPS), returns a 2xx status code, and no firewall is blocking requests. If you configured a trigger secret, confirm that your endpoint is not rejecting the `X-CEKURA-SECRET` header value.
+  </Accordion>
+
+  <Accordion title="Custom Provider: Trigger URL Not Configured">
+    Custom-hosted agents require a trigger URL to use auto outbound calls. Set `provider.credentials.config.trigger_url` in your agent configuration. Without it, enabling `auto_dial_outbound` is rejected by the API, and dispatch returns a "Trigger URL not configured" error.
   </Accordion>
 </AccordionGroup>
 
@@ -174,7 +180,7 @@ A non-JSON response body (e.g. plain text "OK") is also accepted as long as the 
 
 - **Monitor credits**: Track your provider account balance
 - **Valid numbers**: Use correct phone number format (+1XXXXXXXXXX)
-- **Secure webhooks**: Use HTTPS, configure a `trigger_secret` for request verification, and implement rate limiting
+- **Secure webhooks**: Use HTTPS, configure a trigger secret, and validate the `X-CEKURA-SECRET` header on incoming requests
 
 ---
 

--- a/mint.json
+++ b/mint.json
@@ -366,7 +366,13 @@
                 "api-reference/test_framework/api-chat-poll-turn",
                 "api-reference/test_framework/api-chat-end"
               ]
-            }
+            },
+            "api-reference/test_framework/fetch-external-scenarios-json-schema",
+            "api-reference/test_framework/run-external-scenarios-voice",
+            "api-reference/test_framework/fetch-scenarios-json-schema",
+            "api-reference/test_framework/run-scenarios-voice",
+            "api-reference/test_framework/fetch-scenarios-v2-json-schema",
+            "api-reference/test_framework/run-scenarios-v2-voice"
           ]
         },
         {

--- a/openapi.json
+++ b/openapi.json
@@ -181,9 +181,36 @@
             }
         },
         "/app/v1/product-chat/sessions/{session_id}/": {
+            "get": {
+                "operationId": "app-v1-product-chat-sessions-retrieve_2",
+                "description": "Read or delete a product-chat session (legacy v1).\n\nSoft-delete: sets `is_deleted=True` on the conversation. Accepts both\ncanonical UUIDs and legacy session ids.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "session_id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "app"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No response body"
+                    }
+                }
+            },
             "delete": {
                 "operationId": "app-v1-product-chat-sessions-destroy",
-                "description": "Delete a product-chat session (legacy v1).\n\nSoft-delete: sets `is_deleted=True` on the conversation. Accepts both\ncanonical UUIDs and legacy session ids.",
+                "description": "Read or delete a product-chat session (legacy v1).\n\nSoft-delete: sets `is_deleted=True` on the conversation. Accepts both\ncanonical UUIDs and legacy session ids.",
                 "parameters": [
                     {
                         "in": "path",
@@ -11709,7 +11736,7 @@
         "/subscriptions/subscriptions/{id}/select-first-paid-seat-plan/": {
             "post": {
                 "operationId": "subscriptions-subscriptions-select-first-paid-seat-plan-create",
-                "description": "Resolve the one-time choice shown before an org's first paid seat.\n\nSending the current pack code keeps pay-as-you-go. Sending the configured\n``allow_switch_to_plan`` code creates and charges that monthly subscription\nimmediately. Pricing, Stripe IDs, and the customer are always server-owned.",
+                "description": "Resolve a one-time paid-plan choice.\n\nPAYG organizations see it before their first paid seat; developer-trial\norganizations can use it from Manage Plan. Sending the current pack code\nkeeps pay-as-you-go. Sending the configured ``allow_switch_to_plan`` code\ncreates and charges that monthly subscription immediately. Pricing, Stripe\nIDs, and the customer are always server-owned.",
                 "parameters": [
                     {
                         "in": "path",
@@ -31918,6 +31945,43 @@
                 }
             }
         },
+        "/test_framework/v1/scenarios-external/json_schema/": {
+            "get": {
+                "operationId": "scenarios-json-schema",
+                "description": "Fetch the JSON Schema for test-suite spec files",
+                "summary": "Fetch the JSON Schema for test-suite spec files",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "version",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Spec version to fetch. Defaults to the current version."
+                    }
+                ],
+                "tags": [
+                    "Evaluators"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Scenario"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/test_framework/v1/scenarios-external/move_folder/": {
             "post": {
                 "operationId": "scenarios-folder-move",
@@ -32012,73 +32076,30 @@
         },
         "/test_framework/v1/scenarios-external/run_scenarios/": {
             "post": {
-                "operationId": "scenarios-run-voice",
-                "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing. Requires `telephony.phone_number` configured on the agent (any provider).\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.\n\n**Outbound dial window:** for outbound runs (agent `inbound=false`), your agent must dial the run's `outbound_number` before `outbound_dial_window_closes_at` (default 300s after the run reaches `waiting_for_call` / pending state). Dials received after that deadline are dropped and the run returns `status: timeout`.",
-                "summary": "Run evaluators over a voice call",
+                "operationId": "scenarios-external-run-scenarios-create",
+                "description": "Run test scenarios against an AI voice agent",
                 "tags": [
-                    "Evaluators"
+                    "test_framework"
                 ],
                 "requestBody": {
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
-                            },
-                            "examples": {
-                                "RunSelectedScenarios(simplest)": {
-                                    "value": {
-                                        "agent_id": 12,
-                                        "scenarios": [
-                                            101,
-                                            102,
-                                            103
-                                        ],
-                                        "frequency": 1
-                                    },
-                                    "summary": "Run selected scenarios (simplest)"
-                                },
-                                "RunAnEntireFolder,3×Each,5InParallel": {
-                                    "value": {
-                                        "agent_id": 12,
-                                        "folder_path": "Sales.Inbound",
-                                        "project_id": 1376,
-                                        "frequency": 3,
-                                        "concurrency_limit": 5,
-                                        "name": "Nightly Sales.Inbound regression"
-                                    },
-                                    "summary": "Run an entire folder, 3× each, 5 in parallel"
-                                },
-                                "OverridePersonalities+TestProfiles(multipliesRunCount)": {
-                                    "value": {
-                                        "agent_id": 12,
-                                        "scenarios": [
-                                            101
-                                        ],
-                                        "frequency": 2,
-                                        "personality_ids": [
-                                            3,
-                                            7
-                                        ],
-                                        "test_profile_ids": [
-                                            20,
-                                            21
-                                        ]
-                                    },
-                                    "summary": "Override personalities + test profiles (multiplies run count)"
-                                }
+                                "$ref": "#/components/schemas/Scenario"
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
+                                "$ref": "#/components/schemas/Scenario"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
+                                "$ref": "#/components/schemas/Scenario"
                             }
                         }
-                    }
+                    },
+                    "required": true
                 },
                 "security": [
                     {
@@ -32086,222 +32107,11 @@
                     }
                 ],
                 "responses": {
-                    "201": {
+                    "200": {
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "id": {
-                                            "type": "integer",
-                                            "description": "ID of the result"
-                                        },
-                                        "agent": {
-                                            "type": "integer",
-                                            "description": "ID of the agent"
-                                        },
-                                        "status": {
-                                            "type": "string",
-                                            "enum": [
-                                                "pending",
-                                                "running",
-                                                "completed",
-                                                "failed"
-                                            ],
-                                            "description": "Status of the result"
-                                        },
-                                        "run_as_text": {
-                                            "type": "boolean",
-                                            "description": "Whether the scenario ran as text or not",
-                                            "example": false
-                                        },
-                                        "runs": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "id": {
-                                                        "type": "integer",
-                                                        "description": "ID of the run"
-                                                    },
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "pending",
-                                                            "running",
-                                                            "completed",
-                                                            "failed"
-                                                        ],
-                                                        "description": "Status of the run"
-                                                    },
-                                                    "scenario": {
-                                                        "type": "integer",
-                                                        "description": "ID of the scenario"
-                                                    },
-                                                    "number": {
-                                                        "type": "string",
-                                                        "description": "For outbound runs (agent.inbound=False). The given number that must be called from the phone number configured in the cekura agent.",
-                                                        "example": "+11234567890"
-                                                    },
-                                                    "inbound_number": {
-                                                        "type": [
-                                                            "string",
-                                                            "null"
-                                                        ],
-                                                        "description": "For inbound runs (agent.inbound=True). The agent's configured phone number will receive calls from this number.",
-                                                        "example": "+11234567890"
-                                                    },
-                                                    "scenario_name": {
-                                                        "type": "string",
-                                                        "description": "Name of the scenario"
-                                                    },
-                                                    "test_profile_data": {
-                                                        "type": [
-                                                            "object",
-                                                            "null"
-                                                        ],
-                                                        "description": "Details of the test profile associated with this run scenario"
-                                                    },
-                                                    "outbound_dial_window_opens_at": {
-                                                        "type": [
-                                                            "string",
-                                                            "null"
-                                                        ],
-                                                        "format": "date-time",
-                                                        "description": "When the outbound dial window opened (run transitioned to pending/waiting-for-call). Null until dispatched."
-                                                    },
-                                                    "outbound_dial_window_seconds": {
-                                                        "type": [
-                                                            "integer",
-                                                            "null"
-                                                        ],
-                                                        "description": "Duration of the outbound dial window in seconds."
-                                                    },
-                                                    "outbound_dial_window_closes_at": {
-                                                        "type": [
-                                                            "string",
-                                                            "null"
-                                                        ],
-                                                        "format": "date-time",
-                                                        "description": "Deadline by which your agent must dial the outbound number (opens_at + outbound_dial_window_seconds). Dials after this are dropped and the run returns status: timeout."
-                                                    }
-                                                }
-                                            },
-                                            "examples": [
-                                                {
-                                                    "id": 274,
-                                                    "status": "pending",
-                                                    "scenario": 1,
-                                                    "number": null,
-                                                    "inbound_number": "+11234567890",
-                                                    "scenario_name": "Customer Support Call (Agent Inbound = True)",
-                                                    "test_profile_data": null,
-                                                    "outbound_dial_window_opens_at": null,
-                                                    "outbound_dial_window_seconds": null,
-                                                    "outbound_dial_window_closes_at": null
-                                                },
-                                                {
-                                                    "id": 275,
-                                                    "status": "pending",
-                                                    "scenario": 2,
-                                                    "number": "+11234567890",
-                                                    "inbound_number": null,
-                                                    "scenario_name": "Outbound Sales Call (Agent Inbound = False)",
-                                                    "test_profile_data": null,
-                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
-                                                    "outbound_dial_window_seconds": 300,
-                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
-                                                }
-                                            ]
-                                        },
-                                        "created_at": {
-                                            "type": "string",
-                                            "format": "date-time",
-                                            "example": "2025-02-25T21:00:01.990052Z"
-                                        }
-                                    }
-                                },
-                                "examples": {
-                                    "InboundScenario": {
-                                        "value": {
-                                            "id": 167,
-                                            "agent": 1,
-                                            "status": "pending",
-                                            "success_rate": 0,
-                                            "run_as_text": false,
-                                            "runs": [
-                                                {
-                                                    "id": 274,
-                                                    "scenario": 1,
-                                                    "number": null,
-                                                    "inbound_number": "+11234567890",
-                                                    "outbound_dial_window_opens_at": null,
-                                                    "outbound_dial_window_seconds": null,
-                                                    "outbound_dial_window_closes_at": null
-                                                },
-                                                {
-                                                    "id": 273,
-                                                    "scenario": 2,
-                                                    "number": null,
-                                                    "inbound_number": "+11234567891",
-                                                    "outbound_dial_window_opens_at": null,
-                                                    "outbound_dial_window_seconds": null,
-                                                    "outbound_dial_window_closes_at": null
-                                                }
-                                            ],
-                                            "created_at": "2025-02-25T21:00:01.990052Z"
-                                        },
-                                        "summary": "Inbound Scenario"
-                                    },
-                                    "OutboundScenario": {
-                                        "value": {
-                                            "id": 167,
-                                            "agent": 1,
-                                            "status": "pending",
-                                            "success_rate": 0,
-                                            "run_as_text": false,
-                                            "runs": [
-                                                {
-                                                    "id": 274,
-                                                    "scenario": 1,
-                                                    "number": "+11234567890",
-                                                    "inbound_number": null,
-                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
-                                                    "outbound_dial_window_seconds": 300,
-                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
-                                                },
-                                                {
-                                                    "id": 273,
-                                                    "scenario": 2,
-                                                    "number": "+11234567891",
-                                                    "inbound_number": null,
-                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
-                                                    "outbound_dial_window_seconds": 300,
-                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
-                                                }
-                                            ],
-                                            "created_at": "2025-02-25T21:00:01.990052Z"
-                                        },
-                                        "summary": "Outbound Scenario"
-                                    }
-                                }
-                            }
-                        },
-                        "description": ""
-                    },
-                    "400": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "field_name": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
+                                    "$ref": "#/components/schemas/Scenario"
                                 }
                             }
                         },
@@ -33203,6 +33013,342 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/Scenario"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/scenarios-external/run_scenarios_json/": {
+            "post": {
+                "operationId": "scenarios-run-voice",
+                "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing. Requires `telephony.phone_number` configured on the agent (any provider).\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.\n\n**Outbound dial window:** for outbound runs (agent `inbound=false`), your agent must dial the run's `outbound_number` before `outbound_dial_window_closes_at` (default 300s after the run reaches `waiting_for_call` / pending state). Dials received after that deadline are dropped and the run returns `status: timeout`.",
+                "summary": "Run evaluators over a voice call",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "dry_run",
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "description": "Validate and price the spec without running or charging anything."
+                    }
+                ],
+                "tags": [
+                    "Evaluators"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
+                            },
+                            "examples": {
+                                "RunASpec": {
+                                    "value": {
+                                        "agent_id": 12,
+                                        "channel": "voice",
+                                        "spec": {
+                                            "version": "1",
+                                            "scenarios": [
+                                                {
+                                                    "name": "Refund happy path",
+                                                    "instructions": "You are a customer whose order arrived damaged.",
+                                                    "expected_outcome": "The agent confirms a refund.",
+                                                    "metrics": [
+                                                        "greeting_by_name"
+                                                    ],
+                                                    "personality": 3,
+                                                    "test_profile": {
+                                                        "agent_variables": {
+                                                            "order_id": "ORD-4471"
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "summary": "Run a spec"
+                                },
+                                "RunSelectedScenarios(simplest)": {
+                                    "value": {
+                                        "agent_id": 12,
+                                        "scenarios": [
+                                            101,
+                                            102,
+                                            103
+                                        ],
+                                        "frequency": 1
+                                    },
+                                    "summary": "Run selected scenarios (simplest)"
+                                },
+                                "RunAnEntireFolder,3×Each,5InParallel": {
+                                    "value": {
+                                        "agent_id": 12,
+                                        "folder_path": "Sales.Inbound",
+                                        "project_id": 1376,
+                                        "frequency": 3,
+                                        "concurrency_limit": 5,
+                                        "name": "Nightly Sales.Inbound regression"
+                                    },
+                                    "summary": "Run an entire folder, 3× each, 5 in parallel"
+                                },
+                                "OverridePersonalities+TestProfiles(multipliesRunCount)": {
+                                    "value": {
+                                        "agent_id": 12,
+                                        "scenarios": [
+                                            101
+                                        ],
+                                        "frequency": 2,
+                                        "personality_ids": [
+                                            3,
+                                            7
+                                        ],
+                                        "test_profile_ids": [
+                                            20,
+                                            21
+                                        ]
+                                    },
+                                    "summary": "Override personalities + test profiles (multiplies run count)"
+                                }
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {
+                                            "type": "integer",
+                                            "description": "ID of the result"
+                                        },
+                                        "agent": {
+                                            "type": "integer",
+                                            "description": "ID of the agent"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "pending",
+                                                "running",
+                                                "completed",
+                                                "failed"
+                                            ],
+                                            "description": "Status of the result"
+                                        },
+                                        "run_as_text": {
+                                            "type": "boolean",
+                                            "description": "Whether the scenario ran as text or not",
+                                            "example": false
+                                        },
+                                        "runs": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "id": {
+                                                        "type": "integer",
+                                                        "description": "ID of the run"
+                                                    },
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "pending",
+                                                            "running",
+                                                            "completed",
+                                                            "failed"
+                                                        ],
+                                                        "description": "Status of the run"
+                                                    },
+                                                    "scenario": {
+                                                        "type": "integer",
+                                                        "description": "ID of the scenario"
+                                                    },
+                                                    "number": {
+                                                        "type": "string",
+                                                        "description": "For outbound runs (agent.inbound=False). The given number that must be called from the phone number configured in the cekura agent.",
+                                                        "example": "+11234567890"
+                                                    },
+                                                    "inbound_number": {
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ],
+                                                        "description": "For inbound runs (agent.inbound=True). The agent's configured phone number will receive calls from this number.",
+                                                        "example": "+11234567890"
+                                                    },
+                                                    "scenario_name": {
+                                                        "type": "string",
+                                                        "description": "Name of the scenario"
+                                                    },
+                                                    "test_profile_data": {
+                                                        "type": [
+                                                            "object",
+                                                            "null"
+                                                        ],
+                                                        "description": "Details of the test profile associated with this run scenario"
+                                                    },
+                                                    "outbound_dial_window_opens_at": {
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ],
+                                                        "format": "date-time",
+                                                        "description": "When the outbound dial window opened (run transitioned to pending/waiting-for-call). Null until dispatched."
+                                                    },
+                                                    "outbound_dial_window_seconds": {
+                                                        "type": [
+                                                            "integer",
+                                                            "null"
+                                                        ],
+                                                        "description": "Duration of the outbound dial window in seconds."
+                                                    },
+                                                    "outbound_dial_window_closes_at": {
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ],
+                                                        "format": "date-time",
+                                                        "description": "Deadline by which your agent must dial the outbound number (opens_at + outbound_dial_window_seconds). Dials after this are dropped and the run returns status: timeout."
+                                                    }
+                                                }
+                                            },
+                                            "examples": [
+                                                {
+                                                    "id": 274,
+                                                    "status": "pending",
+                                                    "scenario": 1,
+                                                    "number": null,
+                                                    "inbound_number": "+11234567890",
+                                                    "scenario_name": "Customer Support Call (Agent Inbound = True)",
+                                                    "test_profile_data": null,
+                                                    "outbound_dial_window_opens_at": null,
+                                                    "outbound_dial_window_seconds": null,
+                                                    "outbound_dial_window_closes_at": null
+                                                },
+                                                {
+                                                    "id": 275,
+                                                    "status": "pending",
+                                                    "scenario": 2,
+                                                    "number": "+11234567890",
+                                                    "inbound_number": null,
+                                                    "scenario_name": "Outbound Sales Call (Agent Inbound = False)",
+                                                    "test_profile_data": null,
+                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
+                                                    "outbound_dial_window_seconds": 300,
+                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
+                                                }
+                                            ]
+                                        },
+                                        "created_at": {
+                                            "type": "string",
+                                            "format": "date-time",
+                                            "example": "2025-02-25T21:00:01.990052Z"
+                                        }
+                                    }
+                                },
+                                "examples": {
+                                    "InboundScenario": {
+                                        "value": {
+                                            "id": 167,
+                                            "agent": 1,
+                                            "status": "pending",
+                                            "success_rate": 0,
+                                            "run_as_text": false,
+                                            "runs": [
+                                                {
+                                                    "id": 274,
+                                                    "scenario": 1,
+                                                    "number": null,
+                                                    "inbound_number": "+11234567890",
+                                                    "outbound_dial_window_opens_at": null,
+                                                    "outbound_dial_window_seconds": null,
+                                                    "outbound_dial_window_closes_at": null
+                                                },
+                                                {
+                                                    "id": 273,
+                                                    "scenario": 2,
+                                                    "number": null,
+                                                    "inbound_number": "+11234567891",
+                                                    "outbound_dial_window_opens_at": null,
+                                                    "outbound_dial_window_seconds": null,
+                                                    "outbound_dial_window_closes_at": null
+                                                }
+                                            ],
+                                            "created_at": "2025-02-25T21:00:01.990052Z"
+                                        },
+                                        "summary": "Inbound Scenario"
+                                    },
+                                    "OutboundScenario": {
+                                        "value": {
+                                            "id": 167,
+                                            "agent": 1,
+                                            "status": "pending",
+                                            "success_rate": 0,
+                                            "run_as_text": false,
+                                            "runs": [
+                                                {
+                                                    "id": 274,
+                                                    "scenario": 1,
+                                                    "number": "+11234567890",
+                                                    "inbound_number": null,
+                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
+                                                    "outbound_dial_window_seconds": 300,
+                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
+                                                },
+                                                {
+                                                    "id": 273,
+                                                    "scenario": 2,
+                                                    "number": "+11234567891",
+                                                    "inbound_number": null,
+                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
+                                                    "outbound_dial_window_seconds": 300,
+                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
+                                                }
+                                            ],
+                                            "created_at": "2025-02-25T21:00:01.990052Z"
+                                        },
+                                        "summary": "Outbound Scenario"
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
                                 }
                             }
                         },
@@ -37575,6 +37721,51 @@
                 ]
             }
         },
+        "/test_framework/v1/scenarios/json_schema/": {
+            "get": {
+                "operationId": "scenarios-json-schema_2",
+                "description": "Fetch the JSON Schema for test-suite spec files",
+                "summary": "Fetch the JSON Schema for test-suite spec files",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "version",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Spec version to fetch. Defaults to the current version."
+                    }
+                ],
+                "tags": [
+                    "Evaluators"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Scenario"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "scenarios-json-schema",
+                        "description": "Fetch the JSON Schema for test-suite spec files"
+                    }
+                }
+            }
+        },
         "/test_framework/v1/scenarios/move_folder/": {
             "post": {
                 "operationId": "scenarios-folder-move_2",
@@ -37685,73 +37876,30 @@
         },
         "/test_framework/v1/scenarios/run_scenarios/": {
             "post": {
-                "operationId": "scenarios-run-voice_2",
-                "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing. Requires `telephony.phone_number` configured on the agent (any provider).\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.\n\n**Outbound dial window:** for outbound runs (agent `inbound=false`), your agent must dial the run's `outbound_number` before `outbound_dial_window_closes_at` (default 300s after the run reaches `waiting_for_call` / pending state). Dials received after that deadline are dropped and the run returns `status: timeout`.",
-                "summary": "Run evaluators over a voice call",
+                "operationId": "scenarios-run-scenarios-create",
+                "description": "Run test scenarios against an AI voice agent",
                 "tags": [
-                    "Evaluators"
+                    "test_framework"
                 ],
                 "requestBody": {
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
-                            },
-                            "examples": {
-                                "RunSelectedScenarios(simplest)": {
-                                    "value": {
-                                        "agent_id": 12,
-                                        "scenarios": [
-                                            101,
-                                            102,
-                                            103
-                                        ],
-                                        "frequency": 1
-                                    },
-                                    "summary": "Run selected scenarios (simplest)"
-                                },
-                                "RunAnEntireFolder,3×Each,5InParallel": {
-                                    "value": {
-                                        "agent_id": 12,
-                                        "folder_path": "Sales.Inbound",
-                                        "project_id": 1376,
-                                        "frequency": 3,
-                                        "concurrency_limit": 5,
-                                        "name": "Nightly Sales.Inbound regression"
-                                    },
-                                    "summary": "Run an entire folder, 3× each, 5 in parallel"
-                                },
-                                "OverridePersonalities+TestProfiles(multipliesRunCount)": {
-                                    "value": {
-                                        "agent_id": 12,
-                                        "scenarios": [
-                                            101
-                                        ],
-                                        "frequency": 2,
-                                        "personality_ids": [
-                                            3,
-                                            7
-                                        ],
-                                        "test_profile_ids": [
-                                            20,
-                                            21
-                                        ]
-                                    },
-                                    "summary": "Override personalities + test profiles (multiplies run count)"
-                                }
+                                "$ref": "#/components/schemas/Scenario"
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
+                                "$ref": "#/components/schemas/Scenario"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
+                                "$ref": "#/components/schemas/Scenario"
                             }
                         }
-                    }
+                    },
+                    "required": true
                 },
                 "security": [
                     {
@@ -37759,234 +37907,15 @@
                     }
                 ],
                 "responses": {
-                    "201": {
+                    "200": {
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "id": {
-                                            "type": "integer",
-                                            "description": "ID of the result"
-                                        },
-                                        "agent": {
-                                            "type": "integer",
-                                            "description": "ID of the agent"
-                                        },
-                                        "status": {
-                                            "type": "string",
-                                            "enum": [
-                                                "pending",
-                                                "running",
-                                                "completed",
-                                                "failed"
-                                            ],
-                                            "description": "Status of the result"
-                                        },
-                                        "run_as_text": {
-                                            "type": "boolean",
-                                            "description": "Whether the scenario ran as text or not",
-                                            "example": false
-                                        },
-                                        "runs": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "id": {
-                                                        "type": "integer",
-                                                        "description": "ID of the run"
-                                                    },
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "pending",
-                                                            "running",
-                                                            "completed",
-                                                            "failed"
-                                                        ],
-                                                        "description": "Status of the run"
-                                                    },
-                                                    "scenario": {
-                                                        "type": "integer",
-                                                        "description": "ID of the scenario"
-                                                    },
-                                                    "number": {
-                                                        "type": "string",
-                                                        "description": "For outbound runs (agent.inbound=False). The given number that must be called from the phone number configured in the cekura agent.",
-                                                        "example": "+11234567890"
-                                                    },
-                                                    "inbound_number": {
-                                                        "type": [
-                                                            "string",
-                                                            "null"
-                                                        ],
-                                                        "description": "For inbound runs (agent.inbound=True). The agent's configured phone number will receive calls from this number.",
-                                                        "example": "+11234567890"
-                                                    },
-                                                    "scenario_name": {
-                                                        "type": "string",
-                                                        "description": "Name of the scenario"
-                                                    },
-                                                    "test_profile_data": {
-                                                        "type": [
-                                                            "object",
-                                                            "null"
-                                                        ],
-                                                        "description": "Details of the test profile associated with this run scenario"
-                                                    },
-                                                    "outbound_dial_window_opens_at": {
-                                                        "type": [
-                                                            "string",
-                                                            "null"
-                                                        ],
-                                                        "format": "date-time",
-                                                        "description": "When the outbound dial window opened (run transitioned to pending/waiting-for-call). Null until dispatched."
-                                                    },
-                                                    "outbound_dial_window_seconds": {
-                                                        "type": [
-                                                            "integer",
-                                                            "null"
-                                                        ],
-                                                        "description": "Duration of the outbound dial window in seconds."
-                                                    },
-                                                    "outbound_dial_window_closes_at": {
-                                                        "type": [
-                                                            "string",
-                                                            "null"
-                                                        ],
-                                                        "format": "date-time",
-                                                        "description": "Deadline by which your agent must dial the outbound number (opens_at + outbound_dial_window_seconds). Dials after this are dropped and the run returns status: timeout."
-                                                    }
-                                                }
-                                            },
-                                            "examples": [
-                                                {
-                                                    "id": 274,
-                                                    "status": "pending",
-                                                    "scenario": 1,
-                                                    "number": null,
-                                                    "inbound_number": "+11234567890",
-                                                    "scenario_name": "Customer Support Call (Agent Inbound = True)",
-                                                    "test_profile_data": null,
-                                                    "outbound_dial_window_opens_at": null,
-                                                    "outbound_dial_window_seconds": null,
-                                                    "outbound_dial_window_closes_at": null
-                                                },
-                                                {
-                                                    "id": 275,
-                                                    "status": "pending",
-                                                    "scenario": 2,
-                                                    "number": "+11234567890",
-                                                    "inbound_number": null,
-                                                    "scenario_name": "Outbound Sales Call (Agent Inbound = False)",
-                                                    "test_profile_data": null,
-                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
-                                                    "outbound_dial_window_seconds": 300,
-                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
-                                                }
-                                            ]
-                                        },
-                                        "created_at": {
-                                            "type": "string",
-                                            "format": "date-time",
-                                            "example": "2025-02-25T21:00:01.990052Z"
-                                        }
-                                    }
-                                },
-                                "examples": {
-                                    "InboundScenario": {
-                                        "value": {
-                                            "id": 167,
-                                            "agent": 1,
-                                            "status": "pending",
-                                            "success_rate": 0,
-                                            "run_as_text": false,
-                                            "runs": [
-                                                {
-                                                    "id": 274,
-                                                    "scenario": 1,
-                                                    "number": null,
-                                                    "inbound_number": "+11234567890",
-                                                    "outbound_dial_window_opens_at": null,
-                                                    "outbound_dial_window_seconds": null,
-                                                    "outbound_dial_window_closes_at": null
-                                                },
-                                                {
-                                                    "id": 273,
-                                                    "scenario": 2,
-                                                    "number": null,
-                                                    "inbound_number": "+11234567891",
-                                                    "outbound_dial_window_opens_at": null,
-                                                    "outbound_dial_window_seconds": null,
-                                                    "outbound_dial_window_closes_at": null
-                                                }
-                                            ],
-                                            "created_at": "2025-02-25T21:00:01.990052Z"
-                                        },
-                                        "summary": "Inbound Scenario"
-                                    },
-                                    "OutboundScenario": {
-                                        "value": {
-                                            "id": 167,
-                                            "agent": 1,
-                                            "status": "pending",
-                                            "success_rate": 0,
-                                            "run_as_text": false,
-                                            "runs": [
-                                                {
-                                                    "id": 274,
-                                                    "scenario": 1,
-                                                    "number": "+11234567890",
-                                                    "inbound_number": null,
-                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
-                                                    "outbound_dial_window_seconds": 300,
-                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
-                                                },
-                                                {
-                                                    "id": 273,
-                                                    "scenario": 2,
-                                                    "number": "+11234567891",
-                                                    "inbound_number": null,
-                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
-                                                    "outbound_dial_window_seconds": 300,
-                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
-                                                }
-                                            ],
-                                            "created_at": "2025-02-25T21:00:01.990052Z"
-                                        },
-                                        "summary": "Outbound Scenario"
-                                    }
+                                    "$ref": "#/components/schemas/Scenario"
                                 }
                             }
                         },
                         "description": ""
-                    },
-                    "400": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "field_name": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "scenarios-run-voice",
-                        "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing. Requires `telephony.phone_number` configured on the agent (any provider).\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.\n\n**Outbound dial window:** for outbound runs (agent `inbound=false`), your agent must dial the run's `outbound_number` before `outbound_dial_window_closes_at` (default 300s after the run reaches `waiting_for_call` / pending state). Dials received after that deadline are dropped and the run returns `status: timeout`."
                     }
                 }
             }
@@ -38920,6 +38849,350 @@
                             }
                         },
                         "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/scenarios/run_scenarios_json/": {
+            "post": {
+                "operationId": "scenarios-run-voice_2",
+                "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing. Requires `telephony.phone_number` configured on the agent (any provider).\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.\n\n**Outbound dial window:** for outbound runs (agent `inbound=false`), your agent must dial the run's `outbound_number` before `outbound_dial_window_closes_at` (default 300s after the run reaches `waiting_for_call` / pending state). Dials received after that deadline are dropped and the run returns `status: timeout`.",
+                "summary": "Run evaluators over a voice call",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "dry_run",
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "description": "Validate and price the spec without running or charging anything."
+                    }
+                ],
+                "tags": [
+                    "Evaluators"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
+                            },
+                            "examples": {
+                                "RunASpec": {
+                                    "value": {
+                                        "agent_id": 12,
+                                        "channel": "voice",
+                                        "spec": {
+                                            "version": "1",
+                                            "scenarios": [
+                                                {
+                                                    "name": "Refund happy path",
+                                                    "instructions": "You are a customer whose order arrived damaged.",
+                                                    "expected_outcome": "The agent confirms a refund.",
+                                                    "metrics": [
+                                                        "greeting_by_name"
+                                                    ],
+                                                    "personality": 3,
+                                                    "test_profile": {
+                                                        "agent_variables": {
+                                                            "order_id": "ORD-4471"
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "summary": "Run a spec"
+                                },
+                                "RunSelectedScenarios(simplest)": {
+                                    "value": {
+                                        "agent_id": 12,
+                                        "scenarios": [
+                                            101,
+                                            102,
+                                            103
+                                        ],
+                                        "frequency": 1
+                                    },
+                                    "summary": "Run selected scenarios (simplest)"
+                                },
+                                "RunAnEntireFolder,3×Each,5InParallel": {
+                                    "value": {
+                                        "agent_id": 12,
+                                        "folder_path": "Sales.Inbound",
+                                        "project_id": 1376,
+                                        "frequency": 3,
+                                        "concurrency_limit": 5,
+                                        "name": "Nightly Sales.Inbound regression"
+                                    },
+                                    "summary": "Run an entire folder, 3× each, 5 in parallel"
+                                },
+                                "OverridePersonalities+TestProfiles(multipliesRunCount)": {
+                                    "value": {
+                                        "agent_id": 12,
+                                        "scenarios": [
+                                            101
+                                        ],
+                                        "frequency": 2,
+                                        "personality_ids": [
+                                            3,
+                                            7
+                                        ],
+                                        "test_profile_ids": [
+                                            20,
+                                            21
+                                        ]
+                                    },
+                                    "summary": "Override personalities + test profiles (multiplies run count)"
+                                }
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {
+                                            "type": "integer",
+                                            "description": "ID of the result"
+                                        },
+                                        "agent": {
+                                            "type": "integer",
+                                            "description": "ID of the agent"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "pending",
+                                                "running",
+                                                "completed",
+                                                "failed"
+                                            ],
+                                            "description": "Status of the result"
+                                        },
+                                        "run_as_text": {
+                                            "type": "boolean",
+                                            "description": "Whether the scenario ran as text or not",
+                                            "example": false
+                                        },
+                                        "runs": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "id": {
+                                                        "type": "integer",
+                                                        "description": "ID of the run"
+                                                    },
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "pending",
+                                                            "running",
+                                                            "completed",
+                                                            "failed"
+                                                        ],
+                                                        "description": "Status of the run"
+                                                    },
+                                                    "scenario": {
+                                                        "type": "integer",
+                                                        "description": "ID of the scenario"
+                                                    },
+                                                    "number": {
+                                                        "type": "string",
+                                                        "description": "For outbound runs (agent.inbound=False). The given number that must be called from the phone number configured in the cekura agent.",
+                                                        "example": "+11234567890"
+                                                    },
+                                                    "inbound_number": {
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ],
+                                                        "description": "For inbound runs (agent.inbound=True). The agent's configured phone number will receive calls from this number.",
+                                                        "example": "+11234567890"
+                                                    },
+                                                    "scenario_name": {
+                                                        "type": "string",
+                                                        "description": "Name of the scenario"
+                                                    },
+                                                    "test_profile_data": {
+                                                        "type": [
+                                                            "object",
+                                                            "null"
+                                                        ],
+                                                        "description": "Details of the test profile associated with this run scenario"
+                                                    },
+                                                    "outbound_dial_window_opens_at": {
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ],
+                                                        "format": "date-time",
+                                                        "description": "When the outbound dial window opened (run transitioned to pending/waiting-for-call). Null until dispatched."
+                                                    },
+                                                    "outbound_dial_window_seconds": {
+                                                        "type": [
+                                                            "integer",
+                                                            "null"
+                                                        ],
+                                                        "description": "Duration of the outbound dial window in seconds."
+                                                    },
+                                                    "outbound_dial_window_closes_at": {
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ],
+                                                        "format": "date-time",
+                                                        "description": "Deadline by which your agent must dial the outbound number (opens_at + outbound_dial_window_seconds). Dials after this are dropped and the run returns status: timeout."
+                                                    }
+                                                }
+                                            },
+                                            "examples": [
+                                                {
+                                                    "id": 274,
+                                                    "status": "pending",
+                                                    "scenario": 1,
+                                                    "number": null,
+                                                    "inbound_number": "+11234567890",
+                                                    "scenario_name": "Customer Support Call (Agent Inbound = True)",
+                                                    "test_profile_data": null,
+                                                    "outbound_dial_window_opens_at": null,
+                                                    "outbound_dial_window_seconds": null,
+                                                    "outbound_dial_window_closes_at": null
+                                                },
+                                                {
+                                                    "id": 275,
+                                                    "status": "pending",
+                                                    "scenario": 2,
+                                                    "number": "+11234567890",
+                                                    "inbound_number": null,
+                                                    "scenario_name": "Outbound Sales Call (Agent Inbound = False)",
+                                                    "test_profile_data": null,
+                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
+                                                    "outbound_dial_window_seconds": 300,
+                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
+                                                }
+                                            ]
+                                        },
+                                        "created_at": {
+                                            "type": "string",
+                                            "format": "date-time",
+                                            "example": "2025-02-25T21:00:01.990052Z"
+                                        }
+                                    }
+                                },
+                                "examples": {
+                                    "InboundScenario": {
+                                        "value": {
+                                            "id": 167,
+                                            "agent": 1,
+                                            "status": "pending",
+                                            "success_rate": 0,
+                                            "run_as_text": false,
+                                            "runs": [
+                                                {
+                                                    "id": 274,
+                                                    "scenario": 1,
+                                                    "number": null,
+                                                    "inbound_number": "+11234567890",
+                                                    "outbound_dial_window_opens_at": null,
+                                                    "outbound_dial_window_seconds": null,
+                                                    "outbound_dial_window_closes_at": null
+                                                },
+                                                {
+                                                    "id": 273,
+                                                    "scenario": 2,
+                                                    "number": null,
+                                                    "inbound_number": "+11234567891",
+                                                    "outbound_dial_window_opens_at": null,
+                                                    "outbound_dial_window_seconds": null,
+                                                    "outbound_dial_window_closes_at": null
+                                                }
+                                            ],
+                                            "created_at": "2025-02-25T21:00:01.990052Z"
+                                        },
+                                        "summary": "Inbound Scenario"
+                                    },
+                                    "OutboundScenario": {
+                                        "value": {
+                                            "id": 167,
+                                            "agent": 1,
+                                            "status": "pending",
+                                            "success_rate": 0,
+                                            "run_as_text": false,
+                                            "runs": [
+                                                {
+                                                    "id": 274,
+                                                    "scenario": 1,
+                                                    "number": "+11234567890",
+                                                    "inbound_number": null,
+                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
+                                                    "outbound_dial_window_seconds": 300,
+                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
+                                                },
+                                                {
+                                                    "id": 273,
+                                                    "scenario": 2,
+                                                    "number": "+11234567891",
+                                                    "inbound_number": null,
+                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
+                                                    "outbound_dial_window_seconds": 300,
+                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
+                                                }
+                                            ],
+                                            "created_at": "2025-02-25T21:00:01.990052Z"
+                                        },
+                                        "summary": "Outbound Scenario"
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "scenarios-run-voice",
+                        "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing. Requires `telephony.phone_number` configured on the agent (any provider).\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.\n\n**Outbound dial window:** for outbound runs (agent `inbound=false`), your agent must dial the run's `outbound_number` before `outbound_dial_window_closes_at` (default 300s after the run reaches `waiting_for_call` / pending state). Dials received after that deadline are dropped and the run returns `status: timeout`."
                     }
                 }
             }
@@ -51227,6 +51500,43 @@
                 }
             }
         },
+        "/test_framework/v2/scenarios/json_schema/": {
+            "get": {
+                "operationId": "scenarios-json-schema_3",
+                "description": "Fetch the JSON Schema for test-suite spec files",
+                "summary": "Fetch the JSON Schema for test-suite spec files",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "version",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Spec version to fetch. Defaults to the current version."
+                    }
+                ],
+                "tags": [
+                    "Evaluators"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ScenarioSerializerV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/test_framework/v2/scenarios/move_folder/": {
             "post": {
                 "operationId": "scenarios-folder-move_3",
@@ -51321,73 +51631,30 @@
         },
         "/test_framework/v2/scenarios/run_scenarios/": {
             "post": {
-                "operationId": "scenarios-run-voice_3",
-                "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing. Requires `telephony.phone_number` configured on the agent (any provider).\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.\n\n**Outbound dial window:** for outbound runs (agent `inbound=false`), your agent must dial the run's `outbound_number` before `outbound_dial_window_closes_at` (default 300s after the run reaches `waiting_for_call` / pending state). Dials received after that deadline are dropped and the run returns `status: timeout`.",
-                "summary": "Run evaluators over a voice call",
+                "operationId": "test-framework-v2-scenarios-run-scenarios-create",
+                "description": "Scenarios run scenarios",
                 "tags": [
-                    "Evaluators"
+                    "test_framework"
                 ],
                 "requestBody": {
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
-                            },
-                            "examples": {
-                                "RunSelectedScenarios(simplest)": {
-                                    "value": {
-                                        "agent_id": 12,
-                                        "scenarios": [
-                                            101,
-                                            102,
-                                            103
-                                        ],
-                                        "frequency": 1
-                                    },
-                                    "summary": "Run selected scenarios (simplest)"
-                                },
-                                "RunAnEntireFolder,3×Each,5InParallel": {
-                                    "value": {
-                                        "agent_id": 12,
-                                        "folder_path": "Sales.Inbound",
-                                        "project_id": 1376,
-                                        "frequency": 3,
-                                        "concurrency_limit": 5,
-                                        "name": "Nightly Sales.Inbound regression"
-                                    },
-                                    "summary": "Run an entire folder, 3× each, 5 in parallel"
-                                },
-                                "OverridePersonalities+TestProfiles(multipliesRunCount)": {
-                                    "value": {
-                                        "agent_id": 12,
-                                        "scenarios": [
-                                            101
-                                        ],
-                                        "frequency": 2,
-                                        "personality_ids": [
-                                            3,
-                                            7
-                                        ],
-                                        "test_profile_ids": [
-                                            20,
-                                            21
-                                        ]
-                                    },
-                                    "summary": "Override personalities + test profiles (multiplies run count)"
-                                }
+                                "$ref": "#/components/schemas/ScenarioSerializerV2"
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
+                                "$ref": "#/components/schemas/ScenarioSerializerV2"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
+                                "$ref": "#/components/schemas/ScenarioSerializerV2"
                             }
                         }
-                    }
+                    },
+                    "required": true
                 },
                 "security": [
                     {
@@ -51395,222 +51662,11 @@
                     }
                 ],
                 "responses": {
-                    "201": {
+                    "200": {
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "id": {
-                                            "type": "integer",
-                                            "description": "ID of the result"
-                                        },
-                                        "agent": {
-                                            "type": "integer",
-                                            "description": "ID of the agent"
-                                        },
-                                        "status": {
-                                            "type": "string",
-                                            "enum": [
-                                                "pending",
-                                                "running",
-                                                "completed",
-                                                "failed"
-                                            ],
-                                            "description": "Status of the result"
-                                        },
-                                        "run_as_text": {
-                                            "type": "boolean",
-                                            "description": "Whether the scenario ran as text or not",
-                                            "example": false
-                                        },
-                                        "runs": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "id": {
-                                                        "type": "integer",
-                                                        "description": "ID of the run"
-                                                    },
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "pending",
-                                                            "running",
-                                                            "completed",
-                                                            "failed"
-                                                        ],
-                                                        "description": "Status of the run"
-                                                    },
-                                                    "scenario": {
-                                                        "type": "integer",
-                                                        "description": "ID of the scenario"
-                                                    },
-                                                    "number": {
-                                                        "type": "string",
-                                                        "description": "For outbound runs (agent.inbound=False). The given number that must be called from the phone number configured in the cekura agent.",
-                                                        "example": "+11234567890"
-                                                    },
-                                                    "inbound_number": {
-                                                        "type": [
-                                                            "string",
-                                                            "null"
-                                                        ],
-                                                        "description": "For inbound runs (agent.inbound=True). The agent's configured phone number will receive calls from this number.",
-                                                        "example": "+11234567890"
-                                                    },
-                                                    "scenario_name": {
-                                                        "type": "string",
-                                                        "description": "Name of the scenario"
-                                                    },
-                                                    "test_profile_data": {
-                                                        "type": [
-                                                            "object",
-                                                            "null"
-                                                        ],
-                                                        "description": "Details of the test profile associated with this run scenario"
-                                                    },
-                                                    "outbound_dial_window_opens_at": {
-                                                        "type": [
-                                                            "string",
-                                                            "null"
-                                                        ],
-                                                        "format": "date-time",
-                                                        "description": "When the outbound dial window opened (run transitioned to pending/waiting-for-call). Null until dispatched."
-                                                    },
-                                                    "outbound_dial_window_seconds": {
-                                                        "type": [
-                                                            "integer",
-                                                            "null"
-                                                        ],
-                                                        "description": "Duration of the outbound dial window in seconds."
-                                                    },
-                                                    "outbound_dial_window_closes_at": {
-                                                        "type": [
-                                                            "string",
-                                                            "null"
-                                                        ],
-                                                        "format": "date-time",
-                                                        "description": "Deadline by which your agent must dial the outbound number (opens_at + outbound_dial_window_seconds). Dials after this are dropped and the run returns status: timeout."
-                                                    }
-                                                }
-                                            },
-                                            "examples": [
-                                                {
-                                                    "id": 274,
-                                                    "status": "pending",
-                                                    "scenario": 1,
-                                                    "number": null,
-                                                    "inbound_number": "+11234567890",
-                                                    "scenario_name": "Customer Support Call (Agent Inbound = True)",
-                                                    "test_profile_data": null,
-                                                    "outbound_dial_window_opens_at": null,
-                                                    "outbound_dial_window_seconds": null,
-                                                    "outbound_dial_window_closes_at": null
-                                                },
-                                                {
-                                                    "id": 275,
-                                                    "status": "pending",
-                                                    "scenario": 2,
-                                                    "number": "+11234567890",
-                                                    "inbound_number": null,
-                                                    "scenario_name": "Outbound Sales Call (Agent Inbound = False)",
-                                                    "test_profile_data": null,
-                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
-                                                    "outbound_dial_window_seconds": 300,
-                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
-                                                }
-                                            ]
-                                        },
-                                        "created_at": {
-                                            "type": "string",
-                                            "format": "date-time",
-                                            "example": "2025-02-25T21:00:01.990052Z"
-                                        }
-                                    }
-                                },
-                                "examples": {
-                                    "InboundScenario": {
-                                        "value": {
-                                            "id": 167,
-                                            "agent": 1,
-                                            "status": "pending",
-                                            "success_rate": 0,
-                                            "run_as_text": false,
-                                            "runs": [
-                                                {
-                                                    "id": 274,
-                                                    "scenario": 1,
-                                                    "number": null,
-                                                    "inbound_number": "+11234567890",
-                                                    "outbound_dial_window_opens_at": null,
-                                                    "outbound_dial_window_seconds": null,
-                                                    "outbound_dial_window_closes_at": null
-                                                },
-                                                {
-                                                    "id": 273,
-                                                    "scenario": 2,
-                                                    "number": null,
-                                                    "inbound_number": "+11234567891",
-                                                    "outbound_dial_window_opens_at": null,
-                                                    "outbound_dial_window_seconds": null,
-                                                    "outbound_dial_window_closes_at": null
-                                                }
-                                            ],
-                                            "created_at": "2025-02-25T21:00:01.990052Z"
-                                        },
-                                        "summary": "Inbound Scenario"
-                                    },
-                                    "OutboundScenario": {
-                                        "value": {
-                                            "id": 167,
-                                            "agent": 1,
-                                            "status": "pending",
-                                            "success_rate": 0,
-                                            "run_as_text": false,
-                                            "runs": [
-                                                {
-                                                    "id": 274,
-                                                    "scenario": 1,
-                                                    "number": "+11234567890",
-                                                    "inbound_number": null,
-                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
-                                                    "outbound_dial_window_seconds": 300,
-                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
-                                                },
-                                                {
-                                                    "id": 273,
-                                                    "scenario": 2,
-                                                    "number": "+11234567891",
-                                                    "inbound_number": null,
-                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
-                                                    "outbound_dial_window_seconds": 300,
-                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
-                                                }
-                                            ],
-                                            "created_at": "2025-02-25T21:00:01.990052Z"
-                                        },
-                                        "summary": "Outbound Scenario"
-                                    }
-                                }
-                            }
-                        },
-                        "description": ""
-                    },
-                    "400": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "field_name": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
+                                    "$ref": "#/components/schemas/ScenarioSerializerV2"
                                 }
                             }
                         },
@@ -52512,6 +52568,342 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/ScenarioSerializerV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/scenarios/run_scenarios_json/": {
+            "post": {
+                "operationId": "scenarios-run-voice_3",
+                "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing. Requires `telephony.phone_number` configured on the agent (any provider).\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.\n\n**Outbound dial window:** for outbound runs (agent `inbound=false`), your agent must dial the run's `outbound_number` before `outbound_dial_window_closes_at` (default 300s after the run reaches `waiting_for_call` / pending state). Dials received after that deadline are dropped and the run returns `status: timeout`.",
+                "summary": "Run evaluators over a voice call",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "dry_run",
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "description": "Validate and price the spec without running or charging anything."
+                    }
+                ],
+                "tags": [
+                    "Evaluators"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
+                            },
+                            "examples": {
+                                "RunASpec": {
+                                    "value": {
+                                        "agent_id": 12,
+                                        "channel": "voice",
+                                        "spec": {
+                                            "version": "1",
+                                            "scenarios": [
+                                                {
+                                                    "name": "Refund happy path",
+                                                    "instructions": "You are a customer whose order arrived damaged.",
+                                                    "expected_outcome": "The agent confirms a refund.",
+                                                    "metrics": [
+                                                        "greeting_by_name"
+                                                    ],
+                                                    "personality": 3,
+                                                    "test_profile": {
+                                                        "agent_variables": {
+                                                            "order_id": "ORD-4471"
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "summary": "Run a spec"
+                                },
+                                "RunSelectedScenarios(simplest)": {
+                                    "value": {
+                                        "agent_id": 12,
+                                        "scenarios": [
+                                            101,
+                                            102,
+                                            103
+                                        ],
+                                        "frequency": 1
+                                    },
+                                    "summary": "Run selected scenarios (simplest)"
+                                },
+                                "RunAnEntireFolder,3×Each,5InParallel": {
+                                    "value": {
+                                        "agent_id": 12,
+                                        "folder_path": "Sales.Inbound",
+                                        "project_id": 1376,
+                                        "frequency": 3,
+                                        "concurrency_limit": 5,
+                                        "name": "Nightly Sales.Inbound regression"
+                                    },
+                                    "summary": "Run an entire folder, 3× each, 5 in parallel"
+                                },
+                                "OverridePersonalities+TestProfiles(multipliesRunCount)": {
+                                    "value": {
+                                        "agent_id": 12,
+                                        "scenarios": [
+                                            101
+                                        ],
+                                        "frequency": 2,
+                                        "personality_ids": [
+                                            3,
+                                            7
+                                        ],
+                                        "test_profile_ids": [
+                                            20,
+                                            21
+                                        ]
+                                    },
+                                    "summary": "Override personalities + test profiles (multiplies run count)"
+                                }
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {
+                                            "type": "integer",
+                                            "description": "ID of the result"
+                                        },
+                                        "agent": {
+                                            "type": "integer",
+                                            "description": "ID of the agent"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "pending",
+                                                "running",
+                                                "completed",
+                                                "failed"
+                                            ],
+                                            "description": "Status of the result"
+                                        },
+                                        "run_as_text": {
+                                            "type": "boolean",
+                                            "description": "Whether the scenario ran as text or not",
+                                            "example": false
+                                        },
+                                        "runs": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "id": {
+                                                        "type": "integer",
+                                                        "description": "ID of the run"
+                                                    },
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "pending",
+                                                            "running",
+                                                            "completed",
+                                                            "failed"
+                                                        ],
+                                                        "description": "Status of the run"
+                                                    },
+                                                    "scenario": {
+                                                        "type": "integer",
+                                                        "description": "ID of the scenario"
+                                                    },
+                                                    "number": {
+                                                        "type": "string",
+                                                        "description": "For outbound runs (agent.inbound=False). The given number that must be called from the phone number configured in the cekura agent.",
+                                                        "example": "+11234567890"
+                                                    },
+                                                    "inbound_number": {
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ],
+                                                        "description": "For inbound runs (agent.inbound=True). The agent's configured phone number will receive calls from this number.",
+                                                        "example": "+11234567890"
+                                                    },
+                                                    "scenario_name": {
+                                                        "type": "string",
+                                                        "description": "Name of the scenario"
+                                                    },
+                                                    "test_profile_data": {
+                                                        "type": [
+                                                            "object",
+                                                            "null"
+                                                        ],
+                                                        "description": "Details of the test profile associated with this run scenario"
+                                                    },
+                                                    "outbound_dial_window_opens_at": {
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ],
+                                                        "format": "date-time",
+                                                        "description": "When the outbound dial window opened (run transitioned to pending/waiting-for-call). Null until dispatched."
+                                                    },
+                                                    "outbound_dial_window_seconds": {
+                                                        "type": [
+                                                            "integer",
+                                                            "null"
+                                                        ],
+                                                        "description": "Duration of the outbound dial window in seconds."
+                                                    },
+                                                    "outbound_dial_window_closes_at": {
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ],
+                                                        "format": "date-time",
+                                                        "description": "Deadline by which your agent must dial the outbound number (opens_at + outbound_dial_window_seconds). Dials after this are dropped and the run returns status: timeout."
+                                                    }
+                                                }
+                                            },
+                                            "examples": [
+                                                {
+                                                    "id": 274,
+                                                    "status": "pending",
+                                                    "scenario": 1,
+                                                    "number": null,
+                                                    "inbound_number": "+11234567890",
+                                                    "scenario_name": "Customer Support Call (Agent Inbound = True)",
+                                                    "test_profile_data": null,
+                                                    "outbound_dial_window_opens_at": null,
+                                                    "outbound_dial_window_seconds": null,
+                                                    "outbound_dial_window_closes_at": null
+                                                },
+                                                {
+                                                    "id": 275,
+                                                    "status": "pending",
+                                                    "scenario": 2,
+                                                    "number": "+11234567890",
+                                                    "inbound_number": null,
+                                                    "scenario_name": "Outbound Sales Call (Agent Inbound = False)",
+                                                    "test_profile_data": null,
+                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
+                                                    "outbound_dial_window_seconds": 300,
+                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
+                                                }
+                                            ]
+                                        },
+                                        "created_at": {
+                                            "type": "string",
+                                            "format": "date-time",
+                                            "example": "2025-02-25T21:00:01.990052Z"
+                                        }
+                                    }
+                                },
+                                "examples": {
+                                    "InboundScenario": {
+                                        "value": {
+                                            "id": 167,
+                                            "agent": 1,
+                                            "status": "pending",
+                                            "success_rate": 0,
+                                            "run_as_text": false,
+                                            "runs": [
+                                                {
+                                                    "id": 274,
+                                                    "scenario": 1,
+                                                    "number": null,
+                                                    "inbound_number": "+11234567890",
+                                                    "outbound_dial_window_opens_at": null,
+                                                    "outbound_dial_window_seconds": null,
+                                                    "outbound_dial_window_closes_at": null
+                                                },
+                                                {
+                                                    "id": 273,
+                                                    "scenario": 2,
+                                                    "number": null,
+                                                    "inbound_number": "+11234567891",
+                                                    "outbound_dial_window_opens_at": null,
+                                                    "outbound_dial_window_seconds": null,
+                                                    "outbound_dial_window_closes_at": null
+                                                }
+                                            ],
+                                            "created_at": "2025-02-25T21:00:01.990052Z"
+                                        },
+                                        "summary": "Inbound Scenario"
+                                    },
+                                    "OutboundScenario": {
+                                        "value": {
+                                            "id": 167,
+                                            "agent": 1,
+                                            "status": "pending",
+                                            "success_rate": 0,
+                                            "run_as_text": false,
+                                            "runs": [
+                                                {
+                                                    "id": 274,
+                                                    "scenario": 1,
+                                                    "number": "+11234567890",
+                                                    "inbound_number": null,
+                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
+                                                    "outbound_dial_window_seconds": 300,
+                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
+                                                },
+                                                {
+                                                    "id": 273,
+                                                    "scenario": 2,
+                                                    "number": "+11234567891",
+                                                    "inbound_number": null,
+                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
+                                                    "outbound_dial_window_seconds": 300,
+                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
+                                                }
+                                            ],
+                                            "created_at": "2025-02-25T21:00:01.990052Z"
+                                        },
+                                        "summary": "Outbound Scenario"
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
                                 }
                             }
                         },
@@ -63985,6 +64377,11 @@
                         "type": "string",
                         "description": "URL Cekura calls to create outbound ElevenLabs phone calls."
                     },
+                    "trigger_secret": {
+                        "type": "string",
+                        "writeOnly": true,
+                        "description": "Optional shared secret sent as the X-CEKURA-SECRET header on trigger URL requests, so your endpoint can reject calls it didn't expect. Write-only — responses expose trigger_secret_configured instead."
+                    },
                     "elevenlabs_region": {
                         "enum": [
                             "us",
@@ -64864,6 +65261,11 @@
                     "trigger_url": {
                         "type": "string",
                         "description": "URL Cekura calls to create outbound phone calls."
+                    },
+                    "trigger_secret": {
+                        "type": "string",
+                        "writeOnly": true,
+                        "description": "Optional shared secret sent as the X-CEKURA-SECRET header on trigger URL requests, so your endpoint can reject calls it didn't expect. Write-only — responses expose trigger_secret_configured instead."
                     }
                 },
                 "required": [
@@ -75568,6 +75970,11 @@
                         "type": "string",
                         "description": "URL Cekura calls to create outbound Retell phone calls."
                     },
+                    "trigger_secret": {
+                        "type": "string",
+                        "writeOnly": true,
+                        "description": "Optional shared secret sent as the X-CEKURA-SECRET header on trigger URL requests, so your endpoint can reject calls it didn't expect. Write-only — responses expose trigger_secret_configured instead."
+                    },
                     "livekit_server_url": {
                         "type": "string",
                         "description": "Override the default Retell LiveKit server URL, e.g. wss://retell-ai-4ihahnq7.livekit.cloud. Only change if you need a specific Retell region."
@@ -80844,6 +81251,15 @@
                     "send_post_conversation_metadata": {
                         "type": "boolean",
                         "description": "Enable Cekura to accept call transcripts pushed by your agent via POST /custom-provider-webhook/. Set to true when your agent sends its own transcripts to Cekura after each call."
+                    },
+                    "trigger_url": {
+                        "type": "string",
+                        "description": "URL Cekura calls to create outbound phone calls. Required to enable auto_dial_outbound for the custom provider."
+                    },
+                    "trigger_secret": {
+                        "type": "string",
+                        "writeOnly": true,
+                        "description": "Optional shared secret sent as the X-CEKURA-SECRET header on trigger URL requests, so your endpoint can reject calls it didn't expect. Write-only — responses expose trigger_secret_configured instead."
                     }
                 },
                 "title": "Self-hosted"
@@ -81788,6 +82204,11 @@
                     "trigger_url": {
                         "type": "string",
                         "description": "URL Cekura calls to create outbound VAPI phone calls."
+                    },
+                    "trigger_secret": {
+                        "type": "string",
+                        "writeOnly": true,
+                        "description": "Optional shared secret sent as the X-CEKURA-SECRET header on trigger URL requests, so your endpoint can reject calls it didn't expect. Write-only — responses expose trigger_secret_configured instead."
                     }
                 },
                 "title": "VAPI"

--- a/openapi.json
+++ b/openapi.json
@@ -57516,7 +57516,7 @@
             },
             "delete": {
                 "operationId": "projects-external-destroy",
-                "description": "⚠ Irreversible. Deletes the project and everything scoped to it: agents, evaluators, metrics, results, and runs.",
+                "description": "⚠ Irreversible. Deletes the project and everything scoped to it: agents, evaluators, metrics, results, and runs. The last remaining project in an organization cannot be deleted.",
                 "summary": "Delete a project",
                 "parameters": [
                     {
@@ -57539,6 +57539,9 @@
                 ],
                 "responses": {
                     "200": {
+                        "description": "No response body"
+                    },
+                    "400": {
                         "description": "No response body"
                     },
                     "403": {
@@ -58429,7 +58432,7 @@
             },
             "delete": {
                 "operationId": "projects-destroy",
-                "description": "⚠ Irreversible. Deletes the project and everything scoped to it: agents, evaluators, metrics, results, and runs.",
+                "description": "⚠ Irreversible. Deletes the project and everything scoped to it: agents, evaluators, metrics, results, and runs. The last remaining project in an organization cannot be deleted.",
                 "summary": "Delete a project",
                 "parameters": [
                     {
@@ -58454,6 +58457,9 @@
                     "200": {
                         "description": "No response body"
                     },
+                    "400": {
+                        "description": "No response body"
+                    },
                     "403": {
                         "description": "No response body"
                     },
@@ -58466,7 +58472,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "projects-destroy",
-                        "description": "⚠ Irreversible. Deletes the project and everything scoped to it: agents, evaluators, metrics, results, and runs."
+                        "description": "⚠ Irreversible. Deletes the project and everything scoped to it: agents, evaluators, metrics, results, and runs. The last remaining project in an organization cannot be deleted."
                     }
                 }
             }
@@ -81254,7 +81260,7 @@
                     },
                     "trigger_url": {
                         "type": "string",
-                        "description": "URL Cekura calls to create outbound phone calls. Required to enable auto_dial_outbound for the custom provider."
+                        "description": "URL Cekura calls to create outbound phone calls. Required to enable auto_dial_outbound for the custom provider; must answer 2xx within 30s."
                     },
                     "trigger_secret": {
                         "type": "string",


### PR DESCRIPTION
Auto-generated docs sync for backend PR [#10551](https://github.com/cekura-ai/vocera.backend/pull/10551).

Reviewers: @dileep-chagam

## Summary

**Spec/overlay:** Spec changed (schema updates to exposed ops scenarios_run_voice and projects_destroy; 1 newly exposed op scenarios_json_schema). No overlay patches needed: scenarios_run_voice overlay already exists (D2 precedence), no transport-quirk signals fired for new ops. 1 SDK/CLI follow-up for scenarios_json_schema.

**Conceptual docs:** Updated documentation/guides/testing-agents/outbound-auto-call.mdx: added Custom provider to supported providers list, updated trigger URL response requirement from 200/201 to any 2xx, and documented the new optional X-CEKURA-SECRET trigger secret header.

## Changes

- `openapi.json` — regenerate_from_backend
- `documentation/guides/testing-agents/outbound-auto-call.mdx` — update

## SDK / CLI parity follow-ups

- `scenarios_json_schema` (GET `/test_framework/v1/scenarios/json_schema/`) — add

---
*Auto-generated from backend PR #10551.*

<!-- mcp-sync:file-hashes -->
```json
{
  "documentation/guides/testing-agents/outbound-auto-call.mdx": "ff796f6fee296a48408062e7a5d646cf2db6f4c473c867962edc9032562f7290"
}
```
<!-- /mcp-sync:file-hashes -->