### PR TITLE
docs: bump LiveKit and Pipecat SDK minimums

### DIFF
--- a/documentation/integrations/livekit/tracing.mdx
+++ b/documentation/integrations/livekit/tracing.mdx
@@ -37,7 +37,7 @@ export const livekitPrompt = [
   "- Note: track_session takes an additional agent parameter (the Agent instance) so it can inject mock tools.",
   "",
   "Common setup for both (Python):",
-  "1. Install the SDK: pip install \"cekura[livekit]>=1.5.2\"",
+  "1. Install the SDK: pip install \"cekura[livekit]>=1.6.4\"",
   "2. Import LiveKitTracer: from cekura.livekit import LiveKitTracer",
   "3. Initialize the tracer (outside the entrypoint function):",
   "   cekura = LiveKitTracer(",
@@ -210,7 +210,7 @@ Use this setup in your test agents while running simulation calls from the Cekur
 <Tab title="Python">
 
 ```bash
-pip install "cekura[livekit]>=1.5.2"
+pip install "cekura[livekit]>=1.6.4"
 ```
 
 </Tab>
@@ -352,7 +352,7 @@ Use this setup in your production agents for monitoring live calls with audio re
 <Tab title="Python">
 
 ```bash
-pip install "cekura[livekit]>=1.5.2"
+pip install "cekura[livekit]>=1.6.4"
 ```
 
 </Tab>

--- a/documentation/integrations/pipecat/tracing.mdx
+++ b/documentation/integrations/pipecat/tracing.mdx
@@ -35,7 +35,7 @@ export const pipecatPrompt = [
   "- Use cekura.track_pipeline() or cekura.track_and_create_task() — these capture transcripts only, no audio. This is what Cekura simulation calls use.",
   "",
   "Common setup for both:",
-  "1. Install the SDK: pip install \"cekura[pipecat]>=1.6.2\"",
+  "1. Install the SDK: pip install \"cekura[pipecat]>=1.6.4\"",
   "2. Import PipecatTracer: from cekura.pipecat import PipecatTracer",
   "3. Initialize the tracer:",
   "   cekura = PipecatTracer(",
@@ -165,7 +165,7 @@ Use this setup in your test agents while running simulation calls from the Cekur
 <Step title="Install the Cekura Python SDK">
 
 ```bash
-pip install "cekura[pipecat]>=1.6.2"
+pip install "cekura[pipecat]>=1.6.4"
 ```
 
 </Step>
@@ -293,7 +293,7 @@ Use this setup in your production agents for monitoring live calls with audio re
 <Step title="Install the Cekura Python SDK">
 
 ```bash
-pip install "cekura[pipecat]>=1.6.2"
+pip install "cekura[pipecat]>=1.6.4"
 ```
 
 </Step>


### PR DESCRIPTION
Updates the LiveKit and Pipecat tracing guides to require Cekura SDK 1.6.4 or later.\n\nChanges are limited to the install commands in the coding-agent prompt, testing setup, and production setup.