### PR TITLE
Deploy provider MCP on ECS

### DIFF
--- a/.github/workflows/deploy-provider-mcp.yml
+++ b/.github/workflows/deploy-provider-mcp.yml
@@ -1,0 +1,179 @@
+name: Deploy Provider MCP Server (PROD)
+
+# Builds the shared provider MCP service and deploys it to the existing prod
+# us-west-2 ECS cluster. Providers are exposed below provider-mcp.cekura.ai:
+# /elevenlabs/mcp and /vapi/mcp.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'provider_mcp/**'
+      - '.github/workflows/deploy-provider-mcp.yml'
+
+env:
+  AWS_REGION: us-west-2
+  ECR_REPOSITORY: cekura/provider-mcp
+  ECS_CLUSTER: cet-prd-usw2-cekura-ecs-cluster
+  ECS_SERVICE: cet-prd-usw2-provider-mcp-ecs-service
+  ECS_REFERENCE_SERVICE: cet-prd-usw2-mcp-server-ecs-service
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: deploy-provider-mcp-prod
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      image-tag: ${{ steps.construct-tag.outputs.image-tag }}
+      registry: ${{ steps.login-ecr.outputs.registry }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          version: latest
+
+      - name: Configure AWS credentials (shared services for ECR push)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN_SHARED }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Construct Docker image tag
+        id: construct-tag
+        run: |
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          BRANCH_NAME=${GITHUB_REF_NAME//\//-}
+          IMAGE_TAG="${BRANCH_NAME}-${SHORT_SHA}"
+          echo "image-tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push image to ECR
+        uses: docker/build-push-action@v6
+        with:
+          context: ./provider_mcp
+          file: ./provider_mcp/Dockerfile
+          push: true
+          tags: ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ steps.construct-tag.outputs.image-tag }}
+          cache-from: |
+            type=gha,scope=provider-mcp-${{ github.ref_name }}
+            type=gha,scope=provider-mcp-main
+          cache-to: type=gha,mode=max,scope=provider-mcp-${{ github.ref_name }}
+
+  deploy:
+    name: deploy
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (workload account for ECS deploy)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN_PROD }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Render + register task definition
+        id: register
+        run: |
+          sed "s|<IMAGE_TAG>|${{ needs.build.outputs.image-tag }}|g" \
+            provider_mcp/deployment/ecs/prod-usw2/provider-mcp-task-def.json \
+            > /tmp/provider-mcp-task-def.rendered.json
+          TASK_DEF_ARN=$(aws ecs register-task-definition \
+            --cli-input-json file:///tmp/provider-mcp-task-def.rendered.json \
+            --query 'taskDefinition.taskDefinitionArn' --output text)
+          echo "task-def-arn=$TASK_DEF_ARN" >> "$GITHUB_OUTPUT"
+
+      - name: Create or update ECS service
+        run: |
+          TASK_DEF_ARN="${{ steps.register.outputs.task-def-arn }}"
+          SERVICE_ARN=$(aws ecs describe-services \
+            --cluster "$ECS_CLUSTER" \
+            --services "$ECS_SERVICE" \
+            --query 'services[0].serviceArn' \
+            --output text 2>/dev/null || true)
+
+          if [ -n "$SERVICE_ARN" ] && [ "$SERVICE_ARN" != "None" ]; then
+            echo "ECS service exists; updating $ECS_SERVICE"
+            aws ecs update-service \
+              --cluster "$ECS_CLUSTER" \
+              --service "$ECS_SERVICE" \
+              --task-definition "$TASK_DEF_ARN" \
+              --desired-count 1 \
+              --force-new-deployment \
+              --query 'service.[serviceName,taskDefinition,desiredCount]' --output text
+          else
+            echo "ECS service does not exist; creating $ECS_SERVICE"
+            NETWORK_CONFIGURATION=$(aws ecs describe-services \
+              --cluster "$ECS_CLUSTER" \
+              --services "$ECS_REFERENCE_SERVICE" \
+              --query 'services[0].networkConfiguration' \
+              --output json)
+
+            if [ -z "$NETWORK_CONFIGURATION" ] || [ "$NETWORK_CONFIGURATION" = "null" ]; then
+              echo "Unable to read network configuration from $ECS_REFERENCE_SERVICE"
+              exit 1
+            fi
+
+            aws ecs create-service \
+              --cluster "$ECS_CLUSTER" \
+              --service-name "$ECS_SERVICE" \
+              --task-definition "$TASK_DEF_ARN" \
+              --desired-count 1 \
+              --launch-type FARGATE \
+              --network-configuration "$NETWORK_CONFIGURATION" \
+              --query 'service.[serviceName,taskDefinition,desiredCount]' --output text
+          fi
+
+      - name: Wait for service stable
+        run: |
+          aws ecs wait services-stable --cluster "$ECS_CLUSTER" --services "$ECS_SERVICE"
+          echo "✅ Service stable"
+
+  notify:
+    needs: [build, deploy]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Compose message
+        id: collect
+        run: |
+          IMAGE_TAG="${{ needs.build.outputs.image-tag }}"
+          if [ "${{ needs.build.result }}" != "success" ]; then
+            echo "message=*❌ provider-mcp build failed for prod!* (tag: ${IMAGE_TAG:-n/a})" >> "$GITHUB_OUTPUT"
+          elif [ "${{ needs.deploy.result }}" = "success" ]; then
+            echo "message=*✅ provider-mcp deployed to prod* (tag: ${IMAGE_TAG})" >> "$GITHUB_OUTPUT"
+          else
+            DD_LINK="https://us5.datadoghq.com/logs?query=env%3Aprod%20version%3A${IMAGE_TAG}%20service%3Aprovider-mcp"
+            echo "message=*❌ provider-mcp deploy to prod failed* (tag: ${IMAGE_TAG}) - <${DD_LINK}|Datadog logs>" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Notify Slack
+        if: vars.SLACK_DEPLOYMENTS_CHANNEL != ''
+        env:
+          SLACK_TOKEN: ${{ secrets.SLACK_BOT_BEARER_TOKEN }}
+          SLACK_CHANNEL: ${{ vars.SLACK_DEPLOYMENTS_CHANNEL }}
+          MESSAGE: ${{ steps.collect.outputs.message }}
+        run: |
+          if [ -z "$SLACK_TOKEN" ] || [ -z "$SLACK_CHANNEL" ]; then
+            echo "(Slack creds missing — skipping notification)"
+            exit 0
+          fi
+          curl -sS -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer $SLACK_TOKEN" \
+            -H 'Content-Type: application/json; charset=utf-8' \
+            -d "$(jq -n --arg ch "$SLACK_CHANNEL" --arg msg "$MESSAGE" '{channel:$ch,text:$msg}')" \
+            | jq '{ok,error}'

