### PR TITLE
Document test profile placeholders in <dtmf> digits

### DIFF
--- a/documentation/guides/testing-agents/dtmf-testing.mdx
+++ b/documentation/guides/testing-agents/dtmf-testing.mdx
@@ -164,6 +164,27 @@ To send button presses without speaking:
 
 This sends only the button press with no spoken message.
 
+### Digits from a Test Profile
+
+When the digits are caller data rather than a menu choice — an account number, a
+PIN, a date of birth — reference the [test profile](/documentation/key-concepts/evaluators/test-profile)
+instead of hardcoding them, so one evaluator covers every profile you run it with:
+
+```json
+{
+  "action": "<dtmf digits=\"{{test_profile.customer_number}}#\" />"
+}
+```
+
+The placeholder is replaced with the profile value for that run, and any
+formatting in the value (spaces, dashes, parentheses) is stripped before the
+tones are sent — a profile value of `4711 2200` dials `47112200`.
+
+<Note>
+The key must exist in the caller variables of the test profile the run uses. If it
+does not, no tones are sent for that action and the call continues.
+</Note>
+
 ## Valid DTMF Characters
 
 The following characters are supported for DTMF tones:
@@ -176,7 +197,7 @@ The following characters are supported for DTMF tones:
 | `A-D` | Extended DTMF keys (rarely used) |
 
 <Warning>
-Invalid characters in the digits parameter will cause the DTMF send to fail. Always use only the characters listed above.
+Invalid characters in the digits parameter will cause the DTMF send to fail. Use only the characters listed above, or a `{{test_profile.key}}` placeholder that resolves to them.
 </Warning>
 
 ## Common Use Cases

--- a/documentation/key-concepts/evaluators/conditional-actions.mdx
+++ b/documentation/key-concepts/evaluators/conditional-actions.mdx
@@ -611,6 +611,11 @@ Use `<silence>` when you want the conversation to feel natural and allow the mai
 
     **Attributes:**
     - `digits`: DTMF digits to send (required) - e.g., "123", "456#", "*9"
+
+    For caller data such as an account number or PIN, reference the test profile
+    instead of hardcoding the digits — `<dtmf digits="{{test_profile.customer_number}}#" />`.
+    The value is resolved per run and any formatting in it is stripped before the
+    tones are sent. See [DTMF testing](/documentation/guides/testing-agents/dtmf-testing).
   </Accordion>
 
   <Accordion title="<send_sms> - Send SMS" icon="message">

--- a/documentation/key-concepts/evaluators/test-profile.mdx
+++ b/documentation/key-concepts/evaluators/test-profile.mdx
@@ -240,6 +240,20 @@ Your name is John Smith and your patient ID is PT-12345.
 If a template variable references a field that doesn't exist in the test profile, it will be replaced with an empty string. Make sure your test profile includes all fields you reference in your instructions.
 </Tip>
 
+### Inside Structured Test tags
+
+Template variables also work inside the tags of a [Structured Test](/documentation/key-concepts/evaluators/conditional-actions) action, not just in prose instructions — including the digits of a `<dtmf>` tag:
+
+```json
+{
+  "action": "<dtmf digits=\"{{test_profile.customer_number}}#\" />"
+}
+```
+
+That means one evaluator can navigate an IVR with every profile you run it against, instead of needing a copy per customer number. The same applies to the other tags that carry caller data, such as `<spell>{{test_profile.last_name}}</spell>`.
+
+For `<dtmf>` specifically, formatting in the resolved value (spaces, dashes, parentheses) is stripped before the tones are sent, so a profile value of `4711 2200` dials `47112200`.
+
 ### When to Use Template Variables
 
 Template variables are especially useful when:


### PR DESCRIPTION
The digits a <dtmf> tag sends can reference the run's test profile, so an IVR flow that keys in caller data (account number, PIN, date of birth) no longer needs the value hardcoded into the evaluator — one evaluator now covers every profile you run it against.

- dtmf-testing: new "Digits from a Test Profile" section, and the valid characters warning now allows a placeholder that resolves to them.
- conditional-actions: note on the <dtmf> tag pointing at the guide.
- test-profile: new "Inside Structured Test tags" section, since the template-variable docs previously implied prose instructions only.

Also documents that formatting in a resolved value (spaces, dashes, parentheses) is stripped before the tones are sent, and what happens when the profile lacks the referenced key.