### PR TITLE
[Auto] Sync docs for backend PR #10610

### DIFF
--- a/api-reference/test_framework/fetch-external-scenarios-json-schema.mdx
+++ b/api-reference/test_framework/fetch-external-scenarios-json-schema.mdx
@@ -1,0 +1,6 @@
+---
+title: Fetch External Scenarios JSON Schema
+description: "Fetch the JSON Schema for test-suite spec files"
+openapi: get /test_framework/v1/scenarios-external/json_schema/
+slug: fetch-external-scenarios-json-schema
+---

--- a/api-reference/test_framework/fetch-scenarios-json-schema.mdx
+++ b/api-reference/test_framework/fetch-scenarios-json-schema.mdx
@@ -1,0 +1,6 @@
+---
+title: Fetch Scenarios JSON Schema
+description: "Fetch the JSON Schema for test-suite spec files"
+openapi: get /test_framework/v1/scenarios/json_schema/
+slug: fetch-scenarios-json-schema
+---

--- a/api-reference/test_framework/fetch-scenarios-v2-json-schema.mdx
+++ b/api-reference/test_framework/fetch-scenarios-v2-json-schema.mdx
@@ -1,0 +1,6 @@
+---
+title: Fetch Scenarios V2 JSON Schema
+description: "Fetch the JSON Schema for test-suite spec files"
+openapi: get /test_framework/v2/scenarios/json_schema/
+slug: fetch-scenarios-v2-json-schema
+---

--- a/api-reference/test_framework/run-external-scenarios-voice.mdx
+++ b/api-reference/test_framework/run-external-scenarios-voice.mdx
@@ -1,0 +1,6 @@
+---
+title: Run External Scenarios Voice
+description: "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing. Requires `telephony.phone_number` configured on the agent (any provider)."
+openapi: post /test_framework/v1/scenarios-external/run_scenarios_json/
+slug: run-external-scenarios-voice
+---

--- a/api-reference/test_framework/run-scenarios-v2-voice.mdx
+++ b/api-reference/test_framework/run-scenarios-v2-voice.mdx
@@ -1,0 +1,6 @@
+---
+title: Run Scenarios V2 Voice
+description: "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing. Requires `telephony.phone_number` configured on the agent (any provider)."
+openapi: post /test_framework/v2/scenarios/run_scenarios_json/
+slug: run-scenarios-v2-voice
+---

--- a/api-reference/test_framework/run-scenarios-voice.mdx
+++ b/api-reference/test_framework/run-scenarios-voice.mdx
@@ -1,0 +1,6 @@
+---
+title: Run Scenarios Voice
+description: "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing. Requires `telephony.phone_number` configured on the agent (any provider)."
+openapi: post /test_framework/v1/scenarios/run_scenarios_json/
+slug: run-scenarios-voice
+---

--- a/documentation/key-concepts/metrics/build-with-ai.mdx
+++ b/documentation/key-concepts/metrics/build-with-ai.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Build a Metric with AI"
-description: "Refine an LLM Judge or Python metric with an AI agent that runs it on your real calls and runs, fixes clear edge cases itself, and asks you only when a decision is genuinely ambiguous"
+description: "Refine an LLM Judge or Python metric with an AI agent that defines it in one turn or runs it on your real calls and runs for deeper refinement."
 sidebarTitle: "Build with AI"
 icon: "wand-magic-sparkles"
 iconType: "solid"
@@ -15,7 +15,44 @@ rounds of trial and error — write a definition, preview it on some calls,
 notice a case it gets wrong, tighten the wording, repeat. **Build with AI**
 collapses that loop into a single conversation.
 
-When you click **Improve** on a metric's definition, an AI agent:
+The builder offers two modes:
+
+- **Quick** (default) — a single AI turn that refines your definition from the
+  metric intent, agent description, and conversation context alone. No calls or
+  runs are sampled and no preview evaluation is run, so results come back in
+  seconds. Use this when you want a fast first draft or when your agent doesn't
+  have much call history yet.
+- **Detailed** — the AI agent samples your agent's real calls and runs, evaluates
+  the metric against them, and iterates over multiple turns to tighten edge cases.
+  Use this when you have enough call history and want evidence-backed refinement.
+
+If you select **Detailed** but the agent doesn't have enough recorded calls and
+runs to make evaluation useful, the builder automatically falls back to the quick
+path for that turn.
+
+<Note>
+Build with AI works for both **LLM Judge** metrics (it refines the natural-language
+description) and **Python** metrics (it makes surgical edits to your code — see
+below). You commit the final metric yourself; nothing is saved until you click
+**Use this metric** and then **Create**/**Update**.
+</Note>
+
+## Quick mode
+
+When you click **Improve** with the default quick mode, the AI agent:
+
+1. Reads your starting definition and the agent's description.
+2. Checks whether the intent is clear enough to write a metric. If not, it asks
+   one concise clarification question.
+3. Writes the final refined definition in a single pass — no sampling, no
+   preview evaluation.
+
+Quick mode is best for getting a solid first definition fast, especially when
+you're still iterating on what you want the metric to measure.
+
+## Detailed mode
+
+When you select **Detailed**, the AI agent:
 
 1. Cleans up your definition and gives it a quick check. If the intent is
    unclear or the definition has an obvious gap, it asks you a short question
@@ -29,13 +66,6 @@ When you click **Improve** on a metric's definition, an AI agent:
    (for example, "should a partial completion count as PASS?").
 5. Proposes a refined definition for you to review and apply.
 
-<Note>
-Build with AI works for both **LLM Judge** metrics (it refines the natural-language
-description) and **Python** metrics (it makes surgical edits to your code — see
-below). You commit the final metric yourself; nothing is saved until you click
-**Use this metric** and then **Create**/**Update**.
-</Note>
-
 ### Starting a build
 
 <Steps>
@@ -47,7 +77,7 @@ below). You commit the final metric yourself; nothing is saved until you click
   <Step title="Click Improve">
     The **Improve** button sits next to the Description (LLM Judge) or the Custom
     Code editor (Python). Pick the agent whose calls and runs the builder should
-    sample from.
+    sample from, and choose **Quick** or **Detailed** mode.
   </Step>
   <Step title="Chat with the builder">
     The builder works through your calls and runs and either asks a clarifying
@@ -65,8 +95,8 @@ below). You commit the final metric yourself; nothing is saved until you click
 
 ### Working in the background
 
-A build runs an AI agent over dozens of real calls and runs, so it typically
-takes **a few minutes** (usually 4–6). You don't have to wait on it:
+A detailed build runs an AI agent over dozens of real calls and runs, so it
+typically takes **a few minutes** (usually 4–6). You don't have to wait on it:
 
 - **Minimize** the chat and it keeps running as a small card in the corner.
 - The card **follows you across the platform** — open another metric, inspect
@@ -99,8 +129,13 @@ production, so what you review is what you ship.
 
 ### Credits
 
-A build runs your metric against the sampled calls and runs, and consumes credits
-for each pass, priced the same way the metric optimizer is:
+Credits depend on which mode you use:
+
+**Quick mode** charges a single flat minimum per build — no per-evaluation cost,
+since no calls or runs are evaluated.
+
+**Detailed mode** runs your metric against the sampled calls and runs, and
+consumes credits for each pass, priced the same way the metric optimizer is:
 
 - **LLM Judge metrics** — and Python metrics that call `evaluate_llm_judge_metric`
   — are charged at the **LLM-judge** per-evaluation rate.
@@ -110,11 +145,11 @@ for each pass, priced the same way the metric optimizer is:
   judge listens to, not the charge.
 - **Pure Python metrics** are charged at the **custom-code** per-evaluation rate.
 
-The cost of a pass is roughly the number of sampled items (≈50) times that rate.
-A pass runs only when the metric definition actually changed, so answering a
-clarifying question or sending a note that doesn't alter the metric won't
-re-charge. Minimizing the chat doesn't stop the build; if you don't want to spend
-more credits, **Stop** it.
+The cost of a detailed pass is roughly the number of sampled items (≈50) times
+that rate. A pass runs only when the metric definition actually changed, so
+answering a clarifying question or sending a note that doesn't alter the metric
+won't re-charge. Minimizing the chat doesn't stop the build; if you don't want
+to spend more credits, **Stop** it.
 
 ## Related Documentation
 

