### PR TITLE
docs: <ignore_interruptions> protected playback span

### DIFF
--- a/documentation/advanced/ivr-voicemail.mdx
+++ b/documentation/advanced/ivr-voicemail.mdx
@@ -203,6 +203,23 @@ Use the `<ivr>` XML tag to define menu prompts. Remember to set `fixed_message: 
 
 **Provider Support:** The `<ivr>` tag works with all TTS providers (Cartesia, ElevenLabs, etc.)
 
+<Warning>
+`<hold>` and `<audio>` tags are **not supported** inside `<ivr text="...">` and are rejected when you save the evaluator. To play a sequence of audio clips and pauses without interruption, use `<ignore_interruptions>` instead (below).
+</Warning>
+
+### Playing a Sequence Without Interruption
+
+Use the `<ignore_interruptions>` block tag when a multi-part menu — pre-recorded clips, pauses, or spoken text — must play to completion no matter what the main agent says:
+
+```xml
+<ignore_interruptions> <audio id="clip1"/> <hold time="5s" /> <audio id="clip2"/> <hold time="5s" /> <audio id="clip3"/> </ignore_interruptions> <endcall />
+```
+
+- Content goes **between** the opening and closing tags, never in an attribute. The tag protects a span, so normal text or tags can come before and after it, and it can appear more than once per action. Spans cannot nest.
+- The main agent's speech during the span **is still transcribed and evaluated** — it just never interrupts playback or triggers a reply.
+- The `<audio>` ids come from the audio-upload flow; don't write them by hand.
+- Remember to set `fixed_message: true`, like all XML tags.
+
 ### Example: Hospital IVR System
 
 ```json

--- a/documentation/key-concepts/evaluators/conditional-actions.mdx
+++ b/documentation/key-concepts/evaluators/conditional-actions.mdx
@@ -379,6 +379,35 @@ Tags can be combined with text and other sibling tags. They run from left to rig
 
     **Attributes:**
     - `text`: The IVR message to play (required)
+
+    <Warning>
+    `<hold>` and `<audio>` tags are **not supported** inside `<ivr text="...">` and are rejected at save time. To play a sequence of audio clips and pauses without interruption, use `<ignore_interruptions>` instead.
+    </Warning>
+  </Accordion>
+
+  <Accordion title="<ignore_interruptions> - Protected Playback Span" icon="shield">
+    Wrap a span of the action so everything inside plays to completion — nothing the main agent says can interrupt it. Content is unrestricted: spoken text, `<audio>` clips, `<hold>`/`<silence>` pauses, or any mix. The typical use is a multi-part IVR menu of clips and pauses.
+
+    ```json
+    {
+      "id": 1,
+      "type": "action_followup",
+      "condition": 0,
+      "action": "<ignore_interruptions> <audio id=\"2eeb6544\"/> <hold time=\"5s\" /> <audio id=\"f0c5cdfe\"/> <hold time=\"5s\" /> <audio id=\"1bfc2ad2\"/> </ignore_interruptions> <endcall />",
+      "fixed_message": true
+    }
+    ```
+
+    Unlike `<ivr>`, this is a **block tag scoped to a span**: content goes between the opening and closing tags, it can appear more than once per action, and normal text or tags can come before and after it.
+
+    **What the main agent's speech does during the span:**
+    - It does **not** interrupt playback or abort the remaining clips.
+    - It does **not** trigger a reply from the testing agent — during the span or after it ends.
+    - It **is** still transcribed and included in evaluation, so metrics can judge what the agent said over the menu.
+
+    <Note>
+    Nested spans are not supported — use sequential spans instead. Attributes are not supported; content always goes between the tags.
+    </Note>
   </Accordion>
 
   <Accordion title="<voicemail> - Voicemail Greeting" icon="voicemail">


### PR DESCRIPTION
Documents the new `<ignore_interruptions>` conditional-actions tag (runtime: cekura-ai/pipecat-cloud-agents#812, validation: cekura-ai/vocera.backend#10748).

- **conditional-actions.mdx**: new accordion in the XML tag reference, matching the house accordion pattern (JSON example, block-vs-attribute semantics, transcription behavior), plus a Warning on the `<ivr>` accordion that `<hold>`/`<audio>` inside `text="..."` are rejected at save time.
- **ivr-voicemail.mdx**: a "Playing a Sequence Without Interruption" section with the multi-clip pattern, and the same `<ivr>` warning.

Publish after both code PRs deploy — the tag is rejected by validation until the backend PR lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)