### PR TITLE
[Auto] Sync docs for backend PR #10645

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -12063,52 +12063,6 @@
                         "description": "Tenant scope. Supply one of `project_id` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
                     }
                 ]
-            },
-            "post": {
-                "operationId": "slack-slack-workspaces-create",
-                "tags": [
-                    "slack"
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/SlackWorkspace"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/SlackWorkspace"
-                            }
-                        },
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/SlackWorkspace"
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "oauth2": []
-                    },
-                    {
-                        "supabase_session": []
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/SlackWorkspace"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                },
-                "description": "Create a new slack slack workspace"
             }
         },
         "/slack/slack-workspaces/{id}/": {
@@ -14270,6 +14224,392 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/MetricReviewInline"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/metric-reviews/optimizer_chat_cancel/": {
+            "post": {
+                "operationId": "metric-reviews-optimizer-chat-cancel",
+                "description": "Cancel a post-optimization chat session (stops any in-flight agent turn / regression check), or mark it completed with reason='applied' after the proposal has been applied.",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricReviewInline"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricReviewInline"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricReviewInline"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Session cancelled or completed"
+                    }
+                }
+            }
+        },
+        "/test_framework/metric-reviews/optimizer_chat_confirm_samples/": {
+            "post": {
+                "operationId": "metric-reviews-optimizer-chat-confirm-samples",
+                "description": "Confirm which of the agent's proposed regression samples to add to the eval set, and whether to re-optimize afterwards. The chat agent only proposes — this endpoint is what actually writes the eval set.",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricReviewInline"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricReviewInline"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricReviewInline"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Samples added; progress_id when re-optimizing"
+                    }
+                }
+            }
+        },
+        "/test_framework/metric-reviews/optimizer_chat_message/": {
+            "post": {
+                "operationId": "metric-reviews-optimizer-chat-message",
+                "description": "Send a message (and/or structured regression-review verdicts) to the post-optimization review agent. Poll optimizer_chat_progress with the returned progress_id.",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/OptimizerChatMessageRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/OptimizerChatMessageRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/OptimizerChatMessageRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Returns progress_id for the agent turn"
+                    }
+                }
+            }
+        },
+        "/test_framework/metric-reviews/optimizer_chat_progress/": {
+            "get": {
+                "operationId": "metric-reviews-optimizer-chat-progress",
+                "description": "Poll a post-optimization chat turn.",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "progress_id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Chat turn progress state"
+                    }
+                }
+            }
+        },
+        "/test_framework/metric-reviews/optimizer_chat_regression/": {
+            "post": {
+                "operationId": "metric-reviews-optimizer-chat-regression",
+                "description": "Run the optimized proposal on the most recent calls/runs this metric previously evaluated (outside the eval set) and diff the labels. Evaluations are billed like production metric runs.",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricReviewInline"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricReviewInline"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetricReviewInline"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Returns progress_id for the regression check"
+                    }
+                }
+            }
+        },
+        "/test_framework/metric-reviews/optimizer_chat_regression_progress/": {
+            "get": {
+                "operationId": "metric-reviews-optimizer-chat-regression-progress",
+                "description": "Poll a regression check.",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "progress_id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Regression check progress state"
+                    }
+                }
+            }
+        },
+        "/test_framework/metric-reviews/optimizer_chat_reoptimize/": {
+            "post": {
+                "operationId": "metric-reviews-optimizer-chat-reoptimize",
+                "description": "Re-run the optimizer using this review session's current eval set.",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/OptimizerChatReoptimizeRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/OptimizerChatReoptimizeRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/OptimizerChatReoptimizeRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Returns progress_id for the re-optimization"
+                    }
+                }
+            }
+        },
+        "/test_framework/metric-reviews/optimizer_chat_session/": {
+            "get": {
+                "operationId": "metric-reviews-optimizer-chat-session",
+                "description": "Rehydrate a post-optimization review chat session.",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "session_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "test_framework"
+                ],
+                "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricOptimizerChatSession"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test_framework/metric-reviews/optimizer_chat_start/": {
+            "post": {
+                "operationId": "metric-reviews-optimizer-chat-start",
+                "description": "Open (or resume) the post-optimization review chat for a metric. Seeds the session from a completed process_feedbacks run (progress_id) or from the metric's pending optimisation proposal.",
+                "tags": [
+                    "test_framework"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/OptimizerChatStartRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/OptimizerChatStartRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/OptimizerChatStartRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    },
+                    {
+                        "api_key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetricOptimizerChatSession"
                                 }
                             }
                         },