--- a/mint.json
+++ b/mint.json
@@ -366,7 +366,13 @@
                 "api-reference/test_framework/api-chat-poll-turn",
                 "api-reference/test_framework/api-chat-end"
               ]
-            }
+            },
+            "api-reference/test_framework/fetch-external-scenarios-json-schema",
+            "api-reference/test_framework/run-external-scenarios-voice",
+            "api-reference/test_framework/fetch-scenarios-json-schema",
+            "api-reference/test_framework/run-scenarios-voice",
+            "api-reference/test_framework/fetch-scenarios-v2-json-schema",
+            "api-reference/test_framework/run-scenarios-v2-voice"
           ]
         },
         {

--- a/openapi.json
+++ b/openapi.json
@@ -181,9 +181,36 @@
             }
         },
         "/app/v1/product-chat/sessions/{session_id}/": {
+            "get": {
+                "operationId": "app-v1-product-chat-sessions-retrieve_2",
+                "description": "Read or delete a product-chat session (legacy v1).\n\nSoft-delete: sets `is_deleted=True` on the conversation. Accepts both\ncanonical UUIDs and legacy session ids.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "session_id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "app"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No response body"
+                    }
+                }
+            },
             "delete": {
                 "operationId": "app-v1-product-chat-sessions-destroy",
-                "description": "Delete a product-chat session (legacy v1).\n\nSoft-delete: sets `is_deleted=True` on the conversation. Accepts both\ncanonical UUIDs and legacy session ids.",
+                "description": "Read or delete a product-chat session (legacy v1).\n\nSoft-delete: sets `is_deleted=True` on the conversation. Accepts both\ncanonical UUIDs and legacy session ids.",
                 "parameters": [
                     {
                         "in": "path",
@@ -11709,7 +11736,7 @@
         "/subscriptions/subscriptions/{id}/select-first-paid-seat-plan/": {
             "post": {
                 "operationId": "subscriptions-subscriptions-select-first-paid-seat-plan-create",
-                "description": "Resolve the one-time choice shown before an org's first paid seat.\n\nSending the current pack code keeps pay-as-you-go. Sending the configured\n``allow_switch_to_plan`` code creates and charges that monthly subscription\nimmediately. Pricing, Stripe IDs, and the customer are always server-owned.",
+                "description": "Resolve a one-time paid-plan choice.\n\nPAYG organizations see it before their first paid seat; developer-trial\norganizations can use it from Manage Plan. Sending the current pack code\nkeeps pay-as-you-go. Sending the configured ``allow_switch_to_plan`` code\ncreates and charges that monthly subscription immediately. Pricing, Stripe\nIDs, and the customer are always server-owned.",
                 "parameters": [
                     {
                         "in": "path",
@@ -31918,6 +31945,43 @@
                 }
             }
         },
+        "/test_framework/v1/scenarios-external/json_schema/": {
+            "get": {
+                "operationId": "scenarios-json-schema",
+                "description": "Fetch the JSON Schema for test-suite spec files",
+                "summary": "Fetch the JSON Schema for test-suite spec files",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "version",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Spec version to fetch. Defaults to the current version."
+                    }
+                ],
+                "tags": [
+                    "Evaluators"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Scenario"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/test_framework/v1/scenarios-external/move_folder/": {
             "post": {
                 "operationId": "scenarios-folder-move",
@@ -32012,73 +32076,30 @@
         },
         "/test_framework/v1/scenarios-external/run_scenarios/": {
             "post": {
-                "operationId": "scenarios-run-voice",
-                "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing. Requires `telephony.phone_number` configured on the agent (any provider).\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.\n\n**Outbound dial window:** for outbound runs (agent `inbound=false`), your agent must dial the run's `outbound_number` before `outbound_dial_window_closes_at` (default 300s after the run reaches `waiting_for_call` / pending state). Dials received after that deadline are dropped and the run returns `status: timeout`.",
-                "summary": "Run evaluators over a voice call",
+                "operationId": "scenarios-external-run-scenarios-create",
+                "description": "Run test scenarios against an AI voice agent",
                 "tags": [
-                    "Evaluators"
+                    "test_framework"
                 ],
                 "requestBody": {
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
-                            },
-                            "examples": {
-                                "RunSelectedScenarios(simplest)": {
-                                    "value": {
-                                        "agent_id": 12,
-                                        "scenarios": [
-                                            101,
-                                            102,
-                                            103
-                                        ],
-                                        "frequency": 1
-                                    },
-                                    "summary": "Run selected scenarios (simplest)"
-                                },
-                                "RunAnEntireFolder,3×Each,5InParallel": {
-                                    "value": {
-                                        "agent_id": 12,
-                                        "folder_path": "Sales.Inbound",
-                                        "project_id": 1376,
-                                        "frequency": 3,
-                                        "concurrency_limit": 5,
-                                        "name": "Nightly Sales.Inbound regression"
-                                    },
-                                    "summary": "Run an entire folder, 3× each, 5 in parallel"
-                                },
-                                "OverridePersonalities+TestProfiles(multipliesRunCount)": {
-                                    "value": {
-                                        "agent_id": 12,
-                                        "scenarios": [
-                                            101
-                                        ],
-                                        "frequency": 2,
-                                        "personality_ids": [
-                                            3,
-                                            7
-                                        ],
-                                        "test_profile_ids": [
-                                            20,
-                                            21
-                                        ]
-                                    },
-                                    "summary": "Override personalities + test profiles (multiplies run count)"
-                                }
+                                "$ref": "#/components/schemas/Scenario"
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
+                                "$ref": "#/components/schemas/Scenario"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
+                                "$ref": "#/components/schemas/Scenario"
                             }
                         }
-                    }
+                    },
+                    "required": true
                 },
                 "security": [
                     {
@@ -32086,222 +32107,11 @@
                     }
                 ],
                 "responses": {
-                    "201": {
+                    "200": {
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "id": {
-                                            "type": "integer",
-                                            "description": "ID of the result"
-                                        },
-                                        "agent": {
-                                            "type": "integer",
-                                            "description": "ID of the agent"
-                                        },
-                                        "status": {
-                                            "type": "string",
-                                            "enum": [
-                                                "pending",
-                                                "running",
-                                                "completed",
-                                                "failed"
-                                            ],
-                                            "description": "Status of the result"
-                                        },
-                                        "run_as_text": {
-                                            "type": "boolean",
-                                            "description": "Whether the scenario ran as text or not",
-                                            "example": false
-                                        },
-                                        "runs": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "id": {
-                                                        "type": "integer",
-                                                        "description": "ID of the run"
-                                                    },
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "pending",
-                                                            "running",
-                                                            "completed",
-                                                            "failed"
-                                                        ],
-                                                        "description": "Status of the run"
-                                                    },
-                                                    "scenario": {
-                                                        "type": "integer",
-                                                        "description": "ID of the scenario"
-                                                    },
-                                                    "number": {
-                                                        "type": "string",
-                                                        "description": "For outbound runs (agent.inbound=False). The given number that must be called from the phone number configured in the cekura agent.",
-                                                        "example": "+11234567890"
-                                                    },
-                                                    "inbound_number": {
-                                                        "type": [
-                                                            "string",
-                                                            "null"
-                                                        ],
-                                                        "description": "For inbound runs (agent.inbound=True). The agent's configured phone number will receive calls from this number.",
-                                                        "example": "+11234567890"
-                                                    },
-                                                    "scenario_name": {
-                                                        "type": "string",
-                                                        "description": "Name of the scenario"
-                                                    },
-                                                    "test_profile_data": {
-                                                        "type": [
-                                                            "object",
-                                                            "null"
-                                                        ],
-                                                        "description": "Details of the test profile associated with this run scenario"
-                                                    },
-                                                    "outbound_dial_window_opens_at": {
-                                                        "type": [
-                                                            "string",
-                                                            "null"
-                                                        ],
-                                                        "format": "date-time",
-                                                        "description": "When the outbound dial window opened (run transitioned to pending/waiting-for-call). Null until dispatched."
-                                                    },
-                                                    "outbound_dial_window_seconds": {
-                                                        "type": [
-                                                            "integer",
-                                                            "null"
-                                                        ],
-                                                        "description": "Duration of the outbound dial window in seconds."
-                                                    },
-                                                    "outbound_dial_window_closes_at": {
-                                                        "type": [
-                                                            "string",
-                                                            "null"
-                                                        ],
-                                                        "format": "date-time",
-                                                        "description": "Deadline by which your agent must dial the outbound number (opens_at + outbound_dial_window_seconds). Dials after this are dropped and the run returns status: timeout."
-                                                    }
-                                                }
-                                            },
-                                            "examples": [
-                                                {
-                                                    "id": 274,
-                                                    "status": "pending",
-                                                    "scenario": 1,
-                                                    "number": null,
-                                                    "inbound_number": "+11234567890",
-                                                    "scenario_name": "Customer Support Call (Agent Inbound = True)",
-                                                    "test_profile_data": null,
-                                                    "outbound_dial_window_opens_at": null,
-                                                    "outbound_dial_window_seconds": null,
-                                                    "outbound_dial_window_closes_at": null
-                                                },
-                                                {
-                                                    "id": 275,
-                                                    "status": "pending",
-                                                    "scenario": 2,
-                                                    "number": "+11234567890",
-                                                    "inbound_number": null,
-                                                    "scenario_name": "Outbound Sales Call (Agent Inbound = False)",
-                                                    "test_profile_data": null,
-                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
-                                                    "outbound_dial_window_seconds": 300,
-                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
-                                                }
-                                            ]
-                                        },
-                                        "created_at": {
-                                            "type": "string",
-                                            "format": "date-time",
-                                            "example": "2025-02-25T21:00:01.990052Z"
-                                        }
-                                    }
-                                },
-                                "examples": {
-                                    "InboundScenario": {
-                                        "value": {
-                                            "id": 167,
-                                            "agent": 1,
-                                            "status": "pending",
-                                            "success_rate": 0,
-                                            "run_as_text": false,
-                                            "runs": [
-                                                {
-                                                    "id": 274,
-                                                    "scenario": 1,
-                                                    "number": null,
-                                                    "inbound_number": "+11234567890",
-                                                    "outbound_dial_window_opens_at": null,
-                                                    "outbound_dial_window_seconds": null,
-                                                    "outbound_dial_window_closes_at": null
-                                                },
-                                                {
-                                                    "id": 273,
-                                                    "scenario": 2,
-                                                    "number": null,
-                                                    "inbound_number": "+11234567891",
-                                                    "outbound_dial_window_opens_at": null,
-                                                    "outbound_dial_window_seconds": null,
-                                                    "outbound_dial_window_closes_at": null
-                                                }
-                                            ],
-                                            "created_at": "2025-02-25T21:00:01.990052Z"
-                                        },
-                                        "summary": "Inbound Scenario"
-                                    },
-                                    "OutboundScenario": {
-                                        "value": {
-                                            "id": 167,
-                                            "agent": 1,
-                                            "status": "pending",
-                                            "success_rate": 0,
-                                            "run_as_text": false,
-                                            "runs": [
-                                                {
-                                                    "id": 274,
-                                                    "scenario": 1,
-                                                    "number": "+11234567890",
-                                                    "inbound_number": null,
-                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
-                                                    "outbound_dial_window_seconds": 300,
-                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
-                                                },
-                                                {
-                                                    "id": 273,
-                                                    "scenario": 2,
-                                                    "number": "+11234567891",
-                                                    "inbound_number": null,
-                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
-                                                    "outbound_dial_window_seconds": 300,
-                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
-                                                }
-                                            ],
-                                            "created_at": "2025-02-25T21:00:01.990052Z"
-                                        },
-                                        "summary": "Outbound Scenario"
-                                    }
-                                }
-                            }
-                        },
-                        "description": ""
-                    },
-                    "400": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "field_name": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
+                                    "$ref": "#/components/schemas/Scenario"
                                 }
                             }
                         },
