### PR TITLE
[Auto] Sync docs for backend PR #10625

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -12,11 +12,6 @@
                 "tags": [
                     ".well-known"
                 ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
                 "responses": {
                     "200": {
                         "description": "No response body"
@@ -53,7 +48,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -72,7 +70,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -91,7 +92,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -113,7 +114,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -132,7 +136,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -151,7 +158,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -170,7 +180,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -199,7 +212,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -226,7 +242,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -245,7 +264,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -262,7 +284,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -292,7 +317,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -320,7 +348,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -350,7 +381,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -381,7 +415,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -418,7 +455,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -448,7 +488,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -478,7 +521,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -497,7 +543,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -514,7 +560,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -543,7 +589,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -570,7 +616,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -597,7 +643,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -616,7 +662,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -645,7 +691,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -672,7 +718,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -699,7 +745,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -718,7 +764,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -735,7 +781,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -764,7 +810,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -791,7 +837,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -818,7 +864,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -847,7 +893,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -874,7 +920,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -901,7 +947,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -920,7 +966,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -967,6 +1013,18 @@
                     "dashboards"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
                     {
                         "api_key": []
                     }
@@ -1019,6 +1077,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -1062,6 +1132,18 @@
                     "dashboards"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
                     {
                         "api_key": []
                     }
@@ -1124,6 +1206,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -1177,6 +1271,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -1219,6 +1325,18 @@
                     "dashboards"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
                     {
                         "api_key": []
                     }
@@ -1278,6 +1396,18 @@
                     }
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
                     {
                         "api_key": []
                     }
@@ -1342,6 +1472,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -1375,6 +1517,18 @@
                     "dashboards"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
                     {
                         "api_key": []
                     }
@@ -1431,6 +1585,18 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -1483,6 +1649,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -1526,6 +1704,18 @@
                     "dashboards"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
                     {
                         "api_key": []
                     }
@@ -1589,6 +1779,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -1642,6 +1844,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -1684,6 +1898,18 @@
                     "dashboards"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
                     {
                         "api_key": []
                     }
@@ -1733,6 +1959,18 @@
                     "dashboards"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
                     {
                         "api_key": []
                     }
@@ -1808,6 +2046,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -1862,6 +2112,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -1895,7 +2157,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -1942,7 +2207,10 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -1979,7 +2247,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -2034,7 +2305,10 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -2088,7 +2362,10 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -2123,7 +2400,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -2153,7 +2433,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -2179,7 +2462,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -2220,7 +2506,7 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "product_chat_sandbox": []
                     }
                 ],
                 "responses": {
@@ -2245,7 +2531,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -2262,7 +2548,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -2281,7 +2567,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -2321,7 +2607,7 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "product_chat_sandbox": []
                     }
                 ],
                 "responses": {
@@ -2349,7 +2635,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -2365,11 +2651,6 @@
                 "description": "GitHub App webhook. No auth class — the HMAC signature is the gate.",
                 "tags": [
                     "github"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
                 ],
                 "responses": {
                     "200": {
@@ -2406,7 +2687,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -2442,7 +2726,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -2497,7 +2784,10 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -2542,7 +2832,10 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -2568,7 +2861,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -2594,7 +2890,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -2613,7 +2912,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -2632,7 +2934,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -2651,6 +2956,15 @@
                     "observability"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -2698,6 +3012,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -2735,6 +3058,15 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -2771,6 +3103,15 @@
                     "observability"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -2846,6 +3187,12 @@
                 ],
                 "security": [
                     {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -2902,6 +3249,12 @@
                 },
                 "security": [
                     {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -2947,6 +3300,12 @@
                     "observability"
                 ],
                 "security": [
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -3011,6 +3370,12 @@
                 },
                 "security": [
                     {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -3066,6 +3431,12 @@
                 },
                 "security": [
                     {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -3110,6 +3481,12 @@
                 ],
                 "security": [
                     {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -3148,6 +3525,12 @@
                     "observability"
                 ],
                 "security": [
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -3206,6 +3589,12 @@
                 },
                 "security": [
                     {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -3232,6 +3621,12 @@
                     "observability"
                 ],
                 "security": [
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -3278,6 +3673,12 @@
                 ],
                 "security": [
                     {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -3303,6 +3704,12 @@
                     "observability"
                 ],
                 "security": [
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -3412,6 +3819,15 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -3456,6 +3872,15 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -3565,6 +3990,15 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -3610,6 +4044,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -3646,6 +4089,15 @@
                     "observability"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -3718,6 +4170,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -3772,6 +4233,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -3816,6 +4286,15 @@
                     "observability"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -3882,6 +4361,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -3939,6 +4427,15 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -4030,6 +4527,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -4055,6 +4561,15 @@
                     "observability"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -4101,6 +4616,15 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -4180,6 +4704,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -4257,6 +4790,15 @@
                     "observability"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -4470,6 +5012,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -4528,6 +5079,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -4575,6 +5135,15 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -4600,6 +5169,15 @@
                     "observability"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -4627,6 +5205,15 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -4653,6 +5240,15 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -4678,6 +5274,15 @@
                     "observability"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -4724,6 +5329,15 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -4802,6 +5416,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -4859,6 +5482,15 @@
                     "observability"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -4931,6 +5563,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -4985,6 +5626,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -5029,6 +5679,15 @@
                     "observability"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -5095,6 +5754,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -5152,6 +5820,15 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -5222,6 +5899,15 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -5290,6 +5976,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -5315,6 +6010,15 @@
                     "observability"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -5361,6 +6065,15 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -5440,6 +6153,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -5517,6 +6239,15 @@
                     "observability"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -5730,6 +6461,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -5788,6 +6528,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -5835,6 +6584,15 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -5860,6 +6618,15 @@
                     "observability"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -5887,6 +6654,15 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -5913,6 +6689,15 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -5938,6 +6723,15 @@
                     "observability"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -5984,6 +6778,15 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -6062,6 +6865,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -6129,6 +6941,9 @@
                 ],
                 "security": [
                     {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -6172,6 +6987,9 @@
                 },
                 "security": [
                     {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -6209,6 +7027,9 @@
                     "observability"
                 ],
                 "security": [
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -6265,6 +7086,9 @@
                 },
                 "security": [
                     {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -6320,6 +7144,9 @@
                 },
                 "security": [
                     {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -6355,6 +7182,9 @@
                     "observability"
                 ],
                 "security": [
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -6406,6 +7236,9 @@
                 },
                 "security": [
                     {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -6431,6 +7264,15 @@
                     "observability"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -6472,6 +7314,15 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -6506,6 +7357,15 @@
                     "observability"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -6546,6 +7406,15 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -6603,6 +7472,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -6638,6 +7516,15 @@
                     "observability"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -6684,6 +7571,15 @@
                     "observability"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -6745,6 +7641,15 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -6798,6 +7703,15 @@
                     "observability"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -6859,6 +7773,15 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -6903,6 +7826,15 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -6942,6 +7874,15 @@
                     "observability"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -7008,6 +7949,15 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -7076,6 +8026,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -7142,6 +8101,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -7177,6 +8145,15 @@
                     "observability"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -7244,6 +8221,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -7279,6 +8265,15 @@
                     "observability"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -7369,6 +8364,15 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -7406,6 +8410,15 @@
                     "observability"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -7467,6 +8480,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -7502,6 +8524,15 @@
                     "observability"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -7550,6 +8581,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -7585,6 +8625,15 @@
                     "observability"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -7704,6 +8753,9 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -7756,6 +8808,15 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -7803,6 +8864,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -7839,6 +8909,15 @@
                     "observability"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -7895,6 +8974,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -7949,6 +9037,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -7984,6 +9081,15 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -8002,6 +9108,15 @@
                     "observability"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -8028,6 +9143,15 @@
                     "observability"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -8073,11 +9197,6 @@
                 "tags": [
                     "observability"
                 ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
                 "responses": {
                     "200": {
                         "description": "No response body"
@@ -8094,7 +9213,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -8195,6 +9317,15 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -8247,6 +9378,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -8283,6 +9423,15 @@
                     "observability"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -8362,6 +9511,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -8416,6 +9574,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -8460,6 +9627,15 @@
                     "observability"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -8534,6 +9710,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -8591,6 +9776,15 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -8690,6 +9884,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -8715,6 +9918,15 @@
                     "observability"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -8761,6 +9973,15 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -8839,6 +10060,15 @@
                     }
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -8943,6 +10173,15 @@
                     "observability"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -9164,6 +10403,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -9222,6 +10470,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -9277,6 +10534,15 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -9302,6 +10568,15 @@
                     "observability"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -9329,6 +10604,15 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -9355,6 +10639,15 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -9380,6 +10673,15 @@
                     "observability"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -9426,6 +10728,15 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -9503,6 +10814,15 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -9585,6 +10905,12 @@
                     "schedules"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -9671,6 +10997,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -9722,6 +11054,12 @@
                     "schedules"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -9800,6 +11138,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -9836,6 +11180,12 @@
                     "schedules"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -9909,6 +11259,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -9981,6 +11337,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -10017,6 +11379,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -10049,6 +11417,12 @@
                     "schedules"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -10130,6 +11504,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -10202,6 +11582,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -10245,6 +11631,12 @@
                     "schedules"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -10291,6 +11683,12 @@
                     "schedules"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -10340,6 +11738,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -10376,6 +11780,12 @@
                     "schedules"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -10432,6 +11842,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -10486,6 +11902,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -10522,6 +11944,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -10542,11 +11970,6 @@
                 "tags": [
                     "slack"
                 ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
                 "responses": {
                     "200": {
                         "description": "No response body"
@@ -10560,11 +11983,6 @@
                 "description": "Handle Slack interactive component callbacks",
                 "tags": [
                     "slack"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
                 ],
                 "responses": {
                     "200": {
@@ -10581,7 +11999,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -10602,7 +12023,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -10666,7 +12090,10 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -10703,7 +12130,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -10757,7 +12187,10 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -10811,7 +12244,10 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -10846,7 +12282,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -10876,7 +12315,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -10913,7 +12355,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -10950,7 +12395,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -10976,7 +12424,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session_inactive_allowed": []
                     }
                 ],
                 "responses": {
@@ -10996,7 +12444,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session_inactive_allowed": []
                     }
                 ],
                 "responses": {
@@ -11035,7 +12483,7 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session_inactive_allowed": []
                     }
                 ],
                 "responses": {
@@ -11060,7 +12508,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session_inactive_allowed": []
                     }
                 ],
                 "responses": {
@@ -11100,7 +12548,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session_inactive_allowed": []
                     }
                 ],
                 "responses": {
@@ -11147,7 +12595,7 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session_inactive_allowed": []
                     }
                 ],
                 "responses": {
@@ -11193,7 +12641,7 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session_inactive_allowed": []
                     }
                 ],
                 "responses": {
@@ -11238,7 +12686,7 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session_inactive_allowed": []
                     }
                 ],
                 "responses": {
@@ -11285,7 +12733,7 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session_inactive_allowed": []
                     }
                 ],
                 "responses": {
@@ -11311,7 +12759,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session_inactive_allowed": []
                     }
                 ],
                 "responses": {
@@ -11357,7 +12805,7 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session_inactive_allowed": []
                     }
                 ],
                 "responses": {
@@ -11380,11 +12828,6 @@
                 "tags": [
                     "subscriptions"
                 ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
                 "responses": {
                     "200": {
                         "description": "No response body"
@@ -11401,7 +12844,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -11440,7 +12886,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -11495,7 +12944,10 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -11550,7 +13002,10 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -11605,7 +13060,10 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -11660,7 +13118,10 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -11716,7 +13177,10 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -11771,7 +13235,10 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -11826,7 +13293,10 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -11880,7 +13350,10 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -11925,7 +13398,10 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -11951,6 +13427,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -12011,6 +13493,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -12047,6 +13535,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -12116,6 +13610,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -12148,6 +13648,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -12200,6 +13706,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -12238,6 +13750,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -12273,6 +13791,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -12299,6 +13823,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -12324,6 +13854,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -12380,7 +13916,10 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -12433,7 +13972,10 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -12509,7 +14051,10 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -12563,6 +14108,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -12606,7 +14157,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -12655,7 +14209,10 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -12701,7 +14258,10 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -12746,6 +14306,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -12794,6 +14360,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -12832,6 +14404,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -12885,6 +14463,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -12940,6 +14524,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -12983,6 +14573,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -13019,6 +14615,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -13074,6 +14676,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -13128,6 +14736,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -13163,6 +14777,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -13182,7 +14802,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -13201,689 +14824,15 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "No response body"
-                    }
-                }
-            }
-        },
-        "/test_framework/project-default-metrics/": {
-            "get": {
-                "operationId": "test-framework-project-default-metrics-list",
-                "description": "List API not supported",
-                "tags": [
-                    "test_framework"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/ProjectDefaultMetrics"
-                                    }
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            },
-            "post": {
-                "operationId": "test-framework-project-default-metrics-create",
-                "description": "Create or update user's default metrics",
-                "tags": [
-                    "test_framework"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ProjectDefaultMetrics"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ProjectDefaultMetrics"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ProjectDefaultMetrics"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProjectDefaultMetrics"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
-        },
-        "/test_framework/project-default-metrics/{project}/": {
-            "get": {
-                "operationId": "test-framework-project-default-metrics-retrieve",
-                "description": "Get user's default metrics for a specific organization",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "project",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "test_framework"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProjectDefaultMetrics"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            },
-            "put": {
-                "operationId": "test-framework-project-default-metrics-update",
-                "description": "Update user's default metrics",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "project",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "test_framework"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ProjectDefaultMetrics"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ProjectDefaultMetrics"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ProjectDefaultMetrics"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProjectDefaultMetrics"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            },
-            "patch": {
-                "operationId": "test-framework-project-default-metrics-partial-update",
-                "description": "Update a project default metric",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "project",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "test_framework"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchedProjectDefaultMetrics"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchedProjectDefaultMetrics"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchedProjectDefaultMetrics"
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProjectDefaultMetrics"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            },
-            "delete": {
-                "operationId": "test-framework-project-default-metrics-destroy",
-                "description": "Delete a project default metric",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "project",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "test_framework"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No response body"
-                    }
-                }
-            }
-        },
-        "/test_framework/test-sets/": {
-            "get": {
-                "operationId": "test-framework-test-sets-list",
-                "description": "List test sets",
-                "tags": [
-                    "test_framework"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/TestSetList"
-                                    }
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            },
-            "post": {
-                "operationId": "test-framework-test-sets-create",
-                "description": "Create a new test set",
-                "tags": [
-                    "test_framework"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/TestSetDetail"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/TestSetDetail"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/TestSetDetail"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/TestSetDetail"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
-        },
-        "/test_framework/test-sets/{id}/": {
-            "get": {
-                "operationId": "test-framework-test-sets-retrieve",
-                "description": "Override retrieve to optimize query performance with prefetch_related",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "A unique integer value identifying this test set.",
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "test_framework"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/TestSetDetail"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            },
-            "put": {
-                "operationId": "test-framework-test-sets-update",
-                "description": "Update a test set",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "A unique integer value identifying this test set.",
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "test_framework"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/TestSetDetail"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/TestSetDetail"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/TestSetDetail"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/TestSetDetail"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            },
-            "patch": {
-                "operationId": "test-framework-test-sets-partial-update",
-                "description": "Update a test set",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "A unique integer value identifying this test set.",
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "test_framework"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchedTestSetDetail"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchedTestSetDetail"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchedTestSetDetail"
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/TestSetDetail"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            },
-            "delete": {
-                "operationId": "test-framework-test-sets-destroy",
-                "description": "Delete a test set",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "A unique integer value identifying this test set.",
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "test_framework"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No response body"
-                    }
-                }
-            }
-        },
-        "/test_framework/test-sets/{id}/add_metrics/": {
-            "post": {
-                "operationId": "test-framework-test-sets-add-metrics-create",
-                "description": "Test sets add metrics",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "A unique integer value identifying this test set.",
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "test_framework"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/TestSetDetail"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/TestSetDetail"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/TestSetDetail"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/TestSetDetail"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
-        },
-        "/test_framework/test-sets/{id}/review_metrics/": {
-            "post": {
-                "operationId": "test-framework-test-sets-review-metrics-create",
-                "description": "Test sets review metrics",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "A unique integer value identifying this test set.",
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "test_framework"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/TestSetDetail"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/TestSetDetail"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/TestSetDetail"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/TestSetDetail"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
-        },
-        "/test_framework/test-sets/{id}/voice_recording_url/": {
-            "get": {
-                "operationId": "test-framework-test-sets-voice-recording-url-retrieve",
-                "description": "Test sets voice recording url",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "A unique integer value identifying this test set.",
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "test_framework"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/TestSetDetail"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
-        },
-        "/test_framework/test-sets/add/{metric_id}/": {
-            "get": {
-                "operationId": "test-framework-test-sets-add-retrieve",
-                "description": "Retrieve a test set by ID",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "metric_id",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "test_framework"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/TestSetDetail"
-                                }
-                            }
-                        },
-                        "description": ""
                     }
                 }
             }
@@ -13918,6 +14867,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -13946,7 +14901,7 @@
         "/test_framework/test-sets/create_from_call_logs/": {
             "post": {
                 "operationId": "test-framework-test-sets-create-from-call-logs-create",
-                "description": "Test sets create from call logs",
+                "description": "Manage test sets for organizing and curating evaluation data.\n\nTest sets are collections of call transcripts or run data used for metric\nreview and improvement via the Labs workflow. Create test sets from call logs\nor previous runs to build a curated evaluation dataset.",
                 "tags": [
                     "test_framework"
                 ],
@@ -13971,6 +14926,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -14019,6 +14980,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -14047,7 +15014,7 @@
         "/test_framework/test-sets/create_from_runs/": {
             "post": {
                 "operationId": "test-framework-test-sets-create-from-runs-create",
-                "description": "Test sets create from runs",
+                "description": "Manage test sets for organizing and curating evaluation data.\n\nTest sets are collections of call transcripts or run data used for metric\nreview and improvement via the Labs workflow. Create test sets from call logs\nor previous runs to build a curated evaluation dataset.",
                 "tags": [
                     "test_framework"
                 ],
@@ -14073,51 +15040,11 @@
                 },
                 "security": [
                     {
-                        "api_key": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/TestSetDetail"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
-        },
-        "/test_framework/test-sets/create_testsets/": {
-            "post": {
-                "operationId": "test-framework-test-sets-create-testsets-create",
-                "description": "Test sets create testsets",
-                "tags": [
-                    "test_framework"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/TestSetDetail"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/TestSetDetail"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/TestSetDetail"
-                            }
-                        }
+                        "oauth2": []
                     },
-                    "required": true
-                },
-                "security": [
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -14181,6 +15108,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -14342,6 +15275,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -14426,6 +15365,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -14471,6 +15416,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -14501,6 +15452,12 @@
                     "Dynamic Variables"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -14587,6 +15544,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -14634,11 +15597,6 @@
                 "tags": [
                     "test_framework"
                 ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
                 "responses": {
                     "200": {
                         "description": "No response body"
@@ -14674,6 +15632,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -14749,11 +15713,6 @@
                 ],
                 "tags": [
                     "test_framework"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
                 ],
                 "deprecated": true,
                 "responses": {
@@ -14840,6 +15799,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -14918,6 +15883,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -14964,6 +15935,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -15058,6 +16035,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -15168,6 +16151,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -15233,6 +16222,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -15282,6 +16277,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -15319,6 +16320,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -15405,6 +16412,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -15487,6 +16500,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -15549,6 +16568,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -15596,6 +16621,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -15677,6 +16708,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -15732,6 +16769,12 @@
                     }
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -15808,6 +16851,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -15858,6 +16907,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -15915,6 +16970,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -15970,6 +17031,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -16021,6 +17088,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -16079,6 +17152,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -16115,6 +17194,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -16225,6 +17310,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -16268,6 +17359,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -16339,6 +17436,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -16385,7 +17488,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -16429,7 +17532,7 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -16466,7 +17569,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -16521,7 +17624,7 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -16575,7 +17678,7 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -16610,7 +17713,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -16934,6 +18037,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -16988,6 +18097,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -17024,6 +18139,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -17094,6 +18215,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -17147,6 +18274,12 @@
                     }
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -17202,6 +18335,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -17272,6 +18411,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -17326,6 +18471,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -17375,11 +18526,6 @@
                 "tags": [
                     "test_framework"
                 ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
                 "responses": {
                     "200": {
                         "description": "No response body"
@@ -17396,6 +18542,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -17444,6 +18596,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -17480,6 +18638,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -17536,6 +18700,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -17590,6 +18760,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -17624,6 +18800,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -17674,6 +18856,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -17778,6 +18966,15 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -17958,6 +19155,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -18060,6 +19266,15 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -18240,6 +19455,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -18294,6 +19518,15 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -18365,6 +19598,15 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -18448,6 +19690,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -18501,6 +19752,15 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -18567,6 +19827,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -18605,6 +19874,15 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -18635,6 +19913,15 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -18685,6 +19972,9 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "lambda_token": []
+                    },
                     {
                         "api_key": []
                     }
@@ -18743,6 +20033,9 @@
                 },
                 "security": [
                     {
+                        "lambda_token": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -18800,6 +20093,9 @@
                 },
                 "security": [
                     {
+                        "lambda_token": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -18850,6 +20146,15 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -18906,6 +20211,15 @@
                     }
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -18964,6 +20278,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -19020,6 +20343,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -19070,6 +20402,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -19095,6 +20436,15 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -19143,6 +20493,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -19189,6 +20548,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -19214,6 +20582,15 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -19260,6 +20637,15 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -19316,6 +20702,15 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -19384,6 +20779,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -19430,6 +20834,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -19455,6 +20868,9 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "lambda_token": []
+                    },
                     {
                         "api_key": []
                     }
@@ -19482,7 +20898,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "lambda_token": []
                     }
                 ],
                 "responses": {
@@ -19527,6 +20943,15 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -19575,6 +21000,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -19612,6 +21046,15 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -19659,6 +21102,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -19703,6 +21155,15 @@
                     }
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -19759,6 +21220,15 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -19798,6 +21268,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -19827,6 +21306,15 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -19874,6 +21362,15 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -19913,7 +21410,7 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "lambda_token": []
                     }
                 ],
                 "responses": {
@@ -19959,6 +21456,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -19996,6 +21502,15 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -20032,6 +21547,15 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -20103,6 +21627,15 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -20186,6 +21719,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -20239,6 +21781,15 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -20305,6 +21856,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -20343,6 +21903,15 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -20373,6 +21942,15 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -20423,6 +22001,9 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "lambda_token": []
+                    },
                     {
                         "api_key": []
                     }
@@ -20481,6 +22062,9 @@
                 },
                 "security": [
                     {
+                        "lambda_token": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -20538,6 +22122,9 @@
                 },
                 "security": [
                     {
+                        "lambda_token": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -20588,6 +22175,15 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -20644,6 +22240,15 @@
                     }
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -20702,6 +22307,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -20758,6 +22372,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -20808,6 +22431,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -20833,6 +22465,15 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -20881,6 +22522,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -20927,6 +22577,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -20952,6 +22611,15 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -20998,6 +22666,15 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -21054,6 +22731,15 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -21122,6 +22808,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -21168,6 +22863,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -21193,6 +22897,9 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "lambda_token": []
+                    },
                     {
                         "api_key": []
                     }
@@ -21220,7 +22927,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "lambda_token": []
                     }
                 ],
                 "responses": {
@@ -21265,6 +22972,15 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -21313,6 +23029,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -21350,6 +23075,15 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -21397,6 +23131,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -21441,6 +23184,15 @@
                     }
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -21497,6 +23249,15 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -21536,6 +23297,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -21565,6 +23335,15 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -21612,6 +23391,15 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -21651,7 +23439,7 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "lambda_token": []
                     }
                 ],
                 "responses": {
@@ -21697,6 +23485,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -21733,6 +23530,15 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -21777,6 +23583,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -21833,6 +23645,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -21885,6 +23703,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -21932,6 +23756,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -21968,6 +23798,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -22024,6 +23860,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -22078,6 +23920,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -22112,6 +23960,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -22162,6 +24016,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -22220,6 +24080,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -22277,6 +24143,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -22302,6 +24174,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -22329,6 +24207,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -22354,6 +24238,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -22391,6 +24281,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -22447,6 +24343,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -22501,6 +24403,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -22535,6 +24443,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -22585,6 +24499,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -22643,6 +24563,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -22700,6 +24626,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -22725,6 +24657,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -22752,6 +24690,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -22778,6 +24722,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -22803,6 +24753,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -22832,6 +24788,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -22873,6 +24835,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -22909,6 +24877,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -22967,6 +24941,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -23007,6 +24987,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -23043,6 +25029,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -23100,6 +25092,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -23159,6 +25157,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -23177,6 +25181,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -23207,7 +25217,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "patronus_agent_token": []
+                    },
+                    {
+                        "pipecat_agent_token": []
                     }
                 ],
                 "responses": {
@@ -23252,6 +25265,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -23299,6 +25318,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -23344,6 +25369,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -23391,6 +25422,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -23436,6 +25473,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -23483,6 +25526,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -23527,6 +25576,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -23583,6 +25638,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -23608,6 +25669,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -23656,6 +25723,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -23692,6 +25765,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -23748,6 +25827,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -23802,6 +25887,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -23836,6 +25927,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -23876,6 +25973,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -23915,6 +26018,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -23971,6 +26080,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -24025,6 +26140,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -24059,6 +26180,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -24098,6 +26225,12 @@
                     }
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -24189,6 +26322,18 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -24233,6 +26378,18 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -24312,6 +26469,18 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -24357,6 +26526,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -24394,6 +26575,18 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -24618,6 +26811,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -24672,6 +26877,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -24706,6 +26923,18 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -24757,6 +26986,18 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -24823,6 +27064,18 @@
                     }
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -24900,6 +27153,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -24963,6 +27228,18 @@
                     "Results"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -25029,6 +27306,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -25067,6 +27356,18 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -25100,6 +27401,18 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -25147,6 +27460,18 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -25206,6 +27531,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -25243,6 +27580,18 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -25268,6 +27617,18 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -25295,6 +27656,18 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -25320,6 +27693,18 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -25367,6 +27752,18 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -25423,6 +27820,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -25448,6 +27857,18 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -25486,6 +27907,18 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -25710,6 +28143,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -25764,6 +28209,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -25798,6 +28255,18 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -25849,6 +28318,18 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -25915,6 +28396,18 @@
                     }
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -25992,6 +28485,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -26055,6 +28560,18 @@
                     "Results"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -26121,6 +28638,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -26159,6 +28688,18 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -26192,6 +28733,18 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -26239,6 +28792,18 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -26298,6 +28863,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -26335,6 +28912,18 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -26360,6 +28949,18 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -26387,6 +28988,18 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -26412,6 +29025,18 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -26459,6 +29084,18 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -26515,6 +29152,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -26540,6 +29189,18 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -26905,6 +29566,18 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -27272,6 +29945,18 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -27309,6 +29994,18 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -27365,6 +30062,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -27419,6 +30128,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -27453,6 +30174,18 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -27504,6 +30237,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -27553,6 +30298,18 @@
                     "Runs"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -27614,6 +30371,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -27651,6 +30420,18 @@
                     "Runs"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -27696,6 +30477,18 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -27753,6 +30546,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -27808,6 +30613,18 @@
                     }
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -27866,6 +30683,18 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -27956,6 +30785,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -28012,6 +30853,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -28049,6 +30902,18 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -28078,6 +30943,18 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -28115,6 +30992,18 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -28171,6 +31060,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -28225,6 +31126,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -28259,6 +31172,18 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -28310,6 +31235,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -28359,6 +31296,18 @@
                     "Runs"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -28420,6 +31369,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -28457,6 +31418,18 @@
                     "Runs"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -28502,6 +31475,18 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -28559,6 +31544,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -28614,6 +31611,18 @@
                     }
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -28672,6 +31681,18 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -28762,6 +31783,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -28797,6 +31830,15 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -28865,6 +31907,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -28902,6 +31956,18 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -28932,6 +31998,18 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -28958,6 +32036,12 @@
                     "Scenarios"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -29024,6 +32108,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -29068,6 +32158,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -29131,6 +32227,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -29185,6 +32287,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -29227,6 +32335,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -29325,6 +32439,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -29437,6 +32557,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -29569,6 +32695,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -29673,6 +32805,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -29728,6 +32866,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -29799,6 +32943,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -29863,6 +33013,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -29916,6 +33072,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -29980,6 +33142,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -30042,6 +33210,12 @@
                     }
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -30124,6 +33298,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -30201,6 +33381,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -30251,6 +33437,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -30307,6 +33499,12 @@
                     }
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -30365,6 +33563,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -30402,7 +33606,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "pipecat_agent_token": []
                     }
                 ],
                 "responses": {
@@ -30458,6 +33662,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -30516,6 +33726,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -30562,6 +33778,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -30607,6 +33829,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -30684,6 +33912,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -30752,6 +33986,12 @@
                     }
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -30825,6 +34065,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -30884,6 +34130,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -30974,6 +34226,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -31019,6 +34277,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -31072,6 +34336,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -31134,6 +34404,12 @@
                     }
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -31243,6 +34519,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -31326,6 +34608,12 @@
                     "Scenarios"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -31432,6 +34720,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -31477,6 +34771,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -31548,6 +34848,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -31599,6 +34905,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -31635,6 +34947,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -31812,6 +35130,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -31858,6 +35182,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -31902,6 +35232,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -31927,6 +35263,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -31964,6 +35306,12 @@
                     "Evaluators"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -32011,6 +35359,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -32057,6 +35411,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -32102,6 +35462,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -32160,6 +35526,12 @@
                     }
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -32354,6 +35726,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -32429,6 +35807,12 @@
                     }
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -32636,6 +36020,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -32829,6 +36219,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -32912,6 +36308,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -33003,6 +36405,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -33128,6 +36536,12 @@
                     }
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -33386,6 +36800,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -33431,6 +36851,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -33512,6 +36938,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -33721,6 +37153,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -33932,6 +37370,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -34139,6 +37583,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -34343,6 +37793,12 @@
                     }
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -34572,6 +38028,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -34779,6 +38241,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -34993,6 +38461,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -35185,6 +38659,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -35240,6 +38720,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -35284,6 +38770,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -35321,6 +38813,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -35400,6 +38898,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -35464,6 +38968,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -35525,6 +39035,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -35597,6 +39113,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -35659,6 +39181,12 @@
                     }
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -35741,6 +39269,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -35818,6 +39352,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -35868,6 +39408,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -35924,6 +39470,12 @@
                     }
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -35982,6 +39534,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -36019,7 +39577,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "pipecat_agent_token": []
                     }
                 ],
                 "responses": {
@@ -36075,6 +39633,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -36133,6 +39697,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -36187,6 +39757,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -36232,6 +39808,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -36308,6 +39890,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -36386,6 +39974,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -36458,6 +40052,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -36525,6 +40125,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -36623,6 +40229,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -36676,6 +40288,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -36737,6 +40355,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -36807,6 +40431,12 @@
                     }
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -36916,6 +40546,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -37007,6 +40643,12 @@
                     "Scenarios"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -37131,6 +40773,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -37184,6 +40832,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -37263,6 +40917,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -37314,6 +40974,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -37358,6 +41024,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -37543,6 +41215,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -37588,6 +41266,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -37641,6 +41325,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -37666,6 +41356,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -37741,6 +41437,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -37794,6 +41496,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -37849,6 +41557,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -37902,6 +41616,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -37960,6 +41680,12 @@
                     }
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -38162,6 +41888,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -38237,6 +41969,12 @@
                     }
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -38452,6 +42190,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -38653,6 +42397,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -38736,6 +42486,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -38835,6 +42591,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -38960,6 +42722,12 @@
                     }
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -39226,6 +42994,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -39271,6 +43045,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -39352,6 +43132,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -39569,6 +43355,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -39788,6 +43580,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -40003,6 +43801,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -40215,6 +44019,12 @@
                     }
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -40452,6 +44262,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -40667,6 +44483,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -40889,6 +44711,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -41089,6 +44917,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -41152,6 +44986,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -41204,6 +45044,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -41240,7 +45086,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "support_bot_oauth": []
                     }
                 ],
                 "responses": {
@@ -41276,6 +45122,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -41389,6 +45241,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -41479,6 +45337,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -41584,6 +45448,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -41660,6 +45530,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -41735,6 +45611,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -41807,6 +45689,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -41863,6 +45751,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -41907,6 +45801,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -41991,6 +45891,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -42063,6 +45969,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -42127,6 +46039,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -42189,7 +46107,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -42233,7 +46151,7 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -42270,7 +46188,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -42325,7 +46243,7 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -42379,7 +46297,7 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -42414,7 +46332,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -42478,6 +46396,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -42738,6 +46662,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -42878,6 +46808,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -42971,6 +46907,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -43061,6 +47003,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -43131,6 +47079,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -43187,6 +47141,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -43252,6 +47212,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -43306,6 +47272,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -43387,6 +47359,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -43470,6 +47448,12 @@
                     }
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -43573,6 +47557,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -43650,6 +47640,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -43706,6 +47702,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -43760,6 +47762,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -43832,6 +47840,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -43897,6 +47911,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -43933,6 +47953,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -44043,6 +48069,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -44094,6 +48126,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -44164,6 +48202,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -44249,6 +48293,15 @@
                     "Metrics"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -44488,6 +48541,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -44551,6 +48613,15 @@
                     "Metrics"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -44630,6 +48701,15 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -44713,6 +48793,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -44790,6 +48879,15 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -44863,6 +48961,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -44901,6 +49008,15 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -44931,6 +49047,15 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -44981,6 +49106,9 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "lambda_token": []