@@ -35436,30 +35776,73 @@
         },
         "/test_framework/v1/scenarios-external/run_scenarios/": {
             "post": {
-                "operationId": "scenarios-external-run-scenarios-create",
-                "description": "Run test scenarios against an AI voice agent",
+                "operationId": "scenarios-run-voice",
+                "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing. Requires `telephony.phone_number` configured on the agent (any provider).\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.\n\n**Outbound dial window:** for outbound runs (agent `inbound=false`), your agent must dial the run's `outbound_number` before `outbound_dial_window_closes_at` (default 300s after the run reaches `waiting_for_call` / pending state). Dials received after that deadline are dropped and the run returns `status: timeout`.",
+                "summary": "Run evaluators over a voice call",
                 "tags": [
-                    "test_framework"
+                    "Evaluators"
                 ],
                 "requestBody": {
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/Scenario"
+                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
+                            },
+                            "examples": {
+                                "RunSelectedScenarios(simplest)": {
+                                    "value": {
+                                        "agent_id": 12,
+                                        "scenarios": [
+                                            101,
+                                            102,
+                                            103
+                                        ],
+                                        "frequency": 1
+                                    },
+                                    "summary": "Run selected scenarios (simplest)"
+                                },
+                                "RunAnEntireFolder,3×Each,5InParallel": {
+                                    "value": {
+                                        "agent_id": 12,
+                                        "folder_path": "Sales.Inbound",
+                                        "project_id": 1376,
+                                        "frequency": 3,
+                                        "concurrency_limit": 5,
+                                        "name": "Nightly Sales.Inbound regression"
+                                    },
+                                    "summary": "Run an entire folder, 3× each, 5 in parallel"
+                                },
+                                "OverridePersonalities+TestProfiles(multipliesRunCount)": {
+                                    "value": {
+                                        "agent_id": 12,
+                                        "scenarios": [
+                                            101
+                                        ],
+                                        "frequency": 2,
+                                        "personality_ids": [
+                                            3,
+                                            7
+                                        ],
+                                        "test_profile_ids": [
+                                            20,
+                                            21
+                                        ]
+                                    },
+                                    "summary": "Override personalities + test profiles (multiplies run count)"
+                                }
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/Scenario"
+                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/Scenario"
+                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "security": [
                     {
@@ -35473,11 +35856,222 @@
                     }
                 ],
                 "responses": {
-                    "200": {
+                    "201": {
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Scenario"
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {
+                                            "type": "integer",
+                                            "description": "ID of the result"
+                                        },
+                                        "agent": {
+                                            "type": "integer",
+                                            "description": "ID of the agent"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "pending",
+                                                "running",
+                                                "completed",
+                                                "failed"
+                                            ],
+                                            "description": "Status of the result"
+                                        },
+                                        "run_as_text": {
+                                            "type": "boolean",
+                                            "description": "Whether the scenario ran as text or not",
+                                            "example": false
+                                        },
+                                        "runs": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "id": {
+                                                        "type": "integer",
+                                                        "description": "ID of the run"
+                                                    },
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "pending",
+                                                            "running",
+                                                            "completed",
+                                                            "failed"
+                                                        ],
+                                                        "description": "Status of the run"
+                                                    },
+                                                    "scenario": {
+                                                        "type": "integer",
+                                                        "description": "ID of the scenario"
+                                                    },
+                                                    "number": {
+                                                        "type": "string",
+                                                        "description": "For outbound runs (agent.inbound=False). The given number that must be called from the phone number configured in the cekura agent.",
+                                                        "example": "+11234567890"
+                                                    },
+                                                    "inbound_number": {
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ],
+                                                        "description": "For inbound runs (agent.inbound=True). The agent's configured phone number will receive calls from this number.",
+                                                        "example": "+11234567890"
+                                                    },
+                                                    "scenario_name": {
+                                                        "type": "string",
+                                                        "description": "Name of the scenario"
+                                                    },
+                                                    "test_profile_data": {
+                                                        "type": [
+                                                            "object",
+                                                            "null"
+                                                        ],
+                                                        "description": "Details of the test profile associated with this run scenario"
+                                                    },
+                                                    "outbound_dial_window_opens_at": {
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ],
+                                                        "format": "date-time",
+                                                        "description": "When the outbound dial window opened (run transitioned to pending/waiting-for-call). Null until dispatched."
+                                                    },
+                                                    "outbound_dial_window_seconds": {
+                                                        "type": [
+                                                            "integer",
+                                                            "null"
+                                                        ],
+                                                        "description": "Duration of the outbound dial window in seconds."
+                                                    },
+                                                    "outbound_dial_window_closes_at": {
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ],
+                                                        "format": "date-time",
+                                                        "description": "Deadline by which your agent must dial the outbound number (opens_at + outbound_dial_window_seconds). Dials after this are dropped and the run returns status: timeout."
+                                                    }
+                                                }
+                                            },
+                                            "examples": [
+                                                {
+                                                    "id": 274,
+                                                    "status": "pending",
+                                                    "scenario": 1,
+                                                    "number": null,
+                                                    "inbound_number": "+11234567890",
+                                                    "scenario_name": "Customer Support Call (Agent Inbound = True)",
+                                                    "test_profile_data": null,
+                                                    "outbound_dial_window_opens_at": null,
+                                                    "outbound_dial_window_seconds": null,
+                                                    "outbound_dial_window_closes_at": null
+                                                },
+                                                {
+                                                    "id": 275,
+                                                    "status": "pending",
+                                                    "scenario": 2,
+                                                    "number": "+11234567890",
+                                                    "inbound_number": null,
+                                                    "scenario_name": "Outbound Sales Call (Agent Inbound = False)",
+                                                    "test_profile_data": null,
+                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
+                                                    "outbound_dial_window_seconds": 300,
+                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
+                                                }
+                                            ]
+                                        },
+                                        "created_at": {
+                                            "type": "string",
+                                            "format": "date-time",
+                                            "example": "2025-02-25T21:00:01.990052Z"
+                                        }
+                                    }
+                                },
+                                "examples": {
+                                    "InboundScenario": {
+                                        "value": {
+                                            "id": 167,
+                                            "agent": 1,
+                                            "status": "pending",
+                                            "success_rate": 0,
+                                            "run_as_text": false,
+                                            "runs": [
+                                                {
+                                                    "id": 274,
+                                                    "scenario": 1,
+                                                    "number": null,
+                                                    "inbound_number": "+11234567890",
+                                                    "outbound_dial_window_opens_at": null,
+                                                    "outbound_dial_window_seconds": null,
+                                                    "outbound_dial_window_closes_at": null
+                                                },
+                                                {
+                                                    "id": 273,
+                                                    "scenario": 2,
+                                                    "number": null,
+                                                    "inbound_number": "+11234567891",
+                                                    "outbound_dial_window_opens_at": null,
+                                                    "outbound_dial_window_seconds": null,
+                                                    "outbound_dial_window_closes_at": null
+                                                }
+                                            ],
+                                            "created_at": "2025-02-25T21:00:01.990052Z"
+                                        },
+                                        "summary": "Inbound Scenario"
+                                    },
+                                    "OutboundScenario": {
+                                        "value": {
+                                            "id": 167,
+                                            "agent": 1,
+                                            "status": "pending",
+                                            "success_rate": 0,
+                                            "run_as_text": false,
+                                            "runs": [
+                                                {
+                                                    "id": 274,
+                                                    "scenario": 1,
+                                                    "number": "+11234567890",
+                                                    "inbound_number": null,
+                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
+                                                    "outbound_dial_window_seconds": 300,
+                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
+                                                },
+                                                {
+                                                    "id": 273,
+                                                    "scenario": 2,
+                                                    "number": "+11234567891",
+                                                    "inbound_number": null,
+                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
+                                                    "outbound_dial_window_seconds": 300,
+                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
+                                                }
+                                            ],
+                                            "created_at": "2025-02-25T21:00:01.990052Z"
+                                        },
+                                        "summary": "Outbound Scenario"
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
                                 }
                             }
                         },
@@ -36431,9 +37025,9 @@
         },
         "/test_framework/v1/scenarios-external/run_scenarios_json/": {
             "post": {
-                "operationId": "scenarios-run-voice",
-                "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing. Requires `telephony.phone_number` configured on the agent (any provider).\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.\n\n**Outbound dial window:** for outbound runs (agent `inbound=false`), your agent must dial the run's `outbound_number` before `outbound_dial_window_closes_at` (default 300s after the run reaches `waiting_for_call` / pending state). Dials received after that deadline are dropped and the run returns `status: timeout`.",
-                "summary": "Run evaluators over a voice call",
+                "operationId": "scenarios-run-json",
+                "description": "Run agent test cases straight from a JSON spec, without creating evaluators. Keep the spec in your repository and post it from CI.\n\nThe spec describes only what to test. Pick the target with `agent_id` and `channel` on the request — `voice` for a phone call (default), `text` for chat, `elevenlabs` for an ElevenLabs WebRTC session — so one file runs unchanged against any agent or environment.\n\nPass `dry_run=true` to validate only: the response describes the run that would happen (test cases, total runs, estimated cost) and nothing is created or charged. Use that on every commit, and the real call on the branches you want tested.\n\nEvery problem in a spec is reported at once, keyed by its location in the file (for example `scenarios[3].metrics[1]`). Metrics must already exist and be enabled for the target agent; personalities and test profiles can be referenced by ID or defined inline.\n\nFetch the schema this endpoint accepts from `scenarios_json_schema`.\n\n**Cost:** voice- or text-simulation rate per run. Test cases from a spec are removed automatically once no run needs them.",
+                "summary": "Run test cases from a JSON spec file",
                 "parameters": [
                     {
                         "in": "query",
@@ -36451,7 +37045,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
+                                "$ref": "#/components/schemas/TestSuiteSpecUpload"
                             },
                             "examples": {
                                 "RunASpec": {
@@ -36479,58 +37073,17 @@
                                         }
                                     },
                                     "summary": "Run a spec"
-                                },
-                                "RunSelectedScenarios(simplest)": {
-                                    "value": {
-                                        "agent_id": 12,
-                                        "scenarios": [
-                                            101,
-                                            102,
-                                            103
-                                        ],
-                                        "frequency": 1
-                                    },
-                                    "summary": "Run selected scenarios (simplest)"
-                                },
-                                "RunAnEntireFolder,3×Each,5InParallel": {
-                                    "value": {
-                                        "agent_id": 12,
-                                        "folder_path": "Sales.Inbound",
-                                        "project_id": 1376,
-                                        "frequency": 3,
-                                        "concurrency_limit": 5,
-                                        "name": "Nightly Sales.Inbound regression"
-                                    },
-                                    "summary": "Run an entire folder, 3× each, 5 in parallel"
-                                },
-                                "OverridePersonalities+TestProfiles(multipliesRunCount)": {
-                                    "value": {
-                                        "agent_id": 12,
-                                        "scenarios": [
-                                            101
-                                        ],
-                                        "frequency": 2,
-                                        "personality_ids": [
-                                            3,
-                                            7
-                                        ],
-                                        "test_profile_ids": [
-                                            20,
-                                            21
-                                        ]
-                                    },
-                                    "summary": "Override personalities + test profiles (multiplies run count)"
                                 }
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
+                                "$ref": "#/components/schemas/TestSuiteSpecUpload"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
+                                "$ref": "#/components/schemas/TestSuiteSpecUpload"
                             }
                         }
                     }