@@ -33203,6 +33013,342 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/Scenario"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/scenarios-external/run_scenarios_json/": {
+            "post": {
+                "operationId": "scenarios-run-voice",
+                "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing. Requires `telephony.phone_number` configured on the agent (any provider).\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.\n\n**Outbound dial window:** for outbound runs (agent `inbound=false`), your agent must dial the run's `outbound_number` before `outbound_dial_window_closes_at` (default 300s after the run reaches `waiting_for_call` / pending state). Dials received after that deadline are dropped and the run returns `status: timeout`.",
+                "summary": "Run evaluators over a voice call",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "dry_run",
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "description": "Validate and price the spec without running or charging anything."
+                    }
+                ],
+                "tags": [
+                    "Evaluators"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
+                            },
+                            "examples": {
+                                "RunASpec": {
+                                    "value": {
+                                        "agent_id": 12,
+                                        "channel": "voice",
+                                        "spec": {
+                                            "version": "1",
+                                            "scenarios": [
+                                                {
+                                                    "name": "Refund happy path",
+                                                    "instructions": "You are a customer whose order arrived damaged.",
+                                                    "expected_outcome": "The agent confirms a refund.",
+                                                    "metrics": [
+                                                        "greeting_by_name"
+                                                    ],
+                                                    "personality": 3,
+                                                    "test_profile": {
+                                                        "agent_variables": {
+                                                            "order_id": "ORD-4471"
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "summary": "Run a spec"
+                                },
+                                "RunSelectedScenarios(simplest)": {
+                                    "value": {
+                                        "agent_id": 12,
+                                        "scenarios": [
+                                            101,
+                                            102,
+                                            103
+                                        ],
+                                        "frequency": 1
+                                    },
+                                    "summary": "Run selected scenarios (simplest)"
+                                },
+                                "RunAnEntireFolder,3×Each,5InParallel": {
+                                    "value": {
+                                        "agent_id": 12,
+                                        "folder_path": "Sales.Inbound",
+                                        "project_id": 1376,
+                                        "frequency": 3,
+                                        "concurrency_limit": 5,
+                                        "name": "Nightly Sales.Inbound regression"
+                                    },
+                                    "summary": "Run an entire folder, 3× each, 5 in parallel"
+                                },
+                                "OverridePersonalities+TestProfiles(multipliesRunCount)": {
+                                    "value": {
+                                        "agent_id": 12,
+                                        "scenarios": [
+                                            101
+                                        ],
+                                        "frequency": 2,
+                                        "personality_ids": [
+                                            3,
+                                            7
+                                        ],
+                                        "test_profile_ids": [
+                                            20,
+                                            21
+                                        ]
+                                    },
+                                    "summary": "Override personalities + test profiles (multiplies run count)"
+                                }
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {
+                                            "type": "integer",
+                                            "description": "ID of the result"
+                                        },
+                                        "agent": {
+                                            "type": "integer",
+                                            "description": "ID of the agent"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "pending",
+                                                "running",
+                                                "completed",
+                                                "failed"
+                                            ],
+                                            "description": "Status of the result"
+                                        },
+                                        "run_as_text": {
+                                            "type": "boolean",
+                                            "description": "Whether the scenario ran as text or not",
+                                            "example": false
+                                        },
+                                        "runs": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "id": {
+                                                        "type": "integer",
+                                                        "description": "ID of the run"
+                                                    },
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "pending",
+                                                            "running",
+                                                            "completed",
+                                                            "failed"
+                                                        ],
+                                                        "description": "Status of the run"
+                                                    },
+                                                    "scenario": {
+                                                        "type": "integer",
+                                                        "description": "ID of the scenario"
+                                                    },
+                                                    "number": {
+                                                        "type": "string",
+                                                        "description": "For outbound runs (agent.inbound=False). The given number that must be called from the phone number configured in the cekura agent.",
+                                                        "example": "+11234567890"
+                                                    },
+                                                    "inbound_number": {
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ],
+                                                        "description": "For inbound runs (agent.inbound=True). The agent's configured phone number will receive calls from this number.",
+                                                        "example": "+11234567890"
+                                                    },
+                                                    "scenario_name": {
+                                                        "type": "string",
+                                                        "description": "Name of the scenario"
+                                                    },
+                                                    "test_profile_data": {
+                                                        "type": [
+                                                            "object",
+                                                            "null"
+                                                        ],
+                                                        "description": "Details of the test profile associated with this run scenario"
+                                                    },
+                                                    "outbound_dial_window_opens_at": {
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ],
+                                                        "format": "date-time",
+                                                        "description": "When the outbound dial window opened (run transitioned to pending/waiting-for-call). Null until dispatched."
+                                                    },
+                                                    "outbound_dial_window_seconds": {
+                                                        "type": [
+                                                            "integer",
+                                                            "null"
+                                                        ],
+                                                        "description": "Duration of the outbound dial window in seconds."
+                                                    },
+                                                    "outbound_dial_window_closes_at": {
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ],
+                                                        "format": "date-time",
+                                                        "description": "Deadline by which your agent must dial the outbound number (opens_at + outbound_dial_window_seconds). Dials after this are dropped and the run returns status: timeout."
+                                                    }
+                                                }
+                                            },
+                                            "examples": [
+                                                {
+                                                    "id": 274,
+                                                    "status": "pending",
+                                                    "scenario": 1,
+                                                    "number": null,
+                                                    "inbound_number": "+11234567890",
+                                                    "scenario_name": "Customer Support Call (Agent Inbound = True)",
+                                                    "test_profile_data": null,
+                                                    "outbound_dial_window_opens_at": null,
+                                                    "outbound_dial_window_seconds": null,
+                                                    "outbound_dial_window_closes_at": null
+                                                },
+                                                {
+                                                    "id": 275,
+                                                    "status": "pending",
+                                                    "scenario": 2,
+                                                    "number": "+11234567890",
+                                                    "inbound_number": null,
+                                                    "scenario_name": "Outbound Sales Call (Agent Inbound = False)",
+                                                    "test_profile_data": null,
+                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
+                                                    "outbound_dial_window_seconds": 300,
+                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
+                                                }
+                                            ]
+                                        },
+                                        "created_at": {
+                                            "type": "string",
+                                            "format": "date-time",
+                                            "example": "2025-02-25T21:00:01.990052Z"
+                                        }
+                                    }
+                                },
+                                "examples": {
+                                    "InboundScenario": {
+                                        "value": {
+                                            "id": 167,
+                                            "agent": 1,
+                                            "status": "pending",
+                                            "success_rate": 0,
+                                            "run_as_text": false,
+                                            "runs": [
+                                                {
+                                                    "id": 274,
+                                                    "scenario": 1,
+                                                    "number": null,
+                                                    "inbound_number": "+11234567890",
+                                                    "outbound_dial_window_opens_at": null,
+                                                    "outbound_dial_window_seconds": null,
+                                                    "outbound_dial_window_closes_at": null
+                                                },
+                                                {
+                                                    "id": 273,
+                                                    "scenario": 2,
+                                                    "number": null,
+                                                    "inbound_number": "+11234567891",
+                                                    "outbound_dial_window_opens_at": null,
+                                                    "outbound_dial_window_seconds": null,
+                                                    "outbound_dial_window_closes_at": null
+                                                }
+                                            ],
+                                            "created_at": "2025-02-25T21:00:01.990052Z"
+                                        },
+                                        "summary": "Inbound Scenario"
+                                    },
+                                    "OutboundScenario": {
+                                        "value": {
+                                            "id": 167,
+                                            "agent": 1,
+                                            "status": "pending",
+                                            "success_rate": 0,
+                                            "run_as_text": false,
+                                            "runs": [
+                                                {
+                                                    "id": 274,
+                                                    "scenario": 1,
+                                                    "number": "+11234567890",
+                                                    "inbound_number": null,
+                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
+                                                    "outbound_dial_window_seconds": 300,
+                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
+                                                },
+                                                {
+                                                    "id": 273,
+                                                    "scenario": 2,
+                                                    "number": "+11234567891",
+                                                    "inbound_number": null,
+                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
+                                                    "outbound_dial_window_seconds": 300,
+                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
+                                                }
+                                            ],
+                                            "created_at": "2025-02-25T21:00:01.990052Z"
+                                        },
+                                        "summary": "Outbound Scenario"
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
                                 }
                             }
                         },
