### PR TITLE
Remove API-reference pages an API key cannot call

### DIFF
--- a/api-reference/github/authorize-github-repository-checkout.mdx
+++ b/api-reference/github/authorize-github-repository-checkout.mdx
@@ -1,6 +1,0 @@
----
-title: Authorize GitHub Repository Checkout
-description: "Create a short-lived, read-only checkout credential for one repository. Requires an authenticated Cekura agent session, and the repository must be available through the organization's active GitHub connection. Repository access is verified for every request."
-openapi: post /github/checkout-token/
-slug: authorize-github-repository-checkout
----

--- a/api-reference/github/delete-github-connection.mdx
+++ b/api-reference/github/delete-github-connection.mdx
@@ -1,6 +1,0 @@
----
-title: Delete GitHub Connection
-description: "GET connection status for the org; DELETE to disconnect (mark inactive)."
-openapi: delete /github/connection/
-slug: delete-github-connection
----

--- a/api-reference/github/open-github-pull-request.mdx
+++ b/api-reference/github/open-github-pull-request.mdx
@@ -1,6 +1,0 @@
----
-title: Open GitHub Pull Request
-description: "Create a new branch and open a pull request containing the submitted file changes. Requires an authenticated Cekura agent session, and the repository must be available through the organization's active GitHub connection. Direct writes to the default branch are not permitted, and repository access is verified for every request."
-openapi: post /github/open-pr/
-slug: open-github-pull-request
----

--- a/api-reference/github/retrieve-github-connection.mdx
+++ b/api-reference/github/retrieve-github-connection.mdx
@@ -1,6 +1,0 @@
----
-title: Retrieve GitHub Connection
-description: "GET connection status for the org; DELETE to disconnect (mark inactive)."
-openapi: get /github/connection/
-slug: retrieve-github-connection
----

--- a/api-reference/github/retrieve-github-install-url.mdx
+++ b/api-reference/github/retrieve-github-install-url.mdx
@@ -1,6 +1,0 @@
----
-title: Retrieve GitHub Install URL
-description: "Return the GitHub App install URL with a single-use signed state."
-openapi: get /github/install-url/
-slug: retrieve-github-install-url
----

--- a/api-reference/github/setup-github-integration.mdx
+++ b/api-reference/github/setup-github-integration.mdx
@@ -1,6 +1,0 @@
----
-title: Setup GitHub Integration
-description: "Verify the installer with GitHub, then connect the installation."
-openapi: post /github/setup/
-slug: setup-github-integration
----

--- a/api-reference/subscriptions/add-payg-pack.mdx
+++ b/api-reference/subscriptions/add-payg-pack.mdx
@@ -1,6 +1,0 @@
----
-title: Add Pay-As-You-Go Pack
-description: "Start the free pay-as-you-go plan for an organization."
-openapi: post /subscriptions/packs/add_payg_pack/
-slug: add-payg-pack
----

--- a/api-reference/subscriptions/restart-subscription-seat-billing.mdx
+++ b/api-reference/subscriptions/restart-subscription-seat-billing.mdx
@@ -1,6 +1,0 @@
----
-title: Restart Subscription Seat Billing
-description: "Recreate the seat subscription of a perpetual (free base) plan after its"
-openapi: post /subscriptions/subscriptions/{id}/restart-seat-billing/
-slug: restart-subscription-seat-billing
----

--- a/api-reference/subscriptions/setup-subscription-payment-method.mdx
+++ b/api-reference/subscriptions/setup-subscription-payment-method.mdx
@@ -1,6 +1,0 @@
----
-title: Setup Subscription Payment Method
-description: "Start a Stripe setup-mode checkout to save a payment method for the"
-openapi: post /subscriptions/subscriptions/{id}/setup-payment-method/
-slug: setup-subscription-payment-method
----

--- a/api-reference/subscriptions/switch-to-payg.mdx
+++ b/api-reference/subscriptions/switch-to-payg.mdx
@@ -1,6 +1,0 @@
----
-title: Switch To Pay-As-You-Go
-description: "Switch a legacy Stripe-managed self-serve plan (the old developer plan"
-openapi: post /subscriptions/packs/switch_to_payg/
-slug: switch-to-payg
----

--- a/api-reference/user/get-user-onboarding-status.mdx
+++ b/api-reference/user/get-user-onboarding-status.mdx
@@ -1,6 +1,0 @@
----
-title: Get User Onboarding Status
-description: "User onboarding"
-openapi: get /user/onboarding/
-slug: get-user-onboarding-status
----