@@ -36547,7 +37100,7 @@
                     }
                 ],
                 "responses": {
-                    "201": {
+                    "200": {
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -36680,70 +37233,6 @@
                                             "format": "date-time",
                                             "example": "2025-02-25T21:00:01.990052Z"
                                         }
-                                    }
-                                },
-                                "examples": {
-                                    "InboundScenario": {
-                                        "value": {
-                                            "id": 167,
-                                            "agent": 1,
-                                            "status": "pending",
-                                            "success_rate": 0,
-                                            "run_as_text": false,
-                                            "runs": [
-                                                {
-                                                    "id": 274,
-                                                    "scenario": 1,
-                                                    "number": null,
-                                                    "inbound_number": "+11234567890",
-                                                    "outbound_dial_window_opens_at": null,
-                                                    "outbound_dial_window_seconds": null,
-                                                    "outbound_dial_window_closes_at": null
-                                                },
-                                                {
-                                                    "id": 273,
-                                                    "scenario": 2,
-                                                    "number": null,
-                                                    "inbound_number": "+11234567891",
-                                                    "outbound_dial_window_opens_at": null,
-                                                    "outbound_dial_window_seconds": null,
-                                                    "outbound_dial_window_closes_at": null
-                                                }
-                                            ],
-                                            "created_at": "2025-02-25T21:00:01.990052Z"
-                                        },
-                                        "summary": "Inbound Scenario"
-                                    },
-                                    "OutboundScenario": {
-                                        "value": {
-                                            "id": 167,
-                                            "agent": 1,
-                                            "status": "pending",
-                                            "success_rate": 0,
-                                            "run_as_text": false,
-                                            "runs": [
-                                                {
-                                                    "id": 274,
-                                                    "scenario": 1,
-                                                    "number": "+11234567890",
-                                                    "inbound_number": null,
-                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
-                                                    "outbound_dial_window_seconds": 300,
-                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
-                                                },
-                                                {
-                                                    "id": 273,
-                                                    "scenario": 2,
-                                                    "number": "+11234567891",
-                                                    "inbound_number": null,
-                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
-                                                    "outbound_dial_window_seconds": 300,
-                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
-                                                }
-                                            ],
-                                            "created_at": "2025-02-25T21:00:01.990052Z"
-                                        },
-                                        "summary": "Outbound Scenario"
                                     }
                                 }
                             }
@@ -41590,30 +42079,73 @@
         },
         "/test_framework/v1/scenarios/run_scenarios/": {
             "post": {
-                "operationId": "scenarios-run-scenarios-create",
-                "description": "Run test scenarios against an AI voice agent",
+                "operationId": "scenarios-run-voice_2",
+                "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing. Requires `telephony.phone_number` configured on the agent (any provider).\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.\n\n**Outbound dial window:** for outbound runs (agent `inbound=false`), your agent must dial the run's `outbound_number` before `outbound_dial_window_closes_at` (default 300s after the run reaches `waiting_for_call` / pending state). Dials received after that deadline are dropped and the run returns `status: timeout`.",
+                "summary": "Run evaluators over a voice call",
                 "tags": [
-                    "test_framework"
+                    "Evaluators"
                 ],
                 "requestBody": {
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/Scenario"
+                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
+                            },
+                            "examples": {
+                                "RunSelectedScenarios(simplest)": {
+                                    "value": {
+                                        "agent_id": 12,
+                                        "scenarios": [
+                                            101,
+                                            102,
+                                            103
+                                        ],
+                                        "frequency": 1
+                                    },
+                                    "summary": "Run selected scenarios (simplest)"
+                                },
+                                "RunAnEntireFolder,3×Each,5InParallel": {
+                                    "value": {
+                                        "agent_id": 12,
+                                        "folder_path": "Sales.Inbound",
+                                        "project_id": 1376,
+                                        "frequency": 3,
+                                        "concurrency_limit": 5,
+                                        "name": "Nightly Sales.Inbound regression"
+                                    },
+                                    "summary": "Run an entire folder, 3× each, 5 in parallel"
+                                },
+                                "OverridePersonalities+TestProfiles(multipliesRunCount)": {
+                                    "value": {
+                                        "agent_id": 12,
+                                        "scenarios": [
+                                            101
+                                        ],
+                                        "frequency": 2,
+                                        "personality_ids": [
+                                            3,
+                                            7
+                                        ],
+                                        "test_profile_ids": [
+                                            20,
+                                            21
+                                        ]
+                                    },
+                                    "summary": "Override personalities + test profiles (multiplies run count)"
+                                }
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/Scenario"
+                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/Scenario"
+                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "security": [
                     {
@@ -41627,15 +42159,234 @@
                     }
                 ],
                 "responses": {
-                    "200": {
+                    "201": {
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Scenario"
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {
+                                            "type": "integer",
+                                            "description": "ID of the result"
+                                        },
+                                        "agent": {
+                                            "type": "integer",
+                                            "description": "ID of the agent"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "pending",
+                                                "running",
+                                                "completed",
+                                                "failed"
+                                            ],
+                                            "description": "Status of the result"
+                                        },
+                                        "run_as_text": {
+                                            "type": "boolean",
+                                            "description": "Whether the scenario ran as text or not",
+                                            "example": false
+                                        },
+                                        "runs": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "id": {
+                                                        "type": "integer",
+                                                        "description": "ID of the run"
+                                                    },
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "pending",
+                                                            "running",
+                                                            "completed",
+                                                            "failed"
+                                                        ],
+                                                        "description": "Status of the run"
+                                                    },
+                                                    "scenario": {
+                                                        "type": "integer",
+                                                        "description": "ID of the scenario"
+                                                    },
+                                                    "number": {
+                                                        "type": "string",
+                                                        "description": "For outbound runs (agent.inbound=False). The given number that must be called from the phone number configured in the cekura agent.",
+                                                        "example": "+11234567890"
+                                                    },
+                                                    "inbound_number": {
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ],
+                                                        "description": "For inbound runs (agent.inbound=True). The agent's configured phone number will receive calls from this number.",
+                                                        "example": "+11234567890"
+                                                    },
+                                                    "scenario_name": {
+                                                        "type": "string",
+                                                        "description": "Name of the scenario"
+                                                    },
+                                                    "test_profile_data": {
+                                                        "type": [
+                                                            "object",
+                                                            "null"
+                                                        ],
+                                                        "description": "Details of the test profile associated with this run scenario"
+                                                    },
+                                                    "outbound_dial_window_opens_at": {
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ],
+                                                        "format": "date-time",
+                                                        "description": "When the outbound dial window opened (run transitioned to pending/waiting-for-call). Null until dispatched."
+                                                    },
+                                                    "outbound_dial_window_seconds": {
+                                                        "type": [
+                                                            "integer",
+                                                            "null"
+                                                        ],
+                                                        "description": "Duration of the outbound dial window in seconds."
+                                                    },
+                                                    "outbound_dial_window_closes_at": {
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ],
+                                                        "format": "date-time",
+                                                        "description": "Deadline by which your agent must dial the outbound number (opens_at + outbound_dial_window_seconds). Dials after this are dropped and the run returns status: timeout."
+                                                    }
+                                                }
+                                            },
+                                            "examples": [
+                                                {
+                                                    "id": 274,
+                                                    "status": "pending",
+                                                    "scenario": 1,
+                                                    "number": null,
+                                                    "inbound_number": "+11234567890",
+                                                    "scenario_name": "Customer Support Call (Agent Inbound = True)",
+                                                    "test_profile_data": null,
+                                                    "outbound_dial_window_opens_at": null,
+                                                    "outbound_dial_window_seconds": null,
+                                                    "outbound_dial_window_closes_at": null
+                                                },
+                                                {
+                                                    "id": 275,
+                                                    "status": "pending",
+                                                    "scenario": 2,
+                                                    "number": "+11234567890",
+                                                    "inbound_number": null,
+                                                    "scenario_name": "Outbound Sales Call (Agent Inbound = False)",
+                                                    "test_profile_data": null,
+                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
+                                                    "outbound_dial_window_seconds": 300,
+                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
+                                                }
+                                            ]
+                                        },
+                                        "created_at": {
+                                            "type": "string",
+                                            "format": "date-time",
+                                            "example": "2025-02-25T21:00:01.990052Z"
+                                        }
+                                    }
+                                },
+                                "examples": {
+                                    "InboundScenario": {
+                                        "value": {
+                                            "id": 167,
+                                            "agent": 1,
+                                            "status": "pending",
+                                            "success_rate": 0,
+                                            "run_as_text": false,
+                                            "runs": [
+                                                {
+                                                    "id": 274,
+                                                    "scenario": 1,
+                                                    "number": null,
+                                                    "inbound_number": "+11234567890",
+                                                    "outbound_dial_window_opens_at": null,
+                                                    "outbound_dial_window_seconds": null,
+                                                    "outbound_dial_window_closes_at": null
+                                                },
+                                                {
+                                                    "id": 273,
+                                                    "scenario": 2,
+                                                    "number": null,
+                                                    "inbound_number": "+11234567891",
+                                                    "outbound_dial_window_opens_at": null,
+                                                    "outbound_dial_window_seconds": null,
+                                                    "outbound_dial_window_closes_at": null
+                                                }
+                                            ],
+                                            "created_at": "2025-02-25T21:00:01.990052Z"
+                                        },
+                                        "summary": "Inbound Scenario"
+                                    },
+                                    "OutboundScenario": {
+                                        "value": {
+                                            "id": 167,
+                                            "agent": 1,
+                                            "status": "pending",
+                                            "success_rate": 0,
+                                            "run_as_text": false,
+                                            "runs": [
+                                                {
+                                                    "id": 274,
+                                                    "scenario": 1,
+                                                    "number": "+11234567890",
+                                                    "inbound_number": null,
+                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
+                                                    "outbound_dial_window_seconds": 300,
+                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
+                                                },
+                                                {
+                                                    "id": 273,
+                                                    "scenario": 2,
+                                                    "number": "+11234567891",
+                                                    "inbound_number": null,
+                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
+                                                    "outbound_dial_window_seconds": 300,
+                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
+                                                }
+                                            ],
+                                            "created_at": "2025-02-25T21:00:01.990052Z"
+                                        },
+                                        "summary": "Outbound Scenario"
+                                    }
                                 }
                             }
                         },
                         "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "scenarios-run-voice",