@@ -37575,6 +37721,51 @@
                 ]
             }
         },
+        "/test_framework/v1/scenarios/json_schema/": {
+            "get": {
+                "operationId": "scenarios-json-schema_2",
+                "description": "Fetch the JSON Schema for test-suite spec files",
+                "summary": "Fetch the JSON Schema for test-suite spec files",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "version",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Spec version to fetch. Defaults to the current version."
+                    }
+                ],
+                "tags": [
+                    "Evaluators"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Scenario"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "scenarios-json-schema",
+                        "description": "Fetch the JSON Schema for test-suite spec files"
+                    }
+                }
+            }
+        },
         "/test_framework/v1/scenarios/move_folder/": {
             "post": {
                 "operationId": "scenarios-folder-move_2",
@@ -37685,73 +37876,30 @@
         },
         "/test_framework/v1/scenarios/run_scenarios/": {
             "post": {
-                "operationId": "scenarios-run-voice_2",
-                "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing. Requires `telephony.phone_number` configured on the agent (any provider).\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.\n\n**Outbound dial window:** for outbound runs (agent `inbound=false`), your agent must dial the run's `outbound_number` before `outbound_dial_window_closes_at` (default 300s after the run reaches `waiting_for_call` / pending state). Dials received after that deadline are dropped and the run returns `status: timeout`.",
-                "summary": "Run evaluators over a voice call",
+                "operationId": "scenarios-run-scenarios-create",
+                "description": "Run test scenarios against an AI voice agent",
                 "tags": [
-                    "Evaluators"
+                    "test_framework"
                 ],
                 "requestBody": {
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
-                            },
-                            "examples": {
-                                "RunSelectedScenarios(simplest)": {
-                                    "value": {
-                                        "agent_id": 12,
-                                        "scenarios": [
-                                            101,
-                                            102,
-                                            103
-                                        ],
-                                        "frequency": 1
-                                    },
-                                    "summary": "Run selected scenarios (simplest)"
-                                },
-                                "RunAnEntireFolder,3×Each,5InParallel": {
-                                    "value": {
-                                        "agent_id": 12,
-                                        "folder_path": "Sales.Inbound",
-                                        "project_id": 1376,
-                                        "frequency": 3,
-                                        "concurrency_limit": 5,
-                                        "name": "Nightly Sales.Inbound regression"
-                                    },
-                                    "summary": "Run an entire folder, 3× each, 5 in parallel"
-                                },
-                                "OverridePersonalities+TestProfiles(multipliesRunCount)": {
-                                    "value": {
-                                        "agent_id": 12,
-                                        "scenarios": [
-                                            101
-                                        ],
-                                        "frequency": 2,
-                                        "personality_ids": [
-                                            3,
-                                            7
-                                        ],
-                                        "test_profile_ids": [
-                                            20,
-                                            21
-                                        ]
-                                    },
-                                    "summary": "Override personalities + test profiles (multiplies run count)"
-                                }
+                                "$ref": "#/components/schemas/Scenario"
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
+                                "$ref": "#/components/schemas/Scenario"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
+                                "$ref": "#/components/schemas/Scenario"
                             }
                         }
-                    }
+                    },
+                    "required": true
                 },
                 "security": [
                     {
@@ -37759,234 +37907,15 @@
                     }
                 ],
                 "responses": {
-                    "201": {
+                    "200": {
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "id": {
-                                            "type": "integer",
-                                            "description": "ID of the result"
-                                        },
-                                        "agent": {
-                                            "type": "integer",
-                                            "description": "ID of the agent"
-                                        },
-                                        "status": {
-                                            "type": "string",
-                                            "enum": [
-                                                "pending",
-                                                "running",
-                                                "completed",
-                                                "failed"
-                                            ],
-                                            "description": "Status of the result"
-                                        },
-                                        "run_as_text": {
-                                            "type": "boolean",
-                                            "description": "Whether the scenario ran as text or not",
-                                            "example": false
-                                        },
-                                        "runs": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "id": {
-                                                        "type": "integer",
-                                                        "description": "ID of the run"
-                                                    },
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "pending",
-                                                            "running",
-                                                            "completed",
-                                                            "failed"
-                                                        ],
-                                                        "description": "Status of the run"
-                                                    },
-                                                    "scenario": {
-                                                        "type": "integer",
-                                                        "description": "ID of the scenario"
-                                                    },
-                                                    "number": {
-                                                        "type": "string",
-                                                        "description": "For outbound runs (agent.inbound=False). The given number that must be called from the phone number configured in the cekura agent.",
-                                                        "example": "+11234567890"
-                                                    },
-                                                    "inbound_number": {
-                                                        "type": [
-                                                            "string",
-                                                            "null"
-                                                        ],
-                                                        "description": "For inbound runs (agent.inbound=True). The agent's configured phone number will receive calls from this number.",
-                                                        "example": "+11234567890"
-                                                    },
-                                                    "scenario_name": {
-                                                        "type": "string",
-                                                        "description": "Name of the scenario"
-                                                    },
-                                                    "test_profile_data": {
-                                                        "type": [
-                                                            "object",
-                                                            "null"
-                                                        ],
-                                                        "description": "Details of the test profile associated with this run scenario"
-                                                    },
-                                                    "outbound_dial_window_opens_at": {
-                                                        "type": [
-                                                            "string",
-                                                            "null"
-                                                        ],
-                                                        "format": "date-time",
-                                                        "description": "When the outbound dial window opened (run transitioned to pending/waiting-for-call). Null until dispatched."
-                                                    },
-                                                    "outbound_dial_window_seconds": {
-                                                        "type": [
-                                                            "integer",
-                                                            "null"
-                                                        ],
-                                                        "description": "Duration of the outbound dial window in seconds."
-                                                    },
-                                                    "outbound_dial_window_closes_at": {
-                                                        "type": [
-                                                            "string",
-                                                            "null"
-                                                        ],
-                                                        "format": "date-time",
-                                                        "description": "Deadline by which your agent must dial the outbound number (opens_at + outbound_dial_window_seconds). Dials after this are dropped and the run returns status: timeout."
-                                                    }
-                                                }
-                                            },
-                                            "examples": [
-                                                {
-                                                    "id": 274,
-                                                    "status": "pending",
-                                                    "scenario": 1,
-                                                    "number": null,
-                                                    "inbound_number": "+11234567890",
-                                                    "scenario_name": "Customer Support Call (Agent Inbound = True)",
-                                                    "test_profile_data": null,
-                                                    "outbound_dial_window_opens_at": null,
-                                                    "outbound_dial_window_seconds": null,
-                                                    "outbound_dial_window_closes_at": null
-                                                },
-                                                {
-                                                    "id": 275,
-                                                    "status": "pending",
-                                                    "scenario": 2,
-                                                    "number": "+11234567890",
-                                                    "inbound_number": null,
-                                                    "scenario_name": "Outbound Sales Call (Agent Inbound = False)",
-                                                    "test_profile_data": null,
-                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
-                                                    "outbound_dial_window_seconds": 300,
-                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
-                                                }
-                                            ]
-                                        },
-                                        "created_at": {
-                                            "type": "string",
-                                            "format": "date-time",
-                                            "example": "2025-02-25T21:00:01.990052Z"
-                                        }
-                                    }
-                                },
-                                "examples": {
-                                    "InboundScenario": {
-                                        "value": {
-                                            "id": 167,
-                                            "agent": 1,
-                                            "status": "pending",
-                                            "success_rate": 0,
-                                            "run_as_text": false,
-                                            "runs": [
-                                                {
-                                                    "id": 274,
-                                                    "scenario": 1,
-                                                    "number": null,
-                                                    "inbound_number": "+11234567890",
-                                                    "outbound_dial_window_opens_at": null,
-                                                    "outbound_dial_window_seconds": null,
-                                                    "outbound_dial_window_closes_at": null
-                                                },
-                                                {
-                                                    "id": 273,
-                                                    "scenario": 2,
-                                                    "number": null,
-                                                    "inbound_number": "+11234567891",
-                                                    "outbound_dial_window_opens_at": null,
-                                                    "outbound_dial_window_seconds": null,
-                                                    "outbound_dial_window_closes_at": null
-                                                }
-                                            ],
-                                            "created_at": "2025-02-25T21:00:01.990052Z"
-                                        },
-                                        "summary": "Inbound Scenario"
-                                    },
-                                    "OutboundScenario": {
-                                        "value": {
-                                            "id": 167,
-                                            "agent": 1,
-                                            "status": "pending",
-                                            "success_rate": 0,
-                                            "run_as_text": false,
-                                            "runs": [
-                                                {
-                                                    "id": 274,
-                                                    "scenario": 1,
-                                                    "number": "+11234567890",
-                                                    "inbound_number": null,
-                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
-                                                    "outbound_dial_window_seconds": 300,
-                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
-                                                },
-                                                {
-                                                    "id": 273,
-                                                    "scenario": 2,
-                                                    "number": "+11234567891",
-                                                    "inbound_number": null,
-                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
-                                                    "outbound_dial_window_seconds": 300,
-                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
-                                                }
-                                            ],
-                                            "created_at": "2025-02-25T21:00:01.990052Z"
-                                        },
-                                        "summary": "Outbound Scenario"
-                                    }
+                                    "$ref": "#/components/schemas/Scenario"
                                 }
                             }
                         },
                         "description": ""
