### PR TITLE
docs(mcp): add a GitHub Copilot setup guide

### DIFF
--- a/mcp/github-copilot-guide.mdx
+++ b/mcp/github-copilot-guide.mdx
@@ -9,36 +9,31 @@ import { CopyPageButton } from "/snippets/copy-page-button.mdx";
 
 <CopyPageButton />
 
-GitHub Copilot has two separate extension surfaces, and Cekura supports both:
+Copilot has two extension surfaces, and they install Cekura differently. Pick the one you're setting up:
 
-| Surface | How Cekura is installed | What you get |
+| Surface | Install | What you get |
 |---|---|---|
-| **Copilot CLI** | Plugin from the Cekura marketplace | Skills **+** MCP server |
-| **Coding agent, code review, IDE extensions** | Cekura Skills committed to `.github/skills/` in your repo | Skills (MCP is configured per repository) |
-
-Start with the CLI — it's the one-command path and includes live tool access.
+| **Copilot CLI** | Marketplace plugin | Skills **+** MCP server, OAuth sign-in |
+| **Coding agent, code review, IDE extensions** | Skills committed to `.github/skills/` | Skills; MCP configured per repository |
 
 ## Copilot CLI
 
 <Steps>
-  <Step title="Install and sign in to the CLI">
+  <Step title="Install the CLI and sign in">
     ```bash
     npm install -g @github/copilot
     ```
 
-    Run `copilot` once and complete the sign-in prompt. A Copilot licence (Pro, Pro+, Business, or Enterprise) is required.
+    Run `copilot` once and complete the sign-in prompt. Requires a Copilot licence (Pro, Pro+, Business, or Enterprise).
   </Step>
 
   <Step title="Add the Cekura marketplace">
     ```bash
     copilot plugin marketplace add cekura-ai/cekura-skills
-    ```
-
-    Confirm Copilot can read it — this should list one plugin, `cekura`:
-
-    ```bash
     copilot plugin marketplace browse cekura-skills
     ```
+
+    `browse` should list one plugin, `cekura`. If it doesn't, the marketplace isn't registered — nothing below will work.
   </Step>
 
   <Step title="Install the plugin">
@@ -46,41 +41,39 @@ Start with the CLI — it's the one-command path and includes live tool access.
     copilot plugin install cekura@cekura-skills
     ```
 
-    Prefer an interactive session? Run `copilot`, then `/plugin marketplace add cekura-ai/cekura-skills` followed by `/plugin install cekura@cekura-skills`.
+    In an interactive session, use `/plugin marketplace add cekura-ai/cekura-skills` then `/plugin install cekura@cekura-skills`.
   </Step>
 
-  <Step title="Verify Skills and MCP">
+  <Step title="Confirm Skills and MCP loaded">
     ```bash