+                        "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing. Requires `telephony.phone_number` configured on the agent (any provider).\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.\n\n**Outbound dial window:** for outbound runs (agent `inbound=false`), your agent must dial the run's `outbound_number` before `outbound_dial_window_closes_at` (default 300s after the run reaches `waiting_for_call` / pending state). Dials received after that deadline are dropped and the run returns `status: timeout`."
                     }
                 }
             }
@@ -42617,9 +43368,9 @@
         },
         "/test_framework/v1/scenarios/run_scenarios_json/": {
             "post": {
-                "operationId": "scenarios-run-voice_2",
-                "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing. Requires `telephony.phone_number` configured on the agent (any provider).\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.\n\n**Outbound dial window:** for outbound runs (agent `inbound=false`), your agent must dial the run's `outbound_number` before `outbound_dial_window_closes_at` (default 300s after the run reaches `waiting_for_call` / pending state). Dials received after that deadline are dropped and the run returns `status: timeout`.",
-                "summary": "Run evaluators over a voice call",
+                "operationId": "scenarios-run-json_2",
+                "description": "Run agent test cases straight from a JSON spec, without creating evaluators. Keep the spec in your repository and post it from CI.\n\nThe spec describes only what to test. Pick the target with `agent_id` and `channel` on the request — `voice` for a phone call (default), `text` for chat, `elevenlabs` for an ElevenLabs WebRTC session — so one file runs unchanged against any agent or environment.\n\nPass `dry_run=true` to validate only: the response describes the run that would happen (test cases, total runs, estimated cost) and nothing is created or charged. Use that on every commit, and the real call on the branches you want tested.\n\nEvery problem in a spec is reported at once, keyed by its location in the file (for example `scenarios[3].metrics[1]`). Metrics must already exist and be enabled for the target agent; personalities and test profiles can be referenced by ID or defined inline.\n\nFetch the schema this endpoint accepts from `scenarios_json_schema`.\n\n**Cost:** voice- or text-simulation rate per run. Test cases from a spec are removed automatically once no run needs them.",
+                "summary": "Run test cases from a JSON spec file",
                 "parameters": [
                     {
                         "in": "query",
@@ -42637,7 +43388,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
+                                "$ref": "#/components/schemas/TestSuiteSpecUpload"
                             },
                             "examples": {
                                 "RunASpec": {
@@ -42665,58 +43416,17 @@
                                         }
                                     },
                                     "summary": "Run a spec"
-                                },
-                                "RunSelectedScenarios(simplest)": {
-                                    "value": {
-                                        "agent_id": 12,
-                                        "scenarios": [
-                                            101,
-                                            102,
-                                            103
-                                        ],
-                                        "frequency": 1
-                                    },
-                                    "summary": "Run selected scenarios (simplest)"
-                                },
-                                "RunAnEntireFolder,3×Each,5InParallel": {
-                                    "value": {
-                                        "agent_id": 12,
-                                        "folder_path": "Sales.Inbound",
-                                        "project_id": 1376,
-                                        "frequency": 3,
-                                        "concurrency_limit": 5,
-                                        "name": "Nightly Sales.Inbound regression"
-                                    },
-                                    "summary": "Run an entire folder, 3× each, 5 in parallel"
-                                },
-                                "OverridePersonalities+TestProfiles(multipliesRunCount)": {
-                                    "value": {
-                                        "agent_id": 12,
-                                        "scenarios": [
-                                            101
-                                        ],
-                                        "frequency": 2,
-                                        "personality_ids": [
-                                            3,
-                                            7
-                                        ],
-                                        "test_profile_ids": [
-                                            20,
-                                            21
-                                        ]
-                                    },
-                                    "summary": "Override personalities + test profiles (multiplies run count)"
                                 }
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
+                                "$ref": "#/components/schemas/TestSuiteSpecUpload"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
+                                "$ref": "#/components/schemas/TestSuiteSpecUpload"
                             }
                         }
                     }
