### PR TITLE
Document personality idle behavior and forking

### DIFF
--- a/api-reference/test_framework/fork-personality.mdx
+++ b/api-reference/test_framework/fork-personality.mdx
@@ -1,6 +1,6 @@
 ---
 title: Fork Personality
-description: "Copy an existing personality — including a globally available one — into one of your projects, optionally overriding its prompt or idle behavior on the copy."
+description: "Copy an existing personality — including a globally available one — into one of your projects, where you can then change any of its settings."
 openapi: post /test_framework/v1/personalities/{id}/fork/
 slug: fork-personality
 ---

--- a/api-reference/test_framework/fork-personality.mdx
+++ b/api-reference/test_framework/fork-personality.mdx
@@ -1,0 +1,6 @@
+---
+title: Fork Personality
+description: "Copy an existing personality — including a globally available one — into one of your projects, optionally overriding its prompt or idle behavior on the copy."
+openapi: post /test_framework/v1/personalities/{id}/fork/
+slug: fork-personality
+---

--- a/api-reference/test_framework/update-personality.mdx
+++ b/api-reference/test_framework/update-personality.mdx
@@ -1,0 +1,6 @@
+---
+title: Update Personality
+description: "Update an existing personality — including how the simulated caller behaves at the voice layer: idle timeout, idle message count, interruption level, speed, background noise and network simulation."
+openapi: patch /test_framework/v1/personalities/{id}/
+slug: update-personality
+---

--- a/cekura-mcp-server/mcp_tools.json
+++ b/cekura-mcp-server/mcp_tools.json
@@ -174,6 +174,6 @@
     "description_suffix": "Progress poller for `scenarios_generate_bg`. Poll until status is completed or failed. On completion, generated scenario IDs are available in the response."
   },
   "personalities_fork_create": {
-    "description_suffix": "Accepts only project_id, prompt and message_plan. Interruption level, start/stop speaking plans, speed, background noise and network simulation are set on the fork afterwards with personalities_partial_update."
+    "description_suffix": "The copy inherits every setting from its source. To change any of them — idle timeout, interruption level, speaking plans, speed, background noise, network simulation — call personalities_partial_update on the copy afterwards."
   }
 }

--- a/cekura-mcp-server/mcp_tools.json
+++ b/cekura-mcp-server/mcp_tools.json
@@ -172,5 +172,8 @@
   },
   "scenarios_generate_progress": {
     "description_suffix": "Progress poller for `scenarios_generate_bg`. Poll until status is completed or failed. On completion, generated scenario IDs are available in the response."
+  },
+  "personalities_fork_create": {
+    "description_suffix": "Accepts only project_id, prompt and message_plan. Interruption level, start/stop speaking plans, speed, background noise and network simulation are set on the fork afterwards with personalities_partial_update."
   }
 }

--- a/documentation/advanced/creating-custom-personalities.mdx
+++ b/documentation/advanced/creating-custom-personalities.mdx
@@ -80,14 +80,13 @@ Both idle fields must be set together, and both must be 1 or greater — the idl
 
 The same fields are available programmatically:
 
-- [Fork Personality](/api-reference/test_framework/fork-personality) — copy a personality into a project, optionally overriding its prompt or idle behavior on the copy
-- [Update Personality](/api-reference/test_framework/update-personality) — change any setting on a personality your organization already owns, including the fork you just made
+- [Fork Personality](/api-reference/test_framework/fork-personality) — copy a personality into one of your projects
+- [Update Personality](/api-reference/test_framework/update-personality) — change any setting on a personality your organization owns, including a fork you just made
 
-Forking accepts `prompt` and `message_plan`; every other advanced setting is set with Update afterwards. Both steps are one call each, and the fork is yours to edit from then on.
+To customise a pre-defined personality, fork it and then update the copy:
 
