### PR TITLE
Document per-metric Insights opt-in and failure criteria

### DIFF
--- a/documentation/guides/observability/insights.mdx
+++ b/documentation/guides/observability/insights.mdx
@@ -39,12 +39,12 @@ Each failure theme includes a title, a brief description, and clickable call IDs
 
 Insights are opt-in per metric. A metric produces no failure modes until you turn it on and tell Cekura what a passing call looks like for it.
 
-On the Insights page, click **Enable insights for a metric**, pick the metric, then set its **passing criteria** — the conditions a call must meet to count as a pass. Calls that don't meet them are the failures Cekura investigates. Choose whether a call must match **all** or **any** of the conditions.
+On the Insights page, click **Enable insights for a metric**, pick the metric, then set its **passing threshold** — the condition a call must meet to count as a pass. Calls that don't meet it are the failures Cekura investigates.
 
-The conditions use the same shape as a rubric rule, so a threshold you set here reads identically to one on the Rubric page. To change the criteria later, reopen the metric's card configuration; to stop analysing a metric, turn insights off.
+The threshold uses the same condition shape as a rubric rule. It applies only to new evaluated calls after Insights is enabled: Cekura does not reprocess historical calls. Failed calls are triaged as they arrive, so the metric's failure modes populate over time. To change the threshold later, reopen the metric's card configuration; to stop analysing a metric, turn insights off.
 
 <Note>
-  Insights are billed per failure analysed, and the dialog shows the per-failure credit cost and any daily cap before you enable.
+  Insights cost 10 credits per metric per day. The dialog shows this cost before you enable a metric.
 </Note>
 
 ## Which metrics are eligible

--- a/documentation/guides/observability/insights.mdx
+++ b/documentation/guides/observability/insights.mdx
@@ -22,7 +22,7 @@ These insights surface the dominant patterns behind a metric's failures, so you 
 
 ## Viewing and generating insights in the dashboard
 
-Navigate to **Observability → Insights** in the sidebar. The page displays a card for each LLM Judge metric enabled on your project.
+Navigate to **Observability → Insights** in the sidebar. The page displays a card for each metric you've enabled insights for.
 
 Use the **View** dropdown at the top of the page to filter by view. When a view is selected, the page shows only metrics and insights for agents in that view.
 
@@ -35,9 +35,27 @@ Click **Generate** (or **Regenerate** for an existing audit) to run a new analys
 
 Each failure theme includes a title, a brief description, and clickable call IDs that link directly to the corresponding call logs.
 
+## Enabling insights for a metric
+
+Insights are opt-in per metric. A metric produces no failure modes until you turn it on and tell Cekura what a passing call looks like for it.
+
+On the Insights page, click **Enable insights for a metric**, pick the metric, then set its **passing criteria** — the conditions a call must meet to count as a pass. Calls that don't meet them are the failures Cekura investigates. Choose whether a call must match **all** or **any** of the conditions.
+
+The conditions use the same shape as a rubric rule, so a threshold you set here reads identically to one on the Rubric page. To change the criteria later, reopen the metric's card configuration; to stop analysing a metric, turn insights off.
+
+<Note>
+  Insights are billed per failure analysed, and the dialog shows the per-failure credit cost and any daily cap before you enable.
+</Note>
+
 ## Which metrics are eligible
 
-Only supported for LLM Judge type metrics as of now. Code based metrics such as Latency, WPM, Talk Ratio are excluded.
+Any metric you evaluate on call logs can drive insights — LLM Judge, code-based, and predefined metrics alike. Failure is decided by the metric's own passing criteria rather than by its type, so metrics such as Latency, WPM, and Talk Ratio are no longer excluded.
 
-- **Custom metrics** with `type: llm_judge`.
-- **Predefined metrics** — the following: CSAT, Critical Deviations Continuous, Critical Info Check, Critical Info Check bool, Expected Outcome, Gibberish Detection, Hallucination, Letterwise Pronunciation Detection, Main Agent Early End Call, Not Early Termination, Pronunciation Analysis, Pronunciation test, Relevancy, Response Consistency, STT Errors, Tool call Accuracy, Unnecessary Repetition Count, Unnecessary Repetition Score.
+A metric needs both of the following:
+
+- **Evaluated on call logs.** A metric that doesn't run in Observability can never produce a failure to investigate.
+- **Insights enabled, with passing criteria set.** Both come from the step above.
+
+<Warning>
+  The project rubric no longer governs insights. Adding a metric to the rubric does **not** enable insights for it, and enabling insights does **not** make the metric count toward call success — the two are configured independently.
+</Warning>


### PR DESCRIPTION
## Summary
- Documents the simple one-threshold Insights enable flow and the 10-credit-per-metric daily cost.
- Clarifies that only newly evaluated calls are triaged after enabling, so failure modes populate over time rather than from a historical backfill.
- Retains the rubric/Insights independence and expanded metric eligibility documentation.

Pairs with cekura-ai/vocera.backend#10820 and cekura-ai/vocera.frontend.product#3532.