-                    },
-                    "400": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "field_name": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "scenarios-run-voice",
-                        "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing. Requires `telephony.phone_number` configured on the agent (any provider).\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.\n\n**Outbound dial window:** for outbound runs (agent `inbound=false`), your agent must dial the run's `outbound_number` before `outbound_dial_window_closes_at` (default 300s after the run reaches `waiting_for_call` / pending state). Dials received after that deadline are dropped and the run returns `status: timeout`."
                     }
                 }
             }
@@ -38920,6 +38849,350 @@
                             }
                         },
                         "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v1/scenarios/run_scenarios_json/": {
+            "post": {
+                "operationId": "scenarios-run-voice_2",
+                "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing. Requires `telephony.phone_number` configured on the agent (any provider).\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.\n\n**Outbound dial window:** for outbound runs (agent `inbound=false`), your agent must dial the run's `outbound_number` before `outbound_dial_window_closes_at` (default 300s after the run reaches `waiting_for_call` / pending state). Dials received after that deadline are dropped and the run returns `status: timeout`.",
+                "summary": "Run evaluators over a voice call",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "dry_run",
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "description": "Validate and price the spec without running or charging anything."
+                    }
+                ],
+                "tags": [
+                    "Evaluators"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
+                            },
+                            "examples": {
+                                "RunASpec": {
+                                    "value": {
+                                        "agent_id": 12,
+                                        "channel": "voice",
+                                        "spec": {
+                                            "version": "1",
+                                            "scenarios": [
+                                                {
+                                                    "name": "Refund happy path",
+                                                    "instructions": "You are a customer whose order arrived damaged.",
+                                                    "expected_outcome": "The agent confirms a refund.",
+                                                    "metrics": [
+                                                        "greeting_by_name"
+                                                    ],
+                                                    "personality": 3,
+                                                    "test_profile": {
+                                                        "agent_variables": {
+                                                            "order_id": "ORD-4471"
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "summary": "Run a spec"
+                                },
+                                "RunSelectedScenarios(simplest)": {
+                                    "value": {
+                                        "agent_id": 12,
+                                        "scenarios": [
+                                            101,
+                                            102,
+                                            103
+                                        ],
+                                        "frequency": 1
+                                    },
+                                    "summary": "Run selected scenarios (simplest)"
+                                },
+                                "RunAnEntireFolder,3×Each,5InParallel": {
+                                    "value": {
+                                        "agent_id": 12,
+                                        "folder_path": "Sales.Inbound",
+                                        "project_id": 1376,
+                                        "frequency": 3,
+                                        "concurrency_limit": 5,
+                                        "name": "Nightly Sales.Inbound regression"
+                                    },
+                                    "summary": "Run an entire folder, 3× each, 5 in parallel"
+                                },
+                                "OverridePersonalities+TestProfiles(multipliesRunCount)": {
+                                    "value": {
+                                        "agent_id": 12,
+                                        "scenarios": [
+                                            101
+                                        ],
+                                        "frequency": 2,
+                                        "personality_ids": [
+                                            3,
+                                            7
+                                        ],
+                                        "test_profile_ids": [
+                                            20,
+                                            21
+                                        ]
+                                    },
+                                    "summary": "Override personalities + test profiles (multiplies run count)"
+                                }
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {
+                                            "type": "integer",
+                                            "description": "ID of the result"
+                                        },
+                                        "agent": {
+                                            "type": "integer",
+                                            "description": "ID of the agent"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "pending",
+                                                "running",
+                                                "completed",
+                                                "failed"
+                                            ],
+                                            "description": "Status of the result"
+                                        },
+                                        "run_as_text": {
+                                            "type": "boolean",
+                                            "description": "Whether the scenario ran as text or not",
+                                            "example": false
+                                        },
+                                        "runs": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "id": {
+                                                        "type": "integer",
+                                                        "description": "ID of the run"
+                                                    },
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "pending",
+                                                            "running",
+                                                            "completed",
+                                                            "failed"
+                                                        ],
+                                                        "description": "Status of the run"
+                                                    },
+                                                    "scenario": {
+                                                        "type": "integer",
+                                                        "description": "ID of the scenario"
+                                                    },
+                                                    "number": {
+                                                        "type": "string",
+                                                        "description": "For outbound runs (agent.inbound=False). The given number that must be called from the phone number configured in the cekura agent.",
+                                                        "example": "+11234567890"
+                                                    },
+                                                    "inbound_number": {
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ],
+                                                        "description": "For inbound runs (agent.inbound=True). The agent's configured phone number will receive calls from this number.",
+                                                        "example": "+11234567890"
+                                                    },
+                                                    "scenario_name": {
+                                                        "type": "string",
+                                                        "description": "Name of the scenario"
+                                                    },
+                                                    "test_profile_data": {
+                                                        "type": [
+                                                            "object",
+                                                            "null"
+                                                        ],
+                                                        "description": "Details of the test profile associated with this run scenario"
+                                                    },
+                                                    "outbound_dial_window_opens_at": {
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ],
+                                                        "format": "date-time",
+                                                        "description": "When the outbound dial window opened (run transitioned to pending/waiting-for-call). Null until dispatched."
+                                                    },
+                                                    "outbound_dial_window_seconds": {
+                                                        "type": [
+                                                            "integer",
+                                                            "null"
+                                                        ],
+                                                        "description": "Duration of the outbound dial window in seconds."
+                                                    },
+                                                    "outbound_dial_window_closes_at": {
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ],
+                                                        "format": "date-time",
+                                                        "description": "Deadline by which your agent must dial the outbound number (opens_at + outbound_dial_window_seconds). Dials after this are dropped and the run returns status: timeout."
+                                                    }
+                                                }
+                                            },
+                                            "examples": [
+                                                {
+                                                    "id": 274,
+                                                    "status": "pending",
+                                                    "scenario": 1,
+                                                    "number": null,
+                                                    "inbound_number": "+11234567890",
+                                                    "scenario_name": "Customer Support Call (Agent Inbound = True)",
+                                                    "test_profile_data": null,
+                                                    "outbound_dial_window_opens_at": null,
+                                                    "outbound_dial_window_seconds": null,
+                                                    "outbound_dial_window_closes_at": null
+                                                },
+                                                {
+                                                    "id": 275,
+                                                    "status": "pending",
+                                                    "scenario": 2,
+                                                    "number": "+11234567890",
+                                                    "inbound_number": null,
+                                                    "scenario_name": "Outbound Sales Call (Agent Inbound = False)",
+                                                    "test_profile_data": null,
+                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
+                                                    "outbound_dial_window_seconds": 300,
+                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
+                                                }
+                                            ]
+                                        },
+                                        "created_at": {
+                                            "type": "string",
+                                            "format": "date-time",
+                                            "example": "2025-02-25T21:00:01.990052Z"
+                                        }
+                                    }
+                                },
+                                "examples": {
+                                    "InboundScenario": {
+                                        "value": {
+                                            "id": 167,
+                                            "agent": 1,
+                                            "status": "pending",
+                                            "success_rate": 0,
+                                            "run_as_text": false,
+                                            "runs": [
+                                                {
+                                                    "id": 274,
+                                                    "scenario": 1,
+                                                    "number": null,
+                                                    "inbound_number": "+11234567890",
+                                                    "outbound_dial_window_opens_at": null,
+                                                    "outbound_dial_window_seconds": null,
+                                                    "outbound_dial_window_closes_at": null
+                                                },
+                                                {
+                                                    "id": 273,
+                                                    "scenario": 2,
+                                                    "number": null,
+                                                    "inbound_number": "+11234567891",
+                                                    "outbound_dial_window_opens_at": null,
+                                                    "outbound_dial_window_seconds": null,
+                                                    "outbound_dial_window_closes_at": null
+                                                }
+                                            ],
+                                            "created_at": "2025-02-25T21:00:01.990052Z"
+                                        },
+                                        "summary": "Inbound Scenario"
+                                    },
+                                    "OutboundScenario": {
+                                        "value": {
+                                            "id": 167,
+                                            "agent": 1,
+                                            "status": "pending",
+                                            "success_rate": 0,
+                                            "run_as_text": false,
+                                            "runs": [
+                                                {
+                                                    "id": 274,
+                                                    "scenario": 1,
+                                                    "number": "+11234567890",
+                                                    "inbound_number": null,
+                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
+                                                    "outbound_dial_window_seconds": 300,
+                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
+                                                },
+                                                {
+                                                    "id": 273,
+                                                    "scenario": 2,
+                                                    "number": "+11234567891",
+                                                    "inbound_number": null,
+                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
+                                                    "outbound_dial_window_seconds": 300,
+                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
+                                                }
+                                            ],
+                                            "created_at": "2025-02-25T21:00:01.990052Z"
+                                        },
+                                        "summary": "Outbound Scenario"
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "scenarios-run-voice",
+                        "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing. Requires `telephony.phone_number` configured on the agent (any provider).\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.\n\n**Outbound dial window:** for outbound runs (agent `inbound=false`), your agent must dial the run's `outbound_number` before `outbound_dial_window_closes_at` (default 300s after the run reaches `waiting_for_call` / pending state). Dials received after that deadline are dropped and the run returns `status: timeout`."
                     }
                 }
             }
