### PR TITLE
[Auto] Sync docs for backend PR #10648

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -43600,6 +43600,15 @@
                         },
                         "description": ""
                     }
+                },
+                "x-mcp-expose": true,
+                "x-mcp-destructive": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "scenarios-run-json",
+                        "description": "Run agent test cases straight from a JSON spec, without creating evaluators. Keep the spec in your repository and post it from CI.\n\nThe spec describes only what to test. Pick the target with `agent_id` and `channel` on the request — `voice` for a phone call (default), `text` for chat, `elevenlabs` for an ElevenLabs WebRTC session — so one file runs unchanged against any agent or environment.\n\nPass `dry_run=true` to validate only: the response describes the run that would happen (test cases, total runs, estimated cost) and nothing is created or charged. Use that on every commit, and the real call on the branches you want tested.\n\nEvery problem in a spec is reported at once, keyed by its location in the file (for example `scenarios[3].metrics[1]`). Metrics must already exist and be enabled for the target agent; personalities and test profiles can be referenced by ID or defined inline.\n\nFetch the schema this endpoint accepts from `scenarios_json_schema`.\n\n**Cost:** voice- or text-simulation rate per run. Test cases from a spec are removed automatically once no run needs them."
+                    }
                 }
             }
         },


### PR DESCRIPTION
Auto-generated docs sync for backend PR [#10648](https://github.com/cekura-ai/vocera.backend/pull/10648).

Reviewers: @dileep-chagam

## Summary

**Spec/overlay:** 1 newly exposed op (scenarios_run_json, Bucket B-new). No transport-quirk signals fired — no overlay addition needed. 1 SDK/CLI follow-up for the new tool. 1 Bucket C suggestion: confirm the new endpoint's API-key-callable contract is intentional.

**Conceptual docs:** No edits — PR exposes an existing endpoint (`run_scenarios_json`) as an MCP tool with a destructive hint. No API contract, schema, or behavioral change. MCP tool catalogs are auto-populated from `openapi.json` (handled by the spec-update workflow); conceptual docs pages do not enumerate individual MCP tools.

## Changes

- `openapi.json` — regenerate_from_backend

## Exposure suggestions (@mcp_expose candidates)

- **`scenarios_run_json`** (POST `/test_framework/v1/scenarios/run_scenarios_json/`)
  - `POST /test_framework/v1/scenarios/run_scenarios_json/` is entering the public API reference as `X-CEKURA-API-KEY`-callable. Confirm a customer holding only an API key is meant to call this. If the view took `APIKeyAuthentication` by copy-paste and this is really a dashboard surface, drop it or gate the action in `get_permissions()`.

## SDK / CLI parity follow-ups

- `scenarios_run_json` (POST `/test_framework/v1/scenarios/run_scenarios_json/`) — add

---
*Auto-generated from backend PR #10648.*

<!-- mcp-sync:file-hashes -->
```json
{}
```
<!-- /mcp-sync:file-hashes -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cekura-ai/docs/pull/839" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->