### PR TITLE
fix(mcp): compare plugin version at the precision the client reported

### DIFF
--- a/cekura-mcp-server/openapi_mcp_server.py
+++ b/cekura-mcp-server/openapi_mcp_server.py
@@ -625,8 +625,13 @@ def _parse_version(v: Any) -> Tuple[int, ...]:
 
 
 def _is_older_version(reported: str, latest: str) -> bool:
+    # Compare only as precisely as the caller reported. Skills carry a
+    # major.minor tag ("0.10"), so a full-semver latest ("0.10.7") must not
+    # read as newer than an install that is in fact current. Older installs
+    # that still report full semver keep exact comparison.
     try:
-        return _parse_version(reported) < _parse_version(latest)
+        reported_parts = _parse_version(reported)
+        return reported_parts < _parse_version(latest)[: len(reported_parts)]
     except Exception:
         return False
 
@@ -729,7 +734,8 @@ async def _forward_skill_activation(
         "  conversation_id: optional Cekura sandbox / chat conversation ID.\n"
         "  verification_tag: optional tag carried in the skill/command (the value "
         "to thread as `skill_ack` on gated authoring calls).\n"
-        "  plugin_version: optional installed Cekura plugin version (e.g. \"0.8.1\").\n"
+        "  plugin_version: optional installed Cekura plugin version, at whatever "
+        "precision the skill carries (e.g. \"0.10\" or \"0.8.1\").\n"
         "  skill_version: optional per-skill version if the skill declares one."
     ),
     annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, openWorldHint=False),

--- a/cekura-mcp-server/tests/test_version_freshness.py
+++ b/cekura-mcp-server/tests/test_version_freshness.py
@@ -1,0 +1,29 @@
+"""Tests for the plugin-version freshness comparison.
+
+The skill beacon reports whatever precision the installed skills carry
+(major.minor from cekura-skills 0.11 on, full semver before that), so the
+nudge must compare at the reported precision instead of assuming semver.
+"""
+import pytest
+
+from openapi_mcp_server import _is_older_version
+
+
+@pytest.mark.parametrize("reported,latest,expected", [
+    # major.minor tags: patch releases must NOT read as an update
+    ("0.10", "0.10.7", False),
+    ("0.10", "0.10.0", False),
+    ("0.10", "0.10", False),
+    ("0.10", "0.11.0", True),
+    ("0.11", "0.10.7", False),
+    # full semver from older installs keeps exact comparison
+    ("0.9.0", "0.10.7", True),
+    ("0.10.6", "0.10.7", True),
+    ("0.10.7", "0.10.7", False),
+    ("0.10.8", "0.10.7", False),
+    # unparseable input never nudges
+    ("", "0.10.7", False),
+    ("garbage", "0.10.7", False),
+])
+def test_is_older_version(reported, latest, expected):
+    assert _is_older_version(reported, latest) is expected


### PR DESCRIPTION
## Problem

The skill-activation freshness nudge compares the reported plugin version against the latest release as raw integer tuples:

```python
return _parse_version(reported) < _parse_version(latest)
```

`_parse_version("0.10")` is `(0, 10)`, which sorts **below** `(0, 10, 7)`. So any client reporting a coarser precision than the latest release is told it is stale on *every* skill activation, even when it is on the newest build:

```
OLD logic: 0.10 vs 0.10.7 -> True   (spurious nudge)
NEW logic: 0.10 vs 0.10.7 -> False
```

No user hits this today (all installed skills report full semver), but it blocks a change we want in `cekura-skills`.

## Fix

Truncate `latest` to the precision the caller actually reported before comparing. Full-semver reports keep exact comparison; a `major.minor` report only nudges on a real major/minor release.

Also updated the `plugin_version` arg description to say the value comes at whatever precision the skill carries.

## Why now

`cekura-skills` stamps `plugin_version="X.Y.Z"` into 15 skill/command/bundle files, so **every** patch release PR carries ~21 files of pure version churn (e.g. [cekura-skills#133](https://github.com/cekura-ai/cekura-skills/pull/133)). Moving those tags to `major.minor` drops a routine patch release to 6 files. That change is only safe once this server compares at the reported precision — otherwise every user on 0.10.x would get an upgrade nudge on every skill call.

**Merge and deploy this before** the cekura-skills side lands.

## Verification

```
cekura-mcp-server: 11 new cases in tests/test_version_freshness.py
with fix:    59 passed (test_version_freshness + test_skill_gate)
without fix: 4 of the 11 new cases fail (fail-first confirmed)
```

Full suite: 163 passed / 8 failed — all 8 failures are **pre-existing on `main`** (`test_overlays.py::test_no_orphan_overlays`, `test_tool_generator.py` truncation/description cases), verified by stashing this change and re-running. Untouched by this PR.

CRLF line endings on `openapi_mcp_server.py` preserved (patched via `newline=''`); `file` still reports CRLF and the diff is 8 insertions / 2 deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)