@@ -42733,7 +43443,7 @@
                     }
                 ],
                 "responses": {
-                    "201": {
+                    "200": {
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -42867,70 +43577,6 @@
                                             "example": "2025-02-25T21:00:01.990052Z"
                                         }
                                     }
-                                },
-                                "examples": {
-                                    "InboundScenario": {
-                                        "value": {
-                                            "id": 167,
-                                            "agent": 1,
-                                            "status": "pending",
-                                            "success_rate": 0,
-                                            "run_as_text": false,
-                                            "runs": [
-                                                {
-                                                    "id": 274,
-                                                    "scenario": 1,
-                                                    "number": null,
-                                                    "inbound_number": "+11234567890",
-                                                    "outbound_dial_window_opens_at": null,
-                                                    "outbound_dial_window_seconds": null,
-                                                    "outbound_dial_window_closes_at": null
-                                                },
-                                                {
-                                                    "id": 273,
-                                                    "scenario": 2,
-                                                    "number": null,
-                                                    "inbound_number": "+11234567891",
-                                                    "outbound_dial_window_opens_at": null,
-                                                    "outbound_dial_window_seconds": null,
-                                                    "outbound_dial_window_closes_at": null
-                                                }
-                                            ],
-                                            "created_at": "2025-02-25T21:00:01.990052Z"
-                                        },
-                                        "summary": "Inbound Scenario"
-                                    },
-                                    "OutboundScenario": {
-                                        "value": {
-                                            "id": 167,
-                                            "agent": 1,
-                                            "status": "pending",
-                                            "success_rate": 0,
-                                            "run_as_text": false,
-                                            "runs": [
-                                                {
-                                                    "id": 274,
-                                                    "scenario": 1,
-                                                    "number": "+11234567890",
-                                                    "inbound_number": null,
-                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
-                                                    "outbound_dial_window_seconds": 300,
-                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
-                                                },
-                                                {
-                                                    "id": 273,
-                                                    "scenario": 2,
-                                                    "number": "+11234567891",
-                                                    "inbound_number": null,
-                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
-                                                    "outbound_dial_window_seconds": 300,
-                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
-                                                }
-                                            ],
-                                            "created_at": "2025-02-25T21:00:01.990052Z"
-                                        },
-                                        "summary": "Outbound Scenario"
-                                    }
                                 }
                             }
                         },
@@ -42953,14 +43599,6 @@
                             }
                         },
                         "description": ""
-                    }
-                },
-                "x-mcp-expose": true,
-                "x-mint": {
-                    "mcp": {
-                        "enabled": true,
-                        "name": "scenarios-run-voice",
-                        "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing. Requires `telephony.phone_number` configured on the agent (any provider).\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.\n\n**Outbound dial window:** for outbound runs (agent `inbound=false`), your agent must dial the run's `outbound_number` before `outbound_dial_window_closes_at` (default 300s after the run reaches `waiting_for_call` / pending state). Dials received after that deadline are dropped and the run returns `status: timeout`."
                     }
                 }
             }
@@ -56686,30 +57324,73 @@
         },
         "/test_framework/v2/scenarios/run_scenarios/": {
             "post": {
-                "operationId": "test-framework-v2-scenarios-run-scenarios-create",
-                "description": "Scenarios run scenarios",
+                "operationId": "scenarios-run-voice_3",
+                "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing. Requires `telephony.phone_number` configured on the agent (any provider).\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.\n\n**Outbound dial window:** for outbound runs (agent `inbound=false`), your agent must dial the run's `outbound_number` before `outbound_dial_window_closes_at` (default 300s after the run reaches `waiting_for_call` / pending state). Dials received after that deadline are dropped and the run returns `status: timeout`.",
+                "summary": "Run evaluators over a voice call",
                 "tags": [
-                    "test_framework"
+                    "Evaluators"
                 ],
                 "requestBody": {
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/ScenarioSerializerV2"
+                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
+                            },
+                            "examples": {
+                                "RunSelectedScenarios(simplest)": {
+                                    "value": {
+                                        "agent_id": 12,
+                                        "scenarios": [
+                                            101,
+                                            102,
+                                            103
+                                        ],
+                                        "frequency": 1
+                                    },
+                                    "summary": "Run selected scenarios (simplest)"
+                                },
+                                "RunAnEntireFolder,3×Each,5InParallel": {
+                                    "value": {
+                                        "agent_id": 12,
+                                        "folder_path": "Sales.Inbound",
+                                        "project_id": 1376,
+                                        "frequency": 3,
+                                        "concurrency_limit": 5,
+                                        "name": "Nightly Sales.Inbound regression"
+                                    },
+                                    "summary": "Run an entire folder, 3× each, 5 in parallel"
+                                },
+                                "OverridePersonalities+TestProfiles(multipliesRunCount)": {
+                                    "value": {
+                                        "agent_id": 12,
+                                        "scenarios": [
+                                            101
+                                        ],
+                                        "frequency": 2,
+                                        "personality_ids": [
+                                            3,
+                                            7
+                                        ],
+                                        "test_profile_ids": [
+                                            20,
+                                            21
+                                        ]
+                                    },
+                                    "summary": "Override personalities + test profiles (multiplies run count)"
+                                }
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/ScenarioSerializerV2"
+                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/ScenarioSerializerV2"
+                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "security": [
                     {
@@ -56723,11 +57404,222 @@
                     }
                 ],
                 "responses": {
-                    "200": {
+                    "201": {
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ScenarioSerializerV2"
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {
+                                            "type": "integer",
+                                            "description": "ID of the result"
+                                        },
+                                        "agent": {
+                                            "type": "integer",
+                                            "description": "ID of the agent"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "pending",
+                                                "running",
+                                                "completed",
+                                                "failed"
+                                            ],
+                                            "description": "Status of the result"
+                                        },
+                                        "run_as_text": {
+                                            "type": "boolean",
+                                            "description": "Whether the scenario ran as text or not",
+                                            "example": false
+                                        },
+                                        "runs": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "id": {
+                                                        "type": "integer",
+                                                        "description": "ID of the run"
+                                                    },
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "pending",
+                                                            "running",
+                                                            "completed",
+                                                            "failed"
+                                                        ],
+                                                        "description": "Status of the run"
+                                                    },
+                                                    "scenario": {
+                                                        "type": "integer",
+                                                        "description": "ID of the scenario"
+                                                    },
+                                                    "number": {
+                                                        "type": "string",
+                                                        "description": "For outbound runs (agent.inbound=False). The given number that must be called from the phone number configured in the cekura agent.",
+                                                        "example": "+11234567890"
+                                                    },
+                                                    "inbound_number": {
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ],
+                                                        "description": "For inbound runs (agent.inbound=True). The agent's configured phone number will receive calls from this number.",
+                                                        "example": "+11234567890"
+                                                    },
+                                                    "scenario_name": {
+                                                        "type": "string",
+                                                        "description": "Name of the scenario"
+                                                    },
+                                                    "test_profile_data": {
+                                                        "type": [
+                                                            "object",
+                                                            "null"
+                                                        ],
+                                                        "description": "Details of the test profile associated with this run scenario"
+                                                    },
+                                                    "outbound_dial_window_opens_at": {
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ],
+                                                        "format": "date-time",
+                                                        "description": "When the outbound dial window opened (run transitioned to pending/waiting-for-call). Null until dispatched."
+                                                    },
+                                                    "outbound_dial_window_seconds": {
+                                                        "type": [
+                                                            "integer",
+                                                            "null"
+                                                        ],
+                                                        "description": "Duration of the outbound dial window in seconds."
+                                                    },
+                                                    "outbound_dial_window_closes_at": {
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ],
+                                                        "format": "date-time",
+                                                        "description": "Deadline by which your agent must dial the outbound number (opens_at + outbound_dial_window_seconds). Dials after this are dropped and the run returns status: timeout."
+                                                    }
+                                                }
+                                            },
+                                            "examples": [
+                                                {
+                                                    "id": 274,
+                                                    "status": "pending",
+                                                    "scenario": 1,
+                                                    "number": null,
+                                                    "inbound_number": "+11234567890",
+                                                    "scenario_name": "Customer Support Call (Agent Inbound = True)",
+                                                    "test_profile_data": null,
+                                                    "outbound_dial_window_opens_at": null,
+                                                    "outbound_dial_window_seconds": null,
+                                                    "outbound_dial_window_closes_at": null
+                                                },
+                                                {
+                                                    "id": 275,
+                                                    "status": "pending",
+                                                    "scenario": 2,
+                                                    "number": "+11234567890",
+                                                    "inbound_number": null,
+                                                    "scenario_name": "Outbound Sales Call (Agent Inbound = False)",
+                                                    "test_profile_data": null,
+                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
+                                                    "outbound_dial_window_seconds": 300,
+                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
+                                                }
+                                            ]
+                                        },
+                                        "created_at": {
+                                            "type": "string",
+                                            "format": "date-time",
+                                            "example": "2025-02-25T21:00:01.990052Z"
+                                        }
+                                    }
+                                },
+                                "examples": {
+                                    "InboundScenario": {
+                                        "value": {
+                                            "id": 167,
+                                            "agent": 1,
+                                            "status": "pending",
+                                            "success_rate": 0,
+                                            "run_as_text": false,
+                                            "runs": [
+                                                {
+                                                    "id": 274,
+                                                    "scenario": 1,
+                                                    "number": null,
+                                                    "inbound_number": "+11234567890",
+                                                    "outbound_dial_window_opens_at": null,
+                                                    "outbound_dial_window_seconds": null,
+                                                    "outbound_dial_window_closes_at": null
+                                                },
+                                                {
+                                                    "id": 273,
+                                                    "scenario": 2,
+                                                    "number": null,
+                                                    "inbound_number": "+11234567891",
+                                                    "outbound_dial_window_opens_at": null,
+                                                    "outbound_dial_window_seconds": null,
+                                                    "outbound_dial_window_closes_at": null
+                                                }
+                                            ],
+                                            "created_at": "2025-02-25T21:00:01.990052Z"
+                                        },
+                                        "summary": "Inbound Scenario"
+                                    },
+                                    "OutboundScenario": {
+                                        "value": {
+                                            "id": 167,
+                                            "agent": 1,
+                                            "status": "pending",
+                                            "success_rate": 0,
+                                            "run_as_text": false,
+                                            "runs": [
+                                                {
+                                                    "id": 274,
+                                                    "scenario": 1,
+                                                    "number": "+11234567890",
+                                                    "inbound_number": null,
+                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
+                                                    "outbound_dial_window_seconds": 300,
+                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
+                                                },
+                                                {
+                                                    "id": 273,
+                                                    "scenario": 2,
+                                                    "number": "+11234567891",
+                                                    "inbound_number": null,
+                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
+                                                    "outbound_dial_window_seconds": 300,
+                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
+                                                }
+                                            ],
+                                            "created_at": "2025-02-25T21:00:01.990052Z"
+                                        },
+                                        "summary": "Outbound Scenario"
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "field_name": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
                                 }
                             }
                         },
