### PR TITLE
Document expected mock tool data on scenario write/generate APIs

### DIFF
--- a/documentation/key-concepts/evaluators/mock-tools.mdx
+++ b/documentation/key-concepts/evaluators/mock-tools.mdx
@@ -85,7 +85,7 @@ When Auto-Fetch generates mock data for scenarios whose agent has mock tools att
 You can view this data in two ways:
 
 1. **Via the Evaluator UI**: When viewing a scenario in the Cekura dashboard, the generated mock tool entries are displayed so you can see what tool calls the evaluator will make during testing
-2. **Via the API**: Retrieve a scenario using the scenarios retrieve endpoint to access the `generated_mock_tool_entries` field programmatically
+2. **Via the API**: Retrieve a scenario with [Get Evaluator](/api-reference/test_framework/get-evaluator) to access the `generated_mock_tool_entries` field programmatically. The field is also writable — set it when creating an evaluator via [Create Evaluator](/api-reference/test_framework/create-evaluator) or edit it later via [Update Evaluator](/api-reference/test_framework/update-evaluator). Each entry has the shape `{tool_id, tool_name, new_entry: {input, output}}`.
 
 This visibility helps you understand exactly what mock tool interactions will occur during each test run, making it easier to debug and validate your agent's tool-calling behavior.
 
@@ -311,3 +311,9 @@ For programmatic access to mock tools — they are managed directly on the agent
 - [Update Agent](/api-reference/test_framework/update-agent-partial) — create, update, or delete mock tools via the `mock_tools` field
 - [Auto-Fetch Agent from Provider](/api-reference/test_framework/auto-fetch-agent) — re-fetch the agent's full configuration (including tools + mock data) from its provider
 - [Toggle Mock Tools](/api-reference/test_framework/toggle-mock-tools) — enable or disable mock mode on the provider
+
+Per-scenario expected mock tool calls live on the evaluator as `generated_mock_tool_entries`:
+
+- [Get Evaluator](/api-reference/test_framework/get-evaluator) — read a scenario's expected mock tool calls
+- [Create Evaluator](/api-reference/test_framework/create-evaluator) / [Update Evaluator](/api-reference/test_framework/update-evaluator) — set or edit them manually
+- [Generate Evaluators](/api-reference/test_framework/generate-evaluator-bg) — auto-generates them for each scenario when the agent has mock tools attached

--- a/openapi.json
+++ b/openapi.json
@@ -4942,6 +4942,41 @@
                                                         "is_simulating": {
                                                             "type": "boolean",
                                                             "description": "Whether this scenario was created by simulation"
+                                                        },
+                                                        "test_profile_data": {
+                                                            "type": "object",
+                                                            "description": "The test profile generated for this scenario, including its sectioned `information` (main_agent_variables / testing_agent_variables)"
+                                                        },
+                                                        "generated_mock_tool_entries": {
+                                                            "type": "array",
+                                                            "description": "Expected mock tool calls generated for this scenario when the agent has mock tools attached. Empty when the agent has no mock tools.",
+                                                            "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "tool_id": {
+                                                                        "type": "integer",
+                                                                        "description": "ID of the mock tool on the agent"
+                                                                    },
+                                                                    "tool_name": {
+                                                                        "type": "string",
+                                                                        "description": "Name of the tool being mocked"
+                                                                    },
+                                                                    "new_entry": {
+                                                                        "type": "object",
+                                                                        "description": "The expected tool call for this scenario",
+                                                                        "properties": {
+                                                                            "input": {
+                                                                                "type": "object",
+                                                                                "description": "Input parameters the tool call is expected to receive"
+                                                                            },
+                                                                            "output": {
+                                                                                "type": "object",
+                                                                                "description": "Response the mock tool will return"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
                                                         }
                                                     }
                                                 }
