### PR TITLE
chore(mcp): resync ack_tags snapshot with rotated generate-scenarios tag

### DIFF
--- a/cekura-mcp-server/ack_tags.snapshot.json
+++ b/cekura-mcp-server/ack_tags.snapshot.json
@@ -1,14 +1,37 @@
 {
-  "_comment": "Offline fallback snapshot of cekura-skills/cekura/ack-tags.json. The server prefers the live copy at startup and only uses this when that fetch fails. Append-only; keep in sync with the source manifest on plugin releases.",
-  "cekura-eval-design": ["ack:cekura-eval-design:7k3m4q"],
-  "cekura-generate-scenarios": ["ack:cekura-generate-scenarios:4b6t2w"],
-  "cekura-self-improving-agent": ["ack:cekura-self-improving-agent:5x7n3d"],
-  "cekura-infra-test-suite": ["ack:cekura-infra-test-suite:2h6r7k"],
-  "manual-create-update-eval": ["ack:manual-create-update-eval:5m4p7c"],
-  "autogen-eval": ["ack:autogen-eval:3w6k5b"],
-  "cekura-metric-design": ["ack:cekura-metric-design:6n2q5r"],
-  "cekura-metric-improvement": ["ack:cekura-metric-improvement:6t4d5m"],
-  "cekura-predefined-metrics": ["ack:cekura-predefined-metrics:2k7b3x"],
-  "create-metric": ["ack:create-metric:5p4w7h"],
-  "improve-metric": ["ack:improve-metric:4r6m2t"]
+  "_comment": "Append-only manifest of skill/command verification tags. Presenting a tag proves the design playbook was in the model's context. Historical tags stay valid forever so a stale plugin is never blocked. Rotate per plugin release: regenerate tags for changed files and APPEND (never remove) to the arrays.",
+  "cekura-eval-design": [
+    "ack:cekura-eval-design:7k3m4q"
+  ],
+  "cekura-generate-scenarios": [
+    "ack:cekura-generate-scenarios:4b6t2w",
+    "ack:cekura-generate-scenarios:7q3n6v"
+  ],
+  "cekura-self-improving-agent": [
+    "ack:cekura-self-improving-agent:5x7n3d"
+  ],
+  "cekura-infra-test-suite": [
+    "ack:cekura-infra-test-suite:2h6r7k"
+  ],
+  "manual-create-update-eval": [
+    "ack:manual-create-update-eval:5m4p7c"
+  ],
+  "autogen-eval": [
+    "ack:autogen-eval:3w6k5b"
+  ],
+  "cekura-metric-design": [
+    "ack:cekura-metric-design:6n2q5r"
+  ],
+  "cekura-metric-improvement": [
+    "ack:cekura-metric-improvement:6t4d5m"
+  ],
+  "cekura-predefined-metrics": [
+    "ack:cekura-predefined-metrics:2k7b3x"
+  ],
+  "create-metric": [
+    "ack:create-metric:5p4w7h"
+  ],
+  "improve-metric": [
+    "ack:improve-metric:4r6m2t"
+  ]
 }


### PR DESCRIPTION
## Problem

cekura-ai/cekura-skills#122 rotates the `cekura-generate-scenarios` skill verification tag (appends `ack:cekura-generate-scenarios:7q3n6v` to `cekura/ack-tags.json`; the old `4b6t2w` stays valid — append-only manifest). The MCP server fetches that manifest from the skills repo's main branch at startup, so the rotation flows automatically — **except** for the baked offline fallback `cekura-mcp-server/ack_tags.snapshot.json`, which is frozen at the old tag list. A server that falls back to the snapshot (GitHub unreachable at startup) would not recognize the new tag from a freshly installed plugin.

## Fix

Resync `ack_tags.snapshot.json` with the updated manifest. Superset property verified programmatically: every previously valid tag is retained, the only delta is the added `ack:cekura-generate-scenarios:7q3n6v`.

## Verification

- `python -m pytest tests/test_skill_gate.py` — 48 passed
- Superset check (no old tag dropped) — passed

**Merge order:** land after cekura-ai/cekura-skills#122 merges (the new tag is meaningless server-side until the plugin content that presents it ships). Draft until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)