@@ -57681,9 +58573,9 @@
         },
         "/test_framework/v2/scenarios/run_scenarios_json/": {
             "post": {
-                "operationId": "scenarios-run-voice_3",
-                "description": "VOICE RUN: Execute evaluators against your agent using a real voice / phone / SIP call. This is the primary 'run your evaluators' endpoint for voice-mode testing. Requires `telephony.phone_number` configured on the agent (any provider).\n\n**Run-count math:** total calls = `len(scenarios) × frequency × max(1, len(personality_ids)) × max(1, len(test_profile_ids))`. Each call is billed at the voice-simulation rate — check `frequency` carefully.\n\n**Concurrency:** use `concurrency_limit` to cap parallel calls. Default: unbounded (subject to provider rate limits).\n\n**Scenario selection (pick one):**\n- `scenarios` — list of integer evaluator IDs (e.g. `[101, 102]`)\n- `tags` — select by tag\n- `folder_path` — select by folder path (e.g. `\"Sales.Inbound\"`); requires `project_id`\n\n**Phone-number overrides:**\n- `outbound_phone_number` — override the number dialed\n- `agent_number` — override the contact number the inbound agent receives calls on\n- `mode` — `same_number` (all runs use one pair) vs `different_numbers`\n\n**When to use this vs others** (pick the endpoint matching the agent's configured connection — check `aiagents_retrieve`):\n- `run_scenarios_text` — text / SMS / chat mode; cheaper, no voice cost\n- `run_scenarios_with_websockets` — each scenario carries its own websocket URL\n- `run_scenarios_pipecat` — Pipecat/Daily.co WebRTC deployment\n\n**Personality override:** `personality_ids` must be IDs that are already enabled for the agent's project. Check which are enabled via `aiagents_retrieve` → `enabled_personalities` field. To enable a new personality, call `aiagents_partial_update` with the updated `enabled_personalities` list before using it here. Note: enabling a personality applies project-wide, not just to one agent. Passing an ID that is not enabled returns `[\"Invalid personalities provided.\"]`.\n\n**Scheduled runs:** to run on a recurring cron schedule, create a CronJob via `POST /test_framework/v1/cron_jobs/` with `execution_mode=\"voice\"` instead of looping this endpoint.\n\n**Polling for completion:** the response contains a `result.id` with `status: 'running'`. Poll `GET /test_framework/v1/results/{result_id}/` until `status` is 'completed' or 'failed'. There is no separate progress endpoint for runs. Check `failed_reasons` for infrastructure errors; check `runs[run_id].error_message` for per-run errors.\n\n**Outbound dial window:** for outbound runs (agent `inbound=false`), your agent must dial the run's `outbound_number` before `outbound_dial_window_closes_at` (default 300s after the run reaches `waiting_for_call` / pending state). Dials received after that deadline are dropped and the run returns `status: timeout`.",
-                "summary": "Run evaluators over a voice call",
+                "operationId": "scenarios-run-json_3",
+                "description": "Run agent test cases straight from a JSON spec, without creating evaluators. Keep the spec in your repository and post it from CI.\n\nThe spec describes only what to test. Pick the target with `agent_id` and `channel` on the request — `voice` for a phone call (default), `text` for chat, `elevenlabs` for an ElevenLabs WebRTC session — so one file runs unchanged against any agent or environment.\n\nPass `dry_run=true` to validate only: the response describes the run that would happen (test cases, total runs, estimated cost) and nothing is created or charged. Use that on every commit, and the real call on the branches you want tested.\n\nEvery problem in a spec is reported at once, keyed by its location in the file (for example `scenarios[3].metrics[1]`). Metrics must already exist and be enabled for the target agent; personalities and test profiles can be referenced by ID or defined inline.\n\nFetch the schema this endpoint accepts from `scenarios_json_schema`.\n\n**Cost:** voice- or text-simulation rate per run. Test cases from a spec are removed automatically once no run needs them.",
+                "summary": "Run test cases from a JSON spec file",
                 "parameters": [
                     {
                         "in": "query",
@@ -57701,7 +58593,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
+                                "$ref": "#/components/schemas/TestSuiteSpecUpload"
                             },
                             "examples": {
                                 "RunASpec": {
@@ -57729,58 +58621,17 @@
                                         }
                                     },
                                     "summary": "Run a spec"
-                                },
-                                "RunSelectedScenarios(simplest)": {
-                                    "value": {
-                                        "agent_id": 12,
-                                        "scenarios": [
-                                            101,
-                                            102,
-                                            103
-                                        ],
-                                        "frequency": 1
-                                    },
-                                    "summary": "Run selected scenarios (simplest)"
-                                },
-                                "RunAnEntireFolder,3×Each,5InParallel": {
-                                    "value": {
-                                        "agent_id": 12,
-                                        "folder_path": "Sales.Inbound",
-                                        "project_id": 1376,
-                                        "frequency": 3,
-                                        "concurrency_limit": 5,
-                                        "name": "Nightly Sales.Inbound regression"
-                                    },
-                                    "summary": "Run an entire folder, 3× each, 5 in parallel"
-                                },
-                                "OverridePersonalities+TestProfiles(multipliesRunCount)": {
-                                    "value": {
-                                        "agent_id": 12,
-                                        "scenarios": [
-                                            101
-                                        ],
-                                        "frequency": 2,
-                                        "personality_ids": [
-                                            3,
-                                            7
-                                        ],
-                                        "test_profile_ids": [
-                                            20,
-                                            21
-                                        ]
-                                    },
-                                    "summary": "Override personalities + test profiles (multiplies run count)"
                                 }
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
+                                "$ref": "#/components/schemas/TestSuiteSpecUpload"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/SchemaPostRunScenarios"
+                                "$ref": "#/components/schemas/TestSuiteSpecUpload"
                             }
                         }
                     }