@@ -51227,6 +51500,43 @@
                 }
             }
         },
+        "/test_framework/v2/scenarios/json_schema/": {
+            "get": {
+                "operationId": "scenarios-json-schema_3",
+                "description": "Fetch the JSON Schema for test-suite spec files",
+                "summary": "Fetch the JSON Schema for test-suite spec files",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "version",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Spec version to fetch. Defaults to the current version."
+                    }
+                ],
+                "tags": [
+                    "Evaluators"
+                ],
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ScenarioSerializerV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/test_framework/v2/scenarios/move_folder/": {
             "post": {
                 "operationId": "scenarios-folder-move_3",
@@ -51321,73 +51631,30 @@
         },
         "/test_framework/v2/scenarios/run_scenarios/": {
             "post": {
-                "operationId": "scenarios-run-voice_3",
-                "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing. Requires `telephony.phone_number` configured on the agent (any provider).\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.\n\n**Outbound dial window:** for outbound runs (agent `inbound=false`), your agent must dial the run's `outbound_number` before `outbound_dial_window_closes_at` (default 300s after the run reaches `waiting_for_call` / pending state). Dials received after that deadline are dropped and the run returns `status: timeout`.",
-                "summary": "Run evaluators over a voice call",
+                "operationId": "test-framework-v2-scenarios-run-scenarios-create",
+                "description": "Scenarios run scenarios",
                 "tags": [
-                    "Evaluators"
+                    "test_framework"
                 ],
                 "requestBody": {
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
-                            },
-                            "examples": {
-                                "RunSelectedScenarios(simplest)": {
-                                    "value": {
-                                        "agent_id": 12,
-                                        "scenarios": [
-                                            101,
-                                            102,
-                                            103
-                                        ],
-                                        "frequency": 1
-                                    },
-                                    "summary": "Run selected scenarios (simplest)"
-                                },
-                                "RunAnEntireFolder,3×Each,5InParallel": {
-                                    "value": {
-                                        "agent_id": 12,
-                                        "folder_path": "Sales.Inbound",
-                                        "project_id": 1376,
-                                        "frequency": 3,
-                                        "concurrency_limit": 5,
-                                        "name": "Nightly Sales.Inbound regression"
-                                    },
-                                    "summary": "Run an entire folder, 3× each, 5 in parallel"
-                                },
-                                "OverridePersonalities+TestProfiles(multipliesRunCount)": {
-                                    "value": {
-                                        "agent_id": 12,
-                                        "scenarios": [
-                                            101
-                                        ],
-                                        "frequency": 2,
-                                        "personality_ids": [
-                                            3,
-                                            7
-                                        ],
-                                        "test_profile_ids": [
-                                            20,
-                                            21
-                                        ]
-                                    },
-                                    "summary": "Override personalities + test profiles (multiplies run count)"
-                                }
+                                "$ref": "#/components/schemas/ScenarioSerializerV2"
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
+                                "$ref": "#/components/schemas/ScenarioSerializerV2"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
+                                "$ref": "#/components/schemas/ScenarioSerializerV2"
                             }
                         }
-                    }
+                    },
+                    "required": true
                 },
                 "security": [
                     {
@@ -51395,222 +51662,11 @@
                     }
                 ],
                 "responses": {
-                    "201": {
+                    "200": {
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "id": {
-                                            "type": "integer",
-                                            "description": "ID of the result"
-                                        },
-                                        "agent": {
-                                            "type": "integer",
-                                            "description": "ID of the agent"
-                                        },
-                                        "status": {
-                                            "type": "string",
-                                            "enum": [
-                                                "pending",
-                                                "running",
-                                                "completed",
-                                                "failed"
-                                            ],
-                                            "description": "Status of the result"
-                                        },
-                                        "run_as_text": {
-                                            "type": "boolean",
-                                            "description": "Whether the scenario ran as text or not",
-                                            "example": false
-                                        },
-                                        "runs": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "id": {
-                                                        "type": "integer",
-                                                        "description": "ID of the run"
-                                                    },
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "pending",
-                                                            "running",
-                                                            "completed",
-                                                            "failed"
-                                                        ],
-                                                        "description": "Status of the run"
-                                                    },
-                                                    "scenario": {
-                                                        "type": "integer",
-                                                        "description": "ID of the scenario"
-                                                    },
-                                                    "number": {
-                                                        "type": "string",
-                                                        "description": "For outbound runs (agent.inbound=False). The given number that must be called from the phone number configured in the cekura agent.",
-                                                        "example": "+11234567890"
-                                                    },
-                                                    "inbound_number": {
-                                                        "type": [
-                                                            "string",
-                                                            "null"
-                                                        ],
-                                                        "description": "For inbound runs (agent.inbound=True). The agent's configured phone number will receive calls from this number.",
-                                                        "example": "+11234567890"
-                                                    },
-                                                    "scenario_name": {
-                                                        "type": "string",
-                                                        "description": "Name of the scenario"
-                                                    },
-                                                    "test_profile_data": {
-                                                        "type": [
-                                                            "object",
-                                                            "null"
-                                                        ],
-                                                        "description": "Details of the test profile associated with this run scenario"
-                                                    },
-                                                    "outbound_dial_window_opens_at": {
-                                                        "type": [
-                                                            "string",
-                                                            "null"
-                                                        ],
-                                                        "format": "date-time",
-                                                        "description": "When the outbound dial window opened (run transitioned to pending/waiting-for-call). Null until dispatched."
-                                                    },
-                                                    "outbound_dial_window_seconds": {
-                                                        "type": [
-                                                            "integer",
-                                                            "null"
-                                                        ],
-                                                        "description": "Duration of the outbound dial window in seconds."
-                                                    },
-                                                    "outbound_dial_window_closes_at": {
-                                                        "type": [
-                                                            "string",
-                                                            "null"
-                                                        ],
-                                                        "format": "date-time",
-                                                        "description": "Deadline by which your agent must dial the outbound number (opens_at + outbound_dial_window_seconds). Dials after this are dropped and the run returns status: timeout."
-                                                    }
-                                                }
-                                            },
-                                            "examples": [
-                                                {
-                                                    "id": 274,
-                                                    "status": "pending",
-                                                    "scenario": 1,
-                                                    "number": null,
-                                                    "inbound_number": "+11234567890",
-                                                    "scenario_name": "Customer Support Call (Agent Inbound = True)",
-                                                    "test_profile_data": null,
-                                                    "outbound_dial_window_opens_at": null,
-                                                    "outbound_dial_window_seconds": null,
-                                                    "outbound_dial_window_closes_at": null
-                                                },
-                                                {
-                                                    "id": 275,
-                                                    "status": "pending",
-                                                    "scenario": 2,
-                                                    "number": "+11234567890",
-                                                    "inbound_number": null,
-                                                    "scenario_name": "Outbound Sales Call (Agent Inbound = False)",
-                                                    "test_profile_data": null,
-                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
-                                                    "outbound_dial_window_seconds": 300,
-                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
-                                                }
-                                            ]
-                                        },
-                                        "created_at": {
-                                            "type": "string",
-                                            "format": "date-time",
-                                            "example": "2025-02-25T21:00:01.990052Z"
-                                        }
-                                    }
-                                },
-                                "examples": {
-                                    "InboundScenario": {
-                                        "value": {
-                                            "id": 167,
-                                            "agent": 1,
-                                            "status": "pending",
-                                            "success_rate": 0,
-                                            "run_as_text": false,
-                                            "runs": [
-                                                {
-                                                    "id": 274,
-                                                    "scenario": 1,
-                                                    "number": null,
-                                                    "inbound_number": "+11234567890",
-                                                    "outbound_dial_window_opens_at": null,
-                                                    "outbound_dial_window_seconds": null,
-                                                    "outbound_dial_window_closes_at": null
-                                                },
-                                                {
-                                                    "id": 273,
-                                                    "scenario": 2,
-                                                    "number": null,
-                                                    "inbound_number": "+11234567891",
-                                                    "outbound_dial_window_opens_at": null,
-                                                    "outbound_dial_window_seconds": null,
-                                                    "outbound_dial_window_closes_at": null
-                                                }
-                                            ],
-                                            "created_at": "2025-02-25T21:00:01.990052Z"
-                                        },
-                                        "summary": "Inbound Scenario"
-                                    },
-                                    "OutboundScenario": {
-                                        "value": {
-                                            "id": 167,
-                                            "agent": 1,
-                                            "status": "pending",
-                                            "success_rate": 0,
-                                            "run_as_text": false,
-                                            "runs": [
-                                                {
-                                                    "id": 274,
-                                                    "scenario": 1,
-                                                    "number": "+11234567890",
-                                                    "inbound_number": null,
-                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
-                                                    "outbound_dial_window_seconds": 300,
-                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
-                                                },
-                                                {
-                                                    "id": 273,
-                                                    "scenario": 2,
-                                                    "number": "+11234567891",
-                                                    "inbound_number": null,
-                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
-                                                    "outbound_dial_window_seconds": 300,
-                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
-                                                }
-                                            ],
-                                            "created_at": "2025-02-25T21:00:01.990052Z"
-                                        },
-                                        "summary": "Outbound Scenario"
-                                    }
-                                }
-                            }
-                        },
-                        "description": ""
-                    },
-                    "400": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "field_name": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
+                                    "$ref": "#/components/schemas/ScenarioSerializerV2"
                                 }
                             }
                         },