+                    },
                     {
                         "api_key": []
                     }
@@ -45039,6 +49167,9 @@
                 },
                 "security": [
                     {
+                        "lambda_token": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -45096,6 +49227,9 @@
                 },
                 "security": [
                     {
+                        "lambda_token": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -45146,6 +49280,15 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -45202,6 +49345,15 @@
                     }
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -45260,6 +49412,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -45315,6 +49476,15 @@
                     }
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -45374,6 +49544,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -45399,6 +49578,15 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -45447,6 +49635,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -45493,6 +49690,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -45518,6 +49724,15 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -45564,6 +49779,15 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -45620,6 +49844,15 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -45696,6 +49929,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -45742,6 +49984,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -45767,6 +50018,9 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "lambda_token": []
+                    },
                     {
                         "api_key": []
                     }
@@ -45794,7 +50048,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "lambda_token": []
                     }
                 ],
                 "responses": {
@@ -45839,6 +50093,15 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -45894,6 +50157,15 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -45968,6 +50240,15 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -46022,6 +50303,15 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -46074,6 +50364,15 @@
                     }
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -46165,6 +50464,15 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -46211,6 +50519,15 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -46277,6 +50594,15 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -46340,6 +50666,15 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -46387,7 +50722,7 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "lambda_token": []
                     }
                 ],
                 "responses": {
@@ -46432,6 +50767,15 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -46504,6 +50848,15 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -46600,6 +50953,18 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -46652,6 +51017,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -46689,6 +51066,18 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -46920,6 +51309,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -46974,6 +51375,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -47008,6 +51421,18 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -47059,6 +51484,18 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -47133,6 +51570,18 @@
                     }
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -47218,6 +51667,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -47289,6 +51750,18 @@
                     "Results"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -47363,6 +51836,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -47409,6 +51894,18 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -47442,6 +51939,18 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -47497,6 +52006,18 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -47556,6 +52077,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -47593,6 +52126,18 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -47618,6 +52163,18 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -47645,6 +52202,18 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -47670,6 +52239,18 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -47717,6 +52298,18 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -47773,6 +52366,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -47798,6 +52403,18 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -48164,6 +52781,18 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -48200,6 +52829,18 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -48255,6 +52896,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -48309,6 +52962,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -48343,6 +53008,18 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -48394,6 +53071,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -48443,6 +53132,18 @@
                     "Runs"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -48504,6 +53205,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -48541,6 +53254,18 @@
                     "Runs"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -48594,6 +53319,18 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -48651,6 +53388,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -48706,6 +53455,18 @@
                     }
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -48764,6 +53525,18 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -48862,6 +53635,18 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -48917,6 +53702,18 @@
                     }
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -48982,6 +53779,18 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -49018,6 +53827,18 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "shareable_link": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "embedded_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -49124,6 +53945,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -49228,6 +54055,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -49283,6 +54116,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -49354,6 +54193,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -49418,6 +54263,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -49471,6 +54322,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -49535,6 +54392,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -49597,6 +54460,12 @@
                     }
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -49679,6 +54548,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -49756,6 +54631,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -49806,6 +54687,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -49862,6 +54749,12 @@
                     }
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -49920,6 +54813,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -49957,7 +54856,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "pipecat_agent_token": []
                     }
                 ],
                 "responses": {
@@ -50013,6 +54912,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -50071,6 +54976,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -50117,6 +55028,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -50162,6 +55079,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -50239,6 +55162,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -50307,6 +55236,12 @@
                     }
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -50380,6 +55315,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -50439,6 +55380,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -50529,6 +55476,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -50574,6 +55527,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -50627,6 +55586,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -50689,6 +55654,12 @@
                     }
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -50798,6 +55769,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -50881,6 +55858,12 @@
                     "Scenarios"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -50987,6 +55970,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -51032,6 +56021,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -51103,6 +56098,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -51154,6 +56155,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -51190,6 +56197,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -51367,6 +56380,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -51413,6 +56432,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -51457,6 +56482,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -51482,6 +56513,12 @@
                     "test_framework"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -51519,6 +56556,12 @@
                     "Evaluators"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -51566,6 +56609,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -51612,6 +56661,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -51657,6 +56712,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -51715,6 +56776,12 @@
                     }
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -51909,6 +56976,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -51984,6 +57057,12 @@
                     }
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -52191,6 +57270,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -52384,6 +57469,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -52467,6 +57558,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -52558,6 +57655,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -52683,6 +57786,12 @@
                     }
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -52941,6 +58050,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -52986,6 +58101,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -53067,6 +58188,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -53276,6 +58403,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -53487,6 +58620,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -53694,6 +58833,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -53898,6 +59043,12 @@
                     }
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -54127,6 +59278,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -54334,6 +59491,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -54548,6 +59711,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -54740,6 +59909,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -54795,6 +59970,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -54839,6 +60020,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -54865,7 +60052,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -54883,7 +60070,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -54930,6 +60117,9 @@
                 },
                 "security": [
                     {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -54965,7 +60155,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -55018,7 +60208,7 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -55071,7 +60261,7 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -55105,7 +60295,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -55124,7 +60314,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "embedded_session": []
                     }
                 ],
                 "responses": {
@@ -55143,7 +60333,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -55189,7 +60382,10 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -55225,7 +60421,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -55278,7 +60477,10 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -55331,7 +60533,10 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -55365,7 +60570,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -55413,7 +60621,10 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -55469,7 +60680,10 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -55523,7 +60737,10 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -55579,7 +60796,10 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -55605,7 +60825,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -55630,7 +60853,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -55676,7 +60902,10 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -55720,7 +60949,10 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -55746,7 +60978,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session_inactive_allowed": []
                     }
                 ],
                 "responses": {
@@ -55765,7 +60997,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -55805,7 +61040,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -55859,7 +61097,10 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -55894,7 +61135,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -55910,11 +61154,6 @@
                 "operationId": "user-oauth-authorize-retrieve",
                 "tags": [
                     "user"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
                 ],
                 "responses": {
                     "200": {
@@ -55932,7 +61171,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -55950,11 +61189,6 @@
                 "tags": [
                     "user"
                 ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
                 "responses": {
                     "200": {
                         "description": "No response body"
@@ -55967,11 +61201,6 @@
                 "operationId": "user-oauth-revoke-create",
                 "tags": [
                     "user"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
                 ],
                 "responses": {
                     "200": {
@@ -55986,11 +61215,6 @@
                 "operationId": "user-oauth-token-create",
                 "tags": [
                     "user"
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    }
                 ],
                 "responses": {
                     "200": {
@@ -56018,6 +61242,12 @@
                     "user"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -56075,6 +61305,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -56109,6 +61345,12 @@
                     "user"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -56164,6 +61406,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -56217,6 +61465,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -56250,6 +61504,12 @@
                     "user"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -56300,6 +61560,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -56334,6 +61600,12 @@
                     "user"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -56371,6 +61643,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -56407,6 +61685,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -56442,6 +61726,12 @@
                     "user"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -56499,6 +61789,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -56555,6 +61851,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -56600,6 +61902,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -56624,6 +61932,12 @@
                     "user"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -56652,7 +61966,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session_inactive_allowed": []
                     }
                 ],
                 "responses": {
@@ -56671,7 +61985,7 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "supabase_session_inactive_allowed": []
                     }
                 ],
                 "responses": {
@@ -56689,7 +62003,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -56736,7 +62053,10 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -56773,7 +62093,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -56828,7 +62151,10 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -56882,7 +62208,10 @@
                 },
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -56917,7 +62246,10 @@
                 ],
                 "security": [
                     {
-                        "api_key": []
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
                     }
                 ],
                 "responses": {
@@ -57030,6 +62362,9 @@
                 ],
                 "security": [
                     {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -57066,6 +62401,9 @@
                     "user"
                 ],
                 "security": [
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -57111,11 +62449,6 @@
                     },
                     "required": true
                 },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
                 "responses": {
                     "200": {
                         "content": {
@@ -57157,11 +62490,6 @@
                     },
                     "required": true
                 },
-                "security": [
-                    {
-                        "api_key": []
-                    }
-                ],
                 "responses": {
                     "200": {
                         "content": {
@@ -57204,6 +62532,12 @@
                     "user"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -57259,6 +62593,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -57304,6 +62644,12 @@
                     "user"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -57351,6 +62697,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -57387,6 +62739,12 @@
                     "user"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -57443,6 +62801,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -57497,6 +62861,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -57533,6 +62903,12 @@
                     "user"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -57592,6 +62968,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -57638,6 +63020,12 @@
                     "user"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -57696,6 +63084,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -57757,6 +63151,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -57796,6 +63196,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -57832,6 +63238,12 @@
                     "user"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -57870,6 +63282,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -57905,6 +63323,12 @@
                     "user"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -57943,6 +63367,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -57980,6 +63410,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -58016,6 +63452,12 @@
                     "user"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -58075,6 +63517,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -58111,6 +63559,12 @@
                     "user"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -58167,6 +63621,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -58226,6 +63686,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -58250,6 +63716,12 @@
                     "user"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -58287,6 +63759,12 @@
                     "user"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -58351,6 +63829,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -58405,6 +63889,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -58449,6 +63939,12 @@
                     "user"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -58516,6 +64012,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -58562,6 +64064,12 @@
                     "user"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -58620,6 +64128,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -58689,6 +64203,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -58736,6 +64256,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -58772,6 +64298,12 @@
                     "user"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -58810,6 +64342,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -58845,6 +64383,12 @@
                     "user"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -58883,6 +64427,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -58920,6 +64470,12 @@
                 ],
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -58956,6 +64512,12 @@
                     "user"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -59015,6 +64577,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -59051,6 +64619,12 @@
                     "user"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -59107,6 +64681,12 @@
                     "required": true
                 },
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -59166,6 +64746,12 @@
                 },
                 "security": [
                     {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
                         "api_key": []
                     }
                 ],
@@ -59190,6 +64776,12 @@
                     "user"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -59245,6 +64837,12 @@
                     "user"
                 ],
                 "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
                     {
                         "api_key": []
                     }
@@ -68423,6 +74021,7 @@
             },
             "OrganizationInline": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -71530,6 +77129,7 @@
             },
             "PatchedProject": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -71803,36 +77403,6 @@
                         "type": "string",
                         "format": "date-time",
                         "readOnly": true
-                    }
-                }
-            },
-            "PatchedProjectDefaultMetrics": {
-                "type": "object",
-                "properties": {
-                    "project": {
-                        "type": "integer"
-                    },
-                    "predefined_metrics": {
-                        "type": "array",
-                        "items": {
-                            "type": "integer"
-                        }
-                    },
-                    "predefined_metrics_names": {
-                        "type": "string",
-                        "readOnly": true
-                    },
-                    "created_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "description": "When this record was created.\nExample: `2024-03-15T10:30:45Z`"
-                    },
-                    "updated_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "description": "When this record was last updated.\nExample: `2024-03-15T10:35:11Z`"
                     }
                 }
             },