-    copilot plugin list   # cekura listed as installed
-    copilot mcp list      # cekura listed as an MCP server
+    copilot plugin list
+    copilot mcp list
     ```
+
+    `mcp list` should show `cekura` with `Source: Plugin` and the installed plugin version — that's the plugin's MCP config being picked up, not a hand-written one.
   </Step>
 
-  <Step title="Authenticate MCP">
-    The plugin ships the Cekura MCP endpoint, so there's no config to write. The first time Copilot calls a Cekura tool it opens a browser for OAuth sign-in — no API key stored.
+  <Step title="Sign in to MCP">
+    Nothing to configure. The first Cekura tool call opens a browser for OAuth; no API key is stored.
   </Step>
 </Steps>
 
 <Note>
-Copilot plugins don't carry slash commands; the bundled Skills cover those workflows and activate by context. Copilot also only discovers subagents named `*.agent.md`, so the plugin's Claude-style subagents aren't bundled — Skills and MCP are.
+Copilot plugins carry no slash commands, and Copilot only discovers subagents named `*.agent.md` — so the plugin gives you Skills and MCP. The Skills cover the same workflows and activate by context.
 </Note>
 
-<Tip>
-For API-key auth instead of OAuth, see [API-key setup](/mcp/mcp-only#api-key-setup).
-</Tip>
+## Repository surfaces
 
-## Coding agent, code review, and IDE extensions
-
-These surfaces don't load CLI plugins. They read Skills from the `.github/skills/` directory of the repository they're working in, so install the Skills there and commit them:
+The coding agent, code review, and the IDE extensions ignore CLI plugins. They read Skills from `.github/skills/` in the repository they're working in:
 
 ```bash
 npx skills add cekura-ai/cekura-skills --all --agent github-copilot --output .github/skills
 ```
 
-Everyone working in that repository then gets the Cekura playbook, including Copilot code review on pull requests.
+Commit the result and everyone working in that repo gets the Cekura playbook, including code review on pull requests.
 
 <Warning>
-The Copilot coding agent and Copilot code review don't support OAuth-authenticated remote MCP servers. To give them live Cekura tools, register `https://api.cekura.ai/mcp` in your repository's Copilot MCP configuration using the API-key credential — send your key in an `X-CEKURA-API-KEY` header. See GitHub's guide to [configuring MCP servers for your repository](https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/configure-mcp-servers) and [API-key setup](/mcp/mcp-only#api-key-setup). Copilot CLI supports OAuth and needs no key.
+These surfaces don't support OAuth-authenticated remote MCP. For live Cekura tools, register `https://api.cekura.ai/mcp` in the repository's [Copilot MCP configuration](https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/configure-mcp-servers) with an `X-CEKURA-API-KEY` header — see [API-key setup](/mcp/mcp-only#api-key-setup). Copilot CLI needs no key.
 </Warning>
 
 ## Verify setup
@@ -91,27 +84,7 @@ Start Copilot from your agent repo and ask:
 Use the Cekura skills and MCP. List my Cekura agents, pick one, and propose 3 evaluators I should create first. Do not create anything until I approve.
 ```
 
-Copilot should list real agents from your workspace and reason in Cekura terms (evaluators, metrics, test profiles, run results). If it answers in generic terms without naming your agents, the Skills or the MCP server aren't loaded — see Troubleshooting below.
-
-## Recommended workflow
-
-<Steps>
-  <Step title="Run Copilot from the agent repo">
-    Copilot should have access to prompts, tool definitions, schemas, and local tests before it creates Cekura evaluators.
-  </Step>
-
-  <Step title="Plan first, then create">
-    Ask for a coverage matrix. Approve the plan before creating evaluators or metrics.
-  </Step>
-
-  <Step title="Run a small test batch">
-    Run a small set of evaluators first, inspect transcripts, then scale to broader regression runs.
-  </Step>
-
-  <Step title="Patch and re-run">
-    When a run fails, ask Copilot to compare the transcript against your prompt or code, patch the likely issue, and rerun the targeted evaluator.
-  </Step>
-</Steps>
+Copilot should name real agents from your workspace and reason in Cekura terms — evaluators, metrics, test profiles, run results. Generic voice-testing advice means the Skills or MCP aren't loaded.
 
 ## Keep it updated
 
@@ -119,43 +92,28 @@ Copilot should list real agents from your workspace and reason in Cekura terms (
 copilot plugin update cekura
 ```
 
-If a release adds a brand-new Skill, refresh the marketplace snapshot first by re-adding it, then update:
-
-```bash
-copilot plugin marketplace add cekura-ai/cekura-skills
-copilot plugin update cekura
-```
-
-For the `.github/skills/` path, re-run the `npx skills add` command above and commit the result.
-
-<Note>
-Copilot has no auto-update hook yet — run `copilot plugin update cekura` when you want the latest version. `copilot plugin list` shows the installed version.
-</Note>
-
-## No plugin?
-
-Set up [Skills + MCP manually](/mcp/mcp-only), or use the [behavior preset](/mcp/other-agents) fallback.
+Copilot has no auto-update hook, so run this when you want the latest version; `copilot plugin list` shows what's installed. When a release adds a brand-new Skill, re-add the marketplace first to refresh the snapshot, then update. For `.github/skills/`, re-run the `npx skills add` command above.
 
 ## Troubleshooting
 
 <AccordionGroup>
   <Accordion title="Marketplace or plugin not found">
-    Run `copilot plugin marketplace list` to confirm `cekura-skills` is registered, then `copilot plugin marketplace browse cekura-skills` to confirm the `cekura` plugin appears. Re-add with `copilot plugin marketplace add cekura-ai/cekura-skills` if either is missing.
+    `copilot plugin marketplace list` should include `cekura-skills`, and `copilot plugin marketplace browse cekura-skills` should list `cekura`. Re-add with `copilot plugin marketplace add cekura-ai/cekura-skills`.
   </Accordion>
 
   <Accordion title="Skills don't activate">
-    Confirm the plugin is installed with `copilot plugin list`, then ask something explicitly Cekura-shaped ("design Cekura evaluators for my booking agent"). Skills load by matching your request against their descriptions, so a generic prompt may not trigger one.
+    Confirm the plugin is installed (`copilot plugin list`), then ask something explicitly Cekura-shaped — Skills load by matching your request against their descriptions, so a generic prompt may not trigger one.
   </Accordion>
 
-  <Accordion title="MCP tools do not appear">
-    Run `copilot mcp list` and confirm `cekura` is listed. Plugin-provided MCP servers are merged into Copilot's MCP configuration, so update to a current CLI release (`npm install -g @github/copilot`) if the server is missing.
-  </Accordion>
-
-  <Accordion title="OAuth sign-in never opens">
-    Update to a current CLI release and retry the tool call. As a fallback, add the server to `~/.copilot/mcp-config.json` yourself — `{"mcpServers": {"cekura": {"type": "http", "url": "https://api.cekura.ai/mcp", "tools": ["*"]}}}` — or use the [API-key credential](/mcp/mcp-only#api-key-setup).
+  <Accordion title="MCP tools missing, or OAuth never opens">
+    Check `copilot mcp list` shows `cekura`, then update the CLI (`npm install -g @github/copilot`) — plugin-provided MCP servers and their OAuth flow need a current release. Fallback: add the server yourself in `~/.copilot/mcp-config.json`, or use [API-key auth](/mcp/mcp-only#api-key-setup).
   </Accordion>
 
   <Accordion title="Coding agent or code review can't reach Cekura">
-    Those surfaces don't support OAuth remote MCP. Configure the repository's Copilot MCP server with the `X-CEKURA-API-KEY` header instead — see the warning above.
+    Those surfaces need the API-key credential, not OAuth — see the warning above.
   </Accordion>
 </AccordionGroup>
+
+## No plugin?
+
+Set up [Skills + MCP manually](/mcp/mcp-only), or use the [behavior preset](/mcp/other-agents) fallback.

--- a/mcp/github-copilot-guide.mdx
+++ b/mcp/github-copilot-guide.mdx
@@ -1,0 +1,161 @@
+---
+title: "Using Cekura with GitHub Copilot"
+sidebarTitle: "GitHub Copilot"
+description: "Install the Cekura plugin in Copilot CLI for Skills + MCP, or add Cekura Skills to a repository for the Copilot coding agent, code review, and the IDE extensions."
+icon: "github"
+---
+
+import { CopyPageButton } from "/snippets/copy-page-button.mdx";
+
+<CopyPageButton />
+
+GitHub Copilot has two separate extension surfaces, and Cekura supports both:
+
+| Surface | How Cekura is installed | What you get |
+|---|---|---|
+| **Copilot CLI** | Plugin from the Cekura marketplace | Skills **+** MCP server |
+| **Coding agent, code review, IDE extensions** | Cekura Skills committed to `.github/skills/` in your repo | Skills (MCP is configured per repository) |
+
+Start with the CLI — it's the one-command path and includes live tool access.
+
+## Copilot CLI
+
+<Steps>
+  <Step title="Install and sign in to the CLI">
+    ```bash
+    npm install -g @github/copilot
+    ```
+
+    Run `copilot` once and complete the sign-in prompt. A Copilot licence (Pro, Pro+, Business, or Enterprise) is required.
+  </Step>
+
+  <Step title="Add the Cekura marketplace">
+    ```bash
+    copilot plugin marketplace add cekura-ai/cekura-skills
+    ```
+
+    Confirm Copilot can read it — this should list one plugin, `cekura`:
+
+    ```bash
+    copilot plugin marketplace browse cekura-skills
+    ```
+  </Step>
+
+  <Step title="Install the plugin">
+    ```bash
+    copilot plugin install cekura@cekura-skills
+    ```
+
+    Prefer an interactive session? Run `copilot`, then `/plugin marketplace add cekura-ai/cekura-skills` followed by `/plugin install cekura@cekura-skills`.
+  </Step>
+
+  <Step title="Verify Skills and MCP">
+    ```bash
+    copilot plugin list   # cekura listed as installed
+    copilot mcp list      # cekura listed as an MCP server
+    ```
+  </Step>
+
+  <Step title="Authenticate MCP">
+    The plugin ships the Cekura MCP endpoint, so there's no config to write. The first time Copilot calls a Cekura tool it opens a browser for OAuth sign-in — no API key stored.
+  </Step>
+</Steps>
+
+<Note>
+Copilot plugins don't carry slash commands; the bundled Skills cover those workflows and activate by context. Copilot also only discovers subagents named `*.agent.md`, so the plugin's Claude-style subagents aren't bundled — Skills and MCP are.
+</Note>
+
+<Tip>
+For API-key auth instead of OAuth, see [API-key setup](/mcp/mcp-only#api-key-setup).
+</Tip>
+
+## Coding agent, code review, and IDE extensions
+
+These surfaces don't load CLI plugins. They read Skills from the `.github/skills/` directory of the repository they're working in, so install the Skills there and commit them:
+
+```bash
+npx skills add cekura-ai/cekura-skills --all --agent github-copilot --output .github/skills
+```
+
+Everyone working in that repository then gets the Cekura playbook, including Copilot code review on pull requests.
+
+<Warning>
+The Copilot coding agent and Copilot code review don't support OAuth-authenticated remote MCP servers. To give them live Cekura tools, register `https://api.cekura.ai/mcp` in your repository's Copilot MCP configuration using the API-key credential — send your key in an `X-CEKURA-API-KEY` header. See GitHub's guide to [configuring MCP servers for your repository](https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/configure-mcp-servers) and [API-key setup](/mcp/mcp-only#api-key-setup). Copilot CLI supports OAuth and needs no key.
+</Warning>
+
+## Verify setup
+
+Start Copilot from your agent repo and ask:
+
+```plaintext
+Use the Cekura skills and MCP. List my Cekura agents, pick one, and propose 3 evaluators I should create first. Do not create anything until I approve.
+```
+
+Copilot should list real agents from your workspace and reason in Cekura terms (evaluators, metrics, test profiles, run results). If it answers in generic terms without naming your agents, the Skills or the MCP server aren't loaded — see Troubleshooting below.
+
+## Recommended workflow
+
+<Steps>
+  <Step title="Run Copilot from the agent repo">
+    Copilot should have access to prompts, tool definitions, schemas, and local tests before it creates Cekura evaluators.
+  </Step>
+
+  <Step title="Plan first, then create">
+    Ask for a coverage matrix. Approve the plan before creating evaluators or metrics.
+  </Step>
+
+  <Step title="Run a small test batch">
+    Run a small set of evaluators first, inspect transcripts, then scale to broader regression runs.
+  </Step>
+
+  <Step title="Patch and re-run">
+    When a run fails, ask Copilot to compare the transcript against your prompt or code, patch the likely issue, and rerun the targeted evaluator.
+  </Step>
+</Steps>
+
+## Keep it updated
+
+```bash
+copilot plugin update cekura
+```
+
+If a release adds a brand-new Skill, refresh the marketplace snapshot first by re-adding it, then update:
+
+```bash
+copilot plugin marketplace add cekura-ai/cekura-skills
+copilot plugin update cekura
+```
+
+For the `.github/skills/` path, re-run the `npx skills add` command above and commit the result.
+
+<Note>
+Copilot has no auto-update hook yet — run `copilot plugin update cekura` when you want the latest version. `copilot plugin list` shows the installed version.
+</Note>
+
+## No plugin?
+
+Set up [Skills + MCP manually](/mcp/mcp-only), or use the [behavior preset](/mcp/other-agents) fallback.
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="Marketplace or plugin not found">
+    Run `copilot plugin marketplace list` to confirm `cekura-skills` is registered, then `copilot plugin marketplace browse cekura-skills` to confirm the `cekura` plugin appears. Re-add with `copilot plugin marketplace add cekura-ai/cekura-skills` if either is missing.
+  </Accordion>
+
+  <Accordion title="Skills don't activate">
+    Confirm the plugin is installed with `copilot plugin list`, then ask something explicitly Cekura-shaped ("design Cekura evaluators for my booking agent"). Skills load by matching your request against their descriptions, so a generic prompt may not trigger one.
+  </Accordion>
+
+  <Accordion title="MCP tools do not appear">
+    Run `copilot mcp list` and confirm `cekura` is listed. Plugin-provided MCP servers are merged into Copilot's MCP configuration, so update to a current CLI release (`npm install -g @github/copilot`) if the server is missing.
+  </Accordion>
+
+  <Accordion title="OAuth sign-in never opens">
+    Update to a current CLI release and retry the tool call. As a fallback, add the server to `~/.copilot/mcp-config.json` yourself — `{"mcpServers": {"cekura": {"type": "http", "url": "https://api.cekura.ai/mcp", "tools": ["*"]}}}` — or use the [API-key credential](/mcp/mcp-only#api-key-setup).
+  </Accordion>
+
+  <Accordion title="Coding agent or code review can't reach Cekura">
+    Those surfaces don't support OAuth remote MCP. Configure the repository's Copilot MCP server with the `X-CEKURA-API-KEY` header instead — see the warning above.
+  </Accordion>
+</AccordionGroup>

--- a/mcp/mcp-only.mdx
+++ b/mcp/mcp-only.mdx
@@ -95,6 +95,28 @@ Your MCP client opens a browser, you sign into Cekura, and the client manages th
     args = ["-y", "mcp-remote", "https://api.cekura.ai/mcp"]
     ```
   </Tab>
+
+  <Tab title="Copilot CLI">
+    Add this to `~/.copilot/mcp-config.json` — Copilot handles the OAuth browser sign-in on first tool use:
+
+    ```json
+    {
+      "mcpServers": {
+        "cekura": {
+          "type": "http",
+          "url": "https://api.cekura.ai/mcp",
+          "tools": ["*"]
+        }
+      }
+    }
+    ```
+
+    Or add it from the command line:
+
+    ```bash
+    copilot mcp add --transport http cekura https://api.cekura.ai/mcp
+    ```
+  </Tab>
 </Tabs>
 
 ### API-key setup
@@ -156,6 +178,33 @@ Use an API key only when you need a project-scoped credential, a shared service 
     ```bash
     codex mcp add cekura --env CEKURA_API_KEY=YOUR_API_KEY_HERE -- sh -c 'npx -y mcp-remote https://api.cekura.ai/mcp --header "X-CEKURA-API-KEY:$CEKURA_API_KEY"'
     ```
+  </Tab>
+
+  <Tab title="Copilot CLI">
+    Add this to `~/.copilot/mcp-config.json`:
+
+    ```json
+    {
+      "mcpServers": {
+        "cekura": {
+          "type": "http",
+          "url": "https://api.cekura.ai/mcp",
+          "headers": {
+            "X-CEKURA-API-KEY": "YOUR_API_KEY_HERE"
+          },
+          "tools": ["*"]
+        }
+      }
+    }
+    ```
+
+    CLI form:
+
+    ```bash
+    copilot mcp add --transport http --header "X-CEKURA-API-KEY: YOUR_API_KEY_HERE" cekura https://api.cekura.ai/mcp
+    ```
+
+    This is the credential the Copilot coding agent and Copilot code review need — those surfaces don't support OAuth remote MCP.
   </Tab>
 </Tabs>
 

--- a/mcp/overview.mdx
+++ b/mcp/overview.mdx
@@ -69,6 +69,17 @@ Install the Cekura plugin for your assistant — it bundles Skills **and** MCP. 
     `codex mcp login` opens a browser for OAuth — no API key. [Full guide →](/mcp/codex-guide)
   </Tab>
 
+  <Tab title="GitHub Copilot">
+    The plugin bundles Skills + MCP for Copilot CLI. Add the marketplace, then install:
+
+    ```bash
+    copilot plugin marketplace add cekura-ai/cekura-skills
+    copilot plugin install cekura@cekura-skills
+    ```
+
+    OAuth runs in the browser on first use of a Cekura tool — no API key. [Full guide →](/mcp/github-copilot-guide)
+  </Tab>
+
   <Tab title="Gemini CLI">
     Install the extension — it includes the Cekura MCP server and context:
 
@@ -84,7 +95,7 @@ Install the Cekura plugin for your assistant — it bundles Skills **and** MCP. 
 
 | Setup | Best for | What you get |
 |---|---|---|
-| ⭐ **Native plugin** | Claude Code, Claude Desktop, Cursor, Codex, Gemini CLI | Skills **+** MCP, auto-configured (Claude Code also adds slash commands + hooks) |
+| ⭐ **Native plugin** | Claude Code, Claude Desktop, Cursor, Codex, Copilot CLI, Gemini CLI | Skills **+** MCP, auto-configured (Claude Code also adds slash commands + hooks) |
 | [**Manual (Skills + MCP)**](/mcp/mcp-only) | Clients without a plugin | Install Skills, then connect MCP separately |
 | [**Skills only**](/mcp/skills) | Any Agent Skills client, no live tools | Workflow guidance via `npx skills add`; no MCP |
 | [**Behavior preset**](/mcp/other-agents) | Windsurf & assistants without a plugin | Domain knowledge via rules / `AGENTS.md`; no MCP |
@@ -162,6 +173,6 @@ With Skills only, your assistant can advise. With MCP only, your assistant can c
   </Card>
 
   <Card title="Manual setup (Skills + MCP)" icon="wrench" href="/mcp/mcp-only">
-    For clients without a plugin: install Skills, then OAuth/API-key MCP config for Claude Code, Claude Desktop, Cursor, VS Code, and Codex.
+    For clients without a plugin: install Skills, then OAuth/API-key MCP config for Claude Code, Claude Desktop, Cursor, VS Code, Codex, and Copilot CLI.
   </Card>
 </CardGroup>

--- a/mcp/skills.mdx
+++ b/mcp/skills.mdx
@@ -19,7 +19,7 @@ Cekura Skills give your AI assistant the playbook for designing evaluators, crea
 
 | Install path | Best for | Skills | Slash commands | MCP config | Hooks |
 |---|---|---:|---:|---:|---:|
-| Native plugin | Claude Code, Cursor, Codex, Claude Desktop | Yes | Claude Code only | Yes | Claude Code only |
+| Native plugin | Claude Code, Cursor, Codex, Copilot CLI, Claude Desktop | Yes | Claude Code only | Yes | Claude Code only |
 | Native extension | Gemini CLI | Context file | No | Yes | No |
 | `npx skills add` | Any Agent Skills client | Yes | No | No | No |
 | Behavior preset | Assistants without a plugin | Rules only | No | No | No |
@@ -187,6 +187,7 @@ After reinstalling, `claude plugin list` should show one `cekura@cekura-skills` 
 | Claude Code | Plugin + `/setup-mcp` | Full Skills, slash commands, MCP config, update support, and hooks |
 | Cursor | Native plugin | Skills + MCP via the marketplace plugin; `npx skills add` / `.cursor/rules` are no-MCP fallbacks |
 | Codex | Native plugin | Skills + MCP via `codex plugin add` + `codex mcp login`; no slash commands |
+| GitHub Copilot | Native plugin (CLI) | Skills + MCP via `copilot plugin install cekura@cekura-skills`; the coding agent, code review, and IDE extensions read Skills from a repo's `.github/skills/` instead |
 | Gemini CLI | Native extension | MCP + `GEMINI.md` context via `gemini extensions install`; no Skills bundling yet |
 | Claude Desktop | Native plugin | Customize → Plugins gives Skills + MCP (Skills in Chat & Cowork); the connector UI is the MCP-only alternative |
 | Windsurf, other assistants | `npx skills add` or behavior preset | Skills (no MCP) or portable `AGENTS.md`; add MCP manually if supported |

--- a/mint.json
+++ b/mint.json
@@ -569,6 +569,7 @@
         "mcp/claude-desktop-guide",
         "mcp/cursor-guide",
         "mcp/codex-guide",
+        "mcp/github-copilot-guide",
         "mcp/other-agents"
       ]
     },


### PR DESCRIPTION
## Problem

GitHub Copilot became a supported platform in cekura-skills [0.10.11](https://github.com/cekura-ai/cekura-skills/pull/140) — verified on a real Copilot CLI install, where `copilot mcp list` reports the Cekura server with `Source: Plugin` — but the docs site had no page for it. `Set up your assistant` listed Claude Code, Claude Tag, Claude Desktop, Cursor, and Codex; the Copilot install path existed only in the repo README.

## Fix

New page `mcp/github-copilot-guide.mdx` (119 lines), plus parity updates on the pages that enumerate clients.

Copilot is the first client where Cekura installs two genuinely different ways, and conflating them is how people lose an afternoon — so the page opens with the choice, before any commands:

| Surface | Install | What you get |
|---|---|---|
| **Copilot CLI** | Marketplace plugin | Skills + MCP, OAuth |
| **Coding agent, code review, IDE extensions** | Skills committed to `.github/skills/` | Skills; MCP per repository |

Then five steps for the CLI, each paired with the command that proves it worked — `marketplace browse` after the add (the check that the registry resolved at all), `plugin list` + `mcp list` after the install, with `Source: Plugin` called out as the signal that the plugin's MCP config was used and not a hand-written one.

Two limitations are documented because they cost real debugging time otherwise:

- The coding agent and code review **don't support OAuth remote MCP** — live tools there need `X-CEKURA-API-KEY`. In a `<Warning>` on the page and as a new API-key tab on `mcp-only`.
- Copilot plugins carry no slash commands, and Copilot only discovers subagents as `*.agent.md`, so the plugin delivers Skills + MCP.

**Kept deliberately short.** The page carries only what is Copilot-specific. The 4-step "Recommended workflow" block that the Codex and Cursor guides both contain is *not* repeated here — it says nothing about Copilot and pushed troubleshooting a screen further down. Happy to add it back if you'd rather the guides stay structurally identical.

Also in this PR:

- `mcp/mcp-only.mdx` — Copilot CLI tabs under OAuth and API-key setup (`~/.copilot/mcp-config.json`, matching GitHub's documented shape: `type: "http"`, `headers`, `tools: ["*"]`, plus the `copilot mcp add --transport http` form)
- `mcp/overview.mdx` — install tab between Codex and Gemini CLI; Copilot CLI added to the native-plugin and manual-setup client lists
- `mcp/skills.mdx` — Copilot CLI in the install-paths table; a GitHub Copilot row noting the two surfaces
- `mint.json` — nav entry after `mcp/codex-guide`

## Verification

- Mintlify deployment check passes; `mint.json` parses and the page is registered under `Set up your assistant`
- Internal links resolve to existing anchors (`/mcp/mcp-only#api-key-setup`, `/mcp/other-agents`)
- `icon: "github"` has precedent (`documentation/guides/github-actions-ci-cd.mdx`); page structure follows `mcp/codex-guide.mdx`
- Commands and config shapes come from GitHub's docs (CLI plugin reference, `add-mcp-servers`) and from the verified CLI install — not inferred
- **Not** previewed with `mintlify dev` locally — worth an eyeball on the preview for `<Steps>`/`<Warning>` rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)