@@ -6391,6 +6426,41 @@
                                                         "is_simulating": {
                                                             "type": "boolean",
                                                             "description": "Whether this scenario was created by simulation"
+                                                        },
+                                                        "test_profile_data": {
+                                                            "type": "object",
+                                                            "description": "The test profile generated for this scenario, including its sectioned `information` (main_agent_variables / testing_agent_variables)"
+                                                        },
+                                                        "generated_mock_tool_entries": {
+                                                            "type": "array",
+                                                            "description": "Expected mock tool calls generated for this scenario when the agent has mock tools attached. Empty when the agent has no mock tools.",
+                                                            "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "tool_id": {
+                                                                        "type": "integer",
+                                                                        "description": "ID of the mock tool on the agent"
+                                                                    },
+                                                                    "tool_name": {
+                                                                        "type": "string",
+                                                                        "description": "Name of the tool being mocked"
+                                                                    },
+                                                                    "new_entry": {
+                                                                        "type": "object",
+                                                                        "description": "The expected tool call for this scenario",
+                                                                        "properties": {
+                                                                            "input": {
+                                                                                "type": "object",
+                                                                                "description": "Input parameters the tool call is expected to receive"
+                                                                            },
+                                                                            "output": {
+                                                                                "type": "object",
+                                                                                "description": "Response the mock tool will return"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
                                                         }
                                                     }
                                                 }
@@ -10325,6 +10395,41 @@
                                                         "is_simulating": {
                                                             "type": "boolean",
                                                             "description": "Whether this scenario was created by simulation"
+                                                        },
+                                                        "test_profile_data": {
+                                                            "type": "object",
+                                                            "description": "The test profile generated for this scenario, including its sectioned `information` (main_agent_variables / testing_agent_variables)"
+                                                        },
+                                                        "generated_mock_tool_entries": {
+                                                            "type": "array",
+                                                            "description": "Expected mock tool calls generated for this scenario when the agent has mock tools attached. Empty when the agent has no mock tools.",
+                                                            "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "tool_id": {
+                                                                        "type": "integer",
+                                                                        "description": "ID of the mock tool on the agent"
+                                                                    },
+                                                                    "tool_name": {
+                                                                        "type": "string",
+                                                                        "description": "Name of the tool being mocked"
+                                                                    },
+                                                                    "new_entry": {
+                                                                        "type": "object",
+                                                                        "description": "The expected tool call for this scenario",
+                                                                        "properties": {
+                                                                            "input": {
+                                                                                "type": "object",
+                                                                                "description": "Input parameters the tool call is expected to receive"
+                                                                            },
+                                                                            "output": {
+                                                                                "type": "object",
+                                                                                "description": "Response the mock tool will return"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
                                                         }
                                                     }
                                                 }
@@ -35430,6 +35535,41 @@
                                                     "is_simulating": {
                                                         "type": "boolean",
                                                         "description": "Whether this scenario was created by simulation"
+                                                    },
+                                                    "test_profile_data": {
+                                                        "type": "object",
+                                                        "description": "The test profile generated for this scenario, including its sectioned `information` (main_agent_variables / testing_agent_variables)"
+                                                    },
+                                                    "generated_mock_tool_entries": {
+                                                        "type": "array",
+                                                        "description": "Expected mock tool calls generated for this scenario when the agent has mock tools attached. Empty when the agent has no mock tools.",
+                                                        "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "tool_id": {
+                                                                    "type": "integer",
+                                                                    "description": "ID of the mock tool on the agent"
+                                                                },
+                                                                "tool_name": {
+                                                                    "type": "string",
+                                                                    "description": "Name of the tool being mocked"
+                                                                },
+                                                                "new_entry": {
+                                                                    "type": "object",
+                                                                    "description": "The expected tool call for this scenario",
+                                                                    "properties": {
+                                                                        "input": {
+                                                                            "type": "object",
+                                                                            "description": "Input parameters the tool call is expected to receive"
+                                                                        },
+                                                                        "output": {
+                                                                            "type": "object",
+                                                                            "description": "Response the mock tool will return"
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
                                                     }
                                                 }
                                             }