--- a/provider_mcp/README.md
+++ b/provider_mcp/README.md
@@ -13,16 +13,45 @@ There is no generic `/mcp` endpoint.
 
 Deploy one Fargate service and route its public hostname to this container on port `8080`.
 
+Production deployment values:
+
+- ECS family: `provider-mcp`
+- ECS service: `cet-prd-usw2-provider-mcp-ecs-service`
+- ECR repository: `cekura/provider-mcp`
+- Public hostname: `provider-mcp.cekura.ai`
+- Task definition: `deployment/ecs/prod-usw2/provider-mcp-task-def.json`
+- Desired count: `1`
+
+The `Deploy Provider MCP Server (PROD)` workflow builds and deploys the
+service when `provider_mcp/**` changes on `main`. It creates the ECS service if
+missing, copying network configuration from the existing Cekura MCP service,
+or updates the existing service.
+
+Before the first workflow run, create `cekura/provider-mcp` in the shared
+services ECR account and apply the same cross-account AWS Organization pull
+policy used by `cekura/mcp-server`. The production ECS execution role must be
+able to obtain the ECR authorization token and pull this repository.
+
 Add these values to the existing MCP secret:
 
 ```text
 PROVIDER_MCP_OAUTH_TOKEN_SECRET=<same value used by the Cekura backend>
-PROVIDER_MCP_BASE_URL=https://elevenlabs.cekura.ai
+PROVIDER_MCP_BASE_URL=https://provider-mcp.cekura.ai
 PROVIDER_MCP_ISSUER_URL=https://api.cekura.ai
 PROVIDER_MCP_CEKURA_OAUTH_AUDIENCE=https://api.cekura.ai
 ```
 