@@ -57797,7 +58648,7 @@
                     }
                 ],
                 "responses": {
-                    "201": {
+                    "200": {
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -57930,70 +58781,6 @@
                                             "format": "date-time",
                                             "example": "2025-02-25T21:00:01.990052Z"
                                         }
-                                    }
-                                },
-                                "examples": {
-                                    "InboundScenario": {
-                                        "value": {
-                                            "id": 167,
-                                            "agent": 1,
-                                            "status": "pending",
-                                            "success_rate": 0,
-                                            "run_as_text": false,
-                                            "runs": [
-                                                {
-                                                    "id": 274,
-                                                    "scenario": 1,
-                                                    "number": null,
-                                                    "inbound_number": "+11234567890",
-                                                    "outbound_dial_window_opens_at": null,
-                                                    "outbound_dial_window_seconds": null,
-                                                    "outbound_dial_window_closes_at": null
-                                                },
-                                                {
-                                                    "id": 273,
-                                                    "scenario": 2,
-                                                    "number": null,
-                                                    "inbound_number": "+11234567891",
-                                                    "outbound_dial_window_opens_at": null,
-                                                    "outbound_dial_window_seconds": null,
-                                                    "outbound_dial_window_closes_at": null
-                                                }
-                                            ],
-                                            "created_at": "2025-02-25T21:00:01.990052Z"
-                                        },
-                                        "summary": "Inbound Scenario"
-                                    },
-                                    "OutboundScenario": {
-                                        "value": {
-                                            "id": 167,
-                                            "agent": 1,
-                                            "status": "pending",
-                                            "success_rate": 0,
-                                            "run_as_text": false,
-                                            "runs": [
-                                                {
-                                                    "id": 274,
-                                                    "scenario": 1,
-                                                    "number": "+11234567890",
-                                                    "inbound_number": null,
-                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
-                                                    "outbound_dial_window_seconds": 300,
-                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
-                                                },
-                                                {
-                                                    "id": 273,
-                                                    "scenario": 2,
-                                                    "number": "+11234567891",
-                                                    "inbound_number": null,
-                                                    "outbound_dial_window_opens_at": "2026-06-24T10:47:30Z",
-                                                    "outbound_dial_window_seconds": 300,
-                                                    "outbound_dial_window_closes_at": "2026-06-24T10:52:30Z"
-                                                }
-                                            ],
-                                            "created_at": "2025-02-25T21:00:01.990052Z"
-                                        },
-                                        "summary": "Outbound Scenario"
                                     }
                                 }
                             }
@@ -73089,6 +73876,79 @@
                     "project"
                 ]
             },
