### PR TITLE
[Auto] Sync docs for backend PR #10679

### DIFF
--- a/api-reference/user/get-user-onboarding.mdx
+++ b/api-reference/user/get-user-onboarding.mdx
@@ -1,5 +1,5 @@
 ---
-title: Get User Onboarding Status
+title: Get User Onboarding
 description: "User onboarding"
 openapi: get /user/onboarding/
 slug: get-user-onboarding

--- a/api-reference/user/get-user-onboarding.mdx
+++ b/api-reference/user/get-user-onboarding.mdx
@@ -1,0 +1,6 @@
+---
+title: Get User Onboarding Status
+description: "User onboarding"
+openapi: get /user/onboarding/
+slug: get-user-onboarding
+---

--- a/api-reference/user/update-user-onboarding.mdx
+++ b/api-reference/user/update-user-onboarding.mdx
@@ -1,0 +1,6 @@
+---
+title: Update User Onboarding Status
+description: "User onboarding"
+openapi: patch /user/onboarding/
+slug: update-user-onboarding
+---

--- a/api-reference/user/update-user-onboarding.mdx
+++ b/api-reference/user/update-user-onboarding.mdx
@@ -1,5 +1,5 @@
 ---
-title: Update User Onboarding Status
+title: Update User Onboarding
 description: "User onboarding"
 openapi: patch /user/onboarding/
 slug: update-user-onboarding

--- a/mint.json
+++ b/mint.json
@@ -430,9 +430,7 @@
             "api-reference/user/update-project",
             "api-reference/user/delete-project",
             "api-reference/user/enable-project-personalities",
-            "api-reference/user/disable-project-personalities",
-            "api-reference/user/get-user-onboarding",
-            "api-reference/user/update-user-onboarding"
+            "api-reference/user/disable-project-personalities"
           ]
         },
         {
@@ -520,7 +518,9 @@
             "api-reference/github/retrieve-github-install-url",
             "api-reference/github/open-github-pull-request",
             "api-reference/github/setup-github-integration",
-            "api-reference/observability/list-metric-failure-rates"
+            "api-reference/observability/list-metric-failure-rates",
+            "api-reference/user/update-user-onboarding",
+            "api-reference/user/get-user-onboarding"
           ]
         }
       ]

--- a/mint.json
+++ b/mint.json
@@ -430,7 +430,9 @@
             "api-reference/user/update-project",
             "api-reference/user/delete-project",
             "api-reference/user/enable-project-personalities",