@@ -73666,88 +79236,6 @@
                     }
                 }
             },
-            "PatchedTestSetDetail": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
-                    "agent": {
-                        "type": "integer"
-                    },
-                    "name": {
-                        "type": "string",
-                        "description": "\nName of the test set\nExample: `\"Test Set 1\"`\n",
-                        "maxLength": 255
-                    },
-                    "transcript": {
-                        "type": "string",
-                        "description": "Full text transcript of the call.\nExample: \n```text\n[00:01] Testing Agent: Hello. \n[00:02] Main Agent: Hello, how can I help you today?\n[00:03] Testing Agent: Well, I mean, sure. What time exactly are we talking about here\n[00:04] Main Agent: 6 PM.\n[00:05] Testing Agent: Great. I'll book that for you. Just a sec.\n[00:06] Main Agent: Okay.\n```\n"
-                    },
-                    "transcript_object": {
-                        "oneOf": [
-                            {},
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "voice_recording": {
-                        "type": "string",
-                        "format": "uri",
-                        "writeOnly": true
-                    },
-                    "voice_recording_url": {
-                        "type": "string",
-                        "readOnly": true,
-                        "description": "Audio URL"
-                    },
-                    "call_end_reason": {
-                        "type": "string",
-                        "description": "Reason why the call ended.\nExample: \n- `\"customer-ended-call\"`\n- `\"agent-ended-call\"`\n",
-                        "maxLength": 255
-                    },
-                    "duration": {
-                        "type": "string",
-                        "readOnly": true,
-                        "description": "Call duration in minutes in MM:SS format.\nExample: `01:10`"
-                    },
-                    "source_model": {
-                        "enum": [
-                            "CallLog",
-                            "Run"
-                        ],
-                        "type": "string",
-                        "description": "* `CallLog` - Call Log\n* `Run` - Run",
-                        "x-spec-enum-id": "1d8f6db20c0b4cac",
-                        "readOnly": true
-                    },
-                    "source_id": {
-                        "type": "string",
-                        "readOnly": true
-                    },
-                    "metric_reviews": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/MetricReviewInline"
-                        },
-                        "readOnly": true
-                    },
-                    "created_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "description": "When this record was created.\nExample: `2024-03-15T10:30:45Z`"
-                    },
-                    "updated_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "description": "When this record was last updated.\nExample: `2024-03-15T10:35:11Z`"
-                    }
-                }
-            },
             "PatchedTool": {
                 "type": "object",
                 "properties": {
@@ -75051,6 +80539,7 @@
             },
             "Project": {
                 "type": "object",
+                "description": "",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -75328,39 +80817,6 @@
                 },
                 "required": [
                     "name"
-                ]
-            },
-            "ProjectDefaultMetrics": {
-                "type": "object",
-                "properties": {
-                    "project": {
-                        "type": "integer"
-                    },
-                    "predefined_metrics": {
-                        "type": "array",
-                        "items": {
-                            "type": "integer"
-                        }
-                    },
-                    "predefined_metrics_names": {
-                        "type": "string",
-                        "readOnly": true
-                    },
-                    "created_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "description": "When this record was created.\nExample: `2024-03-15T10:30:45Z`"
-                    },
-                    "updated_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "description": "When this record was last updated.\nExample: `2024-03-15T10:35:11Z`"
-                    }
-                },
-                "required": [
-                    "project"
                 ]
             },
             "ProjectInline": {
@@ -81833,71 +87289,6 @@
                     "agent"
                 ]
             },