@@ -41507,6 +41647,41 @@
                                                     "is_simulating": {
                                                         "type": "boolean",
                                                         "description": "Whether this scenario was created by simulation"
+                                                    },
+                                                    "test_profile_data": {
+                                                        "type": "object",
+                                                        "description": "The test profile generated for this scenario, including its sectioned `information` (main_agent_variables / testing_agent_variables)"
+                                                    },
+                                                    "generated_mock_tool_entries": {
+                                                        "type": "array",
+                                                        "description": "Expected mock tool calls generated for this scenario when the agent has mock tools attached. Empty when the agent has no mock tools.",
+                                                        "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "tool_id": {
+                                                                    "type": "integer",
+                                                                    "description": "ID of the mock tool on the agent"
+                                                                },
+                                                                "tool_name": {
+                                                                    "type": "string",
+                                                                    "description": "Name of the tool being mocked"
+                                                                },
+                                                                "new_entry": {
+                                                                    "type": "object",
+                                                                    "description": "The expected tool call for this scenario",
+                                                                    "properties": {
+                                                                        "input": {
+                                                                            "type": "object",
+                                                                            "description": "Input parameters the tool call is expected to receive"
+                                                                        },
+                                                                        "output": {
+                                                                            "type": "object",
+                                                                            "description": "Response the mock tool will return"
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
                                                     }
                                                 }
                                             }
@@ -56680,6 +56855,41 @@
                                                     "is_simulating": {
                                                         "type": "boolean",
                                                         "description": "Whether this scenario was created by simulation"
+                                                    },
+                                                    "test_profile_data": {
+                                                        "type": "object",
+                                                        "description": "The test profile generated for this scenario, including its sectioned `information` (main_agent_variables / testing_agent_variables)"
+                                                    },
+                                                    "generated_mock_tool_entries": {
+                                                        "type": "array",
+                                                        "description": "Expected mock tool calls generated for this scenario when the agent has mock tools attached. Empty when the agent has no mock tools.",
+                                                        "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "tool_id": {
+                                                                    "type": "integer",
+                                                                    "description": "ID of the mock tool on the agent"
+                                                                },
+                                                                "tool_name": {
+                                                                    "type": "string",
+                                                                    "description": "Name of the tool being mocked"
+                                                                },
+                                                                "new_entry": {
+                                                                    "type": "object",
+                                                                    "description": "The expected tool call for this scenario",
+                                                                    "properties": {
+                                                                        "input": {
+                                                                            "type": "object",
+                                                                            "description": "Input parameters the tool call is expected to receive"
+                                                                        },
+                                                                        "output": {
+                                                                            "type": "object",
+                                                                            "description": "Response the mock tool will return"
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
                                                     }
                                                 }
                                             }

--- a/openapi.json
+++ b/openapi.json
@@ -12063,52 +12063,6 @@
                         "description": "Tenant scope. Supply one of `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ]