@@ -52512,6 +52568,342 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/ScenarioSerializerV2"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/v2/scenarios/run_scenarios_json/": {
+            "post": {
+                "operationId": "scenarios-run-voice_3",
+                "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing. Requires `telephony.phone_number` configured on the agent (any provider).\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.\n\n**Outbound dial window:** for outbound runs (agent `inbound=false`), your agent must dial the run's `outbound_number` before `outbound_dial_window_closes_at` (default 300s after the run reaches `waiting_for_call` / pending state). Dials received after that deadline are dropped and the run returns `status: timeout`.",
+                "summary": "Run evaluators over a voice call",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "dry_run",
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "description": "Validate and price the spec without running or charging anything."
+                    }
+                ],
+                "tags": [
+                    "Evaluators"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
+                            },
+                            "examples": {
+                                "RunASpec": {
+                                    "value": {
+                                        "agent_id": 12,
+                                        "channel": "voice",
+                                        "spec": {
+                                            "version": "1",
+                                            "scenarios": [
+                                                {
+                                                    "name": "Refund happy path",
+                                                    "instructions": "You are a customer whose order arrived damaged.",
+                                                    "expected_outcome": "The agent confirms a refund.",
+                                                    "metrics": [
+                                                        "greeting_by_name"
+                                                    ],
+                                                    "personality": 3,
+                                                    "test_profile": {
+                                                        "agent_variables": {
+                                                            "order_id": "ORD-4471"
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "summary": "Run a spec"
+                                },
+                                "RunSelectedScenarios(simplest)": {
+                                    "value": {
+                                        "agent_id": 12,
+                                        "scenarios": [
+                                            101,
+                                            102,
+                                            103
+                                        ],
+                                        "frequency": 1
+                                    },
+                                    "summary": "Run selected scenarios (simplest)"
+                                },
+                                "RunAnEntireFolder,3×Each,5InParallel": {
+                                    "value": {
+                                        "agent_id": 12,
+                                        "folder_path": "Sales.Inbound",
+                                        "project_id": 1376,
+                                        "frequency": 3,
+                                        "concurrency_limit": 5,
+                                        "name": "Nightly Sales.Inbound regression"
+                                    },
+                                    "summary": "Run an entire folder, 3× each, 5 in parallel"
+                                },
+                                "OverridePersonalities+TestProfiles(multipliesRunCount)": {
+                                    "value": {
+                                        "agent_id": 12,
+                                        "scenarios": [
+                                            101
+                                        ],
+                                        "frequency": 2,
+                                        "personality_ids": [
+                                            3,
+                                            7
+                                        ],
+                                        "test_profile_ids": [
+                                            20,
+                                            21
+                                        ]
+                                    },
+                                    "summary": "Override personalities + test profiles (multiplies run count)"
+                                }
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {
+                                            "type": "integer",
+                                            "description": "ID of the result"
+                                        },
+                                        "agent": {
+                                            "type": "integer",
+                                            "description": "ID of the agent"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "pending",
+                                                "running",
+                                                "completed",
+                                                "failed"
+                                            ],
+                                            "description": "Status of the result"
+                                        },
+                                        "run_as_text": {
+                                            "type": "boolean",
+                                            "description": "Whether the scenario ran as text or not",
+                                            "example": false
+                                        },
+                                        "runs": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "id": {
+                                                        "type": "integer",
+                                                        "description": "ID of the run"
+                                                    },
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "pending",
+                                                            "running",
+                                                            "completed",
+                                                            "failed"
+                                                        ],
+                                                        "description": "Status of the run"
+                                                    },
+                                                    "scenario": {
+                                                        "type": "integer",
+                                                        "description": "ID of the scenario"
+                                                    },
+                                                    "number": {
+                                                        "type": "string",
+                                                        "description": "For outbound runs (agent.inbound=False). The given number that must be called from the phone number configured in the cekura agent.",
+                                                        "example": "+11234567890"
+                                                    },
+                                                    "inbound_number": {
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ],
+                                                        "description": "For inbound runs (agent.inbound=True). The agent's configured phone number will receive calls from this number.",
+                                                        "example": "+11234567890"
+                                                    },
+                                                    "scenario_name": {
+                                                        "type": "string",
+                                                        "description": "Name of the scenario"
+                                                    },
+                                                    "test_profile_data": {
+                                                        "type": [
+                                                            "object",
+                                                            "null"
+                                                        ],
+                                                        "description": "Details of the test profile associated with this run scenario"
+                                                    },
+                                                    "outbound_dial_window_opens_at": {
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ],
+                                                        "format": "date-time",
+                                                        "description": "When the outbound dial window opened (run transitioned to pending/waiting-for-call). Null until dispatched."
+                                                    },
+                                                    "outbound_dial_window_seconds": {
+                                                        "type": [
+                                                            "integer",
+                                                            "null"
+                                                        ],
+                                                        "description": "Duration of the outbound dial window in seconds."
+                                                    },
+                                                    "outbound_dial_window_closes_at": {
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ],
+                                                        "format": "date-time",
+                                                        "description": "Deadline by which your agent must dial the outbound number (opens_at + outbound_dial_window_seconds). Dials after this are dropped and the run returns status: timeout."
+                                                    }
+                                                }
+                                            },
+                                            "examples": [
+                                                {
+                                                    "id": 274,
+                                                    "status": "pending",
+                                                    "scenario": 1,
+                                                    "number": null,
+                                                    "inbound_number": "+11234567890",
+                                                    "scenario_name": "Customer Support Call (Agent Inbound = True)",
+                                                    "test_profile_data": null,
+                                                    "outbound_dial_window_opens_at": null,
+                                                    "outbound_dial_window_seconds": null,
+                                                    "outbound_dial_window_closes_at": null
+                                                },
+                                                {
+                                                    "id": 275,
+                                                    "status": "pending",
+                                                    "scenario": 2,
+                                                    "number": "+11234567890",
+                                                    "inbound_number": null,
+                                                    "scenario_name": "Outbound Sales Call (Agent Inbound = False)",
+                                                    "test_profile_data": null,
+                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
+                                                    "outbound_dial_window_seconds": 300,
+                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
+                                                }
+                                            ]
+                                        },
+                                        "created_at": {
+                                            "type": "string",
+                                            "format": "date-time",
+                                            "example": "2025-02-25T21:00:01.990052Z"
+                                        }
+                                    }
+                                },
+                                "examples": {
+                                    "InboundScenario": {
+                                        "value": {
+                                            "id": 167,
+                                            "agent": 1,
+                                            "status": "pending",
+                                            "success_rate": 0,
+                                            "run_as_text": false,
+                                            "runs": [
+                                                {
+                                                    "id": 274,
+                                                    "scenario": 1,
+                                                    "number": null,
+                                                    "inbound_number": "+11234567890",
+                                                    "outbound_dial_window_opens_at": null,
+                                                    "outbound_dial_window_seconds": null,
+                                                    "outbound_dial_window_closes_at": null
+                                                },
+                                                {
+                                                    "id": 273,
+                                                    "scenario": 2,
+                                                    "number": null,
+                                                    "inbound_number": "+11234567891",
+                                                    "outbound_dial_window_opens_at": null,
+                                                    "outbound_dial_window_seconds": null,
+                                                    "outbound_dial_window_closes_at": null
+                                                }
+                                            ],
+                                            "created_at": "2025-02-25T21:00:01.990052Z"
+                                        },
+                                        "summary": "Inbound Scenario"
+                                    },
+                                    "OutboundScenario": {
+                                        "value": {
+                                            "id": 167,
+                                            "agent": 1,
+                                            "status": "pending",
+                                            "success_rate": 0,
+                                            "run_as_text": false,
+                                            "runs": [
+                                                {
+                                                    "id": 274,
+                                                    "scenario": 1,
+                                                    "number": "+11234567890",
+                                                    "inbound_number": null,
+                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
+                                                    "outbound_dial_window_seconds": 300,
+                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
+                                                },
+                                                {
+                                                    "id": 273,
+                                                    "scenario": 2,
+                                                    "number": "+11234567891",
+                                                    "inbound_number": null,
+                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
+                                                    "outbound_dial_window_seconds": 300,
+                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
+                                                }
+                                            ],
+                                            "created_at": "2025-02-25T21:00:01.990052Z"
+                                        },
+                                        "summary": "Outbound Scenario"
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
                                 }
                             }
                         },