-            "TestSetList": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
-                    "agent": {
-                        "type": "integer"
-                    },
-                    "name": {
-                        "type": "string",
-                        "description": "\nName of the test set\nExample: `\"Test Set 1\"`\n",
-                        "maxLength": 255
-                    },
-                    "transcript_short": {
-                        "type": "string",
-                        "readOnly": true
-                    },
-                    "call_end_reason": {
-                        "type": "string",
-                        "description": "Reason why the call ended.\nExample: \n- `\"customer-ended-call\"`\n- `\"agent-ended-call\"`\n",
-                        "maxLength": 255
-                    },
-                    "duration": {
-                        "type": "string",
-                        "readOnly": true,
-                        "description": "Call duration in minutes in MM:SS format.\nExample: `01:10`"
-                    },
-                    "has_recording": {
-                        "type": "string",
-                        "readOnly": true,
-                        "description": "Whether the test set has a voice recording"
-                    },
-                    "source_model": {
-                        "enum": [
-                            "CallLog",
-                            "Run",
-                            ""
-                        ],
-                        "type": "string",
-                        "description": "* `CallLog` - Call Log\n* `Run` - Run",
-                        "x-spec-enum-id": "1d8f6db20c0b4cac"
-                    },
-                    "source_id": {
-                        "type": "string",
-                        "maxLength": 255
-                    },
-                    "created_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "description": "When this record was created.\nExample: `2024-03-15T10:30:45Z`"
-                    },
-                    "updated_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "description": "When this record was last updated.\nExample: `2024-03-15T10:35:11Z`"
-                    }
-                },
-                "required": [
-                    "agent"
-                ]
-            },
             "TokenRefresh": {
                 "type": "object",
                 "properties": {
@@ -82699,9 +88090,69 @@
         "securitySchemes": {
             "api_key": {
                 "type": "apiKey",
-                "name": "X-CEKURA-API-KEY",
                 "in": "header",
+                "name": "X-CEKURA-API-KEY",
                 "description": "API Key Authentication. It should be included in the header of each request."
+            },
+            "embedded_session": {
+                "type": "http",
+                "scheme": "bearer",
+                "bearerFormat": "JWT",
+                "description": "Embedded-dashboard session token. Internal."
+            },
+            "lambda_token": {
+                "type": "http",
+                "scheme": "bearer",
+                "bearerFormat": "JWT",
+                "description": "Internal Lambda-to-backend token."
+            },
+            "oauth2": {
+                "type": "http",
+                "scheme": "bearer",
+                "bearerFormat": "JWT",
+                "description": "OAuth access token issued by Cekura for connected apps."
+            },
+            "patronus_agent_token": {
+                "type": "apiKey",
+                "in": "header",
+                "name": "X-CEKURA-PIPECAT-AGENT-TOKEN",
+                "description": "Internal Patronus agent token."
+            },
+            "pipecat_agent_token": {
+                "type": "apiKey",
+                "in": "header",
+                "name": "X-CEKURA-PIPECAT-AGENT-TOKEN",
+                "description": "Internal Pipecat/Patronus agent token."
+            },
+            "product_chat_sandbox": {
+                "type": "http",
+                "scheme": "bearer",
+                "bearerFormat": "JWT",
+                "description": "Product-chat sandbox token. Internal."
+            },
+            "shareable_link": {
+                "type": "apiKey",
+                "in": "header",
+                "name": "X-VOCERA-SHAREABLE-LINK-TOKEN",
+                "description": "Share-link token scoped to a single shared resource."
+            },
+            "supabase_session": {
+                "type": "http",
+                "scheme": "bearer",
+                "bearerFormat": "JWT",
+                "description": "Cekura dashboard session token. Not a customer API credential."
+            },
+            "supabase_session_inactive_allowed": {
+                "type": "http",
+                "scheme": "bearer",
+                "bearerFormat": "JWT",
+                "description": "Cekura dashboard session token, accepted before account activation. Not a customer API credential."
+            },
+            "support_bot_oauth": {
+                "type": "http",
+                "scheme": "bearer",
+                "bearerFormat": "JWT",
+                "description": "Internal Cekura support-bot token."
             }
         }
     },


### PR DESCRIPTION
Auto-generated docs sync for backend PR [#10625](https://github.com/cekura-ai/vocera.backend/pull/10625).

Reviewers: @dileep-chagam

## Summary

**Spec/overlay:** Spec-only sync: per-operation security derivation replaces the global X-CEKURA-API-KEY blanket. ~969 operations now carry truthful security lists reflecting each view's actual authenticators. 10 new securitySchemes added (oauth2, supabase_session, embedded_session, lambda_token, patronus_agent_token, pipecat_agent_token, product_chat_sandbox, shareable_link, supabase_session_inactive_allowed, support_bot_oauth). 17 dashboard-only operations removed from the spec (TestSetViewSet CRUD, ProjectDefaultMetricsViewSet) via @extend_schema(exclude=True). No MCP exposure changes — 167 operations remain exposed. No overlay patches needed.

**Conceptual docs:** No edits — PR changes OpenAPI spec generation internals (per-operation security derivation, UI-only route exclusion) with no user-visible behavior change. Conceptual docs describe workflows and concepts, not authentication scheme metadata on individual operations.

## Changes

- `openapi.json` — regenerate_from_backend

---
*Auto-generated from backend PR #10625.*

<!-- mcp-sync:file-hashes -->
```json
{}
```
<!-- /mcp-sync:file-hashes -->