--- a/api-reference/user/get-user-onboarding.mdx
+++ b/api-reference/user/get-user-onboarding.mdx
@@ -1,6 +1,0 @@
----
-title: Get User Onboarding Status
-description: "User onboarding"
-openapi: get /user/onboarding/
-slug: get-user-onboarding
----

--- a/api-reference/user/update-user-onboarding-status.mdx
+++ b/api-reference/user/update-user-onboarding-status.mdx
@@ -1,6 +1,0 @@
----
-title: Update User Onboarding Status
-description: "User onboarding"
-openapi: patch /user/onboarding/
-slug: update-user-onboarding-status
----

--- a/api-reference/user/update-user-onboarding.mdx
+++ b/api-reference/user/update-user-onboarding.mdx
@@ -1,6 +1,0 @@
----
-title: Update User Onboarding
-description: "User onboarding"
-openapi: patch /user/onboarding/
-slug: update-user-onboarding
----

--- a/mint.json
+++ b/mint.json
@@ -509,19 +509,7 @@
             "api-reference/observability/get-agent-improvement-session",
             "api-reference/observability/list-metric-failure-mode-insight-category-calls",
             "api-reference/observability/delete-metric-failure-mode-insight-category",
-            "api-reference/subscriptions/add-payg-pack",
-            "api-reference/subscriptions/switch-to-payg",
-            "api-reference/subscriptions/restart-subscription-seat-billing",
-            "api-reference/subscriptions/setup-subscription-payment-method",
-            "api-reference/github/authorize-github-repository-checkout",
-            "api-reference/github/retrieve-github-connection",
-            "api-reference/github/delete-github-connection",
-            "api-reference/github/retrieve-github-install-url",
-            "api-reference/github/open-github-pull-request",
-            "api-reference/github/setup-github-integration",
-            "api-reference/observability/list-metric-failure-rates",
-            "api-reference/user/update-user-onboarding",
-            "api-reference/user/get-user-onboarding-status"
+            "api-reference/observability/list-metric-failure-rates"
           ]
         }
       ]


### PR DESCRIPTION
## Problem

The API reference renders each page's `security` as the call contract. Fourteen auto-generated pages document operations whose `security` does not offer `api_key`, so a customer who follows any of them gets a 403 — the same failure class as the 16 production 403s on 2026-07-29.

Audited every `api-reference/**/*.mdx` on `main` against the freshly regenerated spec (188 pages; 174 are api_key-callable):

| Page group | Count | Security offered |
|---|---|---|
| `api-reference/github/*` | 6 | `supabase_session` (connect / disconnect / install-url) and `product_chat_sandbox` (checkout-token, open-pr) |
| `api-reference/subscriptions/*` | 4 | `supabase_session_inactive_allowed`, `oauth2` + `supabase_session` |
| `api-reference/user/*onboarding*` | 4 | `oauth2` + `supabase_session` |

The four onboarding pages are two duplicate pairs over the same two operations (`GET`/`PATCH /user/onboarding/`), and those operations are **already** marked `x-docs-exclude` upstream. The generator only skips *newly-added* operations, so pages published before the marker was added were never withdrawn. Two of the four were not even in `mint.json` — orphan files reachable by direct URL.

All fourteen were added between 2026-07-22 and 2026-08-05 by the same generator gap.

## Change

Deleted the 14 `.mdx` files and their 12 `mint.json` nav entries. `api-reference/github/` and `api-reference/subscriptions/` are now empty and removed.

`mint.json` was edited structurally and re-dumped; it round-trips byte-identically through `json.dumps(indent=2)`, so the diff is exactly the 12 removed lines.

**No redirects.** None of these URLs was ever a working contract, and there is no customer-facing endpoint to point them at. Say so if you'd rather they land on the API reference index.

## Upstream

[vocera.backend#10879](https://github.com/cekura-ai/vocera.backend/pull/10879) stops this recurring: the docs generator now deterministically drops any newly-added operation whose `security` lacks `api_key` before the LLM include/exclude judgment runs, and the 10 operations here that lacked an upstream marker get `@docs_exclude()`. Merge order does not matter — this PR only removes files.

The trigger was [#863](https://github.com/cekura-ai/docs/pull/863), where the generator gave `POST /subscriptions/subscriptions/{id}/upgrade-plan/` a page that had to be removed by hand in `745bf3e`.

## Verification

- `mint.json` parses; no nav entry points at a missing file and no file is orphaned from nav.
- Grepped the whole tree for the removed paths — no residual references in `llms.txt`, `redirects`, snippets, or MDX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)