-            "api-reference/user/disable-project-personalities"
+            "api-reference/user/disable-project-personalities",
+            "api-reference/user/get-user-onboarding",
+            "api-reference/user/update-user-onboarding"
           ]
         },
         {

--- a/openapi.json
+++ b/openapi.json
@@ -3731,7 +3731,7 @@
         "/observability/v1/call-logs/": {
             "get": {
                 "operationId": "call-logs-list",
-                "description": "List **production** call logs for an agent or project. Production-only — test/simulation runs triggered via `run_scenarios_*` do NOT create call logs; use `results_list` + `runs_bulk_retrieve` for simulation data instead.\n\nAlways pass `agent_id` or `project_id` to scope results — without one, the response may be very large. **`project_id` is required when using an organization-level API key.**\n\n**Filtering:**\n- `timestamp_from` / `timestamp_to` — ISO 8601 date range filter\n- `call_ids` — comma-separated **CallLog IDs** (integer DB IDs of call logs in this list response), e.g. `\"123,456\"`. Distinct from simulation `run_id`s and from each call log's own `call_id` field (which holds the provider's call identifier string).\n- `filters_v2` — structured JSON filter (same format as dashboard filters). Simple: `{\"field\": \"success\", \"op\": \"eq\", \"value\": true}`. Compound: `{\"operator\": \"and\", \"conditions\": [{...}, {...}]}`. Supported operators: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `contains`, `startswith`, `in`, `isnull`.",
+                "description": "List **production** call logs for an agent or project. Production-only — test/simulation runs triggered via `run_scenarios_*` do NOT create call logs; use `results_list` + `runs_bulk_retrieve` for simulation data instead.\n\nAlways pass `agent_id` or `project_id` to scope results — without one, the response may be very large. **`project_id` is required when using an organization-level API key.**\n\n**Time window:** results default to the **last 30 days** when no timestamp range is given. A supplied range must not exceed **31 days** (wider ranges return `400`); pass `timestamp_from`/`timestamp_to` (ISO 8601) to select a window within that limit.\n\n**Filtering:**\n- `timestamp_from` / `timestamp_to` — ISO 8601 date range filter\n- `call_ids` — comma-separated **CallLog IDs** (integer DB IDs of call logs in this list response), e.g. `\"123,456\"`. Distinct from simulation `run_id`s and from each call log's own `call_id` field (which holds the provider's call identifier string).\n- `filters_v2` — structured JSON filter (same format as dashboard filters). Simple: `{\"field\": \"success\", \"op\": \"eq\", \"value\": true}`. Compound: `{\"operator\": \"and\", \"conditions\": [{...}, {...}]}`. Supported operators: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `contains`, `startswith`, `in`, `isnull`.",
                 "summary": "List call logs",
                 "parameters": [
                     {
@@ -3902,7 +3902,7 @@
         "/observability/v1/call-logs-external/": {
             "get": {
                 "operationId": "call-logs-external-list",
-                "description": "List **production** call logs for an agent or project. Production-only — test/simulation runs triggered via `run_scenarios_*` do NOT create call logs; use `results_list` + `runs_bulk_retrieve` for simulation data instead.\n\nAlways pass `agent_id` or `project_id` to scope results — without one, the response may be very large. **`project_id` is required when using an organization-level API key.**\n\n**Filtering:**\n- `timestamp_from` / `timestamp_to` — ISO 8601 date range filter\n- `call_ids` — comma-separated **CallLog IDs** (integer DB IDs of call logs in this list response), e.g. `\"123,456\"`. Distinct from simulation `run_id`s and from each call log's own `call_id` field (which holds the provider's call identifier string).\n- `filters_v2` — structured JSON filter (same format as dashboard filters). Simple: `{\"field\": \"success\", \"op\": \"eq\", \"value\": true}`. Compound: `{\"operator\": \"and\", \"conditions\": [{...}, {...}]}`. Supported operators: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `contains`, `startswith`, `in`, `isnull`.",
+                "description": "List **production** call logs for an agent or project. Production-only — test/simulation runs triggered via `run_scenarios_*` do NOT create call logs; use `results_list` + `runs_bulk_retrieve` for simulation data instead.\n\nAlways pass `agent_id` or `project_id` to scope results — without one, the response may be very large. **`project_id` is required when using an organization-level API key.**\n\n**Time window:** results default to the **last 30 days** when no timestamp range is given. A supplied range must not exceed **31 days** (wider ranges return `400`); pass `timestamp_from`/`timestamp_to` (ISO 8601) to select a window within that limit.\n\n**Filtering:**\n- `timestamp_from` / `timestamp_to` — ISO 8601 date range filter\n- `call_ids` — comma-separated **CallLog IDs** (integer DB IDs of call logs in this list response), e.g. `\"123,456\"`. Distinct from simulation `run_id`s and from each call log's own `call_id` field (which holds the provider's call identifier string).\n- `filters_v2` — structured JSON filter (same format as dashboard filters). Simple: `{\"field\": \"success\", \"op\": \"eq\", \"value\": true}`. Compound: `{\"operator\": \"and\", \"conditions\": [{...}, {...}]}`. Supported operators: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `contains`, `startswith`, `in`, `isnull`.",
                 "summary": "List call logs",
                 "parameters": [
                     {
@@ -4942,6 +4942,41 @@
                                                         "is_simulating": {
                                                             "type": "boolean",
                                                             "description": "Whether this scenario was created by simulation"
+                                                        },
+                                                        "test_profile_data": {
+                                                            "type": "object",
+                                                            "description": "The test profile generated for this scenario, including its sectioned `information` (main_agent_variables / testing_agent_variables)"
+                                                        },
+                                                        "generated_mock_tool_entries": {
+                                                            "type": "array",
+                                                            "description": "Expected mock tool calls generated for this scenario when the agent has mock tools attached. Empty when the agent has no mock tools.",
+                                                            "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "tool_id": {
+                                                                        "type": "integer",
+                                                                        "description": "ID of the mock tool on the agent"
+                                                                    },
+                                                                    "tool_name": {
+                                                                        "type": "string",
+                                                                        "description": "Name of the tool being mocked"
+                                                                    },
+                                                                    "new_entry": {
+                                                                        "type": "object",
+                                                                        "description": "The expected tool call for this scenario",
+                                                                        "properties": {
+                                                                            "input": {
+                                                                                "type": "object",
+                                                                                "description": "Input parameters the tool call is expected to receive"
+                                                                            },
+                                                                            "output": {
+                                                                                "type": "object",
+                                                                                "description": "Response the mock tool will return"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
                                                         }
                                                     }
                                                 }
@@ -6391,6 +6426,41 @@
                                                         "is_simulating": {
                                                             "type": "boolean",
                                                             "description": "Whether this scenario was created by simulation"
+                                                        },
+                                                        "test_profile_data": {
+                                                            "type": "object",
+                                                            "description": "The test profile generated for this scenario, including its sectioned `information` (main_agent_variables / testing_agent_variables)"
+                                                        },
+                                                        "generated_mock_tool_entries": {
+                                                            "type": "array",
+                                                            "description": "Expected mock tool calls generated for this scenario when the agent has mock tools attached. Empty when the agent has no mock tools.",
+                                                            "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "tool_id": {
+                                                                        "type": "integer",
+                                                                        "description": "ID of the mock tool on the agent"
+                                                                    },
+                                                                    "tool_name": {
+                                                                        "type": "string",
+                                                                        "description": "Name of the tool being mocked"
+                                                                    },
+                                                                    "new_entry": {
+                                                                        "type": "object",
+                                                                        "description": "The expected tool call for this scenario",
+                                                                        "properties": {
+                                                                            "input": {
+                                                                                "type": "object",
+                                                                                "description": "Input parameters the tool call is expected to receive"
+                                                                            },
+                                                                            "output": {
+                                                                                "type": "object",
+                                                                                "description": "Response the mock tool will return"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
                                                         }
                                                     }
                                                 }
@@ -8259,8 +8329,27 @@
         "/observability/v1/metric-failure-mode-insights/categories/": {
             "get": {
                 "operationId": "metric-failure-mode-insights-categories-retrieve",
-                "description": "Return the persistent failure categories for a project (optionally one metric), each with a call count and example call ids. Filter by `date_from` / `date_to` (ISO datetimes for an exact window, or bare dates for whole-day bounds) to count only assignments in that range; results are sorted by count descending.",
+                "description": "Return the persistent failure categories for a project (optionally one metric), each with a call count and example call ids. Filter by `date_from` / `date_to` (ISO datetimes for an exact window, or bare dates for whole-day bounds) to count only assignments in that range, and by `agent_ids` (comma-separated agent ids) to count only calls handled by those agents; results are sorted by count descending.",
                 "summary": "List accumulating failure categories for a metric",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "agent_ids",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Comma-separated agent ids; only calls handled by these agents are counted."
+                    },
+                    {
+                        "name": "project",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Tenant scope. Supply one of `project` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
+                    }
+                ],
                 "tags": [
                     "observability"
                 ],
@@ -8295,20 +8384,9 @@
                     "mcp": {
                         "enabled": true,
                         "name": "metric-failure-mode-insights-categories-retrieve",
-                        "description": "Return the persistent failure categories for a project (optionally one metric), each with a call count and example call ids. Filter by `date_from` / `date_to` (ISO datetimes for an exact window, or bare dates for whole-day bounds) to count only assignments in that range; results are sorted by count descending."
+                        "description": "Return the persistent failure categories for a project (optionally one metric), each with a call count and example call ids. Filter by `date_from` / `date_to` (ISO datetimes for an exact window, or bare dates for whole-day bounds) to count only assignments in that range, and by `agent_ids` (comma-separated agent ids) to count only calls handled by those agents; results are sorted by count descending."
                     }
-                },
-                "parameters": [
-                    {
-                        "name": "project",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "Tenant scope. Supply one of `project` when authenticating with a user session or OAuth bearer token; omit when using an API key already scoped to the tenant."
-                    }
-                ]
+                }
             }
         },
         "/observability/v1/metric-failure-mode-insights/categories/{category_slug}/calls/": {
@@ -8357,6 +8435,14 @@
                             "type": "string",
                             "format": "date-time"
                         }
+                    },
+                    {
+                        "in": "query",
+                        "name": "agent_ids",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Comma-separated agent ids; only calls handled by these agents are returned."
                     }
                 ],
                 "tags": [
@@ -8518,8 +8604,18 @@
         "/observability/v1/metric-failure-mode-insights/failure-rates/": {
             "get": {
                 "operationId": "metric-failure-mode-insights-failure-rates-retrieve",
-                "description": "Return the percentage of evaluated calls that failed each metric during the selected Insights date range.",
+                "description": "Return the percentage of evaluated calls that failed each metric during the selected Insights date range. Optionally scope to `agent_ids` (comma-separated agent ids).",
                 "summary": "List metric failure rates for the insights window",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "agent_ids",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Comma-separated agent ids; only calls handled by these agents are counted."
+                    }
+                ],
                 "tags": [
                     "observability"
                 ],
@@ -9229,7 +9325,7 @@
         "/observability/v2/call-logs/": {
             "get": {
                 "operationId": "observability-v2-call-logs-list",
-                "description": "List **production** call logs for an agent or project. Production-only — test/simulation runs triggered via `run_scenarios_*` do NOT create call logs; use `results_list` + `runs_bulk_retrieve` for simulation data instead.\n\nAlways pass `agent_id` or `project_id` to scope results — without one, the response may be very large. **`project_id` is required when using an organization-level API key.**\n\n**Filtering:**\n- `timestamp_from` / `timestamp_to` — ISO 8601 date range filter\n- `call_ids` — comma-separated **CallLog IDs** (integer DB IDs of call logs in this list response), e.g. `\"123,456\"`. Distinct from simulation `run_id`s and from each call log's own `call_id` field (which holds the provider's call identifier string).\n- `filters_v2` — structured JSON filter (same format as dashboard filters). Simple: `{\"field\": \"success\", \"op\": \"eq\", \"value\": true}`. Compound: `{\"operator\": \"and\", \"conditions\": [{...}, {...}]}`. Supported operators: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `contains`, `startswith`, `in`, `isnull`.",
+                "description": "List **production** call logs for an agent or project. Production-only — test/simulation runs triggered via `run_scenarios_*` do NOT create call logs; use `results_list` + `runs_bulk_retrieve` for simulation data instead.\n\nAlways pass `agent_id` or `project_id` to scope results — without one, the response may be very large. **`project_id` is required when using an organization-level API key.**\n\n**Time window:** results default to the **last 30 days** when no timestamp range is given. A supplied range must not exceed **31 days** (wider ranges return `400`); pass `timestamp_from`/`timestamp_to` (ISO 8601) to select a window within that limit.\n\n**Filtering:**\n- `timestamp_from` / `timestamp_to` — ISO 8601 date range filter\n- `call_ids` — comma-separated **CallLog IDs** (integer DB IDs of call logs in this list response), e.g. `\"123,456\"`. Distinct from simulation `run_id`s and from each call log's own `call_id` field (which holds the provider's call identifier string).\n- `filters_v2` — structured JSON filter (same format as dashboard filters). Simple: `{\"field\": \"success\", \"op\": \"eq\", \"value\": true}`. Compound: `{\"operator\": \"and\", \"conditions\": [{...}, {...}]}`. Supported operators: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `contains`, `startswith`, `in`, `isnull`.",
                 "summary": "List call logs",
                 "parameters": [
                     {
@@ -9346,7 +9442,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "observability-v2-call-logs-list",
-                        "description": "List **production** call logs for an agent or project. Production-only — test/simulation runs triggered via `run_scenarios_*` do NOT create call logs; use `results_list` + `runs_bulk_retrieve` for simulation data instead.\n\nAlways pass `agent_id` or `project_id` to scope results — without one, the response may be very large. **`project_id` is required when using an organization-level API key.**\n\n**Filtering:**\n- `timestamp_from` / `timestamp_to` — ISO 8601 date range filter\n- `call_ids` — comma-separated **CallLog IDs** (integer DB IDs of call logs in this list response), e.g. `\"123,456\"`. Distinct from simulation `run_id`s and from each call log's own `call_id` field (which holds the provider's call identifier string).\n- `filters_v2` — structured JSON filter (same format as dashboard filters). Simple: `{\"field\": \"success\", \"op\": \"eq\", \"value\": true}`. Compound: `{\"operator\": \"and\", \"conditions\": [{...}, {...}]}`. Supported operators: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `contains`, `startswith`, `in`, `isnull`."
+                        "description": "List **production** call logs for an agent or project. Production-only — test/simulation runs triggered via `run_scenarios_*` do NOT create call logs; use `results_list` + `runs_bulk_retrieve` for simulation data instead.\n\nAlways pass `agent_id` or `project_id` to scope results — without one, the response may be very large. **`project_id` is required when using an organization-level API key.**\n\n**Time window:** results default to the **last 30 days** when no timestamp range is given. A supplied range must not exceed **31 days** (wider ranges return `400`); pass `timestamp_from`/`timestamp_to` (ISO 8601) to select a window within that limit.\n\n**Filtering:**\n- `timestamp_from` / `timestamp_to` — ISO 8601 date range filter\n- `call_ids` — comma-separated **CallLog IDs** (integer DB IDs of call logs in this list response), e.g. `\"123,456\"`. Distinct from simulation `run_id`s and from each call log's own `call_id` field (which holds the provider's call identifier string).\n- `filters_v2` — structured JSON filter (same format as dashboard filters). Simple: `{\"field\": \"success\", \"op\": \"eq\", \"value\": true}`. Compound: `{\"operator\": \"and\", \"conditions\": [{...}, {...}]}`. Supported operators: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `contains`, `startswith`, `in`, `isnull`."
                     }
                 }
             },
@@ -10325,6 +10421,41 @@
                                                         "is_simulating": {
                                                             "type": "boolean",
                                                             "description": "Whether this scenario was created by simulation"
+                                                        },
+                                                        "test_profile_data": {
+                                                            "type": "object",
+                                                            "description": "The test profile generated for this scenario, including its sectioned `information` (main_agent_variables / testing_agent_variables)"
+                                                        },
+                                                        "generated_mock_tool_entries": {
+                                                            "type": "array",
+                                                            "description": "Expected mock tool calls generated for this scenario when the agent has mock tools attached. Empty when the agent has no mock tools.",
+                                                            "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "tool_id": {
+                                                                        "type": "integer",
+                                                                        "description": "ID of the mock tool on the agent"
+                                                                    },
+                                                                    "tool_name": {
+                                                                        "type": "string",
+                                                                        "description": "Name of the tool being mocked"
+                                                                    },
+                                                                    "new_entry": {
+                                                                        "type": "object",
+                                                                        "description": "The expected tool call for this scenario",
+                                                                        "properties": {
+                                                                            "input": {
+                                                                                "type": "object",
+                                                                                "description": "Input parameters the tool call is expected to receive"
+                                                                            },
+                                                                            "output": {
+                                                                                "type": "object",
+                                                                                "description": "Response the mock tool will return"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
                                                         }
                                                     }
                                                 }
@@ -13212,7 +13343,7 @@
         "/subscriptions/subscriptions/{id}/setup-payment-method/": {
             "post": {
                 "operationId": "subscriptions-subscriptions-setup-payment-method-create",
-                "description": "Start a Stripe setup-mode checkout to save a payment method for the\norganization. Used by plans without a Stripe subscription (e.g. the free\npay-as-you-go plan) before top-ups, auto-refill, or adding paid members.\nThe checkout.session.completed webhook makes the card the customer default.",
+                "description": "Start a Stripe setup-mode checkout to save a payment method for the\norganization. Used by plans without a Stripe subscription (e.g. the free\npay-as-you-go plan) before top-ups, auto-refill, or adding paid members.\nThe checkout.session.completed webhook makes the card the customer default.\n\nOptional body field `return_path` (relative path, e.g. \"/onboarding/ui\")\nsends the user back to the page they started from after Stripe; invalid\nor missing paths fall back to the global STRIPE_SUCCESS_URL/CANCEL_URL.",
                 "parameters": [
                     {
                         "in": "path",
@@ -15488,7 +15619,7 @@
             },
             "post": {
                 "operationId": "aiagents-v1-create",
-                "description": "aiagents_create: Register a new AI voice agent with Cekura for testing / observability. Required: `agent_name`, `project` (project ID), `assistant_provider`. Other fields depend on the provider (see below).\n\n**Most common case:** you already have an agent running on your own provider stack with a dedicated phone number. Pass `agent_name`, `description`, `inbound`, `project`, `contact_number` (E.164 format, e.g. `+14155551234`), and `language` — Cekura observes that number without needing provider credentials. Set `assistant_provider=\"self_hosted\"` (optionally `websocket_url` for text-mode runs).\n\n**Provider integrations:** set `assistant_provider` to one of the valid values below and pass the matching credentials. `assistant_id` alone does NOT substitute for provider credentials — providers like VAPI, Retell, and Bland validate their api_key on create.\n\n**Valid `assistant_provider` values** (live enum — superset of prose docs you may see elsewhere):\n- `self_hosted` — websocket or observation-only; no api_key needed. Use `websocket_url` + `websocket_headers` for text-mode runs.\n- `vapi` — requires `vapi_api_key`; optional `assistant_id`, `vapi_data.public_key`.\n- `retell` — requires `retell_api_key` AND `chat_assistant_id` (yes — Retell uses this field even for voice).\n- `bland` — requires `bland_api_key` AND `chat_assistant_id` (Bland internally calls this `pathway_id`); `bland_data.encrypted_key` for Twilio.\n- `livekit` — requires `livekit_api_key` + `livekit_data.api_secret` + `livekit_data.url`.\n- `elevenlabs` — requires `elevenlabs_api_key`.\n- `agentforce` — Salesforce Agentforce; needs `agentforce_client_secret` + `agentforce_data` (client_id, domain, agent_id).\n- `cisco` — Cisco Webex.\n- `vocera` — Cekura-hosted agent.\n- `sms` — text-only SMS channel; use `chat_assistant_id`.\n- `whatsapp` — text-only WhatsApp channel; use `chat_assistant_id`.\n- `\"\"` (empty string) — unset; agent is not runnable until a provider is configured.\n\n**Note:** the serializer exposes fields for some providers (`pipecat_*`, `synthflow_*`, `koreai_*`, `genesys_*`, `custom_provider_*`) that are NOT currently in the `assistant_provider` enum. Those fields exist for response/config purposes but the matching provider value cannot be selected today.\n\n**Outbound agents:** set `inbound=false`. Actual call placement uses the scenario's configured phone number or a number from the org's provisioned pool — `outbound_numbers` is not required for calls to be placed (it is used for webhook validation only).\n\n**Other fields to know:**\n- `language` — BCP-47 locale (`en`, `es`, `fr`, …). Must match the personalities used for evaluators.\n- `transcript_provider` — STT vendor (`vapi | retell | synthflow | elevenlabs | bland | livekit | pipecat | koreai | custom | cisco | genesys`). Does NOT auto-pair with `assistant_provider`; set both independently when needed.\n- `llm_model`, `llm_temperature`, `llm_max_tokens`, `llm_system_prompt` — simulation LLM settings (used by Cekura when simulating callers in test runs; NOT your agent's own LLM).\n- `auto_fetch_calls_enabled` — auto-import calls from the provider every 30s (VAPI/Retell only).\n- `auto_sync_prompt_enabled` — one-way prompt sync from the provider to Cekura on a schedule; Cekura updates its agent description and does not push changes back to the provider. Supported for VAPI, Retell, ElevenLabs, Synthflow, Telnyx, and Bland.\n\n**Read-only status fields** like `vapi_api_key_configured`, `retell_api_key_configured` appear in the response to indicate which provider credentials are stored (credentials themselves are masked).",
+                "description": "aiagents_create: Register a new AI voice agent with Cekura for testing / observability. Required: `agent_name`, `project` (project ID), `assistant_provider`. Other fields depend on the provider (see below).\n\n**Most common case:** you already have an agent running on your own provider stack with a dedicated phone number. Pass `agent_name`, `description`, `inbound`, `project`, `contact_number` (E.164 format, e.g. `+14155551234`), and `language` — Cekura observes that number without needing provider credentials. Set `assistant_provider=\"self_hosted\"` (optionally `websocket_url` for text-mode runs).\n\n**Provider integrations:** set `assistant_provider` to one of the valid values below and pass the matching credentials. `assistant_id` alone does NOT substitute for provider credentials — providers like VAPI, Retell, and Bland validate their api_key on create.\n\n**Valid `assistant_provider` values** (live enum — superset of prose docs you may see elsewhere):\n- `self_hosted` — websocket or observation-only; no api_key needed. Use `websocket_url` + `websocket_headers` for text-mode runs.\n- `vapi` — requires `vapi_api_key`; optional `assistant_id`, `vapi_data.public_key`.\n- `retell` — requires `retell_api_key` AND `chat_assistant_id` (yes — Retell uses this field even for voice).\n- `bland` — requires `bland_api_key` AND `chat_assistant_id` (Bland internally calls this `pathway_id`); `bland_data.encrypted_key` for Twilio.\n- `livekit` — requires `livekit_api_key` + `livekit_data.url`; `livekit_data.api_secret` is needed at run time for WebRTC.\n- `elevenlabs` — requires `elevenlabs_api_key`.\n- `agentforce` — Salesforce Agentforce; needs `agentforce_client_secret` + `agentforce_data` (client_id, domain, agent_id).\n- `cisco` — Cisco Webex.\n- `vocera` — Cekura-hosted agent.\n- `sms` — text-only SMS channel; use `chat_assistant_id`.\n- `whatsapp` — text-only WhatsApp channel; use `chat_assistant_id`.\n- `\"\"` (empty string) — unset; agent is not runnable until a provider is configured.\n\n**Note:** the serializer exposes fields for some providers (`pipecat_*`, `synthflow_*`, `koreai_*`, `genesys_*`, `custom_provider_*`) that are NOT currently in the `assistant_provider` enum. Those fields exist for response/config purposes but the matching provider value cannot be selected today.\n\n**Outbound agents:** set `inbound=false`. Actual call placement uses the scenario's configured phone number or a number from the org's provisioned pool — `outbound_numbers` is not required for calls to be placed (it is used for webhook validation only).\n\n**Other fields to know:**\n- `language` — BCP-47 locale (`en`, `es`, `fr`, …). Must match the personalities used for evaluators.\n- `transcript_provider` — STT vendor (`vapi | retell | synthflow | elevenlabs | bland | livekit | pipecat | koreai | custom | cisco | genesys`). Does NOT auto-pair with `assistant_provider`; set both independently when needed.\n- `llm_model`, `llm_temperature`, `llm_max_tokens`, `llm_system_prompt` — simulation LLM settings (used by Cekura when simulating callers in test runs; NOT your agent's own LLM).\n- `auto_fetch_calls_enabled` — auto-import calls from the provider every 30s (VAPI/Retell/ElevenLabs/Bland).\n- `auto_sync_prompt_enabled` — one-way prompt sync from the provider to Cekura on a schedule; Cekura updates its agent description and does not push changes back to the provider. Supported for VAPI, Retell, ElevenLabs, Synthflow, Telnyx, and Bland.\n\n**Read-only status fields** like `vapi_api_key_configured`, `retell_api_key_configured` appear in the response to indicate which provider credentials are stored (credentials themselves are masked).",
                 "summary": "Create an AI voice agent",
                 "tags": [
                     "AI Agents"
@@ -16882,7 +17013,7 @@
             },
             "delete": {
                 "operationId": "aiagents-v1-destroy",
-                "description": "⚠ Irreversible. Deletes the agent.\n\n**Cascade behaviour (controlled by `delete_related` query param):**\n- `delete_related=true` (default) — also deletes the agent's evaluators, results, and runs.\n- `delete_related=false` — detaches evaluators (sets agent=null) and leaves results untouched.",
+                "description": "⚠ Irreversible. Deletes the agent.\n\n**Cascade behaviour (controlled by `delete_related` query param):**\n- `delete_related=true` (default) — also deletes the agent's call logs, evaluators, results, and runs.\n- `delete_related=false` — detaches scenario evaluators (sets agent=null), and leaves call logs, metric evaluations, results, and runs untouched.",
                 "summary": "Delete an AI voice agent",
                 "parameters": [
                     {
@@ -16900,7 +17031,7 @@
                         "schema": {
                             "type": "boolean"
                         },
-                        "description": "If true (default), delete associated evaluators, results and runs. If false, detach evaluators and leave results as-is."
+                        "description": "If true (default), delete associated call logs, scenario evaluators, results and runs. If false, detach scenario evaluators and leave call logs, metric evaluations, results and runs as-is."
                     }
                 ],
                 "tags": [
@@ -35086,7 +35217,7 @@
         "/test_framework/v1/scenarios-external/generate-bg/": {
             "post": {
                 "operationId": "scenarios-generate-bg",
-                "description": "Generate scenarios for a given agent in the background. Returns a `progress_id` immediately; poll GET /scenarios/generate-progress/?progress_id={id} until `total_scenarios == completed_scenarios`.\n\n**What happens automatically on generation:**\n- A scenario-specific test profile is created and its `information` is populated using the sectioned shape: `main_agent_variables` (dynamic-variable values that reach the agent under test at call time — e.g. `user_id`, `account_id`) and `testing_agent_variables` (persona/context used by the simulated caller — e.g. `customer_name`, `date_of_birth`). Section values are kept consistent with any generated mock-tool data.\n- 10 project-level evaluation metrics are attached to every generated scenario automatically (e.g. Latency, Pitch, Interruption Score). Scenarios created manually via `scenarios_create` start with no metrics attached.\n\n**Response fields:** `progress_id` (UUID string) for polling; `session_id` is always null.",
+                "description": "Generate scenarios for a given agent in the background. Returns a `progress_id` immediately; poll GET /scenarios/generate-progress/?progress_id={id} until `total_scenarios == completed_scenarios`.\n\n**What happens automatically on generation:**\n- A scenario-specific test profile is created and its `information` is populated using the sectioned shape: `main_agent_variables` (dynamic-variable values that reach the agent under test at call time — e.g. `user_id`, `account_id`) and `testing_agent_variables` (persona/context used by the simulated caller — e.g. `customer_name`, `date_of_birth`). Section values are kept consistent with any generated mock-tool data.\n- When the agent has mock tools attached, each generated scenario also gets `generated_mock_tool_entries` — the expected mock tool calls for that scenario, shaped `[{tool_id, tool_name, new_entry: {input, output}}]`. These are returned on scenario reads and can be edited later via `scenarios_partial_update`.\n- 10 project-level evaluation metrics are attached to every generated scenario automatically (e.g. Latency, Pitch, Interruption Score). Scenarios created manually via `scenarios_create` start with no metrics attached.\n\n**Response fields:** `progress_id` (UUID string) for polling; `session_id` is always null.",
                 "tags": [
                     "test_framework"
                 ],
@@ -35430,6 +35561,41 @@
                                                     "is_simulating": {
                                                         "type": "boolean",
                                                         "description": "Whether this scenario was created by simulation"
+                                                    },
+                                                    "test_profile_data": {
+                                                        "type": "object",
+                                                        "description": "The test profile generated for this scenario, including its sectioned `information` (main_agent_variables / testing_agent_variables)"
+                                                    },
+                                                    "generated_mock_tool_entries": {
+                                                        "type": "array",
+                                                        "description": "Expected mock tool calls generated for this scenario when the agent has mock tools attached. Empty when the agent has no mock tools.",
+                                                        "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "tool_id": {
+                                                                    "type": "integer",
+                                                                    "description": "ID of the mock tool on the agent"
+                                                                },
+                                                                "tool_name": {
+                                                                    "type": "string",
+                                                                    "description": "Name of the tool being mocked"
+                                                                },
+                                                                "new_entry": {
+                                                                    "type": "object",
+                                                                    "description": "The expected tool call for this scenario",
+                                                                    "properties": {
+                                                                        "input": {
+                                                                            "type": "object",
+                                                                            "description": "Input parameters the tool call is expected to receive"
+                                                                        },
+                                                                        "output": {
+                                                                            "type": "object",
+                                                                            "description": "Response the mock tool will return"
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
                                                     }
                                                 }
                                             }
@@ -41296,7 +41462,7 @@
         "/test_framework/v1/scenarios/generate-bg/": {
             "post": {
                 "operationId": "scenarios-generate-bg_2",
-                "description": "Generate scenarios for a given agent in the background. Returns a `progress_id` immediately; poll GET /scenarios/generate-progress/?progress_id={id} until `total_scenarios == completed_scenarios`.\n\n**What happens automatically on generation:**\n- A scenario-specific test profile is created and its `information` is populated using the sectioned shape: `main_agent_variables` (dynamic-variable values that reach the agent under test at call time — e.g. `user_id`, `account_id`) and `testing_agent_variables` (persona/context used by the simulated caller — e.g. `customer_name`, `date_of_birth`). Section values are kept consistent with any generated mock-tool data.\n- 10 project-level evaluation metrics are attached to every generated scenario automatically (e.g. Latency, Pitch, Interruption Score). Scenarios created manually via `scenarios_create` start with no metrics attached.\n\n**Response fields:** `progress_id` (UUID string) for polling; `session_id` is always null.",
+                "description": "Generate scenarios for a given agent in the background. Returns a `progress_id` immediately; poll GET /scenarios/generate-progress/?progress_id={id} until `total_scenarios == completed_scenarios`.\n\n**What happens automatically on generation:**\n- A scenario-specific test profile is created and its `information` is populated using the sectioned shape: `main_agent_variables` (dynamic-variable values that reach the agent under test at call time — e.g. `user_id`, `account_id`) and `testing_agent_variables` (persona/context used by the simulated caller — e.g. `customer_name`, `date_of_birth`). Section values are kept consistent with any generated mock-tool data.\n- When the agent has mock tools attached, each generated scenario also gets `generated_mock_tool_entries` — the expected mock tool calls for that scenario, shaped `[{tool_id, tool_name, new_entry: {input, output}}]`. These are returned on scenario reads and can be edited later via `scenarios_partial_update`.\n- 10 project-level evaluation metrics are attached to every generated scenario automatically (e.g. Latency, Pitch, Interruption Score). Scenarios created manually via `scenarios_create` start with no metrics attached.\n\n**Response fields:** `progress_id` (UUID string) for polling; `session_id` is always null.",
                 "tags": [
                     "test_framework"
                 ],
@@ -41371,7 +41537,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "scenarios-generate-bg",
-                        "description": "Generate scenarios for a given agent in the background. Returns a `progress_id` immediately; poll GET /scenarios/generate-progress/?progress_id={id} until `total_scenarios == completed_scenarios`.\n\n**What happens automatically on generation:**\n- A scenario-specific test profile is created and its `information` is populated using the sectioned shape: `main_agent_variables` (dynamic-variable values that reach the agent under test at call time — e.g. `user_id`, `account_id`) and `testing_agent_variables` (persona/context used by the simulated caller — e.g. `customer_name`, `date_of_birth`). Section values are kept consistent with any generated mock-tool data.\n- 10 project-level evaluation metrics are attached to every generated scenario automatically (e.g. Latency, Pitch, Interruption Score). Scenarios created manually via `scenarios_create` start with no metrics attached.\n\n**Response fields:** `progress_id` (UUID string) for polling; `session_id` is always null."
+                        "description": "Generate scenarios for a given agent in the background. Returns a `progress_id` immediately; poll GET /scenarios/generate-progress/?progress_id={id} until `total_scenarios == completed_scenarios`.\n\n**What happens automatically on generation:**\n- A scenario-specific test profile is created and its `information` is populated using the sectioned shape: `main_agent_variables` (dynamic-variable values that reach the agent under test at call time — e.g. `user_id`, `account_id`) and `testing_agent_variables` (persona/context used by the simulated caller — e.g. `customer_name`, `date_of_birth`). Section values are kept consistent with any generated mock-tool data.\n- When the agent has mock tools attached, each generated scenario also gets `generated_mock_tool_entries` — the expected mock tool calls for that scenario, shaped `[{tool_id, tool_name, new_entry: {input, output}}]`. These are returned on scenario reads and can be edited later via `scenarios_partial_update`.\n- 10 project-level evaluation metrics are attached to every generated scenario automatically (e.g. Latency, Pitch, Interruption Score). Scenarios created manually via `scenarios_create` start with no metrics attached.\n\n**Response fields:** `progress_id` (UUID string) for polling; `session_id` is always null."
                     }
                 }
             }
@@ -41656,6 +41822,41 @@
                                                     "is_simulating": {
                                                         "type": "boolean",
                                                         "description": "Whether this scenario was created by simulation"
+                                                    },
+                                                    "test_profile_data": {
+                                                        "type": "object",
+                                                        "description": "The test profile generated for this scenario, including its sectioned `information` (main_agent_variables / testing_agent_variables)"
+                                                    },
+                                                    "generated_mock_tool_entries": {
+                                                        "type": "array",
+                                                        "description": "Expected mock tool calls generated for this scenario when the agent has mock tools attached. Empty when the agent has no mock tools.",
+                                                        "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "tool_id": {
+                                                                    "type": "integer",
+                                                                    "description": "ID of the mock tool on the agent"
+                                                                },
+                                                                "tool_name": {
+                                                                    "type": "string",
+                                                                    "description": "Name of the tool being mocked"
+                                                                },
+                                                                "new_entry": {
+                                                                    "type": "object",
+                                                                    "description": "The expected tool call for this scenario",
+                                                                    "properties": {
+                                                                        "input": {
+                                                                            "type": "object",
+                                                                            "description": "Input parameters the tool call is expected to receive"
+                                                                        },
+                                                                        "output": {
+                                                                            "type": "object",
+                                                                            "description": "Response the mock tool will return"
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
                                                     }
                                                 }
                                             }
@@ -47718,7 +47919,7 @@
                         "schema": {
                             "type": "boolean"
                         },
-                        "description": "If true (default), delete associated evaluators, results and runs. If false, detach evaluators and leave results as-is."
+                        "description": "If true (default), delete associated call logs, scenario evaluators, results and runs. If false, detach scenario evaluators and leave call logs, metric evaluations, results and runs as-is."
                     }
                 ],
                 "tags": [
@@ -56643,7 +56844,7 @@
         "/test_framework/v2/scenarios/generate-bg/": {
             "post": {
                 "operationId": "scenarios-generate-bg_3",
-                "description": "Generate scenarios for a given agent in the background. Returns a `progress_id` immediately; poll GET /scenarios/generate-progress/?progress_id={id} until `total_scenarios == completed_scenarios`.\n\n**What happens automatically on generation:**\n- A scenario-specific test profile is created and its `information` is populated using the sectioned shape: `main_agent_variables` (dynamic-variable values that reach the agent under test at call time — e.g. `user_id`, `account_id`) and `testing_agent_variables` (persona/context used by the simulated caller — e.g. `customer_name`, `date_of_birth`). Section values are kept consistent with any generated mock-tool data.\n- 10 project-level evaluation metrics are attached to every generated scenario automatically (e.g. Latency, Pitch, Interruption Score). Scenarios created manually via `scenarios_create` start with no metrics attached.\n\n**Response fields:** `progress_id` (UUID string) for polling; `session_id` is always null.",
+                "description": "Generate scenarios for a given agent in the background. Returns a `progress_id` immediately; poll GET /scenarios/generate-progress/?progress_id={id} until `total_scenarios == completed_scenarios`.\n\n**What happens automatically on generation:**\n- A scenario-specific test profile is created and its `information` is populated using the sectioned shape: `main_agent_variables` (dynamic-variable values that reach the agent under test at call time — e.g. `user_id`, `account_id`) and `testing_agent_variables` (persona/context used by the simulated caller — e.g. `customer_name`, `date_of_birth`). Section values are kept consistent with any generated mock-tool data.\n- When the agent has mock tools attached, each generated scenario also gets `generated_mock_tool_entries` — the expected mock tool calls for that scenario, shaped `[{tool_id, tool_name, new_entry: {input, output}}]`. These are returned on scenario reads and can be edited later via `scenarios_partial_update`.\n- 10 project-level evaluation metrics are attached to every generated scenario automatically (e.g. Latency, Pitch, Interruption Score). Scenarios created manually via `scenarios_create` start with no metrics attached.\n\n**Response fields:** `progress_id` (UUID string) for polling; `session_id` is always null.",
                 "tags": [
                     "test_framework"
                 ],
@@ -56987,6 +57188,41 @@
                                                     "is_simulating": {
                                                         "type": "boolean",
                                                         "description": "Whether this scenario was created by simulation"
+                                                    },
+                                                    "test_profile_data": {
+                                                        "type": "object",
+                                                        "description": "The test profile generated for this scenario, including its sectioned `information` (main_agent_variables / testing_agent_variables)"
+                                                    },
+                                                    "generated_mock_tool_entries": {
+                                                        "type": "array",
+                                                        "description": "Expected mock tool calls generated for this scenario when the agent has mock tools attached. Empty when the agent has no mock tools.",
+                                                        "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "tool_id": {
+                                                                    "type": "integer",
+                                                                    "description": "ID of the mock tool on the agent"
+                                                                },
+                                                                "tool_name": {
+                                                                    "type": "string",
+                                                                    "description": "Name of the tool being mocked"
+                                                                },
+                                                                "new_entry": {
+                                                                    "type": "object",
+                                                                    "description": "The expected tool call for this scenario",
+                                                                    "properties": {
+                                                                        "input": {
+                                                                            "type": "object",
+                                                                            "description": "Input parameters the tool call is expected to receive"
+                                                                        },
+                                                                        "output": {
+                                                                            "type": "object",
+                                                                            "description": "Response the mock tool will return"
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
                                                     }
                                                 }
                                             }
@@ -62020,6 +62256,48 @@
                 "description": "User oauth token"
             }
         },
+        "/user/onboarding/": {
+            "get": {
+                "operationId": "user-onboarding-retrieve",
+                "tags": [
+                    "user"
+                ],
+                "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No response body"
+                    }
+                },
+                "description": "User onboarding"
+            },
+            "patch": {
+                "operationId": "user-onboarding-partial-update",
+                "tags": [
+                    "user"
+                ],
+                "security": [
+                    {
+                        "oauth2": []
+                    },
+                    {
+                        "supabase_session": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No response body"
+                    }
+                },
+                "description": "User onboarding"
+            }
+        },
         "/user/organizations/": {
             "get": {
                 "operationId": "user-organizations-list",
@@ -62321,7 +62599,7 @@
         "/user/organizations/{id}/onboarding-flow/": {
             "patch": {
                 "operationId": "user-organizations-onboarding-flow-partial-update",
-                "description": "Set onboarding_flow flag to True for the organization.\nCan be called by any org member or admin.",
+                "description": "DEPRECATED — the first user's PATCH /user/onboarding/ ({\"variant\": ...})\nstamps the org flow; this endpoint remains the way to change it later.\nCan be called by any org member or admin.",
                 "parameters": [
                     {
                         "in": "path",
@@ -62382,6 +62660,7 @@
         "/user/organizations/{id}/onboarding-tasks/": {
             "get": {
                 "operationId": "user-organizations-onboarding-tasks-retrieve",
+                "description": "DEPRECATED — use GET /user/onboarding/?organization=<id>, which\nreturns these tasks plus the caller's per-user onboarding state.",
                 "parameters": [
                     {
                         "in": "path",
@@ -62417,8 +62696,7 @@
                         },
                         "description": ""
                     }
-                },
-                "description": "User organizations onboarding tasks"
+                }
             }
         },
         "/user/organizations/{id}/overview/": {
@@ -62550,7 +62828,7 @@
         "/user/organizations/{id}/skip-onboarding/": {
             "patch": {
                 "operationId": "user-organizations-skip-onboarding-partial-update",
-                "description": "Set skip_onboarding flag to True for the organization.\nCan be called by any org member or admin.",
+                "description": "DEPRECATED — per-user skip lives on PATCH /user/onboarding/\n({\"status\": \"skipped\"}). This org-wide flag remains as a legacy\nsuppressor and ops lever. Can be called by any org member or admin.",
                 "parameters": [
                     {
                         "in": "path",
@@ -65905,7 +66183,7 @@
                         "type": "string",
                         "x-spec-enum-id": "be289759a77f8b31",
                         "default": "",
-                        "description": "\nService provider for the AI assistant functionality. Valid values (live enum):\n\n- `self_hosted` — websocket or observation-only; no api_key needed. Use `websocket_url` + `websocket_headers` for text-mode runs.\n- `vapi` — requires `vapi_api_key`; optional `assistant_id`, `vapi_data.public_key`.\n- `retell` — requires `retell_api_key` AND `chat_assistant_id` (used for voice too).\n- `bland` — requires `bland_api_key`; `assistant_id` is the Bland persona_id (voice), `chat_assistant_id` the pathway_id (text); `bland_data.encrypted_key` for Twilio.\n- `livekit` — requires `livekit_api_key` + `livekit_data.api_secret` + `livekit_data.url`.\n- `elevenlabs` — requires `elevenlabs_api_key`.\n- `agentforce` — requires `agentforce_client_secret` + `agentforce_data`.\n- `sierra` — requires `sierra_agent_token`; optional `sierra_data` (host, api_secret). Chat/text runs only.\n- `amazon_connect` — requires `amazon_connect_data` with `snippet_id` and `connect_host`; optional `amazon_connect_security_token` and `region`.\n- `cisco` — Cisco Webex.\n- `vocera` — Cekura-hosted.\n- `sms` / `whatsapp` — text-only channels; use `chat_assistant_id`.\n- `\"\"` (empty) — unset; agent is not runnable until a provider is configured.\n\nNote: the serializer also exposes `pipecat_*`, `synthflow_*`, `koreai_*`, `genesys_*`, `custom_provider_*` fields, but those provider values are not currently selectable in this enum.\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `elevenlabs` - Elevenlabs\n* `vocera` - Vocera\n* `sms` - Sms\n* `whatsapp` - Whatsapp\n* `self_hosted` - Self Hosted\n* `agentforce` - Agentforce\n* `cisco` - Cisco\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `synthflow` - Synthflow\n* `agora` - Agora\n* `koreai` - Koreai\n* `genesys` - Genesys\n* `amazon_connect` - Amazon Connect\n* `telnyx` - Telnyx\n* `sierra` - Sierra"
+                        "description": "\nService provider for the AI assistant functionality. Valid values (live enum):\n\n- `self_hosted` — websocket or observation-only; no api_key needed. Use `websocket_url` + `websocket_headers` for text-mode runs.\n- `vapi` — requires `vapi_api_key`; optional `assistant_id`, `vapi_data.public_key`.\n- `retell` — requires `retell_api_key` AND `chat_assistant_id` (used for voice too).\n- `bland` — requires `bland_api_key`; `assistant_id` is the Bland persona_id (voice), `chat_assistant_id` the pathway_id (text); `bland_data.encrypted_key` for Twilio.\n- `livekit` — requires `livekit_api_key` + `livekit_data.url`; `livekit_data.api_secret` is needed at run time for WebRTC.\n- `elevenlabs` — requires `elevenlabs_api_key`.\n- `agentforce` — requires `agentforce_client_secret` + `agentforce_data`.\n- `sierra` — requires `sierra_agent_token`; optional `sierra_data` (host, api_secret). Chat/text runs only.\n- `amazon_connect` — requires `amazon_connect_data` with `snippet_id` and `connect_host`; optional `amazon_connect_security_token` and `region`.\n- `cisco` — Cisco Webex.\n- `vocera` — Cekura-hosted.\n- `sms` / `whatsapp` — text-only channels; use `chat_assistant_id`.\n- `\"\"` (empty) — unset; agent is not runnable until a provider is configured.\n\nNote: the serializer also exposes `pipecat_*`, `synthflow_*`, `koreai_*`, `genesys_*`, `custom_provider_*` fields, but those provider values are not currently selectable in this enum.\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `elevenlabs` - Elevenlabs\n* `vocera` - Vocera\n* `sms` - Sms\n* `whatsapp` - Whatsapp\n* `self_hosted` - Self Hosted\n* `agentforce` - Agentforce\n* `cisco` - Cisco\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `synthflow` - Synthflow\n* `agora` - Agora\n* `koreai` - Koreai\n* `genesys` - Genesys\n* `amazon_connect` - Amazon Connect\n* `telnyx` - Telnyx\n* `sierra` - Sierra"
                     },
                     "vapi_api_key": {
                         "type": "string",
@@ -65954,7 +66232,7 @@
                     "livekit_api_key": {
                         "type": "string",
                         "writeOnly": true,
-                        "description": "\nAPI key for LiveKit service provider. Required when `assistant_provider=\"livekit\"` (also requires `livekit_data.api_secret` and `livekit_data.url`).\nExample: `\"livekit_api_key_123\"`\n"
+                        "description": "\nAPI key for LiveKit service provider. Required together with `livekit_data.url` when `assistant_provider=\"livekit\"`.\nExample: `\"livekit_api_key_123\"`\n"
                     },
                     "livekit_api_key_configured": {
                         "type": "string",
@@ -65962,7 +66240,7 @@
                     },
                     "livekit_data": {
                         "type": "string",
-                        "description": "\nLiveKit additional data (api_secret, url, and config). Required alongside `livekit_api_key` when `assistant_provider=\"livekit\"`.\nOn response, secrets are masked (the `api_secret` key is stripped and replaced with `api_secret_configured: true`).\n"
+                        "description": "\nLiveKit additional data (api_secret, url, and config). `url` is required alongside `livekit_api_key` when `assistant_provider=\"livekit\"`;\n`api_secret` is optional to save but needed at run time for WebRTC token minting.\nOn response, secrets are masked (the `api_secret` key is stripped and replaced with `api_secret_configured: true`).\n"
                     },
                     "pipecat_api_key": {
                         "type": "string",
@@ -66170,7 +66448,7 @@
                     "auto_fetch_calls_enabled": {
                         "type": "boolean",
                         "default": false,
-                        "description": "Enable automatic fetching of calls every 30 seconds (VAPI/Retell only)"
+                        "description": "Enable automatic fetching of calls every 30 seconds (VAPI/Retell/ElevenLabs/Bland)"
                     },
                     "auto_sync_prompt_enabled": {
                         "type": "boolean",
@@ -67050,16 +67328,28 @@
                     "scenario_ids": {
                         "readOnly": true
                     },
+                    "clone_assistant_id": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "scenario_validation_result_ids": {
+                        "readOnly": true
+                    },
+                    "current_phase": {
+                        "type": "string",
+                        "readOnly": true
+                    },
                     "status": {
                         "enum": [
                             "pending",
                             "running",
                             "succeeded",
-                            "failed"
+                            "failed",
+                            "cancelled"
                         ],
                         "type": "string",
-                        "description": "* `pending` - Pending\n* `running` - Running\n* `succeeded` - Succeeded\n* `failed` - Failed",
-                        "x-spec-enum-id": "7a7ee2ea425ee5c6",
+                        "description": "* `pending` - Pending\n* `running` - Running\n* `succeeded` - Succeeded\n* `failed` - Failed\n* `cancelled` - Cancelled",
+                        "x-spec-enum-id": "ea8144caab6e77c3",
                         "readOnly": true
                     },
                     "conversation_id": {
@@ -67080,6 +67370,9 @@
                     },
                     "error_message": {
                         "type": "string",
+                        "readOnly": true
+                    },
+                    "reproduction_summary": {
                         "readOnly": true
                     },
                     "summary_json": {
@@ -74937,6 +75230,10 @@
                         "description": "* `simulation` - Simulation\n* `observability` - Observability",
                         "x-spec-enum-id": "bd0a2727bbf39892"
                     },
+                    "user_onboarding": {
+                        "type": "string",
+                        "readOnly": true
+                    },
                     "phone_number_verified": {
                         "type": "boolean",
                         "readOnly": true
@@ -77881,6 +78178,10 @@
                         "description": "* `simulation` - Simulation\n* `observability` - Observability",
                         "x-spec-enum-id": "bd0a2727bbf39892"
                     },
+                    "user_onboarding": {
+                        "type": "string",
+                        "readOnly": true
+                    },
                     "phone_number_verified": {
                         "type": "boolean",
                         "readOnly": true
@@ -78543,6 +78844,11 @@
                         "type": "string",
                         "readOnly": true,
                         "description": "List of run IDs that got connected successfully (have transcript data). Returns empty list if no connected runs."
+                    },
+                    "not_connected_runs": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "List of run IDs that never connected (no transcript data). Returns empty list if every run connected."
                     },
                     "failed_infrastructure_runs": {
                         "type": "string",
@@ -79618,6 +79924,15 @@
                             "null"
                         ],
                         "description": "Dot-separated path of the folder to assign this evaluator to (e.g. \"Sales.Inbound\"). Folders must be created before use — they are not auto-created. Use `scenarios_create_folder_create` to create each level before assigning evaluators. Example: to use \"Sales.Inbound\", first create \"Sales\", then create \"Inbound\" inside it."
+                    },
+                    "generated_mock_tool_entries": {
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Expected mock tool calls for this evaluator. Each entry has shape {tool_id, tool_name, new_entry: {input, output}}. Auto-generated during scenario generation when the agent has mock tools attached; can also be set or edited manually."
                     }
                 }
             },
@@ -79849,7 +80164,7 @@
                         "type": "string",
                         "x-spec-enum-id": "be289759a77f8b31",
                         "default": "",
-                        "description": "\nService provider for the AI assistant functionality. Valid values (live enum):\n\n- `self_hosted` — websocket or observation-only; no api_key needed. Use `websocket_url` + `websocket_headers` for text-mode runs.\n- `vapi` — requires `vapi_api_key`; optional `assistant_id`, `vapi_data.public_key`.\n- `retell` — requires `retell_api_key` AND `chat_assistant_id` (used for voice too).\n- `bland` — requires `bland_api_key`; `assistant_id` is the Bland persona_id (voice), `chat_assistant_id` the pathway_id (text); `bland_data.encrypted_key` for Twilio.\n- `livekit` — requires `livekit_api_key` + `livekit_data.api_secret` + `livekit_data.url`.\n- `elevenlabs` — requires `elevenlabs_api_key`.\n- `agentforce` — requires `agentforce_client_secret` + `agentforce_data`.\n- `sierra` — requires `sierra_agent_token`; optional `sierra_data` (host, api_secret). Chat/text runs only.\n- `amazon_connect` — requires `amazon_connect_data` with `snippet_id` and `connect_host`; optional `amazon_connect_security_token` and `region`.\n- `cisco` — Cisco Webex.\n- `vocera` — Cekura-hosted.\n- `sms` / `whatsapp` — text-only channels; use `chat_assistant_id`.\n- `\"\"` (empty) — unset; agent is not runnable until a provider is configured.\n\nNote: the serializer also exposes `pipecat_*`, `synthflow_*`, `koreai_*`, `genesys_*`, `custom_provider_*` fields, but those provider values are not currently selectable in this enum.\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `elevenlabs` - Elevenlabs\n* `vocera` - Vocera\n* `sms` - Sms\n* `whatsapp` - Whatsapp\n* `self_hosted` - Self Hosted\n* `agentforce` - Agentforce\n* `cisco` - Cisco\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `synthflow` - Synthflow\n* `agora` - Agora\n* `koreai` - Koreai\n* `genesys` - Genesys\n* `amazon_connect` - Amazon Connect\n* `telnyx` - Telnyx\n* `sierra` - Sierra"
+                        "description": "\nService provider for the AI assistant functionality. Valid values (live enum):\n\n- `self_hosted` — websocket or observation-only; no api_key needed. Use `websocket_url` + `websocket_headers` for text-mode runs.\n- `vapi` — requires `vapi_api_key`; optional `assistant_id`, `vapi_data.public_key`.\n- `retell` — requires `retell_api_key` AND `chat_assistant_id` (used for voice too).\n- `bland` — requires `bland_api_key`; `assistant_id` is the Bland persona_id (voice), `chat_assistant_id` the pathway_id (text); `bland_data.encrypted_key` for Twilio.\n- `livekit` — requires `livekit_api_key` + `livekit_data.url`; `livekit_data.api_secret` is needed at run time for WebRTC.\n- `elevenlabs` — requires `elevenlabs_api_key`.\n- `agentforce` — requires `agentforce_client_secret` + `agentforce_data`.\n- `sierra` — requires `sierra_agent_token`; optional `sierra_data` (host, api_secret). Chat/text runs only.\n- `amazon_connect` — requires `amazon_connect_data` with `snippet_id` and `connect_host`; optional `amazon_connect_security_token` and `region`.\n- `cisco` — Cisco Webex.\n- `vocera` — Cekura-hosted.\n- `sms` / `whatsapp` — text-only channels; use `chat_assistant_id`.\n- `\"\"` (empty) — unset; agent is not runnable until a provider is configured.\n\nNote: the serializer also exposes `pipecat_*`, `synthflow_*`, `koreai_*`, `genesys_*`, `custom_provider_*` fields, but those provider values are not currently selectable in this enum.\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `elevenlabs` - Elevenlabs\n* `vocera` - Vocera\n* `sms` - Sms\n* `whatsapp` - Whatsapp\n* `self_hosted` - Self Hosted\n* `agentforce` - Agentforce\n* `cisco` - Cisco\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `synthflow` - Synthflow\n* `agora` - Agora\n* `koreai` - Koreai\n* `genesys` - Genesys\n* `amazon_connect` - Amazon Connect\n* `telnyx` - Telnyx\n* `sierra` - Sierra"
                     },
                     "vapi_api_key": {
                         "type": "string",
@@ -79898,7 +80213,7 @@
                     "livekit_api_key": {
                         "type": "string",
                         "writeOnly": true,
-                        "description": "\nAPI key for LiveKit service provider. Required when `assistant_provider=\"livekit\"` (also requires `livekit_data.api_secret` and `livekit_data.url`).\nExample: `\"livekit_api_key_123\"`\n"
+                        "description": "\nAPI key for LiveKit service provider. Required together with `livekit_data.url` when `assistant_provider=\"livekit\"`.\nExample: `\"livekit_api_key_123\"`\n"
                     },
                     "livekit_api_key_configured": {
                         "type": "string",
@@ -79906,7 +80221,7 @@
                     },
                     "livekit_data": {
                         "type": "string",
-                        "description": "\nLiveKit additional data (api_secret, url, and config). Required alongside `livekit_api_key` when `assistant_provider=\"livekit\"`.\nOn response, secrets are masked (the `api_secret` key is stripped and replaced with `api_secret_configured: true`).\n"
+                        "description": "\nLiveKit additional data (api_secret, url, and config). `url` is required alongside `livekit_api_key` when `assistant_provider=\"livekit\"`;\n`api_secret` is optional to save but needed at run time for WebRTC token minting.\nOn response, secrets are masked (the `api_secret` key is stripped and replaced with `api_secret_configured: true`).\n"
                     },
                     "pipecat_api_key": {
                         "type": "string",
@@ -80114,7 +80429,7 @@
                     "auto_fetch_calls_enabled": {
                         "type": "boolean",
                         "default": false,
-                        "description": "Enable automatic fetching of calls every 30 seconds (VAPI/Retell only)"
+                        "description": "Enable automatic fetching of calls every 30 seconds (VAPI/Retell/ElevenLabs/Bland)"
                     },
                     "auto_sync_prompt_enabled": {
                         "type": "boolean",
@@ -82241,6 +82556,11 @@
                         "readOnly": true,
                         "description": "List of run IDs that got connected successfully (have transcript data). Returns empty list if no connected runs."
                     },
+                    "not_connected_runs": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "List of run IDs that never connected (no transcript data). Returns empty list if every run connected."
+                    },
                     "failed_infrastructure_runs": {
                         "type": "string",
                         "readOnly": true,
@@ -82813,7 +83133,10 @@
                         "readOnly": true
                     },
                     "expected_outcome": {
-                        "description": "\nExpected outcome of the run\nExample:\n```json\n{\n    \"score\": 100,\n    \"explanation\": [\n        \"❌ The main agent did not provide the standard greeting, emergency disclaimer, or ask how they can help (00:21).\",\n    ],\n    \"outcome_alignments\": [\n        {\n            \"aligned\": false,\n            \"outcome\": \"The main agent did not provide the standard greeting, emergency disclaimer, or ask how they can help (00:21).\",\n            \"prompt_part\": \"The main agent should provide the standard greeting and emergency disclaimer, asking how they can help.\"\n        },\n        {\n            \"aligned\": false,\n            \"outcome\": \"The main agent did not explain the distinction between Nacogdoches Health Partners and FastTrack Express Clinic (entire call).\",\n            \"prompt_part\": \"The main agent should explain the distinction between Nacogdoches Health Partners (focused on comprehensive primary care and chronic conditions) and FastTrack Express Clinic (focused on acute or urgent matters).\"\n        }\n    ]\n}\n```\n"
+                        "type": "object",
+                        "additionalProperties": {},
+                        "description": "Expected-outcome evaluation. Supports key selection — `?ql={expected_outcome{score}}` omits the explanation and alignment arrays.",
+                        "readOnly": true
                     },
                     "success": {
                         "type": "boolean",
@@ -82831,7 +83154,12 @@
                         ],
                         "format": "date-time"
                     },
-                    "metadata": {},
+                    "metadata": {
+                        "type": "object",
+                        "additionalProperties": {},
+                        "description": "Provider call metadata. Supports key selection — `?ql={metadata{ended_reason,ringing_duration}}` returns only those keys instead of the full provider payload.",
+                        "readOnly": true
+                    },
                     "outbound_number": {
                         "type": "string",
                         "readOnly": true
@@ -86843,6 +87171,15 @@
                             "null"
                         ],
                         "description": "Dot-separated path of the folder to assign this evaluator to (e.g. \"Sales.Inbound\"). Folders must be created before use — they are not auto-created. Use `scenarios_create_folder_create` to create each level before assigning evaluators. Example: to use \"Sales.Inbound\", first create \"Sales\", then create \"Inbound\" inside it."
+                    },
+                    "generated_mock_tool_entries": {
+                        "oneOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Expected mock tool calls for this evaluator. Each entry has shape {tool_id, tool_name, new_entry: {input, output}}. Auto-generated during scenario generation when the agent has mock tools attached; can also be set or edited manually."
                     }
                 },
                 "required": [
@@ -87349,7 +87686,7 @@
                         "type": "string",
                         "x-spec-enum-id": "be289759a77f8b31",
                         "default": "",
-                        "description": "\nService provider for the AI assistant functionality. Valid values (live enum):\n\n- `self_hosted` — websocket or observation-only; no api_key needed. Use `websocket_url` + `websocket_headers` for text-mode runs.\n- `vapi` — requires `vapi_api_key`; optional `assistant_id`, `vapi_data.public_key`.\n- `retell` — requires `retell_api_key` AND `chat_assistant_id` (used for voice too).\n- `bland` — requires `bland_api_key`; `assistant_id` is the Bland persona_id (voice), `chat_assistant_id` the pathway_id (text); `bland_data.encrypted_key` for Twilio.\n- `livekit` — requires `livekit_api_key` + `livekit_data.api_secret` + `livekit_data.url`.\n- `elevenlabs` — requires `elevenlabs_api_key`.\n- `agentforce` — requires `agentforce_client_secret` + `agentforce_data`.\n- `sierra` — requires `sierra_agent_token`; optional `sierra_data` (host, api_secret). Chat/text runs only.\n- `amazon_connect` — requires `amazon_connect_data` with `snippet_id` and `connect_host`; optional `amazon_connect_security_token` and `region`.\n- `cisco` — Cisco Webex.\n- `vocera` — Cekura-hosted.\n- `sms` / `whatsapp` — text-only channels; use `chat_assistant_id`.\n- `\"\"` (empty) — unset; agent is not runnable until a provider is configured.\n\nNote: the serializer also exposes `pipecat_*`, `synthflow_*`, `koreai_*`, `genesys_*`, `custom_provider_*` fields, but those provider values are not currently selectable in this enum.\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `elevenlabs` - Elevenlabs\n* `vocera` - Vocera\n* `sms` - Sms\n* `whatsapp` - Whatsapp\n* `self_hosted` - Self Hosted\n* `agentforce` - Agentforce\n* `cisco` - Cisco\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `synthflow` - Synthflow\n* `agora` - Agora\n* `koreai` - Koreai\n* `genesys` - Genesys\n* `amazon_connect` - Amazon Connect\n* `telnyx` - Telnyx\n* `sierra` - Sierra"
+                        "description": "\nService provider for the AI assistant functionality. Valid values (live enum):\n\n- `self_hosted` — websocket or observation-only; no api_key needed. Use `websocket_url` + `websocket_headers` for text-mode runs.\n- `vapi` — requires `vapi_api_key`; optional `assistant_id`, `vapi_data.public_key`.\n- `retell` — requires `retell_api_key` AND `chat_assistant_id` (used for voice too).\n- `bland` — requires `bland_api_key`; `assistant_id` is the Bland persona_id (voice), `chat_assistant_id` the pathway_id (text); `bland_data.encrypted_key` for Twilio.\n- `livekit` — requires `livekit_api_key` + `livekit_data.url`; `livekit_data.api_secret` is needed at run time for WebRTC.\n- `elevenlabs` — requires `elevenlabs_api_key`.\n- `agentforce` — requires `agentforce_client_secret` + `agentforce_data`.\n- `sierra` — requires `sierra_agent_token`; optional `sierra_data` (host, api_secret). Chat/text runs only.\n- `amazon_connect` — requires `amazon_connect_data` with `snippet_id` and `connect_host`; optional `amazon_connect_security_token` and `region`.\n- `cisco` — Cisco Webex.\n- `vocera` — Cekura-hosted.\n- `sms` / `whatsapp` — text-only channels; use `chat_assistant_id`.\n- `\"\"` (empty) — unset; agent is not runnable until a provider is configured.\n\nNote: the serializer also exposes `pipecat_*`, `synthflow_*`, `koreai_*`, `genesys_*`, `custom_provider_*` fields, but those provider values are not currently selectable in this enum.\n\n\n* `vapi` - Vapi\n* `retell` - Retell\n* `elevenlabs` - Elevenlabs\n* `vocera` - Vocera\n* `sms` - Sms\n* `whatsapp` - Whatsapp\n* `self_hosted` - Self Hosted\n* `agentforce` - Agentforce\n* `cisco` - Cisco\n* `bland` - Bland\n* `livekit` - Livekit\n* `pipecat` - Pipecat\n* `synthflow` - Synthflow\n* `agora` - Agora\n* `koreai` - Koreai\n* `genesys` - Genesys\n* `amazon_connect` - Amazon Connect\n* `telnyx` - Telnyx\n* `sierra` - Sierra"
                     },
                     "vapi_api_key": {
                         "type": "string",
@@ -87398,7 +87735,7 @@
                     "livekit_api_key": {
                         "type": "string",
                         "writeOnly": true,
-                        "description": "\nAPI key for LiveKit service provider. Required when `assistant_provider=\"livekit\"` (also requires `livekit_data.api_secret` and `livekit_data.url`).\nExample: `\"livekit_api_key_123\"`\n"
+                        "description": "\nAPI key for LiveKit service provider. Required together with `livekit_data.url` when `assistant_provider=\"livekit\"`.\nExample: `\"livekit_api_key_123\"`\n"
                     },
                     "livekit_api_key_configured": {
                         "type": "string",
@@ -87406,7 +87743,7 @@
                     },
                     "livekit_data": {
                         "type": "string",
-                        "description": "\nLiveKit additional data (api_secret, url, and config). Required alongside `livekit_api_key` when `assistant_provider=\"livekit\"`.\nOn response, secrets are masked (the `api_secret` key is stripped and replaced with `api_secret_configured: true`).\n"
+                        "description": "\nLiveKit additional data (api_secret, url, and config). `url` is required alongside `livekit_api_key` when `assistant_provider=\"livekit\"`;\n`api_secret` is optional to save but needed at run time for WebRTC token minting.\nOn response, secrets are masked (the `api_secret` key is stripped and replaced with `api_secret_configured: true`).\n"
                     },
                     "pipecat_api_key": {
                         "type": "string",
@@ -87614,7 +87951,7 @@
                     "auto_fetch_calls_enabled": {
                         "type": "boolean",
                         "default": false,
-                        "description": "Enable automatic fetching of calls every 30 seconds (VAPI/Retell only)"
+                        "description": "Enable automatic fetching of calls every 30 seconds (VAPI/Retell/ElevenLabs/Bland)"
                     },
                     "auto_sync_prompt_enabled": {
                         "type": "boolean",
@@ -87881,6 +88218,10 @@
                         "type": "boolean",
                         "readOnly": true
                     },
+                    "status": {
+                        "type": "string",
+                        "readOnly": true
+                    },
                     "is_trial": {
                         "type": "string",
                         "readOnly": true
@@ -87898,6 +88239,10 @@
                         "readOnly": true
                     },
                     "has_payment_method": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "is_stripe_managed": {
                         "type": "string",
                         "readOnly": true
                     },


### PR DESCRIPTION
Auto-generated docs sync for backend PR [#10679](https://github.com/cekura-ai/vocera.backend/pull/10679).

Reviewers: @dileep-chagam, @voceradharam

## Summary

**Spec/overlay:** Spec-only sync: 22 operations modified (6 exposed, 16 not exposed), 2 new operations added (not exposed). Changes are description and parameter updates from relaxing LiveKit/Pipecat save-time validation. No new MCP exposures, no retractions, no renames. 2 new onboarding endpoints flagged for missing @docs_exclude() (session-only, no API key auth).

**Conceptual docs:** No edits — PR relaxes save-time validation for LiveKit/Pipecat (api_secret optional to save, tracing_enabled no longer gates saving, contact_number/sip_endpoint accepted as alternatives). Docs pages describe what's needed for features to work end-to-end (runtime requirements), not save-time validation rules. Runtime behavior is unchanged: WebRTC testing still requires api_secret for token minting, automated flows still need full credentials. Pages remain accurate for their described workflows.

## Changes

- `openapi.json` — regenerate_from_backend

## Exposure suggestions (@mcp_expose candidates)

- **`user_onboarding_retrieve`** (GET `/user/onboarding/`)
  - `GET /user/onboarding/` is not callable with `X-CEKURA-API-KEY` — it accepts `oauth2, supabase_session`. If it is dashboard-only, add `@docs_exclude()` from `app.docs_decorators` so it does not get an API-reference page; a customer who follows that page gets a 403. If customers are meant to call it, add `APIKeyAuthentication` to the view's `authentication_classes` and make sure `get_permissions()` authorises a `UserAPIKey` for this action.
- **`user_onboarding_partial_update`** (PATCH `/user/onboarding/`)
  - `PATCH /user/onboarding/` is not callable with `X-CEKURA-API-KEY` — it accepts `oauth2, supabase_session`. If it is dashboard-only, add `@docs_exclude()` from `app.docs_decorators` so it does not get an API-reference page; a customer who follows that page gets a 403. If customers are meant to call it, add `APIKeyAuthentication` to the view's `authentication_classes` and make sure `get_permissions()` authorises a `UserAPIKey` for this action.

---
*Auto-generated from backend PR #10679.*

<!-- mcp-sync:file-hashes -->
```json
{}
```
<!-- /mcp-sync:file-hashes -->