-Configure the existing ALB and `elevenlabs.cekura.ai` DNS record to forward the shared service. The service has public health checks at `/elevenlabs/mcp/health` and `/vapi/mcp/health`. Do not expose port `8080` directly.
+The task reuses the existing MCP task role and execution role. No new secret
+or IAM role is required. Keep the existing `elevenlabs-mcp` ECS service and
+`elevenlabs.cekura.ai` endpoint during migration so they remain available as a
+rollback path.
+
+Configure the existing public HTTPS ALB with a host-only rule for
+`provider-mcp.cekura.ai` forwarding to an IP target group on port `8080`. Use
+`/elevenlabs/mcp/health` as the target-group health check. Create a Route 53
+alias for `provider-mcp.cekura.ai` to the ALB. The service has public health
+checks at `/elevenlabs/mcp/health` and `/vapi/mcp/health`. Do not expose port
+`8080` directly.
 
 ## How to use
 
@@ -32,12 +61,12 @@ Each provider is configured as its own MCP connection and shares the Cekura OAut
 
 ```bash
 codex mcp add elevenlabs \
-  --url https://elevenlabs.cekura.ai/elevenlabs/mcp \
-  --oauth-resource https://elevenlabs.cekura.ai/elevenlabs/mcp
+  --url https://provider-mcp.cekura.ai/elevenlabs/mcp \
+  --oauth-resource https://provider-mcp.cekura.ai/elevenlabs/mcp
 
 codex mcp add vapi \
-  --url https://elevenlabs.cekura.ai/vapi/mcp \
-  --oauth-resource https://elevenlabs.cekura.ai/vapi/mcp
+  --url https://provider-mcp.cekura.ai/vapi/mcp \
+  --oauth-resource https://provider-mcp.cekura.ai/vapi/mcp
 ```
 
 Add provider keys to `~/.codex/config.toml`:
@@ -60,10 +89,10 @@ codex mcp login vapi
 ### Claude Code
 
 ```bash
-claude mcp add --transport http elevenlabs https://elevenlabs.cekura.ai/elevenlabs/mcp \
+claude mcp add --transport http elevenlabs https://provider-mcp.cekura.ai/elevenlabs/mcp \
   --header "xi-elevenlabs-api-key: YOUR_ELEVENLABS_API_KEY"
 
-claude mcp add --transport http vapi https://elevenlabs.cekura.ai/vapi/mcp \
+claude mcp add --transport http vapi https://provider-mcp.cekura.ai/vapi/mcp \
   --header "x-vapi-api-key: YOUR_VAPI_API_KEY"
 ```
 

