### PR TITLE
Update PAYG to Startup chatbot guidance

### DIFF
--- a/api-reference/organization/get-billing-info.mdx
+++ b/api-reference/organization/get-billing-info.mdx
@@ -4,3 +4,5 @@ description: "Returns credits remaining, credits used, and subscription status f
 openapi: get /test_framework/billing/info/
 slug: get-billing-info
 ---
+
+The response separates recurring plan credits in `balance` from non-expiring purchased or complimentary credits in `extra_balance`. `total_balance` is the sum available to the organization. Usage normally consumes `balance` before `extra_balance` when the combined balance covers the charge.

--- a/documentation/FAQ.mdx
+++ b/documentation/FAQ.mdx
@@ -29,11 +29,12 @@ If you run a **2-minute voice test** and evaluate it with **5 metrics**, the tot
 If you are importing external calls (e.g., from Retell or Twilio) for quality assurance and run **10 metrics** to evaluate the performance of that call, the total cost is **2 credits**:
 *   Evaluation: 10 metrics × 0.2 credits = 2 credits
 
-#### 3. Overages and Manual Top-ups
+#### 3. Overages and Credit Top-ups
 To ensure your testing and monitoring are never interrupted, Cekura provides flexible credit management options:
 
 *   **Overages:** When enabled, overages allow the platform to continue processing calls and metrics even after your base credit limit is reached. This is critical for production monitoring to ensure you don't lose data during high-volume periods. Overages are billed at **2× your committed credit rate** for your tier. On annual contracts, unused credits roll over to the following month; an overage occurs when usage in a month exceeds your monthly credit allocation plus any rolled-over credits from prior months. Overages are invoiced monthly; if a card is on file, it can be charged directly.