-```json Fork with a longer idle timeout
+```json Update the fork with a longer idle timeout
 {
-  "project_id": 1234,
   "message_plan": {
     "idle_timeout_seconds": 45,
     "idle_message_max_spoken_count": 1

--- a/documentation/advanced/creating-custom-personalities.mdx
+++ b/documentation/advanced/creating-custom-personalities.mdx
@@ -80,8 +80,10 @@ Both idle fields must be set together, and both must be 1 or greater — the idl
 
 The same fields are available programmatically:
 
-- [Fork Personality](/api-reference/test_framework/fork-personality) — copy a personality into a project, optionally passing `message_plan` to override idle behavior on the copy
-- [Update Personality](/api-reference/test_framework/update-personality) — change a personality your organization already owns
+- [Fork Personality](/api-reference/test_framework/fork-personality) — copy a personality into a project, optionally overriding its prompt or idle behavior on the copy
+- [Update Personality](/api-reference/test_framework/update-personality) — change any setting on a personality your organization already owns, including the fork you just made
+
+Forking accepts `prompt` and `message_plan`; every other advanced setting is set with Update afterwards. Both steps are one call each, and the fork is yours to edit from then on.
 
 ```json Fork with a longer idle timeout
 {

--- a/documentation/advanced/creating-custom-personalities.mdx
+++ b/documentation/advanced/creating-custom-personalities.mdx
@@ -22,10 +22,15 @@ import { CopyPageButton } from "/snippets/copy-page-button.mdx";
 
 ### 2. Creating a New Personality
 
-You have two options for setting up personalities:
+You have three options for setting up personalities:
 
 1. **Use Pre-defined Personalities**: Choose from Cekura's curated collection of optimized personalities
-2. **Create Custom Personality**: Design a completely new personality from scratch
+2. **Fork a Pre-defined Personality**: Copy one into your project and change only what you need — everything else is inherited
+3. **Create Custom Personality**: Design a completely new personality from scratch
+
+<Note>
+Pre-defined personalities are shared across all workspaces, so they cannot be edited directly. **Fork** one when you want to keep its voice and accent but change its behavior — for example to raise the idle timeout. Forking is also the quickest route to a custom personality, since you don't have to re-pick the voice settings.
+</Note>
 
 ### To create a custom personality:
 
@@ -53,6 +58,40 @@ You have two options for setting up personalities:
 
 <img src="/images/personality/form.png" alt="Voice Settings" />
 
+## Advanced settings
+
+Open the **Advanced Settings** section of the personality form for these. They control how the testing agent *behaves* during a call, and cannot be set from an evaluator — instructions and expected outcomes only control what the testing agent says, so anything in this section has to be configured here.
+
+| Setting | What it controls | Default |
+|---|---|---|
+| **Idle Timeout (seconds)** | Seconds of silence before the testing agent prompts ("Are you still there?") | 10 |
+| **Max Idle Prompts** | How many times it prompts before ending the call | 3 |
+| **Interruption Level** | How aggressively the testing agent talks over your agent | Preset per personality |
+| **Start Wait Seconds / stop speaking plan** | Fine-grained control over when the caller starts and stops speaking. Ignored when an Interruption Level preset is set | — |
+| **Network Simulation** | Packet loss, jitter and latency, for degraded-network testing | Off |
+
+<Tip>
+**Making the testing agent wait in silence.** If your test needs the testing agent to say nothing while your agent works — a long lookup, hold music, an IVR menu — raise **Idle Timeout** past the expected pause. Adding "stay silent" or "do not respond" to the agent description or the evaluator's instructions will not work: the idle timeout fires regardless.
+</Tip>
+
+Both idle fields must be set together, and both must be 1 or greater — the idle prompt can be pushed out but not switched off entirely.
+
+## Updating a personality over the API
+
+The same fields are available programmatically:
+
+- [Fork Personality](/api-reference/test_framework/fork-personality) — copy a personality into a project, optionally passing `message_plan` to override idle behavior on the copy
+- [Update Personality](/api-reference/test_framework/update-personality) — change a personality your organization already owns
+
+```json Fork with a longer idle timeout
+{
+  "project_id": 1234,
+  "message_plan": {
+    "idle_timeout_seconds": 45,
+    "idle_message_max_spoken_count": 1
+  }
+}
+```
 
 ## Next Steps
 After creating your personality, you can:

--- a/documentation/key-concepts/evaluators/conditional-actions.mdx
+++ b/documentation/key-concepts/evaluators/conditional-actions.mdx
@@ -458,6 +458,7 @@ Tags can be combined with text and other sibling tags. They run from left to rig
 | Interruptible | ✅ Yes — main agent can interrupt | ❌ No — testing agent won’t be interrupted |
 | After interruption | Condition matching restarts after main agent stops speaking | N/A |
 | Background noise | Continues to play during the pause | Does **not** play during the pause |
+| [Idle prompt](/documentation/key-concepts/evaluators/personality) | Fires if the pause outlasts the personality's idle timeout | Suppressed — the idle timer is paused for the hold |
 
 Use `<silence>` when you want the conversation to feel natural and allow the main agent to jump in. Use `<hold>` when you need a guaranteed delay before the next message.
 </Note>
@@ -481,7 +482,7 @@ Use `<silence>` when you want the conversation to feel natural and allow the mai
   </Accordion>
 
   <Accordion title="<hold> - Hold Between Messages (not interruptible)" icon="pause">
-    Wait before sending the next message. **Not interruptible** — the testing agent will not be interrupted during a hold, regardless of what the main agent says. Background noise does not play during a hold.
+    Wait before sending the next message. **Not interruptible** — the testing agent will not be interrupted during a hold, regardless of what the main agent says. Background noise does not play during a hold, and the idle prompt ("Are you still there?") is suppressed for its duration — so a hold can safely be longer than the personality's idle timeout.
 
     ```json
     {

--- a/documentation/key-concepts/evaluators/personality.mdx
+++ b/documentation/key-concepts/evaluators/personality.mdx
@@ -44,7 +44,7 @@ Behavior in this list is set on the personality and **cannot be overridden from 
 
 If a test needs the testing agent to stay quiet longer than the idle timeout, raise **Idle Timeout** on the personality. Because the pre-defined personalities are shared across all workspaces, they can't be edited in place — fork one into your project first, then change the timeout on the fork. See [Creating Custom Personalities](/documentation/advanced/creating-custom-personalities#advanced-settings).
 
-For a pause in one specific step rather than call-wide, use a `<hold>` tag in a [conditional action](/documentation/key-concepts/evaluators/conditional-actions) instead. A hold does not raise the idle timeout, so when you need a pause longer than the timeout, raise the timeout on the personality as well.
+For a pause in one specific step rather than call-wide, use a `<hold>` tag in a [conditional action](/documentation/key-concepts/evaluators/conditional-actions) instead. The idle timer is paused for the duration of a hold, so a hold longer than the idle timeout does not trigger the idle prompt — you only need to change the personality when the silence is *not* inside a hold.
 </Warning>
 
 ### Example Personalities

--- a/documentation/key-concepts/evaluators/personality.mdx
+++ b/documentation/key-concepts/evaluators/personality.mdx
@@ -37,6 +37,15 @@ Personalities control several behavioral aspects:
 - **Interruption Patterns**: Tests how your agent handles being interrupted mid-sentence
 - **Speaking Pace**: Varies from slow and deliberate to fast and hurried
 - **Emotional Tone**: Ranges from calm and patient to frustrated or urgent
+- **Idle (stall) Behavior**: How long the testing agent waits in silence before prompting ("Are you still there?"), and how many times it prompts before giving up. Defaults are 10 seconds and 3 prompts.
+
+<Warning>
+Behavior in this list is set on the personality and **cannot be overridden from an evaluator**. Instructions, expected outcomes, and your agent's description control what the testing agent *says* — not how long it stays silent, how fast it speaks, or when it interrupts.
+
+If a test needs the testing agent to stay quiet longer than the idle timeout, raise **Idle Timeout** on the personality. Because the pre-defined personalities are shared across all workspaces, they can't be edited in place — fork one into your project first, then change the timeout on the fork. See [Creating Custom Personalities](/documentation/advanced/creating-custom-personalities#advanced-settings).
+
+For a pause in one specific step rather than call-wide, use a `<hold>` tag in a [conditional action](/documentation/key-concepts/evaluators/conditional-actions) instead. A hold does not raise the idle timeout, so when you need a pause longer than the timeout, raise the timeout on the personality as well.
+</Warning>
 
 ### Example Personalities
 

--- a/mint.json
+++ b/mint.json
@@ -485,6 +485,8 @@
           "pages": [
             "api-reference/test_framework/list-personalities",
             "api-reference/test_framework/create-personality",
+            "api-reference/test_framework/update-personality",
+            "api-reference/test_framework/fork-personality",
             "api-reference/test_framework/list-predefined-metrics",
             "api-reference/test_framework/list-inbound-phone-numbers",
             "api-reference/observability/create-scenarios-from-call-logs",

--- a/openapi.json
+++ b/openapi.json
@@ -24423,7 +24423,8 @@
             },
             "patch": {
                 "operationId": "personalities-external-partial-update",
-                "description": "Update a caller personality",
+                "description": "Update an existing personality. Send only the fields you want to change.\n\nUse this to change how the simulated caller behaves at the voice layer — `message_plan` (how long it waits in silence before prompting, and how many times it prompts), `interruption_level`, `speed`, `background_noise`, `network_simulation`. Evaluator instructions cannot override these; they must be set here.\n\nOnly personalities owned by your organization can be updated. To change a globally available personality, fork it into your project first, then update the fork.",
+                "summary": "Update a personality",
                 "parameters": [
                     {
                         "in": "path",
@@ -24645,7 +24646,8 @@
         "/test_framework/v1/personalities-external/{id}/fork/": {
             "post": {
                 "operationId": "personalities-external-fork-create",
-                "description": "Personalities fork",
+                "description": "Copy an existing personality — including a globally available one — into one of your projects so it can be customised. Voice, accent, language and interruption settings are inherited from the source; pass `prompt` or `message_plan` to override them on the copy.\n\nUse this when no available personality has the behavior a test needs: fork the closest match, then set `message_plan.idle_timeout_seconds` (seconds of silence before the caller prompts, default 10) or `message_plan.idle_message_max_spoken_count` (how many times it prompts before giving up, default 3). The fork is enabled for the project automatically.",
+                "summary": "Fork a personality into a project",
                 "parameters": [
                     {
                         "in": "path",
@@ -24664,21 +24666,20 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/CreatePersonality"
+                                "$ref": "#/components/schemas/ForkPersonality"
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/CreatePersonality"
+                                "$ref": "#/components/schemas/ForkPersonality"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/CreatePersonality"
+                                "$ref": "#/components/schemas/ForkPersonality"
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "security": [
                     {
@@ -24906,7 +24907,8 @@
             },
             "patch": {
                 "operationId": "personalities-partial-update",
-                "description": "Update a caller personality",
+                "description": "Update an existing personality. Send only the fields you want to change.\n\nUse this to change how the simulated caller behaves at the voice layer — `message_plan` (how long it waits in silence before prompting, and how many times it prompts), `interruption_level`, `speed`, `background_noise`, `network_simulation`. Evaluator instructions cannot override these; they must be set here.\n\nOnly personalities owned by your organization can be updated. To change a globally available personality, fork it into your project first, then update the fork.",
+                "summary": "Update a personality",
                 "parameters": [
                     {
                         "in": "path",
@@ -24961,6 +24963,14 @@
                             }
                         },
                         "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "personalities-partial-update",
+                        "description": "Update an existing personality. Send only the fields you want to change.\n\nUse this to change how the simulated caller behaves at the voice layer — `message_plan` (how long it waits in silence before prompting, and how many times it prompts), `interruption_level`, `speed`, `background_noise`, `network_simulation`. Evaluator instructions cannot override these; they must be set here.\n\nOnly personalities owned by your organization can be updated. To change a globally available personality, fork it into your project first, then update the fork."
                     }
                 }
             },
@@ -25128,7 +25138,8 @@
         "/test_framework/v1/personalities/{id}/fork/": {
             "post": {
                 "operationId": "personalities-fork-create",
-                "description": "Personalities fork",
+                "description": "Copy an existing personality — including a globally available one — into one of your projects so it can be customised. Voice, accent, language and interruption settings are inherited from the source; pass `prompt` or `message_plan` to override them on the copy.\n\nUse this when no available personality has the behavior a test needs: fork the closest match, then set `message_plan.idle_timeout_seconds` (seconds of silence before the caller prompts, default 10) or `message_plan.idle_message_max_spoken_count` (how many times it prompts before giving up, default 3). The fork is enabled for the project automatically.",
+                "summary": "Fork a personality into a project",
                 "parameters": [
                     {
                         "in": "path",
@@ -25147,21 +25158,20 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/CreatePersonality"
+                                "$ref": "#/components/schemas/ForkPersonality"
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/CreatePersonality"
+                                "$ref": "#/components/schemas/ForkPersonality"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/CreatePersonality"
+                                "$ref": "#/components/schemas/ForkPersonality"
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "security": [
                     {
@@ -25184,6 +25194,14 @@
                             }
                         },
                         "description": ""
+                    }
+                },
+                "x-mcp-expose": true,
+                "x-mint": {
+                    "mcp": {
+                        "enabled": true,
+                        "name": "personalities-fork-create",
+                        "description": "Copy an existing personality — including a globally available one — into one of your projects so it can be customised. Voice, accent, language and interruption settings are inherited from the source; pass `prompt` or `message_plan` to override them on the copy.\n\nUse this when no available personality has the behavior a test needs: fork the closest match, then set `message_plan.idle_timeout_seconds` (seconds of silence before the caller prompts, default 10) or `message_plan.idle_message_max_spoken_count` (how many times it prompts before giving up, default 3). The fork is enabled for the project automatically."
                     }
                 }
             }
@@ -71391,6 +71409,24 @@
                     "call_log_ids",
                     "count"
                 ]
+            },
+            "ForkPersonality": {
+                "type": "object",
+                "description": "Fields that can be overridden on a forked personality. Anything omitted is\ninherited from the source personality.",
+                "properties": {
+                    "project_id": {
+                        "type": "integer",
+                        "description": "Project the fork is created in. Inferred from a project-scoped API key when omitted."
+                    },
+                    "prompt": {
+                        "type": "string",
+                        "description": "Replaces the source personality's prompt on the fork. Inherited when omitted."
+                    },
+                    "message_plan": {
+                        "type": "string",
+                        "description": "\nIdle behavior overrides for the fork, applied on top of the inherited settings.\nSupports idle_timeout_seconds (positive int) and idle_message_max_spoken_count (positive int).\nExample: {\"idle_timeout_seconds\": 45}\n"
+                    }
+                }
             },
             "GenerateClarifyAnswer": {
                 "type": "object",

--- a/openapi.json
+++ b/openapi.json
@@ -24646,7 +24646,7 @@
         "/test_framework/v1/personalities-external/{id}/fork/": {
             "post": {
                 "operationId": "personalities-external-fork-create",
-                "description": "Copy a personality into one of your projects, inheriting every setting you do not override. Use this to customise a globally available personality, which is shared and cannot be edited in place. The fork is enabled for the project automatically, and any setting this endpoint does not accept can be changed on it afterwards by updating the fork.",
+                "description": "Copy a personality into one of your projects, inheriting all of its settings. Use this to customise a globally available personality, which is shared and cannot be edited in place — the copy is yours to change by updating it. The copy is enabled for the project automatically.",
                 "summary": "Fork a personality into a project",
                 "parameters": [
                     {
@@ -25138,7 +25138,7 @@
         "/test_framework/v1/personalities/{id}/fork/": {
             "post": {
                 "operationId": "personalities-fork-create",
-                "description": "Copy a personality into one of your projects, inheriting every setting you do not override. Use this to customise a globally available personality, which is shared and cannot be edited in place. The fork is enabled for the project automatically, and any setting this endpoint does not accept can be changed on it afterwards by updating the fork.",
+                "description": "Copy a personality into one of your projects, inheriting all of its settings. Use this to customise a globally available personality, which is shared and cannot be edited in place — the copy is yours to change by updating it. The copy is enabled for the project automatically.",
                 "summary": "Fork a personality into a project",
                 "parameters": [
                     {
@@ -25201,7 +25201,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "personalities-fork-create",
-                        "description": "Copy a personality into one of your projects, inheriting every setting you do not override. Use this to customise a globally available personality, which is shared and cannot be edited in place. The fork is enabled for the project automatically, and any setting this endpoint does not accept can be changed on it afterwards by updating the fork."
+                        "description": "Copy a personality into one of your projects, inheriting all of its settings. Use this to customise a globally available personality, which is shared and cannot be edited in place — the copy is yours to change by updating it. The copy is enabled for the project automatically."
                     }
                 }
             }
@@ -71412,7 +71412,7 @@
             },
             "ForkPersonality": {
                 "type": "object",
-                "description": "Fields that can be overridden on a forked personality. Anything omitted is\ninherited from the source personality, so this deliberately does not advertise the\nvoice fields that creating a personality from scratch requires.",
+                "description": "Request body for forking a personality. A fork inherits every setting from its\nsource, so this deliberately does not advertise the voice fields that creating a\npersonality from scratch requires.",
                 "properties": {
                     "project_id": {
                         "type": "integer",
@@ -71421,10 +71421,6 @@
                     "prompt": {
                         "type": "string",
                         "description": "Replaces the source personality's prompt on the fork."
-                    },
-                    "message_plan": {
-                        "type": "string",
-                        "description": "Idle behavior overrides. Supports idle_timeout_seconds and idle_message_max_spoken_count (positive ints)."
                     }
                 }
             },

--- a/openapi.json
+++ b/openapi.json
@@ -24423,7 +24423,7 @@
             },
             "patch": {
                 "operationId": "personalities-external-partial-update",
-                "description": "Update an existing personality. Send only the fields you want to change.\n\nUse this to change how the simulated caller behaves at the voice layer — `message_plan` (how long it waits in silence before prompting, and how many times it prompts), `interruption_level`, `speed`, `background_noise`, `network_simulation`. Evaluator instructions cannot override these; they must be set here.\n\nOnly personalities owned by your organization can be updated. To change a globally available personality, fork it into your project first, then update the fork.",
+                "description": "Update an existing personality, sending only the fields you want to change. This is the only place the simulated caller's voice-layer behavior can be set — evaluator instructions cannot override it. Globally available personalities are shared and cannot be updated; fork one into your project first, then update the fork.",
                 "summary": "Update a personality",
                 "parameters": [
                     {
@@ -24646,7 +24646,7 @@
         "/test_framework/v1/personalities-external/{id}/fork/": {
             "post": {
                 "operationId": "personalities-external-fork-create",
-                "description": "Copy an existing personality — including a globally available one — into one of your projects so it can be customised. Voice, accent, language and interruption settings are inherited from the source; pass `prompt` or `message_plan` to override them on the copy.\n\nUse this when no available personality has the behavior a test needs: fork the closest match, then set `message_plan.idle_timeout_seconds` (seconds of silence before the caller prompts, default 10) or `message_plan.idle_message_max_spoken_count` (how many times it prompts before giving up, default 3). The fork is enabled for the project automatically.",
+                "description": "Copy an existing personality — including a globally available one — into one of your projects so it can be customised, inheriting everything you do not override. Use this when no available personality has the behavior a test needs: fork the closest match and pass `message_plan` to change its idle behavior. The fork is enabled for the project automatically.",
                 "summary": "Fork a personality into a project",
                 "parameters": [
                     {
@@ -24907,7 +24907,7 @@
             },
             "patch": {
                 "operationId": "personalities-partial-update",
-                "description": "Update an existing personality. Send only the fields you want to change.\n\nUse this to change how the simulated caller behaves at the voice layer — `message_plan` (how long it waits in silence before prompting, and how many times it prompts), `interruption_level`, `speed`, `background_noise`, `network_simulation`. Evaluator instructions cannot override these; they must be set here.\n\nOnly personalities owned by your organization can be updated. To change a globally available personality, fork it into your project first, then update the fork.",
+                "description": "Update an existing personality, sending only the fields you want to change. This is the only place the simulated caller's voice-layer behavior can be set — evaluator instructions cannot override it. Globally available personalities are shared and cannot be updated; fork one into your project first, then update the fork.",
                 "summary": "Update a personality",
                 "parameters": [
                     {
@@ -24970,7 +24970,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "personalities-partial-update",
-                        "description": "Update an existing personality. Send only the fields you want to change.\n\nUse this to change how the simulated caller behaves at the voice layer — `message_plan` (how long it waits in silence before prompting, and how many times it prompts), `interruption_level`, `speed`, `background_noise`, `network_simulation`. Evaluator instructions cannot override these; they must be set here.\n\nOnly personalities owned by your organization can be updated. To change a globally available personality, fork it into your project first, then update the fork."
+                        "description": "Update an existing personality, sending only the fields you want to change. This is the only place the simulated caller's voice-layer behavior can be set — evaluator instructions cannot override it. Globally available personalities are shared and cannot be updated; fork one into your project first, then update the fork."
                     }
                 }
             },
@@ -25138,7 +25138,7 @@
         "/test_framework/v1/personalities/{id}/fork/": {
             "post": {
                 "operationId": "personalities-fork-create",
-                "description": "Copy an existing personality — including a globally available one — into one of your projects so it can be customised. Voice, accent, language and interruption settings are inherited from the source; pass `prompt` or `message_plan` to override them on the copy.\n\nUse this when no available personality has the behavior a test needs: fork the closest match, then set `message_plan.idle_timeout_seconds` (seconds of silence before the caller prompts, default 10) or `message_plan.idle_message_max_spoken_count` (how many times it prompts before giving up, default 3). The fork is enabled for the project automatically.",
+                "description": "Copy an existing personality — including a globally available one — into one of your projects so it can be customised, inheriting everything you do not override. Use this when no available personality has the behavior a test needs: fork the closest match and pass `message_plan` to change its idle behavior. The fork is enabled for the project automatically.",
                 "summary": "Fork a personality into a project",
                 "parameters": [
                     {
@@ -25201,7 +25201,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "personalities-fork-create",
-                        "description": "Copy an existing personality — including a globally available one — into one of your projects so it can be customised. Voice, accent, language and interruption settings are inherited from the source; pass `prompt` or `message_plan` to override them on the copy.\n\nUse this when no available personality has the behavior a test needs: fork the closest match, then set `message_plan.idle_timeout_seconds` (seconds of silence before the caller prompts, default 10) or `message_plan.idle_message_max_spoken_count` (how many times it prompts before giving up, default 3). The fork is enabled for the project automatically."
+                        "description": "Copy an existing personality — including a globally available one — into one of your projects so it can be customised, inheriting everything you do not override. Use this when no available personality has the behavior a test needs: fork the closest match and pass `message_plan` to change its idle behavior. The fork is enabled for the project automatically."
                     }
                 }
             }
@@ -71412,7 +71412,7 @@
             },
             "ForkPersonality": {
                 "type": "object",
-                "description": "Fields that can be overridden on a forked personality. Anything omitted is\ninherited from the source personality.",
+                "description": "Fields that can be overridden on a forked personality. Anything omitted is\ninherited from the source personality, so this deliberately does not advertise the\nvoice fields that creating a personality from scratch requires.",
                 "properties": {
                     "project_id": {
                         "type": "integer",
@@ -71420,11 +71420,11 @@
                     },
                     "prompt": {
                         "type": "string",
-                        "description": "Replaces the source personality's prompt on the fork. Inherited when omitted."
+                        "description": "Replaces the source personality's prompt on the fork."
                     },
                     "message_plan": {
                         "type": "string",
-                        "description": "\nIdle behavior overrides for the fork, applied on top of the inherited settings.\nSupports idle_timeout_seconds (positive int) and idle_message_max_spoken_count (positive int).\nExample: {\"idle_timeout_seconds\": 45}\n"
+                        "description": "Idle behavior overrides. Supports idle_timeout_seconds and idle_message_max_spoken_count (positive ints)."
                     }
                 }
             },

--- a/openapi.json
+++ b/openapi.json
@@ -24646,7 +24646,7 @@
         "/test_framework/v1/personalities-external/{id}/fork/": {
             "post": {
                 "operationId": "personalities-external-fork-create",
-                "description": "Copy an existing personality — including a globally available one — into one of your projects so it can be customised, inheriting everything you do not override. Use this when no available personality has the behavior a test needs: fork the closest match and pass `message_plan` to change its idle behavior. The fork is enabled for the project automatically.",
+                "description": "Copy a personality into one of your projects, inheriting every setting you do not override. Use this to customise a globally available personality, which is shared and cannot be edited in place. The fork is enabled for the project automatically, and any setting this endpoint does not accept can be changed on it afterwards by updating the fork.",
                 "summary": "Fork a personality into a project",
                 "parameters": [
                     {
@@ -25138,7 +25138,7 @@
         "/test_framework/v1/personalities/{id}/fork/": {
             "post": {
                 "operationId": "personalities-fork-create",
-                "description": "Copy an existing personality — including a globally available one — into one of your projects so it can be customised, inheriting everything you do not override. Use this when no available personality has the behavior a test needs: fork the closest match and pass `message_plan` to change its idle behavior. The fork is enabled for the project automatically.",
+                "description": "Copy a personality into one of your projects, inheriting every setting you do not override. Use this to customise a globally available personality, which is shared and cannot be edited in place. The fork is enabled for the project automatically, and any setting this endpoint does not accept can be changed on it afterwards by updating the fork.",
                 "summary": "Fork a personality into a project",
                 "parameters": [
                     {
@@ -25201,7 +25201,7 @@
                     "mcp": {
                         "enabled": true,
                         "name": "personalities-fork-create",
-                        "description": "Copy an existing personality — including a globally available one — into one of your projects so it can be customised, inheriting everything you do not override. Use this when no available personality has the behavior a test needs: fork the closest match and pass `message_plan` to change its idle behavior. The fork is enabled for the project automatically."
+                        "description": "Copy a personality into one of your projects, inheriting every setting you do not override. Use this to customise a globally available personality, which is shared and cannot be edited in place. The fork is enabled for the project automatically, and any setting this endpoint does not accept can be changed on it afterwards by updating the fork."
                     }
                 }
             }


### PR DESCRIPTION
## Problem

Idle timeout was absent from the personality documentation entirely. `personality.mdx` listed the components as language, background noise, interruption patterns, speaking pace and emotional tone; `creating-custom-personalities.mdx` covered basic info, prompt/temperature/model and voice settings. Neither mentioned the idle timeout, the idle message count, network simulation, the speaking plans, or forking — which is how customising a pre-defined personality actually works in the dashboard.

A user trying to keep the testing agent silent had no page to land on, so the natural next guess was the agent description, which cannot override any of it. The API reference had pages only for listing and creating a personality, so the REST route was undiscoverable too.

## Fix

- `personality.mdx` — idle/stall behavior added to the components list, with an explicit warning that nothing in that list can be overridden from an evaluator, plus what to do instead.
- `creating-custom-personalities.mdx` — a new **Advanced settings** section (idle timeout, max idle prompts, interruption level, speaking plans, network simulation) with the dashboard's own field labels, a forking step, and the API payload for a longer idle timeout. States plainly that both idle fields must be set together and both must be at least 1 — the prompt can be pushed out, not switched off.
- `conditional-actions.mdx` — the `<silence>` vs `<hold>` table gains an idle-prompt row, and the `<hold>` accordion now says the idle prompt is suppressed for a hold's duration, so a hold can safely be longer than the idle timeout.
- New API reference pages for updating and forking a personality, wired into the nav.
- `openapi.json`: the two personality operations only.

The spec merge is deliberately surgical rather than a full regeneration. A full regen at this moment also pulls in the in-flight `scenarios-refine` rename and several unrelated new operations, which belong to their own PRs.

## Verification

`cekura-mcp-server` tests: 152 passed, 8 failed — the same 8 fail on a clean tree at this commit (config fixtures and overlay drift from the `scenarios-refine` rename), so nothing here regressed them. `validate_overlays.py` reports only that pre-existing drift.

Confirmed by diffing the regenerated spec against this one that the only new `x-mcp-expose` entries are `PATCH /personalities/{id}/` and `POST /personalities/{id}/fork/`.

The `<hold>` claim is checked against the runtime, not assumed: a hold cancels the idle timer for its duration and resumes it afterwards, deferring while either party is still speaking.

## Merge order

Land cekura-ai/vocera.backend first — the spec here is generated from it, and this is what makes the two operations callable as tools.
