### PR TITLE
Document language coverage for Transcription Accuracy number matching

### DIFF
--- a/documentation/key-concepts/metrics/pre-defined-metrics.mdx
+++ b/documentation/key-concepts/metrics/pre-defined-metrics.mdx
@@ -121,6 +121,8 @@ These metrics evaluate whether your agent provides correct and consistent inform
 
     **Rendering-only differences are not errors.** Differences that only change how a value is *rendered* are treated as equivalent and don't count at all — spelled-out vs digit numbers, and spelled-out vs abbreviated units (e.g. "five kilowatts" vs "5 kW", "two hundred thirty volt" vs "230 V"). Only a genuine change in the value or the unit ("20 watts" vs "20 volts") is a real error. Backchannel acknowledgements ("uh-huh" vs "aha") are treated as minor variations.
 
+    Spoken numbers are matched to their digit form in English, Spanish, French, German, Portuguese, Italian, Dutch and Hindi. A value read aloud ("ciento veintitrés", "पैंतालीस हज़ार") scores the same as the value written in digits ("123", "45000"), and identifiers keep their leading zeroes, so a postal code read out as "cero seis seis cero cero" matches "06600". A different value is still a real error — "06600" and "06680" do not match. In other languages a spelled-out number and its digit form are compared as written, so the difference is reported.
+
     **Reading the explanation.** Errors are grouped into **Major Variations** (drive the base score) and **Minor Variations** (each applies the 0.1% penalty), so you can see exactly which mistranscriptions drove the score. Both sections always appear — `None` means there were no errors of that kind. A summary at the bottom shows the **Metric Score** and the **WER** percentage.
 
     **Interpretation**: Higher scores indicate better transcription accuracy. Use this metric when you need to verify that the agent's TTS is rendering content correctly (correct words, correct numbers), not just that speech is audible.


### PR DESCRIPTION
## Summary

The "Rendering-only differences are not errors" paragraph told customers that spelled-out vs digit numbers are treated as equivalent, without saying which languages that held for. It was English-only. cekura-ai/vocera.backend#10779 extends it to Spanish, French, German, Portuguese, Italian, Dutch and Hindi.

Adds one paragraph naming the covered languages, showing that leading-zero identifiers (postal codes, phone numbers) are preserved, and stating that a genuinely different value is still an error and that other languages compare spelled-out numbers as written.

Backend PR: cekura-ai/vocera.backend#10779