-*   **Manual Top-ups:** If you are in a sandbox or trial phase and run out of credits, our support team can manually add credits to your account to ensure your development work continues without delay.
+*   **One-time top-ups:** If your plan allows additional credits, organization admins can select **Add Credits** on [Settings → Billing](https://dashboard.cekura.ai/settings/org/billing) and make a one-time purchase. Purchases must be between **$10 and $10,000**. Cekura prompts you to add a payment method when needed, and some cards may require an additional confirmation step.
+*   **Auto-refill:** On supported payment methods, admins can configure an automatic credit purchase from the **Auto-refill** tab in **Add Credits**. The minimum balance threshold is **$1**, and the minimum refill amount is **$10**.
 
 #### 4. BestPractices for Credit Optimization
 To manage your credit burn effectively, consider the following strategies:
@@ -726,6 +727,44 @@ Purchased credits and plan credits are shown on the Billing page. Their availabi
 For questions about custom or Enterprise plans, contact [support@cekura.ai](mailto:support@cekura.ai).
 
 
+## How do I buy credits or configure auto-refill?
+
+Organization admins can open [Settings → Billing](https://dashboard.cekura.ai/settings/org/billing) and select **Add Credits**.
+
+- **One-time top-up:** Choose **One-time top-up**, enter an amount from **$10 to $10,000**, and complete the payment. The credits are added after the payment succeeds.
+- **Auto-refill:** Choose **Auto-refill**, set the balance threshold and refill amount, and save the settings. The minimum threshold is **$1**, and the minimum refill amount is **$10**. When the value of your available credits falls to the threshold, Cekura purchases the configured refill amount.
+
+Both options require an active, non-expired plan that allows additional credit purchases. If there is no payment method on file, Cekura prompts you to add one before continuing. Some payment methods, including cards that require manual confirmation, may support one-time top-ups but not automatic off-session refills. For example, an Indian card may ask you to confirm a one-time payment.
+
+Auto-refill complements, but does not replace, [Low Credits Alerts](/documentation/advanced/credit-alerts). An alert can notify admins if a refill fails or the available balance remains low.
+
+
+## Why does the Billing page show plan credits and additional credits?
+
+Cekura maintains two credit balances:
+
+- **Plan credits** are the recurring credits included with the current plan. Their renewal, rollover, and expiry behavior follows that plan.
+- **Additional credits** are credits from one-time purchases, auto-refills, or eligible complimentary grants. They do not expire.
+
+The displayed available balance combines both. Usage consumes plan credits first and then additional credits when the combined balance is sufficient.
+
+Eligible organizations that activate Pay As You Go may receive one-time complimentary credits in the additional-credit balance. This grant does not recur. Eligibility depends on account and email-domain history, so reactivating PAYG or switching back from another plan does not grant the credits again.
+
+
+## How are Pay As You Go members charged, and why can Stripe show a $0 trial invoice?
+
+The first member on Pay As You Go is free. Additional members are billed monthly at the seat price returned by Cekura's billing configuration. For a USD organization, the current standard price is **$30 per additional member per month**. Adding a member during a billing period can create a prorated invoice line such as **Member seat**.
+
+When an organization switches from a paid subscription to PAYG before its paid-through date, Cekura starts the free PAYG base plan immediately but defers additional-seat billing until that date. Stripe may create a **$0** invoice with a line such as **Trial period for Pay As You Go** for this deferred period. This is not a new free product trial and does not provide recurring trial credits. After the deferral ends, Stripe bills the organization's additional PAYG seats at the configured seat price.
+
+
+## What happens if payment for Pay As You Go seats fails?
+
+The free PAYG base plan remains active. Cekura allows a configured payment grace period for the overdue seat invoice. After that period, additional paid members are blocked from that organization, while the free-plan owner keeps access so an admin can correct the billing issue.
+
+An organization admin should open [Settings → Billing](https://dashboard.cekura.ai/settings/org/billing), update the payment method through **Manage Billing**, and pay or resolve the outstanding invoice. Access for paid members is restored after the seat billing issue is resolved.
+
+
 ## How do I switch from Pay As You Go to the Startup monthly plan?
 
 Organization admins can open the direct [Startup switch page](https://dashboard.cekura.ai/settings/org/billing?switch_plan=startupplan). Cekura resolves the eligible plan and price from the organization's billing configuration; the URL cannot select an arbitrary plan or price.
@@ -1106,13 +1145,15 @@ If you are integrating your conversation data for monitoring, you can find more 
 Cekura's **pay-as-you-go plan** is designed for individual developers and small teams. The pricing structure is per seat:
 
 - **First user:** free
-- **Each additional user:** $30 per user per month
+- **Each additional user:** the server-provided seat price, currently $30 per user per month for USD organizations
 
 Credits are purchased separately from the seat price. Adding a team member does not automatically increase your credit allocation — credits are bought independently as needed.
 
 For higher credit volumes, concurrent call limits above 10, or multi-project access, contact [support@cekura.ai](mailto:support@cekura.ai) to discuss available plans.
 
 Eligible organizations can move the whole team to Startup from [Settings → Billing](https://dashboard.cekura.ai/settings/org/billing) or the direct [Startup switch page](https://dashboard.cekura.ai/settings/org/billing?switch_plan=startupplan). The dashboard displays the configured price and plan comparison before charging. See [How do I switch from Pay As You Go to the Startup monthly plan?](#how-do-i-switch-from-pay-as-you-go-to-the-startup-monthly-plan) for eligibility and step-by-step instructions.
+
+For prorated seat charges and the `$0` deferred-billing invoice that can appear after moving to PAYG, see [How are Pay As You Go members charged?](#how-are-pay-as-you-go-members-charged-and-why-can-stripe-show-a-0-trial-invoice).
 
 
 ## What is the maximum number of projects I can create on my plan?
@@ -1328,7 +1369,7 @@ Deferred upload does not begin audio capture at the consent timestamp. Audio is 
 
 The sandbox plan gives access to the full Cekura platform. You can run real pre-production tests against your agents, use all testing, evaluation, and observability features, and validate your integration before going live.
 
-If you run out of credits during your sandbox phase, reach out via your support channel to request a top-up.
+If the sandbox plan allows additional credit purchases, an organization admin can use **Add Credits** on [Settings → Billing](https://dashboard.cekura.ai/settings/org/billing). If **Add Credits** is unavailable for your sandbox configuration, reach out through your support channel. See [buying credits and configuring auto-refill](#how-do-i-buy-credits-or-configure-auto-refill) for requirements and limits.
 
 ## Can I assign the same contact number to multiple agents?
 
@@ -1423,13 +1464,15 @@ Note: Cekura does not offer automatic URL redirection from an external `call_id`
 
 ## How can I view my total credit usage or expenses from a previous month?
 
-The Cekura dashboard does not currently provide a single consolidated "last month" credit summary or billing history export. What is available:
+Open [Settings → Billing](https://dashboard.cekura.ai/settings/org/billing) and use the history tabs and date filter:
 
-- **Settings → Billing:** Use the date filter to view credit usage over a selected window. The maximum filter window is **30 days**, so you can manually set a range that covers the month you want to review. This gives you an indication of usage for that period rather than a pre-built monthly report.
-- **Subscription invoices:** For subscription fees and payment history, go to **Settings → Billing → Manage Plan** to access the Stripe billing portal.
+- **Usage History:** Review credit additions and deductions, including their timestamps, types, descriptions, and amounts.
+- **Usage by Metric:** Review credits consumed by each metric, monitored call counts, and average credits per call.
+- **Billing History:** Review payment records such as **Subscription**, **Seat Charge**, **Credits Purchase**, and **Autopay**.
+- **Stripe invoices:** Select **Manage Billing** to open the Stripe billing portal for downloadable subscription and seat invoices.
 - **Detailed usage on request:** If you need a precise breakdown (credits consumed by type, overages vs. subscription, etc.), the Cekura team can pull this for you. Reach out via your support channel.
 
-A full billing history view is on the roadmap.
+Use the date filter to select the month or period you want to review. The dashboard does not currently provide a separate consolidated monthly export, so contact support if you need a custom report.
 
 
 ## Does Cekura require access to my codebase during onboarding?

--- a/documentation/FAQ.mdx
+++ b/documentation/FAQ.mdx
@@ -709,15 +709,44 @@ For more technical details on accessing test profile data in your metrics and ou
 Yes, integrating custom ASR models for simulation and observability is supported. This feature is available exclusively on our Enterprise plans. Please reach out to our support team for more details on how to set this up.
 
 
-## How do I set up or activate a subscription?
+## How do I set up, activate, or reactivate a subscription?
 
-To subscribe or re-activate a Cekura plan, visit [dashboard.cekura.ai/select-plan](https://dashboard.cekura.ai/select-plan) to view available plans and complete signup.
+Open [Settings → Billing](https://dashboard.cekura.ai/settings/org/billing). This page shows your current plan and the actions available for your organization:
 
-Alternatively, from within the dashboard navigate to **Settings → Billing → Manage Billing**. This opens the Stripe billing portal where you can add or update a payment method and choose or reactivate a plan. Note: the reactivation option in the Stripe portal requires a payment method to already be on file — if no option appears, use the `dashboard.cekura.ai/select-plan` URL directly.
+- If you do not have an active plan, select **Purchase Plan** or **Reactivate Plan** and follow the prompts.
+- If paid seats on Pay As You Go are scheduled for cancellation, select **Resume Paid Seats** to keep those seats active.
+- Use **Manage Billing** to update payment details or review Stripe invoices. Plan availability and reactivation actions are controlled from the Cekura Billing page.
 
-**Subscription and credits:** An active subscription is required to access the Cekura platform at all times. Pre-loaded credits cannot be used while the subscription is inactive. Credits do not expire — once you reactivate, any credits you have purchased will be available immediately.
+You must be an organization admin to change billing. If a paid action requires a card, Cekura will first prompt you to add a payment method and then return you to the billing flow.
+
+If the expected action is not available, contact [support@cekura.ai](mailto:support@cekura.ai) or your Cekura support channel. The action may be unavailable because of the organization's current plan, an unpaid invoice, member limits, or plan eligibility.
+
+Purchased credits and plan credits are shown on the Billing page. Their availability after a plan change depends on the source plan and the selected destination plan; review the confirmation shown before changing plans.
 
 For questions about custom or Enterprise plans, contact [support@cekura.ai](mailto:support@cekura.ai).
+
+
+## How do I switch from Pay As You Go to the Startup monthly plan?
+
+Organization admins can open the direct [Startup switch page](https://dashboard.cekura.ai/settings/org/billing?switch_plan=startupplan). Cekura resolves the eligible plan and price from the organization's billing configuration; the URL cannot select an arbitrary plan or price.
+
+You can also switch from the normal [Billing page](https://dashboard.cekura.ai/settings/org/billing):
+
+1. Find **Switch to Startup monthly** below **Cancel Paid Seats** or **Resume Paid Seats**. The action includes the server-provided monthly price, such as `$500/mo` for a USD organization.
+2. Alternatively, open **Cancel Paid Seats** and select **Switch to Startup monthly** in the cancellation dialog.
+3. Review the plan comparison, the amount charged today, included credits, limits, and renewal terms.
+4. Confirm **Switch to Startup**. Startup applies immediately, and Cekura stops the superseded PAYG paid-seat subscription.
+
+If a payment method is required, follow the prompt to add one and then return to the Billing page.
+
+The Startup switch is shown only when the backend confirms that the organization is eligible. It can be unavailable when:
+
+- the organization is not on the eligible Pay As You Go plan;
+- the Startup target is not configured or cannot cover the current team size;
+- the organization has an unpaid invoice or cannot be charged;
+- the organization already completed this one-time Pay As You Go to Startup switch.
+
+Declining the original first-paid-seat offer does not permanently hide it: the direct switch page can reopen a previously declined offer. However, returning to Pay As You Go after a successful Startup switch does not reset the one-time offer. Contact support if you need a different plan change.
 
 
 ## Can I freeze or pause my subscription for a few weeks while my project is on hold?
@@ -731,21 +760,22 @@ To pause your subscription:
 4. You will be redirected to our secure Stripe billing portal.
 5. Select the option to pause your subscription.
 
-To reactivate your plan, return to the same **Billing → Manage Plan** section and follow the prompts in the Stripe portal. All your existing agent configurations, evaluators, and historical data will remain intact.
+To reactivate your plan, return to [Settings → Billing](https://dashboard.cekura.ai/settings/org/billing) and select the available **Reactivate Plan**, **Renew Subscription**, or **Resume Paid Seats** action. All your existing agent configurations, evaluators, and historical data will remain intact.
 
-If the reactivation option is not available in the Stripe portal (for example, no payment method is on file), go directly to [dashboard.cekura.ai/select-plan](https://dashboard.cekura.ai/select-plan) to choose a plan. If you still cannot reactivate, contact support and the team can activate it for you directly.
+If no reactivation action appears, contact support.
 
 
 ## How do I cancel my subscription?
 
-You can cancel your subscription directly from the Cekura dashboard through the Stripe billing portal.
+You can cancel a subscription or paid PAYG seats from [Settings → Billing](https://dashboard.cekura.ai/settings/org/billing).
 
 To cancel your subscription:
 1. Log in to your Cekura account.
-2. Navigate to **Billing**.
-3. Click on **Manage Plan**.
-4. You will be redirected to our secure Stripe billing portal.
-5. Select the option to cancel your subscription.
+2. Navigate to **Settings → Billing**.
+3. Select **Cancel Subscription** for a monthly subscription, or **Cancel Paid Seats** for Pay As You Go.
+4. Review the access and billing impact, enter a cancellation reason, and confirm.
+
+Cancelling paid seats does not cancel the free PAYG base plan. The first user remains active, while additional paid members lose access after the paid-seat period and grace period. If your organization is eligible for Startup, the cancellation dialog also offers **Switch to Startup monthly**, and the same server-priced switch action appears below **Cancel Paid Seats** or **Resume Paid Seats** on the Billing page.
 
 If the cancel option is not visible or you are unable to complete the cancellation, contact support and the team can assist directly.
 
@@ -1081,6 +1111,8 @@ Cekura's **pay-as-you-go plan** is designed for individual developers and small 
 Credits are purchased separately from the seat price. Adding a team member does not automatically increase your credit allocation — credits are bought independently as needed.
 
 For higher credit volumes, concurrent call limits above 10, or multi-project access, contact [support@cekura.ai](mailto:support@cekura.ai) to discuss available plans.
+
+Eligible organizations can move the whole team to Startup from [Settings → Billing](https://dashboard.cekura.ai/settings/org/billing) or the direct [Startup switch page](https://dashboard.cekura.ai/settings/org/billing?switch_plan=startupplan). The dashboard displays the configured price and plan comparison before charging. See [How do I switch from Pay As You Go to the Startup monthly plan?](#how-do-i-switch-from-pay-as-you-go-to-the-startup-monthly-plan) for eligibility and step-by-step instructions.
 
 
 ## What is the maximum number of projects I can create on my plan?

--- a/documentation/advanced/credit-alerts.mdx
+++ b/documentation/advanced/credit-alerts.mdx
@@ -70,7 +70,7 @@ curl -X PATCH https://api.cekura.ai/user/organizations/{organization_id}/ \
 
 
 <Tip>
-Enable auto-refill in your billing settings to automatically top up credits when your balance runs low.
+Enable auto-refill in your billing settings to automatically top up credits when your balance runs low. See [buying credits and configuring auto-refill](/documentation/FAQ#how-do-i-buy-credits-or-configure-auto-refill) for payment requirements and limits.
 </Tip>
 
 ## Best Practices


### PR DESCRIPTION
## Summary

- removes every stale `dashboard.cekura.ai/select-plan` reference from the chatbot FAQ source;
- directs activation, reactivation, cancellation, and paid-seat management to Settings → Billing;
- adds step-by-step PAYG to Startup switch guidance for the direct link, billing-card action, and Cancel Paid Seats dialog;
- documents server-owned pricing, admin/payment requirements, eligibility gates, and one-time switch behavior;
- explains PAYG member pricing, prorated seat charges, the `$0` deferred-billing invoice, and overdue-seat access behavior;
- documents one-time credit purchases, auto-refill limits, payment-method requirements, and low-credit alerts;
- explains recurring plan credits, non-expiring additional credits, consumption order, and one-time PAYG complimentary credits;
- updates the Billing History guidance for Usage History, Usage by Metric, Billing History, and Stripe invoices;
- corrects stale sandbox top-up guidance and adds credit-balance details to the billing API reference.

## Related implementation

- Backend: cekura-ai/vocera.backend#10759
- Frontend: cekura-ai/vocera.frontend.product#3506

## Validation

- `rg` confirms no `/select-plan`, stale billing-history roadmap, or support-only top-up references remain.
- `git diff --check` passes.
- `mintlify broken-links` reports only the 10 pre-existing broken links in unrelated files; none are introduced by this PR.