### PR DESCRIPTION
Auto-generated docs sync for backend PR [#10610](https://github.com/cekura-ai/vocera.backend/pull/10610).

Reviewers: @dileep-chagam, @satvik-cek

## Summary

**Spec/overlay:** Spec differs from main: 1 newly exposed op (scenarios_json_schema, Bucket B-new), 1 exposed op with schema change (scenarios_run_voice, Bucket A — requestBody updated). No transport-quirk signals fired; no overlay patches needed. 7 new operations added total (3 json_schema variants, 3 run_scenarios variants, 1 product-chat retrieve variant). No renames detected. No Bucket C suggestions — metric builder build-agent ops touched by the PR are interactive chatbot endpoints, not clean CRUD patterns suitable for MCP exposure.

**Conceptual docs:** Updated documentation/key-concepts/metrics/build-with-ai.mdx to reflect the new quick/detailed build modes. Quick mode (now the default) skips sampling and evaluation, using a single AI turn to refine the metric definition. Detailed mode retains the existing behavior. 1 developer suggestion queued.

## Changes

- `openapi.json` — regenerate_from_backend
- `documentation/key-concepts/metrics/build-with-ai.mdx` — update

## SDK / CLI parity follow-ups

- `scenarios_json_schema` (GET `/test_framework/v1/scenarios/json_schema/`) — add

---
*Auto-generated from backend PR #10610.*

<!-- mcp-sync:file-hashes -->
```json
{
  "documentation/key-concepts/metrics/build-with-ai.mdx": "09e070530fa0347da837cc0a9499267fbea966324274e75dd0ea747c8f947499"
}
```
<!-- /mcp-sync:file-hashes -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cekura-ai/docs/pull/826" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->