+            "MetricOptimizerChatSession": {
+                "type": "object",
+                "description": "Read-only serializer for the post-optimization review chat session.",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "metric": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "project": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
+                        "readOnly": true
+                    },
+                    "agent": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
+                        "readOnly": true
+                    },
+                    "status": {
+                        "enum": [
+                            "awaiting_user",
+                            "agent_running",
+                            "regression_running",
+                            "reoptimizing",
+                            "completed",
+                            "cancelled",
+                            "failed"
+                        ],
+                        "type": "string",
+                        "description": "* `awaiting_user` - Awaiting User\n* `agent_running` - Agent Running\n* `regression_running` - Regression Running\n* `reoptimizing` - Reoptimizing\n* `completed` - Completed\n* `cancelled` - Cancelled\n* `failed` - Failed",
+                        "x-spec-enum-id": "8b33c50cd513306a",
+                        "readOnly": true
+                    },
+                    "conversation_history": {
+                        "readOnly": true,
+                        "description": "[{role, content, timestamp, message_type?, payload?, questions?}]"
+                    },
+                    "proposal": {
+                        "readOnly": true,
+                        "description": "Snapshot of the latest process_feedbacks output (the optimized proposal)"
+                    },
+                    "regression_results": {
+                        "readOnly": true,
+                        "description": "Latest regression check: {samples: [...], summary: {...}, run_at}"
+                    },
+                    "active_progress": {
+                        "readOnly": true,
+                        "description": "In-flight progress ids: {chat_turn?, regression?, reoptimize?}"
+                    },
+                    "test_set_ids": {
+                        "readOnly": true,
+                        "description": "Eval-set test_set ids for the optimization run; grows when samples are added"
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    }
+                }
+            },
             "MetricPreview": {
                 "type": "object",
                 "properties": {
@@ -73662,6 +74522,92 @@
                     "files",
                     "repo",
                     "title"
+                ]
+            },
+            "OptimizerChatMessageRequest": {
+                "type": "object",
+                "properties": {
+                    "session_id": {
+                        "type": "integer"
+                    },
+                    "user_message": {
+                        "type": "string",
+                        "default": ""
+                    },
+                    "review_payload": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/OptimizerChatRegressionReviewItem"
+                        },
+                        "description": "Structured verdicts for regression-diff samples the user reviewed"
+                    }
+                },
+                "required": [
+                    "session_id"
+                ]
+            },
+            "OptimizerChatRegressionReviewItem": {
+                "type": "object",
+                "properties": {
+                    "source_type": {
+                        "enum": [
+                            "call_log",
+                            "run"
+                        ],
+                        "type": "string",
+                        "description": "* `call_log` - call_log\n* `run` - run",
+                        "x-spec-enum-id": "6a2f1f0669817ff1"
+                    },
+                    "source_id": {
+                        "type": "integer"
+                    },
+                    "new_label_correct": {
+                        "type": "boolean"
+                    },
+                    "correct_label": {
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "feedback": {
+                        "type": "string",
+                        "default": ""
+                    }
+                },
+                "required": [
+                    "new_label_correct",
+                    "source_id",
+                    "source_type"
+                ]
+            },
+            "OptimizerChatReoptimizeRequest": {
+                "type": "object",
+                "properties": {
+                    "session_id": {
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "session_id"
+                ]
+            },
+            "OptimizerChatStartRequest": {
+                "type": "object",
+                "properties": {
+                    "metric_id": {
+                        "type": "integer",
+                        "description": "Metric whose optimization proposal the chat reviews"
+                    },
+                    "progress_id": {
+                        "type": "string",
+                        "description": "process_feedbacks progress_id whose output seeds the session. If omitted, falls back to the metric's pending optimisation proposal."
+                    }
+                },
+                "required": [
+                    "metric_id"
                 ]
             },
             "Organization": {
@@ -79391,10 +80337,6 @@
                         ],
                         "readOnly": true
                     },
-                    "user_id": {
-                        "type": "integer",
-                        "writeOnly": true
-                    },
                     "role": {
                         "enum": [
                             "admin",
@@ -82111,6 +83053,17 @@
             "RunReviewsRequest": {
                 "type": "object",
                 "properties": {
+                    "llm_provider": {
+                        "enum": [
+                            "openai",
+                            "gemini",
+                            "dspy-gepa-gemini-flash",
+                            "deepseek-v4-flash"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "6d1d2e77c71d1721",
+                        "description": "Override the judge provider while running unsaved Labs changes\n\n* `openai` - OpenAI\n* `gemini` - Gemini\n* `dspy-gepa-gemini-flash` - Dspy Gepa Gemini Flash\n* `deepseek-v4-flash` - DeepSeek V4 Flash"
+                    },
                     "evaluation_trigger": {
                         "type": "string",
                         "description": "Override evaluation trigger setting"
@@ -82118,6 +83071,19 @@
                     "evaluation_trigger_prompt": {
                         "type": "string",
                         "description": "Override evaluation trigger prompt"
+                    },
+                    "trigger_type": {
+                        "enum": [
+                            "llm_judge",
+                            "custom_code"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "2adad4b8df61914f",
+                        "description": "Override evaluation trigger implementation\n\n* `llm_judge` - LLM Judge\n* `custom_code` - Custom Code"
+                    },
+                    "evaluation_trigger_custom_code": {
+                        "type": "string",
+                        "description": "Override custom-code evaluation trigger"
                     },
                     "description": {
                         "type": "string",
@@ -87289,6 +88255,39 @@
                     "agent"
                 ]
             },
+            "TestSuiteSpecUpload": {
+                "type": "object",
+                "description": "Accepts a spec as a JSON body or an uploaded file.\n\nCI posts JSON directly; the dashboard uploads the same file the customer has\nin their repo. Both land in ``spec``.",
+                "properties": {
+                    "spec": {
+                        "description": "The test-suite spec. Use this when posting JSON directly."
+                    },
+                    "file": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "A .json spec file. Use this instead of 'spec' for uploads."
+                    },
+                    "agent_id": {
+                        "type": "integer",
+                        "description": "Agent to test. Overrides 'agent_id' in the spec, letting one spec file run against several environments."
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Label for this run. Defaults to the spec's suite name.",
+                        "maxLength": 255
+                    },
+                    "channel": {
+                        "enum": [
+                            "voice",
+                            "text",
+                            "elevenlabs"
+                        ],
+                        "type": "string",
+                        "x-spec-enum-id": "173ddbb9888b2f07",
+                        "description": "How to reach the agent: 'voice' for a phone call (the default), 'text' for chat, 'elevenlabs' for an ElevenLabs WebRTC session.\n\n* `voice` - voice\n* `text` - text\n* `elevenlabs` - elevenlabs"
+                    }
+                }
+            },
             "TokenRefresh": {
                 "type": "object",
                 "properties": {
@@ -87554,10 +88553,6 @@
                             }
                         ],
                         "readOnly": true
-                    },
-                    "user_id": {
-                        "type": "integer",
-                        "writeOnly": true
                     },
                     "role": {
                         "enum": [


### PR DESCRIPTION
Auto-generated docs sync for backend PR [#10645](https://github.com/cekura-ai/vocera.backend/pull/10645).

Reviewers: @dileep-chagam

## Summary

**Spec/overlay:** 1 Bucket A change: `scenarios_run_voice` MCP tool rebinds from `run_scenarios_json` to `run_scenarios` (correct action). Tool name and overlay key unchanged — no overlay edit needed. 9 new session-only `optimizer_chat_*` endpoints lack `@docs_exclude()` and will get API-reference pages despite being uncallable with an API key. 1 removed non-exposed endpoint (`POST /slack/slack-workspaces/`).

**Conceptual docs:** No edits — PR is a pure decorator relocation (bug fix) that restores the correct MCP tool binding for `scenarios-run-voice`. No user-facing API contract, schema, or behavior changed; conceptual docs already describe the intended (now-restored) behavior.

## Changes

- `openapi.json` — regenerate_from_backend

## Exposure suggestions (@mcp_expose candidates)

- **`metric_reviews_optimizer_chat_start`** (POST `/test_framework/metric-reviews/optimizer_chat_start/`)
  - `POST /test_framework/metric-reviews/optimizer_chat_start/` is not callable with `X-CEKURA-API-KEY` — it accepts `oauth2, supabase_session`. If it is dashboard-only, add `@docs_exclude()` from `app.docs_decorators` so it does not get an API-reference page; a customer who follows that page gets a 403.
- **`metric_reviews_optimizer_chat_message`** (POST `/test_framework/metric-reviews/optimizer_chat_message/`)
  - `POST /test_framework/metric-reviews/optimizer_chat_message/` is not callable with `X-CEKURA-API-KEY` — it accepts `oauth2, supabase_session`. If it is dashboard-only, add `@docs_exclude()` from `app.docs_decorators` so it does not get an API-reference page; a customer who follows that page gets a 403.
- **`metric_reviews_optimizer_chat_session`** (GET `/test_framework/metric-reviews/optimizer_chat_session/`)
  - `GET /test_framework/metric-reviews/optimizer_chat_session/` is not callable with `X-CEKURA-API-KEY` — it accepts `oauth2, supabase_session`. If it is dashboard-only, add `@docs_exclude()` from `app.docs_decorators` so it does not get an API-reference page; a customer who follows that page gets a 403.
- **`metric_reviews_optimizer_chat_progress`** (GET `/test_framework/metric-reviews/optimizer_chat_progress/`)
  - `GET /test_framework/metric-reviews/optimizer_chat_progress/` is not callable with `X-CEKURA-API-KEY` — it accepts `oauth2, supabase_session`. If it is dashboard-only, add `@docs_exclude()` from `app.docs_decorators` so it does not get an API-reference page; a customer who follows that page gets a 403.
- **`metric_reviews_optimizer_chat_cancel`** (POST `/test_framework/metric-reviews/optimizer_chat_cancel/`)
  - `POST /test_framework/metric-reviews/optimizer_chat_cancel/` is not callable with `X-CEKURA-API-KEY` — it accepts `oauth2, supabase_session`. If it is dashboard-only, add `@docs_exclude()` from `app.docs_decorators` so it does not get an API-reference page; a customer who follows that page gets a 403.
- **`metric_reviews_optimizer_chat_confirm_samples`** (POST `/test_framework/metric-reviews/optimizer_chat_confirm_samples/`)
  - `POST /test_framework/metric-reviews/optimizer_chat_confirm_samples/` is not callable with `X-CEKURA-API-KEY` — it accepts `oauth2, supabase_session`. If it is dashboard-only, add `@docs_exclude()` from `app.docs_decorators` so it does not get an API-reference page; a customer who follows that page gets a 403.
- **`metric_reviews_optimizer_chat_regression`** (POST `/test_framework/metric-reviews/optimizer_chat_regression/`)
  - `POST /test_framework/metric-reviews/optimizer_chat_regression/` is not callable with `X-CEKURA-API-KEY` — it accepts `oauth2, supabase_session`. If it is dashboard-only, add `@docs_exclude()` from `app.docs_decorators` so it does not get an API-reference page; a customer who follows that page gets a 403.
- **`metric_reviews_optimizer_chat_regression_progress`** (GET `/test_framework/metric-reviews/optimizer_chat_regression_progress/`)
  - `GET /test_framework/metric-reviews/optimizer_chat_regression_progress/` is not callable with `X-CEKURA-API-KEY` — it accepts `oauth2, supabase_session`. If it is dashboard-only, add `@docs_exclude()` from `app.docs_decorators` so it does not get an API-reference page; a customer who follows that page gets a 403.
- **`metric_reviews_optimizer_chat_reoptimize`** (POST `/test_framework/metric-reviews/optimizer_chat_reoptimize/`)
  - `POST /test_framework/metric-reviews/optimizer_chat_reoptimize/` is not callable with `X-CEKURA-API-KEY` — it accepts `oauth2, supabase_session`. If it is dashboard-only, add `@docs_exclude()` from `app.docs_decorators` so it does not get an API-reference page; a customer who follows that page gets a 403.

---
*Auto-generated from backend PR #10645.*

<!-- mcp-sync:file-hashes -->
```json
{}
```
<!-- /mcp-sync:file-hashes -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cekura-ai/docs/pull/835" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->