### PR TITLE
docs(conditional-actions): document the <voice> tag

### DIFF
--- a/documentation/key-concepts/evaluators/conditional-actions.mdx
+++ b/documentation/key-concepts/evaluators/conditional-actions.mdx
@@ -515,6 +515,51 @@ Use `<silence>` when you want the conversation to feel natural and allow the mai
     - `ratio`: Volume multiplier (required) - Valid range: **0 to 2**<br />
       Examples: `"1.5"` for 50% louder, `"0.5"` for 50% quieter
   </Accordion>
+
+  <Accordion title="<voice> - Switch the Testing Agent's Voice" icon="user-group">
+    Switch the testing agent's TTS voice mid-call. Everything spoken after the tag — including
+    later conditions — uses the new voice until another `<voice>` tag changes it.
+
+    This is how you put more than one speaker in a single simulated call: a caller handing the
+    phone to a family member, a supervisor taking over, or a different person picking up.
+
+    ```json
+    {
+      "conditions": [
+        {
+          "id": 2,
+          "condition": "agent asks to speak to the account holder",
+          "action": "Hold on, let me get my husband. <voice provider=\"11labs\" id=\"21m00Tcm4TlvDq8ikWAM\" /> Hi, this is Mark speaking.",
+          "type": "standard",
+          "fixed_message": true
+        }
+      ]
+    }
+    ```
+
+    The switch applies between utterances, so any text before the tag is spoken fully in the
+    previous voice.
+
+    **Attributes:**
+    - `provider`: Voice provider (required) - `cartesia` or `11labs`. Must be the **same provider
+      the evaluator already runs on**.
+    - `id`: Voice ID (required) - must belong to that provider:
+
+      | Provider | Voice ID format | Example |
+      |---|---|---|
+      | `cartesia` | UUID | `b7d50908-b17c-442d-ad8d-810c63997ed9` |
+      | `11labs` | Alphanumeric, no dashes | `21m00Tcm4TlvDq8ikWAM` |
+
+    - `model`: TTS model (optional) - omit it to use the provider's default:
+      `sonic-3.5` for Cartesia, `eleven_turbo_v2_5` for ElevenLabs.
+
+    <Warning>
+      **The provider cannot change mid-call.** `provider` states which provider the voice ID
+      belongs to so a mismatched pair is caught when you save the evaluator, rather than failing
+      mid-call. To use a voice from a different provider, change the evaluator's voice
+      configuration instead.
+    </Warning>
+  </Accordion>
 </AccordionGroup>
 
 ### Interaction Tags
@@ -856,6 +901,10 @@ Attach a pre-recorded audio clip to a condition and the testing agent **plays th
 <Note>
 Audio can only be attached to a **fixed-message** condition (`fixed_message: true`). It is not available on instruction-based (`fixed_message: false`) conditions — those are meant to vary, and a recording is fixed by definition.
 </Note>
+
+<Tip>
+If you only need a **second speaker** rather than a specific recording, use the [`<voice>` tag](#supported-tags) instead — it keeps the dialogue generated so the conversation can still adapt.
+</Tip>
 
 ### How it works
 


### PR DESCRIPTION
Documents `<voice provider="P" id="X" model="Y"/>`, which switches the testing agent's TTS voice mid-call so a scripted evaluator can hand the call to a second speaker.

Covers the provider/voice-id format pairing (Cartesia ids are UUIDs, ElevenLabs ids are alphanumeric), the per-provider default models, and why the provider itself cannot change mid-call. Also points the Attached Audio section at this tag for the "I just need another speaker" case, where a recording would fix the dialogue unnecessarily.