### PR TITLE
feat(mcp): support alias_of overlay entries for retired tool names

### DIFF
--- a/cekura-mcp-server/openapi_mcp_server.py
+++ b/cekura-mcp-server/openapi_mcp_server.py
@@ -8,7 +8,7 @@ import sys
 import time
 import uuid
 from contextvars import ContextVar
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 import httpx
 import jwt
@@ -35,6 +35,7 @@ from tool_generator import (
     compute_annotations,
     generate_tool_description,
     generate_tool_name,
+    load_tool_aliases,
     maybe_append_org_project_hint,
     should_include_operation,
 )
@@ -226,10 +227,15 @@ async def initialize_server():
                 logger.error(f"Error registering tool for {operation.path}: {e}", exc_info=True)
                 continue
 
+        alias_names = register_tool_aliases(blocked_tools)
+        tools_registered += len(alias_names)
+
         if blocked_hits:
             logger.info(f"Registered {tools_registered} MCP tools (blocked: {sorted(blocked_hits)})")
         else:
             logger.info(f"Registered {tools_registered} MCP tools")
+        if alias_names:
+            logger.info(f"Registered {len(alias_names)} retired tool alias(es): {alias_names}")
 
         # Non-fatal drift check: log a warning for each overlay that has diverged
         # from the live openapi.json + whitelist. Keeps production booting while
@@ -395,6 +401,43 @@ def register_tool(
         'description': description,
         'annotations': annotations,
     }
+
+
+def register_tool_aliases(blocked_tools: Set[str]) -> List[str]:
+    """Register retired tool names against the tools that replaced them.
+
+    Must run after normal registration so alias targets already exist. An alias
+    reuses its target's operation, schema, and annotations; its description is
+    the target's with the alias entry's own prefix/suffix applied, which is
+    where the "this name is retired, use X" notice lives.
+
+    A missing target is skipped with a warning rather than raised: an overlay
+    may declare an alias before the spec rename that creates its target lands.
+    """
+    registered: List[str] = []
+    for alias_name, target in sorted(load_tool_aliases().items()):
+        if alias_name in blocked_tools:
+            continue
+        if alias_name in operations_registry:
+            logger.warning(
+                f"Alias '{alias_name}' collides with a registered tool name — skipping"
+            )
+            continue
+        target_data = operations_registry.get(target)
+        if target_data is None:
+            logger.warning(
+                f"Alias '{alias_name}' targets unregistered tool '{target}' — skipping"
+            )
+            continue
+        register_tool(
+            alias_name,
+            apply_overlay_to_description(alias_name, target_data['description']),
+            target_data['schema'],
+            target_data['operation'],
+            annotations=target_data['annotations'],
+        )
+        registered.append(alias_name)
+    return registered
 
 
 @mcp.tool(

--- a/cekura-mcp-server/tests/test_overlays.py
+++ b/cekura-mcp-server/tests/test_overlays.py
@@ -138,3 +138,47 @@ def test_generate_improve_tools_have_clarifying_suffix(tool):
     )
     suffix = overlays[tool].get("description_suffix", "")
     assert suffix, f"{tool} overlay must define a non-empty description_suffix."
+
+
+# ---------------------------------------------------------------------------
+# Alias entries — retired tool names kept resolving after a rename
+# ---------------------------------------------------------------------------
+
+
+def _categories(findings):
+    return {f.category for f in findings}
+
+
+def _real_tool_name():
+    """Any tool the live spec actually registers, for use as an alias target."""
+    return "scenarios_create"
+
+
+def test_alias_entry_is_not_reported_as_orphan():
+    findings = run_checks(overlays={"retired_name": {"alias_of": _real_tool_name()}})
+    assert "orphan" not in _categories(findings)
+    assert "alias_target_missing" not in _categories(findings)
+
+
+def test_alias_to_unknown_target_is_an_error():
+    findings = run_checks(overlays={"retired_name": {"alias_of": "no_such_tool"}})
+    missing = [f for f in findings if f.category == "alias_target_missing"]
+    assert len(missing) == 1
+    assert missing[0].level == "error"
+
+
+def test_alias_that_shadows_a_real_tool_is_an_error():
+    findings = run_checks(
+        overlays={_real_tool_name(): {"alias_of": "scenarios_list"}}
+    )
+    shadowing = [f for f in findings if f.category == "alias_shadows_tool"]
+    assert len(shadowing) == 1
+    assert shadowing[0].level == "error"
+
+
+def test_plain_orphan_is_still_an_error():
+    # The alias exemption must not weaken the orphan check for normal entries.
+    findings = run_checks(overlays={"totally_made_up_tool": {"description_suffix": "x"}})
+    orphans = [f for f in findings if f.category == "orphan"]
+    assert len(orphans) == 1
+    assert orphans[0].level == "error"