-            },
-            "post": {
-                "operationId": "slack-slack-workspaces-create",
-                "tags": [
-                    "slack"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/SlackWorkspace"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/SlackWorkspace"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/SlackWorkspace"
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "oauth2": []
-                    },
-                    {
-                        "supabase_session": []
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/SlackWorkspace"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Create a new slack slack workspace"
             }
         },
         "/slack/slack-workspaces/{id}/": {
@@ -14270,6 +14224,392 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/MetricReviewInline"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/metric-reviews/optimizer_chat_cancel/": {
+            "post": {
+                "operationId": "metric-reviews-optimizer-chat-cancel",
+                "description": "Cancel a post-optimization chat session (stops any in-flight agent turn / regression check), or mark it completed with reason='applied' after the proposal has been applied.",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricReviewInline"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricReviewInline"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricReviewInline"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Session cancelled or completed"
+                    }
+                }
+            }
+        },
+        "/test_framework/metric-reviews/optimizer_chat_confirm_samples/": {
+            "post": {
+                "operationId": "metric-reviews-optimizer-chat-confirm-samples",
+                "description": "Confirm which of the agent's proposed regression samples to add to the eval set, and whether to re-optimize afterwards. The chat agent only proposes — this endpoint is what actually writes the eval set.",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricReviewInline"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricReviewInline"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricReviewInline"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Samples added; progress_id when re-optimizing"
+                    }
+                }
+            }
+        },
+        "/test_framework/metric-reviews/optimizer_chat_message/": {
+            "post": {
+                "operationId": "metric-reviews-optimizer-chat-message",
+                "description": "Send a message (and/or structured regression-review verdicts) to the post-optimization review agent. Poll optimizer_chat_progress with the returned progress_id.",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/OptimizerChatMessageRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/OptimizerChatMessageRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/OptimizerChatMessageRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Returns progress_id for the agent turn"
+                    }
+                }
+            }
+        },
+        "/test_framework/metric-reviews/optimizer_chat_progress/": {
+            "get": {
+                "operationId": "metric-reviews-optimizer-chat-progress",
+                "description": "Poll a post-optimization chat turn.",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "progress_id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Chat turn progress state"
+                    }
+                }
+            }
+        },
+        "/test_framework/metric-reviews/optimizer_chat_regression/": {
+            "post": {
+                "operationId": "metric-reviews-optimizer-chat-regression",
+                "description": "Run the optimized proposal on the most recent calls/runs this metric previously evaluated (outside the eval set) and diff the labels. Evaluations are billed like production metric runs.",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricReviewInline"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricReviewInline"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricReviewInline"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Returns progress_id for the regression check"
+                    }
+                }
+            }
+        },
+        "/test_framework/metric-reviews/optimizer_chat_regression_progress/": {
+            "get": {
+                "operationId": "metric-reviews-optimizer-chat-regression-progress",
+                "description": "Poll a regression check.",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "progress_id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Regression check progress state"
+                    }
+                }
+            }
+        },
+        "/test_framework/metric-reviews/optimizer_chat_reoptimize/": {
+            "post": {
+                "operationId": "metric-reviews-optimizer-chat-reoptimize",
+                "description": "Re-run the optimizer using this review session's current eval set.",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/OptimizerChatReoptimizeRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/OptimizerChatReoptimizeRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/OptimizerChatReoptimizeRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Returns progress_id for the re-optimization"
+                    }
+                }
+            }
+        },
+        "/test_framework/metric-reviews/optimizer_chat_session/": {
+            "get": {
+                "operationId": "metric-reviews-optimizer-chat-session",
+                "description": "Rehydrate a post-optimization review chat session.",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "session_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricOptimizerChatSession"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/metric-reviews/optimizer_chat_start/": {
+            "post": {
+                "operationId": "metric-reviews-optimizer-chat-start",
+                "description": "Open (or resume) the post-optimization review chat for a metric. Seeds the session from a completed process_feedbacks run (progress_id) or from the metric's pending optimisation proposal.",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/OptimizerChatStartRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/OptimizerChatStartRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/OptimizerChatStartRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricOptimizerChatSession"
                                 }
                             }
                         },
