### PR TITLE
Document the agent filter and metric reordering on the Insights page

### DIFF
--- a/documentation/guides/observability/insights.mdx
+++ b/documentation/guides/observability/insights.mdx
@@ -37,6 +37,10 @@ Click **Generate** (or **Regenerate** for an existing audit) to run a new analys
 
 Each failure theme includes a title, a brief description, and clickable call IDs that link directly to the corresponding call logs.
 
+### Prioritizing metrics
+
+Metric cards are grouped into **Custom Metrics** and **Predefined Metrics** sections. Drag the grip handle in a card's top-right corner to reorder cards within their section, so the metrics your team watches most sit at the top. The order is saved for the whole project, so everyone viewing Insights sees the same arrangement. Reordering isn't available to members with read-only Insights access.
+
 ## Which metrics are eligible
 
 Only supported for LLM Judge type metrics as of now. Code based metrics such as Latency, WPM, Talk Ratio are excluded.

--- a/documentation/guides/observability/insights.mdx
+++ b/documentation/guides/observability/insights.mdx
@@ -3,7 +3,7 @@ title: "Failure-Mode Insights"
 sidebarTitle: "Insights"
 icon: "lightbulb"
 iconType: "regular"
-description: "Cluster failing calls into qualitative failure-mode themes per metric — categorized continuously as calls come in, with running counts you can filter by date range."
+description: "Cluster failing calls into qualitative failure-mode themes per metric — categorized continuously as calls come in, with running counts you can filter by agent and date range."
 ---
 
 import { CopyPageButton } from "/snippets/copy-page-button.mdx";
@@ -25,6 +25,8 @@ These insights surface the dominant patterns behind a metric's failures, so you 
 Navigate to **Observability → Insights** in the sidebar. The page displays a card for each LLM Judge metric enabled on your project.
 
 Use the **View** dropdown at the top of the page to filter by view. When a view is selected, the page shows only metrics and insights for agents in that view.
+
+Use the **agents** dropdown next to the date-range picker to filter by specific agents. When agents are selected, failure-mode counts, example calls, and failure rates reflect only calls handled by those agents; failure modes with no matching calls are hidden. Clear the selection to include every agent.
 
 Each card shows one of the following:
 - The latest failure-mode audit with identified themes


### PR DESCRIPTION
## Summary
- Documents the new agent multi-select filter on Observability → Insights: selecting agents scopes failure-mode counts, example calls, and failure rates to calls handled by those agents.
- Documents metric card reordering: cards are grouped into Custom and Predefined sections and can be dragged by the grip handle to set the order the whole project sees.

Pairs with cekura-ai/vocera.backend#10655 and cekura-ai/vocera.frontend.product#3471 (agent filter), and cekura-ai/vocera.backend#10726 with cekura-ai/vocera.frontend.product#3494 (metric reordering).