--- a/cekura-mcp-server/tests/test_tool_aliases.py
+++ b/cekura-mcp-server/tests/test_tool_aliases.py
@@ -1,0 +1,111 @@
+"""Tests for retired-tool-name aliases (`alias_of` overlay entries).
+
+Tool names are derived from spec operation ids, so renaming an operation
+renames its MCP tool and breaks callers that hardcoded the old name. An alias
+keeps the old name resolving to the new tool.
+"""
+import pytest
+
+from openapi_mcp_server import operations_registry, register_tool, register_tool_aliases
+from tool_generator import load_tool_aliases
+
+
+class FakeOp:
+    """Stand-in for an Operation — aliases only ever pass it through."""
+
+    def __init__(self, path="/api/v1/thing/"):
+        self.path = path
+        self.method = "POST"
+
+
+@pytest.fixture
+def clean_registry():
+    """Swap in an empty registry so tests never disturb real registrations."""
+    saved = dict(operations_registry)
+    operations_registry.clear()
+    yield operations_registry
+    operations_registry.clear()
+    operations_registry.update(saved)
+
+
+def _overlays(monkeypatch, overlays):
+    monkeypatch.setattr("tool_generator.load_tool_overlays", lambda: overlays)
+
+
+class TestLoadToolAliases:
+    """Only entries carrying `alias_of` are aliases."""
+
+    def test_extracts_alias_entries(self, monkeypatch):
+        _overlays(monkeypatch, {
+            "old_name": {"alias_of": "new_name"},
+            "unrelated_tool": {"description_suffix": "hi"},
+        })
+        assert load_tool_aliases() == {"old_name": "new_name"}
+
+    def test_no_aliases_when_none_declared(self, monkeypatch):
+        _overlays(monkeypatch, {"some_tool": {"destructive": True}})
+        assert load_tool_aliases() == {}
+
+    def test_ignores_non_dict_entries(self, monkeypatch):
+        _overlays(monkeypatch, {"weird": "not-an-object"})
+        assert load_tool_aliases() == {}
+
+
+class TestRegisterToolAliases:
+    """Registration copies the target's operation, schema, and annotations."""
+
+    def test_alias_resolves_to_target_operation(self, monkeypatch, clean_registry):
+        op = FakeOp()
+        schema = {"type": "object", "properties": {"a": {"type": "string"}}}
+        register_tool("new_name", "Target description.", schema, op, annotations="ann")
+        _overlays(monkeypatch, {"old_name": {"alias_of": "new_name"}})
+
+        assert register_tool_aliases(set()) == ["old_name"]
+        alias = operations_registry["old_name"]
+        assert alias["operation"] is op
+        assert alias["schema"] is schema
+        assert alias["annotations"] == "ann"
+
+    def test_alias_description_carries_its_own_prefix(self, monkeypatch, clean_registry):
+        register_tool("new_name", "Target description.", {}, FakeOp())
+        _overlays(monkeypatch, {
+            "old_name": {"alias_of": "new_name", "description_prefix": "RETIRED NAME."},
+        })
+
+        register_tool_aliases(set())
+        description = operations_registry["old_name"]["description"]
+        assert description.startswith("RETIRED NAME.")
+        assert "Target description." in description
+
+    def test_missing_target_is_skipped_not_fatal(self, monkeypatch, clean_registry):
+        # An overlay may declare the alias before the rename that creates its
+        # target reaches the spec.
+        _overlays(monkeypatch, {"old_name": {"alias_of": "not_registered_yet"}})
+
+        assert register_tool_aliases(set()) == []
+        assert "old_name" not in operations_registry
+
+    def test_alias_never_shadows_a_real_tool(self, monkeypatch, clean_registry):
+        register_tool("new_name", "New.", {}, FakeOp())
+        register_tool("old_name", "A real tool that still exists.", {}, FakeOp())
+        _overlays(monkeypatch, {"old_name": {"alias_of": "new_name"}})
+
+        assert register_tool_aliases(set()) == []
+        assert operations_registry["old_name"]["description"] == "A real tool that still exists."
+
+    def test_blocked_alias_is_not_registered(self, monkeypatch, clean_registry):
+        register_tool("new_name", "New.", {}, FakeOp())
+        _overlays(monkeypatch, {"old_name": {"alias_of": "new_name"}})
+
+        assert register_tool_aliases({"old_name"}) == []
+        assert "old_name" not in operations_registry
+
+    def test_alias_is_dispatchable_like_any_tool(self, monkeypatch, clean_registry):
+        # The dispatch layer looks tools up in this registry by name only, so an
+        # alias entry is indistinguishable from a directly registered tool.
+        op = FakeOp()
+        register_tool("new_name", "New.", {"type": "object"}, op)
+        _overlays(monkeypatch, {"old_name": {"alias_of": "new_name"}})
+        register_tool_aliases(set())
+
+        assert operations_registry["old_name"]["operation"] is operations_registry["new_name"]["operation"]

--- a/cekura-mcp-server/tool_generator.py
+++ b/cekura-mcp-server/tool_generator.py
@@ -70,6 +70,25 @@ def load_tool_overlays() -> Dict[str, Any]:
         return _OVERLAY_CACHE
 
 