@@ -34746,7 +35086,7 @@
         "/test_framework/v1/scenarios-external/generate-bg/": {
             "post": {
                 "operationId": "scenarios-generate-bg",
-                "description": "Generate scenarios for a given agent in the background. Returns a `progress_id` immediately; poll GET /scenarios/generate-progress/?progress_id={id} until `total_scenarios == completed_scenarios`.\n\n**What happens automatically on generation:**\n- A scenario-specific test profile is created and its `information` is populated using the sectioned shape: `main_agent_variables` (dynamic-variable values that reach the agent under test at call time — e.g. `user_id`, `account_id`) and `testing_agent_variables` (persona/context used by the simulated caller — e.g. `customer_name`, `date_of_birth`). Section values are kept consistent with any generated mock-tool data.\n- 10 project-level evaluation metrics are attached to every generated scenario automatically (e.g. Latency, Pitch, Interruption Score). Scenarios created manually via `scenarios_create` start with no metrics attached.\n\n**Response fields:** `progress_id` (UUID string) for polling; `session_id` is always null.",
+                "description": "Generate scenarios for a given agent in the background. Returns a `progress_id` immediately; poll GET /scenarios/generate-progress/?progress_id={id} until `total_scenarios == completed_scenarios`.\n\n**What happens automatically on generation:**\n- A scenario-specific test profile is created and its `information` is populated using the sectioned shape: `main_agent_variables` (dynamic-variable values that reach the agent under test at call time — e.g. `user_id`, `account_id`) and `testing_agent_variables` (persona/context used by the simulated caller — e.g. `customer_name`, `date_of_birth`). Section values are kept consistent with any generated mock-tool data.\n- When the agent has mock tools attached, each generated scenario also gets `generated_mock_tool_entries` — the expected mock tool calls for that scenario, shaped `[{tool_id, tool_name, new_entry: {input, output}}]`. These are returned on scenario reads and can be edited later via `scenarios_partial_update`.\n- 10 project-level evaluation metrics are attached to every generated scenario automatically (e.g. Latency, Pitch, Interruption Score). Scenarios created manually via `scenarios_create` start with no metrics attached.\n\n**Response fields:** `progress_id` (UUID string) for polling; `session_id` is always null.",
                 "tags": [
                     "test_framework"
                 ],
@@ -40807,7 +41147,7 @@
         "/test_framework/v1/scenarios/generate-bg/": {
             "post": {
                 "operationId": "scenarios-generate-bg_2",
-                "description": "Generate scenarios for a given agent in the background. Returns a `progress_id` immediately; poll GET /scenarios/generate-progress/?progress_id={id} until `total_scenarios == completed_scenarios`.\n\n**What happens automatically on generation:**\n- A scenario-specific test profile is created and its `information` is populated using the sectioned shape: `main_agent_variables` (dynamic-variable values that reach the agent under test at call time — e.g. `user_id`, `account_id`) and `testing_agent_variables` (persona/context used by the simulated caller — e.g. `customer_name`, `date_of_birth`). Section values are kept consistent with any generated mock-tool data.\n- 10 project-level evaluation metrics are attached to every generated scenario automatically (e.g. Latency, Pitch, Interruption Score). Scenarios created manually via `scenarios_create` start with no metrics attached.\n\n**Response fields:** `progress_id` (UUID string) for polling; `session_id` is always null.",
+                "description": "Generate scenarios for a given agent in the background. Returns a `progress_id` immediately; poll GET /scenarios/generate-progress/?progress_id={id} until `total_scenarios == completed_scenarios`.\n\n**What happens automatically on generation:**\n- A scenario-specific test profile is created and its `information` is populated using the sectioned shape: `main_agent_variables` (dynamic-variable values that reach the agent under test at call time — e.g. `user_id`, `account_id`) and `testing_agent_variables` (persona/context used by the simulated caller — e.g. `customer_name`, `date_of_birth`). Section values are kept consistent with any generated mock-tool data.\n- When the agent has mock tools attached, each generated scenario also gets `generated_mock_tool_entries` — the expected mock tool calls for that scenario, shaped `[{tool_id, tool_name, new_entry: {input, output}}]`. These are returned on scenario reads and can be edited later via `scenarios_partial_update`.\n- 10 project-level evaluation metrics are attached to every generated scenario automatically (e.g. Latency, Pitch, Interruption Score). Scenarios created manually via `scenarios_create` start with no metrics attached.\n\n**Response fields:** `progress_id` (UUID string) for polling; `session_id` is always null.",
                 "tags": [
                     "test_framework"
                 ],
@@ -40882,7 +41222,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-generate-bg",
-                        "description": "Generate scenarios for a given agent in the background. Returns a `progress_id` immediately; poll GET /scenarios/generate-progress/?progress_id={id} until `total_scenarios == completed_scenarios`.\n\n**What happens automatically on generation:**\n- A scenario-specific test profile is created and its `information` is populated using the sectioned shape: `main_agent_variables` (dynamic-variable values that reach the agent under test at call time — e.g. `user_id`, `account_id`) and `testing_agent_variables` (persona/context used by the simulated caller — e.g. `customer_name`, `date_of_birth`). Section values are kept consistent with any generated mock-tool data.\n- 10 project-level evaluation metrics are attached to every generated scenario automatically (e.g. Latency, Pitch, Interruption Score). Scenarios created manually via `scenarios_create` start with no metrics attached.\n\n**Response fields:** `progress_id` (UUID string) for polling; `session_id` is always null."
+                        "description": "Generate scenarios for a given agent in the background. Returns a `progress_id` immediately; poll GET /scenarios/generate-progress/?progress_id={id} until `total_scenarios == completed_scenarios`.\n\n**What happens automatically on generation:**\n- A scenario-specific test profile is created and its `information` is populated using the sectioned shape: `main_agent_variables` (dynamic-variable values that reach the agent under test at call time — e.g. `user_id`, `account_id`) and `testing_agent_variables` (persona/context used by the simulated caller — e.g. `customer_name`, `date_of_birth`). Section values are kept consistent with any generated mock-tool data.\n- When the agent has mock tools attached, each generated scenario also gets `generated_mock_tool_entries` — the expected mock tool calls for that scenario, shaped `[{tool_id, tool_name, new_entry: {input, output}}]`. These are returned on scenario reads and can be edited later via `scenarios_partial_update`.\n- 10 project-level evaluation metrics are attached to every generated scenario automatically (e.g. Latency, Pitch, Interruption Score). Scenarios created manually via `scenarios_create` start with no metrics attached.\n\n**Response fields:** `progress_id` (UUID string) for polling; `session_id` is always null."
                     }
                 }
             }
@@ -55996,7 +56336,7 @@
         "/test_framework/v2/scenarios/generate-bg/": {
             "post": {
                 "operationId": "scenarios-generate-bg_3",
-                "description": "Generate scenarios for a given agent in the background. Returns a `progress_id` immediately; poll GET /scenarios/generate-progress/?progress_id={id} until `total_scenarios == completed_scenarios`.\n\n**What happens automatically on generation:**\n- A scenario-specific test profile is created and its `information` is populated using the sectioned shape: `main_agent_variables` (dynamic-variable values that reach the agent under test at call time — e.g. `user_id`, `account_id`) and `testing_agent_variables` (persona/context used by the simulated caller — e.g. `customer_name`, `date_of_birth`). Section values are kept consistent with any generated mock-tool data.\n- 10 project-level evaluation metrics are attached to every generated scenario automatically (e.g. Latency, Pitch, Interruption Score). Scenarios created manually via `scenarios_create` start with no metrics attached.\n\n**Response fields:** `progress_id` (UUID string) for polling; `session_id` is always null.",
+                "description": "Generate scenarios for a given agent in the background. Returns a `progress_id` immediately; poll GET /scenarios/generate-progress/?progress_id={id} until `total_scenarios == completed_scenarios`.\n\n**What happens automatically on generation:**\n- A scenario-specific test profile is created and its `information` is populated using the sectioned shape: `main_agent_variables` (dynamic-variable values that reach the agent under test at call time — e.g. `user_id`, `account_id`) and `testing_agent_variables` (persona/context used by the simulated caller — e.g. `customer_name`, `date_of_birth`). Section values are kept consistent with any generated mock-tool data.\n- When the agent has mock tools attached, each generated scenario also gets `generated_mock_tool_entries` — the expected mock tool calls for that scenario, shaped `[{tool_id, tool_name, new_entry: {input, output}}]`. These are returned on scenario reads and can be edited later via `scenarios_partial_update`.\n- 10 project-level evaluation metrics are attached to every generated scenario automatically (e.g. Latency, Pitch, Interruption Score). Scenarios created manually via `scenarios_create` start with no metrics attached.\n\n**Response fields:** `progress_id` (UUID string) for polling; `session_id` is always null.",
                 "tags": [
                     "test_framework"
                 ],
@@ -73089,6 +73429,79 @@
                     "project"
                 ]
             },
+            "MetricOptimizerChatSession": {
+                "type": "object",
+                "description": "Read-only serializer for the post-optimization review chat session.",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "metric": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "project": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
+                        "readOnly": true
+                    },
+                    "agent": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
+                        "readOnly": true
+                    },
+                    "status": {
+                        "enum": [
+                            "awaiting_user",
+                            "agent_running",
+                            "regression_running",
+                            "reoptimizing",
+                            "completed",
+                            "cancelled",
+                            "failed"
+                        ],
+                        "type": "string",
+                        "description": "* `awaiting_user` - Awaiting User\n* `agent_running` - Agent Running\n* `regression_running` - Regression Running\n* `reoptimizing` - Reoptimizing\n* `completed` - Completed\n* `cancelled` - Cancelled\n* `failed` - Failed",
+                        "x-spec-enum-id": "8b33c50cd513306a",
+                        "readOnly": true
+                    },
+                    "conversation_history": {
+                        "readOnly": true,
+                        "description": "[{role, content, timestamp, message_type?, payload?, questions?}]"
+                    },
+                    "proposal": {
+                        "readOnly": true,
+                        "description": "Snapshot of the latest process_feedbacks output (the optimized proposal)"
+                    },
+                    "regression_results": {
+                        "readOnly": true,
+                        "description": "Latest regression check: {samples: [...], summary: {...}, run_at}"
+                    },
+                    "active_progress": {
+                        "readOnly": true,
+                        "description": "In-flight progress ids: {chat_turn?, regression?, reoptimize?}"
+                    },
+                    "test_set_ids": {
+                        "readOnly": true,
+                        "description": "Eval-set test_set ids for the optimization run; grows when samples are added"
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    }
+                }
+            },
             "MetricPreview": {
                 "type": "object",
                 "properties": {
@@ -73662,6 +74075,92 @@
                     "files",
                     "repo",
                     "title"
+                ]
+            },
+            "OptimizerChatMessageRequest": {
+                "type": "object",
+                "properties": {
+                    "session_id": {
+                        "type": "integer"
+                    },
+                    "user_message": {
+                        "type": "string",
+                        "default": ""
+                    },
+                    "review_payload": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/OptimizerChatRegressionReviewItem"
+                        },
+                        "description": "Structured verdicts for regression-diff samples the user reviewed"
+                    }
+                },
+                "required": [
+                    "session_id"
+                ]
+            },
+            "OptimizerChatRegressionReviewItem": {
+                "type": "object",
+                "properties": {
+                    "source_type": {
+                        "enum": [
+                            "call_log",
+                            "run"
+                        ],
+                        "type": "string",
+                        "description": "* `call_log` - call_log\n* `run` - run",
+                        "x-spec-enum-id": "6a2f1f0669817ff1"
+                    },
+                    "source_id": {
+                        "type": "integer"
+                    },
+                    "new_label_correct": {
+                        "type": "boolean"
+                    },
+                    "correct_label": {
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "feedback": {
+                        "type": "string",
+                        "default": ""
+                    }
+                },
+                "required": [
+                    "new_label_correct",
+                    "source_id",
+                    "source_type"
+                ]
+            },
+            "OptimizerChatReoptimizeRequest": {
+                "type": "object",
+                "properties": {
+                    "session_id": {
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "session_id"
+                ]
+            },
+            "OptimizerChatStartRequest": {
+                "type": "object",
+                "properties": {
+                    "metric_id": {
+                        "type": "integer",
+                        "description": "Metric whose optimization proposal the chat reviews"
+                    },
+                    "progress_id": {
+                        "type": "string",
+                        "description": "process_feedbacks progress_id whose output seeds the session. If omitted, falls back to the metric's pending optimisation proposal."
+                    }
+                },
+                "required": [
+                    "metric_id"
                 ]
             },
             "Organization": {
@@ -78663,6 +79162,15 @@
                             "null"
                         ],
                         "description": "Dot-separated path of the folder to assign this evaluator to (e.g. \"Sales.Inbound\"). Folders must be created before use — they are not auto-created. Use `scenarios_create_folder_create` to create each level before assigning evaluators. Example: to use \"Sales.Inbound\", first create \"Sales\", then create \"Inbound\" inside it."
+                    },
+                    "generated_mock_tool_entries": {
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Expected mock tool calls for this evaluator. Each entry has shape {tool_id, tool_name, new_entry: {input, output}}. Auto-generated during scenario generation when the agent has mock tools attached; can also be set or edited manually."
                     }
                 }
             },