--- a/provider_mcp/deployment/ecs/prod-usw2/provider-mcp-task-def.json
+++ b/provider_mcp/deployment/ecs/prod-usw2/provider-mcp-task-def.json
@@ -1,0 +1,116 @@
+{
+  "containerDefinitions": [
+    {
+      "name": "provider-mcp",
+      "image": "212351099297.dkr.ecr.us-west-2.amazonaws.com/cekura/provider-mcp:<IMAGE_TAG>",
+      "cpu": 0,
+      "portMappings": [
+        {
+          "containerPort": 8080,
+          "hostPort": 8080,
+          "protocol": "tcp",
+          "name": "provider-mcp-8080-port",
+          "appProtocol": "http"
+        }
+      ],
+      "essential": true,
+      "environment": [
+        {
+          "name": "AWS_SECRET_NAME",
+          "value": "arn:aws:secretsmanager:us-west-2:593108103736:secret:cet-prd-usw2-mcp-secret-HnC2v3"
+        }
+      ],
+      "mountPoints": [],
+      "volumesFrom": [],
+      "logConfiguration": {
+        "logDriver": "awsfirelens",
+        "options": {
+          "dd_message_key": "log",
+          "provider": "ecs",
+          "dd_service": "provider-mcp",
+          "Host": "http-intake.logs.us5.datadoghq.com",
+          "TLS": "on",
+          "dd_source": "provider-mcp",
+          "dd_tags": "env:prod,version:<IMAGE_TAG>",
+          "Name": "datadog"
+        },
+        "secretOptions": [
+          {
+            "name": "apikey",
+            "valueFrom": "arn:aws:secretsmanager:us-west-2:593108103736:secret:cet-prd-usw2-datadog-api-key-secret-HSzirQ"
+          }
+        ]
+      },
+      "systemControls": []
+    },
+    {
+      "name": "log_router",
+      "image": "public.ecr.aws/aws-observability/aws-for-fluent-bit:stable",
+      "cpu": 0,
+      "memoryReservation": 51,
+      "portMappings": [],
+      "essential": false,
+      "environment": [],
+      "mountPoints": [],
+      "volumesFrom": [],
+      "user": "0",
+      "systemControls": [],
+      "firelensConfiguration": {
+        "type": "fluentbit",
+        "options": {
+          "enable-ecs-log-metadata": "true"
+        }
+      }
+    },
+    {
+      "name": "datadog-agent",
+      "image": "212351099297.dkr.ecr.us-west-2.amazonaws.com/datadog/agent:7.70.0",
+      "cpu": 0,
+      "portMappings": [],
+      "essential": false,
+      "environment": [
+        {
+          "name": "ECS_FARGATE",
+          "value": "true"
+        },
+        {
+          "name": "DD_APM_ENABLED",
+          "value": "true"
+        },
+        {
+          "name": "DD_TAGS",
+          "value": "service:provider-mcp env:prod version:<IMAGE_TAG>"
+        },
+        {
+          "name": "DD_SITE",
+          "value": "us5.datadoghq.com"
+        }
+      ],
+      "environmentFiles": [],
+      "mountPoints": [],
+      "secrets": [
+        {
+          "name": "DD_API_KEY",
+          "valueFrom": "arn:aws:secretsmanager:us-west-2:593108103736:secret:cet-prd-usw2-datadog-api-key-secret-HSzirQ"
+        }
+      ],
+      "systemControls": [],
+      "volumesFrom": []
+    }
+  ],
+  "family": "provider-mcp",
+  "taskRoleArn": "arn:aws:iam::593108103736:role/cet-prd-usw2-mcp-server-task-iam-role",
+  "executionRoleArn": "arn:aws:iam::593108103736:role/cet-prd-usw2-backend-task-exec-iam-role",
+  "networkMode": "awsvpc",
+  "volumes": [],
+  "placementConstraints": [],
+  "runtimePlatform": {
+    "cpuArchitecture": "X86_64",
+    "operatingSystemFamily": "LINUX"
+  },
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "cpu": "1024",
+  "memory": "2048"
+}


### PR DESCRIPTION
## Summary
- deploy the shared `provider_mcp` service as a production Fargate service
- expose `/elevenlabs/mcp` and `/vapi/mcp` behind `provider-mcp.cekura.ai`
- add create-or-update ECS deployment workflow
- reuse the existing MCP secret, task role, execution role, cluster networking, and Datadog/FireLens pattern

## Deployment configuration
- ECR: `cekura/provider-mcp`
- ECS family: `provider-mcp`
- ECS service: `cet-prd-usw2-provider-mcp-ecs-service`
- Container port: `8080`
- Desired count: `1`
- Public URL: `https://provider-mcp.cekura.ai`

## One-time AWS setup
- create `cekura/provider-mcp` ECR repository and copy the existing MCP cross-account pull policy
- add `PROVIDER_MCP_*` keys to the existing MCP secret
- create an IP target group on port `8080` with health check `/elevenlabs/mcp/health`
- add the `provider-mcp.cekura.ai` ALB host rule
- add Route 53 alias to the public ALB
- the workflow creates the ECS service if missing and copies network configuration from the existing MCP service

## Migration safety
The existing `elevenlabs-mcp` service and `elevenlabs.cekura.ai` endpoint are intentionally unchanged and should remain available for rollback until the new service is validated and consumers are migrated.

## Validation
- provider Python modules compile successfully
- task definition JSON parses successfully
- workflow YAML and shell blocks validate successfully