+def load_tool_aliases() -> Dict[str, str]:
+    """Map retired tool name -> current tool name.
+
+    An overlay entry carrying `alias_of` is not an enrichment for a registered
+    tool; it declares a name that no longer exists in the spec and must keep
+    resolving to the tool that replaced it. Tool names are derived from the
+    spec's operation ids, so renaming one silently breaks every caller that
+    hardcoded the old name. MCP has no redirect of its own — this is it.
+    """
+    aliases: Dict[str, str] = {}
+    for name, overlay in load_tool_overlays().items():
+        if not isinstance(overlay, dict):
+            continue
+        target = overlay.get('alias_of')
+        if target:
+            aliases[name] = target
+    return aliases
+
+
 def apply_overlay_to_description(tool_name: str, description: str) -> str:
     overlay = load_tool_overlays().get(tool_name)
     if not overlay:

--- a/cekura-mcp-server/validate_overlays.py
+++ b/cekura-mcp-server/validate_overlays.py
@@ -78,8 +78,12 @@ def _build_context(
 
 
 def _check_orphans(ctx: _Context) -> None:
-    for tool_name in ctx.overlays:
+    for tool_name, overlay in ctx.overlays.items():
         if tool_name in ctx.operations_by_tool:
+            continue
+        if overlay.get("alias_of"):
+            # Alias entries are *expected* to have no operation of their own —
+            # that is the point. `_check_aliases` validates them instead.
             continue
         ctx.add(
             "error",
@@ -88,6 +92,32 @@ def _check_orphans(ctx: _Context) -> None:
             f"Overlay entry '{tool_name}' does not match any registered tool. "
             "Either the tool was renamed/removed upstream, or the overlay key is a typo.",
         )
+
+
+def _check_aliases(ctx: _Context) -> None:
+    """Validate `alias_of` entries — retired tool names kept alive after a rename."""
+    for alias_name, overlay in ctx.overlays.items():
+        target = overlay.get("alias_of")
+        if not target:
+            continue
+        if alias_name in ctx.operations_by_tool:
+            ctx.add(
+                "error",
+                "alias_shadows_tool",
+                alias_name,
+                f"Overlay declares '{alias_name}' as an alias of '{target}', but a real tool "
+                "registers under that name. The alias would be dropped; remove the "
+                "`alias_of` entry or rename the operation.",
+            )
+        if target not in ctx.operations_by_tool:
+            ctx.add(
+                "error",
+                "alias_target_missing",
+                alias_name,
+                f"Alias '{alias_name}' targets '{target}', which no tool registers under. "
+                "Either the target's operation id has not landed in the spec yet, or the "
+                "target name is a typo — the alias is skipped at registration either way.",
+            )
 
 
 def _check_required_fields(ctx: _Context) -> None:
@@ -197,6 +227,7 @@ def run_checks(
     ctx = _build_context(spec_path=spec_path, overlays=overlays)
 
     _check_orphans(ctx)
+    _check_aliases(ctx)
     _check_required_fields(ctx)
     _check_example_fields(ctx)
     _check_schema_example_fields(ctx)


### PR DESCRIPTION
## Problem

MCP tool names are derived from spec operation ids (`-` → `_`, trailing `_<digit>` collision suffix stripped). Rename an operation id and its tool is renamed too — with **no redirect of any kind**. Every caller that hardcoded the old name breaks silently, and there is no deprecation window.

This is not hypothetical. `validate_overlays.py` currently reports 7 orphan entries on `main`, several of which are debris from exactly this: `call_logs_list` → `observability_v2_call_logs_list`, `call_logs_retrieve`, `scenarios_create_from_transcript` → `..._bg`. Those old tool names died quietly.

## Fix

An overlay entry carrying `alias_of` registers a retired name against the tool that replaced it:

```json
"old_name": {
  "alias_of": "new_name",
  "description_prefix": "⚠ RETIRED NAME — this tool is now `new_name`. …"
}
```

- `load_tool_aliases()` collects those entries.
- `register_tool_aliases()` runs **after** the main registration loop and reuses the target's operation, schema, and annotations. Dispatch looks tools up by name only, so an alias is indistinguishable from a real tool.
- The alias's description is its target's, with the alias entry's own prefix/suffix applied — that's where the "use the new name" notice lives.
- A **missing target is skipped with a warning**, not raised, so an alias may be declared before the rename that creates its target lands.
- An alias may **never shadow a real tool**.

`validate_overlays` exempts alias entries from the orphan check (they have no operation of their own, by design) and instead adds `alias_target_missing` and `alias_shadows_tool`.

## Verification

- `pytest tests/` → **135 passed, 8 failed**
- clean `origin/main` baseline in a separate worktree → **122 passed, the same 8 failed**

So: +13 new passing tests, zero new failures. The 8 pre-existing failures are 5 env-dependent `test_config` cases, the 2 overlay-drift tests (the 7 orphans above), and 1 description-truncation case.

New tests cover alias extraction, operation/schema/annotation reuse, the description prefix, missing-target skip, shadow refusal, blocked-tool suppression, and dispatch equivalence.

## Notes

No behavior change until an alias is actually declared — this PR declares none. It is a standalone mechanism, safe to merge on its own, and is a prerequisite for the `scenarios_refine` rename (see #TBD in this repo and the backend rename PR).

Follow-up worth considering: the 7 pre-existing orphans are now fixable with `alias_of` records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)