@@ -79390,10 +79898,6 @@
                             }
                         ],
                         "readOnly": true
-                    },
-                    "user_id": {
-                        "type": "integer",
-                        "writeOnly": true
                     },
                     "role": {
                         "enum": [
@@ -82111,6 +82615,17 @@
             "RunReviewsRequest": {
                 "type": "object",
                 "properties": {
+                    "llm_provider": {
+                        "enum": [
+                            "openai",
+                            "gemini",
+                            "dspy-gepa-gemini-flash",
+                            "deepseek-v4-flash"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "6d1d2e77c71d1721",
+                        "description": "Override the judge provider while running unsaved Labs changes\n\n* `openai` - OpenAI\n* `gemini` - Gemini\n* `dspy-gepa-gemini-flash` - Dspy Gepa Gemini Flash\n* `deepseek-v4-flash` - DeepSeek V4 Flash"
+                    },
                     "evaluation_trigger": {
                         "type": "string",
                         "description": "Override evaluation trigger setting"
@@ -82118,6 +82633,19 @@
                     "evaluation_trigger_prompt": {
                         "type": "string",
                         "description": "Override evaluation trigger prompt"
+                    },
+                    "trigger_type": {
+                        "enum": [
+                            "llm_judge",
+                            "custom_code"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "2adad4b8df61914f",
+                        "description": "Override evaluation trigger implementation\n\n* `llm_judge` - LLM Judge\n* `custom_code` - Custom Code"
+                    },
+                    "evaluation_trigger_custom_code": {
+                        "type": "string",
+                        "description": "Override custom-code evaluation trigger"
                     },
                     "description": {
                         "type": "string",
@@ -85868,6 +86396,15 @@
                             "null"
                         ],
                         "description": "Dot-separated path of the folder to assign this evaluator to (e.g. \"Sales.Inbound\"). Folders must be created before use — they are not auto-created. Use `scenarios_create_folder_create` to create each level before assigning evaluators. Example: to use \"Sales.Inbound\", first create \"Sales\", then create \"Inbound\" inside it."
+                    },
+                    "generated_mock_tool_entries": {
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Expected mock tool calls for this evaluator. Each entry has shape {tool_id, tool_name, new_entry: {input, output}}. Auto-generated during scenario generation when the agent has mock tools attached; can also be set or edited manually."
                     }
                 },
                 "required": [
@@ -87554,10 +88091,6 @@
                             }
                         ],
                         "readOnly": true
-                    },
-                    "user_id": {
-                        "type": "integer",
-                        "writeOnly": true
                     },
                     "role": {
                         "enum": [


### PR DESCRIPTION
## Summary
- Regenerates `openapi.json` from backend branch in cekura-ai/vocera.backend#10641: `generated_mock_tool_entries` (expected mock tool calls, shape `[{tool_id, tool_name, new_entry: {input, output}}]`) now appears on the **Create Evaluator** and **Update Evaluator** request schemas (v1/v2/external variants), and the **Generate Evaluators** description documents that generated scenarios get this data when the agent has mock tools attached.
- The regen also picks up spec drift the docs copy was missing from recently merged backend changes (Optimizer v3 endpoints from vocera.backend#10162).
- `documentation/key-concepts/evaluators/mock-tools.mdx`: documents that the field is writable via the scenario APIs and adds scenario-level endpoint links to the API Reference section.

Overlay validator (`cekura-mcp-server/validate_overlays.py`) passes with no new warnings vs. main (one stale-example warning on main is cleared by the regen).

⚠️ Merge after cekura-ai/vocera.backend#10641 — otherwise the next spec auto-sync from backend main would revert the field additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)