### PR TITLE
fix(mcp): repair the rotted server test suite and overlay validation

### DIFF
--- a/.github/workflows/mcp-server-tests.yml
+++ b/.github/workflows/mcp-server-tests.yml
@@ -1,0 +1,62 @@
+name: MCP Server Tests
+
+# The suite and the overlay validator existed but nothing ran them, so drift
+# accumulated silently: by the time this workflow was added, 8 tests were failing
+# and `validate_overlays.py` reported 7 errors on main. Runs on pull requests so
+# the gate is visible before merge, not after deploy.
+
+on:
+  pull_request:
+    paths:
+      - 'openapi.json'
+      - 'cekura-mcp-server/**'
+      - '.github/workflows/mcp-server-tests.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'openapi.json'
+      - 'cekura-mcp-server/**'
+      - '.github/workflows/mcp-server-tests.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mcp-server-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Matches the runtime in cekura-mcp-server/Dockerfile.
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          cache: pip
+          cache-dependency-path: cekura-mcp-server/requirements.txt
+
+      - name: Install dependencies
+        working-directory: cekura-mcp-server
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      # Guards against the failure that an unpinned `mcp` reintroduces: 2.x drops
+      # `mcp.server.fastmcp`, so the server module stops importing at all.
+      - name: Check the server module imports
+        working-directory: cekura-mcp-server
+        run: python -c "import openapi_mcp_server"
+
+      - name: Validate overlays against openapi.json
+        working-directory: cekura-mcp-server
+        run: python validate_overlays.py
+
+      - name: Run tests
+        working-directory: cekura-mcp-server
+        run: python -m pytest

--- a/cekura-mcp-server/README.md
+++ b/cekura-mcp-server/README.md
@@ -53,7 +53,7 @@ pip install -r requirements.txt
 **Default Configuration:**
 ```bash
 CEKURA_BASE_URL=https://api.cekura.ai (production)
-CEKURA_OPENAPI_SPEC=../openapi.json (from docs root)
+CEKURA_OPENAPI_SPEC_PATH=../openapi.json (relative to cekura-mcp-server/)
 ```
 
 **Optional:** Override defaults for staging/dev environments:
@@ -265,7 +265,7 @@ The server provides 84 tools across two main groups:
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `CEKURA_BASE_URL` | No | `https://api.cekura.ai` | Cekura API base URL (override for staging/dev) |
-| `CEKURA_OPENAPI_SPEC` | No | `../openapi.json` | Path to OpenAPI spec (from docs root) |
+| `CEKURA_OPENAPI_SPEC_PATH` | No | `../openapi.json` | Path to OpenAPI spec (relative to `cekura-mcp-server/`) |
 | `CEKURA_MAX_TOOLS` | No | - | Max tools to register (for testing) |
 
 **Note:** All configuration is optional. The set of registered tools is determined by the `x-mcp-expose: true` marker on each operation in `openapi.json`.

--- a/cekura-mcp-server/config.py
+++ b/cekura-mcp-server/config.py
@@ -18,8 +18,19 @@ VALID_SKILL_GATE_MODES = ("off", "shadow", "warn", "enforce", "strict")
 
 
 class MCPServerConfig(BaseModel):
-    base_url: str = Field(default_factory=lambda: os.getenv("CEKURA_BASE_URL", "https://api.cekura.ai"))
-    openapi_spec_path: str = Field(default_factory=lambda: os.getenv("CEKURA_OPENAPI_SPEC_PATH", "../openapi.json"))
+    # `validate_default=True` is load-bearing: every field here is populated by a
+    # default_factory reading the environment, and pydantic skips validators on
+    # defaults unless asked. Without it `validate_base_url`/`validate_spec_path`
+    # never run, so a malformed CEKURA_BASE_URL or a missing spec file sails
+    # through config load and only surfaces later as a confusing runtime error.
+    base_url: str = Field(
+        default_factory=lambda: os.getenv("CEKURA_BASE_URL", "https://api.cekura.ai"),
+        validate_default=True,
+    )
+    openapi_spec_path: str = Field(
+        default_factory=lambda: os.getenv("CEKURA_OPENAPI_SPEC_PATH", "../openapi.json"),
+        validate_default=True,
+    )
     max_tools: Optional[int] = Field(default_factory=lambda: _parse_int_env("CEKURA_MAX_TOOLS"))
     expose_project_destroy: bool = Field(default_factory=lambda: _parse_bool_env("CEKURA_EXPOSE_PROJECT_DESTROY", False))
     blocked_tools: List[str] = Field(default_factory=lambda: _parse_list_env("CEKURA_BLOCKED_TOOLS") or [])

--- a/cekura-mcp-server/mcp_tools.json
+++ b/cekura-mcp-server/mcp_tools.json
@@ -21,11 +21,11 @@
   "runs_bulk_retrieve": {
     "description_suffix": "`run_ids` must be a bare comma-separated string (e.g. `\"86368,86369\"`). Passing a JSON array `[86368, 86369]` or a JSON-quoted string both return `400: run_ids must be comma-separated integers`.\n\nDashboard link — a run is viewed inside its parent result; that result opens at `https://dashboard.cekura.ai/<project_id>/results/<result_id>`, where `<result_id>` is the run's `result_id` field and `<project_id>` is the project you are operating in."
   },
-  "call_logs_evaluate_metrics_create": {
+  "observability_v2_call_logs_evaluate_metrics_create": {
     "description_suffix": "Known issue: the `metrics` filter is not enforced — all metrics assigned to the call log are evaluated regardless of which IDs are passed."
   },
-  "call_logs_list": {
-    "description_suffix": "Heavy response: every item carries the full `transcript` plus all per-metric results, and there is no field-selection parameter to trim it — so a default-size page commonly overflows the MCP output token limit. Work narrow, not wide: isolate the calls you need with `filters_v2` (e.g. `{\"field\": \"success\", \"op\": \"eq\", \"value\": false}`) and a `timestamp_from`/`timestamp_to` window, request `page_size=5`, then walk pages with `page`. If you already know the call, skip the list entirely and pull it by ID with `call_logs_retrieve`.\n\nDashboard link — each call log opens at `https://dashboard.cekura.ai/<project>/calls?callId=<id>`, using the item's `project` and `id` fields."
+  "observability_v2_call_logs_list": {
+    "description_suffix": "Heavy response: every item carries the full `transcript` plus all per-metric results, and there is no field-selection parameter to trim it — so a default-size page commonly overflows the MCP output token limit. Work narrow, not wide: isolate the calls you need with `filters_v2` (e.g. `{\"field\": \"success\", \"op\": \"eq\", \"value\": false}`) and a `timestamp_from`/`timestamp_to` window, request `page_size=5`, then walk pages with `page`. If you already know the call, skip the list entirely and pull it by ID with `observability_v2_call_logs_retrieve`.\n\nDashboard link — each call log opens at `https://dashboard.cekura.ai/<project>/calls?callId=<id>`, using the item's `project` and `id` fields."
   },
   "metrics_create": {
     "description_suffix": "**Skills tip:** authoring here is skill-guided work — quality is markedly better with the Cekura skills installed. No plugin/skills yet? See https://docs.cekura.ai/mcp/overview.\n\n**Prefer `metrics_generate`** (AI-authored from agent prompt) over this tool unless the user has explicitly given concrete field values to write. Use `metrics_generate_clean_description_create` to clean up an existing description and `metrics_generate_evaluation_trigger_create` to derive a trigger. The `prompt` field is only active when explicitly setting `llm_provider` to a non-default value — for standard `llm_judge` metrics, the criterion goes in `description`. `assistant_id` is optional despite appearing required in some schema views — omit it entirely; passing an empty string returns a 400 error. `add_to_new_agents`: when omitted or `true`, this metric is automatically assigned to every new agent created in the project — set to `false` to scope to specific agents only. To attach a metric to evaluators after creation, use `scenarios_partial_update` with `metrics: [id1, id2, ...]`; use `metrics_list(agent_id=<id>)` to find available IDs."
@@ -66,9 +66,6 @@
   "scenarios_folder_move": {
     "description_suffix": "To assign a scenario to a folder, use `scenarios_partial_update` with the `folder_path` field instead."
   },
-  "scenarios_create_from_transcript": {
-    "description_suffix": "**Skills tip:** authoring here is skill-guided work — quality is markedly better with the Cekura skills installed. No plugin/skills yet? See https://docs.cekura.ai/mcp/overview."
-  },
   "scenarios_create_from_transcript_bg": {
     "description_suffix": "**Skills tip:** authoring here is skill-guided work — quality is markedly better with the Cekura skills installed. No plugin/skills yet? See https://docs.cekura.ai/mcp/overview."
   },
@@ -92,7 +89,7 @@
   "scenarios_bulk_update": {
     "description_suffix": "**Skills tip:** authoring here is skill-guided work — quality is markedly better with the Cekura skills installed. No plugin/skills yet? See https://docs.cekura.ai/mcp/overview.\n\nAffects every ID in the `scenarios` array in one transaction. `append_instruction` is non-idempotent — re-running with the same value appends it again. For single-scenario edits prefer `scenarios_partial_update`."
   },
-  "call_logs_mark_metric_vote_create": {
+  "observability_v2_call_logs_mark_metric_vote_create": {
     "description_suffix": "Use `metrics_list(agent_id=<id>)` to find available metric IDs before voting. Pass the metric ID in the `metric_id` field."
   },
   "runs_mark_metric_vote_create": {
@@ -119,19 +116,13 @@
   "aiagents_auto_fetch_progress_retrieve": {
     "description_suffix": "Poll with the progress_id from aiagents_auto_fetch_create. Status values: queued, in_progress, completed (with staged configuration), failed (with error)."
   },
-  "aiagents_toggle_mock_tools_create": {
-    "description_suffix": "Async — returns a progress_id. Poll aiagents_toggle_mock_tools_progress_retrieve with the progress_id until completed or failed. Run aiagents_auto_fetch_create first to populate mock tool data before enabling."
-  },
-  "aiagents_toggle_mock_tools_progress_retrieve": {
-    "description_suffix": "Poll with the progress_id from aiagents_toggle_mock_tools_create. Status values: queued, in_progress, completed (mock mode applied), failed (with error)."
-  },
   "results_retrieve": {
     "description_suffix": "Dashboard link — this result opens at `https://dashboard.cekura.ai/<project_id>/results/<id>`, where `<id>` is this result's `id` and `<project_id>` is the project you are operating in."
   },
   "results_list": {
     "description_suffix": "Dashboard link — each result opens at `https://dashboard.cekura.ai/<project_id>/results/<result_id>`, using the item's `id` and the project you are operating in."
   },
-  "call_logs_retrieve": {
+  "observability_v2_call_logs_retrieve": {
     "description_suffix": "Dashboard link — this call log opens at `https://dashboard.cekura.ai/<project>/calls?callId=<id>`, using the response's `project` and `id` fields."
   },
   "scenarios_retrieve": {

--- a/cekura-mcp-server/requirements.txt
+++ b/cekura-mcp-server/requirements.txt
@@ -1,5 +1,8 @@
 # Core dependencies
-mcp>=1.27.0
+# Cap below 2.0: mcp 2.x drops `mcp.server.fastmcp`, which openapi_mcp_server
+# imports at module scope, so an unpinned install builds an image that cannot
+# start. Lift the cap only together with the FastMCP migration.
+mcp>=1.27.0,<2
 httpx>=0.24.0
 pydantic>=2.0.0
 python-dotenv>=1.0.0

--- a/cekura-mcp-server/skill_gate.py
+++ b/cekura-mcp-server/skill_gate.py
@@ -61,7 +61,6 @@ _FAMILIES = (
             "scenarios_create",
             "scenarios_bulk_update",
             "scenarios_partial_update",
-            "scenarios_create_from_transcript",
             "scenarios_create_from_transcript_bg",
             "scenarios_update_scenario_with_transcript_create",
             "test_profiles_create",

--- a/cekura-mcp-server/tests/test_config.py
+++ b/cekura-mcp-server/tests/test_config.py
@@ -16,20 +16,22 @@ class TestConfig:
         spec_file.write_text('{"openapi": "3.0.0"}')
 
         monkeypatch.setenv("CEKURA_BASE_URL", "https://api.test.com")
-        monkeypatch.setenv("CEKURA_OPENAPI_SPEC", str(spec_file))
+        monkeypatch.setenv("CEKURA_OPENAPI_SPEC_PATH", str(spec_file))
 
         config = load_config()
         assert config.base_url == "https://api.test.com"
         assert config.openapi_spec_path == str(spec_file)
 
-    def test_load_config_missing_base_url(self, monkeypatch):
-        """Test that missing base URL raises error"""
-        from pydantic import ValidationError
-        monkeypatch.delenv("CEKURA_BASE_URL", raising=False)
-        monkeypatch.delenv("CEKURA_OPENAPI_SPEC", raising=False)
+    def test_load_config_missing_base_url_uses_default(self, monkeypatch, tmp_path):
+        """An absent CEKURA_BASE_URL falls back to the public API host."""
+        spec_file = tmp_path / "test_openapi.json"
+        spec_file.write_text('{"openapi": "3.0.0"}')
 
-        with pytest.raises((RuntimeError, ValidationError)):
-            load_config()
+        monkeypatch.delenv("CEKURA_BASE_URL", raising=False)
+        monkeypatch.setenv("CEKURA_OPENAPI_SPEC_PATH", str(spec_file))
+
+        config = load_config()
+        assert config.base_url == "https://api.cekura.ai"
 
     def test_load_config_invalid_url_format(self, monkeypatch, tmp_path):
         """Test that invalid URL format raises error"""
@@ -39,10 +41,10 @@ class TestConfig:
 
         # Clear any existing env vars first
         monkeypatch.delenv("CEKURA_BASE_URL", raising=False)
-        monkeypatch.delenv("CEKURA_OPENAPI_SPEC", raising=False)
+        monkeypatch.delenv("CEKURA_OPENAPI_SPEC_PATH", raising=False)
 
         monkeypatch.setenv("CEKURA_BASE_URL", "invalid-url")
-        monkeypatch.setenv("CEKURA_OPENAPI_SPEC", str(spec_file))
+        monkeypatch.setenv("CEKURA_OPENAPI_SPEC_PATH", str(spec_file))
 
         with pytest.raises((RuntimeError, ValidationError)):
             load_config()
@@ -53,10 +55,10 @@ class TestConfig:
 
         # Clear any existing env vars first
         monkeypatch.delenv("CEKURA_BASE_URL", raising=False)
-        monkeypatch.delenv("CEKURA_OPENAPI_SPEC", raising=False)
+        monkeypatch.delenv("CEKURA_OPENAPI_SPEC_PATH", raising=False)
 
         monkeypatch.setenv("CEKURA_BASE_URL", "https://api.test.com")
-        monkeypatch.setenv("CEKURA_OPENAPI_SPEC", "/nonexistent/spec.json")
+        monkeypatch.setenv("CEKURA_OPENAPI_SPEC_PATH", "/nonexistent/spec.json")
 
         with pytest.raises((RuntimeError, ValidationError)):
             load_config()
@@ -67,7 +69,7 @@ class TestConfig:
         spec_file.write_text('{"openapi": "3.0.0"}')
 
         monkeypatch.setenv("CEKURA_BASE_URL", "https://api.test.com")
-        monkeypatch.setenv("CEKURA_OPENAPI_SPEC", str(spec_file))
+        monkeypatch.setenv("CEKURA_OPENAPI_SPEC_PATH", str(spec_file))
         monkeypatch.setenv("CEKURA_MAX_TOOLS", "50")
 
         config = load_config()
@@ -103,7 +105,7 @@ class TestConfig:
         spec_file.write_text('{"openapi": "3.0.0"}')
 
         monkeypatch.setenv("CEKURA_BASE_URL", "https://api.test.com/")
-        monkeypatch.setenv("CEKURA_OPENAPI_SPEC", str(spec_file))
+        monkeypatch.setenv("CEKURA_OPENAPI_SPEC_PATH", str(spec_file))
 
         config = load_config()
         assert config.base_url == "https://api.test.com"

--- a/cekura-mcp-server/tests/test_skill_gate.py
+++ b/cekura-mcp-server/tests/test_skill_gate.py
@@ -8,12 +8,16 @@ reaches the backend.
 import json
 import logging
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import pytest
 
 import skill_gate
 from openapi_mcp_server import _dispatch_args, _upgrade_skills_reliable, MCP_INSTRUCTIONS
+
+HERE = Path(__file__).parent
+ROOT = HERE.parent
 
 
 # ── fixtures / helpers ───────────────────────────────────────────────────────
@@ -47,12 +51,31 @@ JSON_ARRAY_BODY = {"content": {"application/json": {"schema": {"type": "array", 
 # ── family / tool table ──────────────────────────────────────────────────────
 
 class TestFamilyTable:
-    def test_exactly_eleven_gated_tools(self):
-        assert len(skill_gate.GATED_TOOLS) == 11
+    def test_exactly_ten_gated_tools(self):
+        assert len(skill_gate.GATED_TOOLS) == 10
 
     def test_every_gated_tool_maps_to_a_family(self):
         for tool in skill_gate.GATED_TOOLS:
             assert skill_gate._family_for_tool(tool) is not None
+
+    def test_every_gated_tool_is_a_registered_tool(self):
+        """A gated name that no tool answers to gates nothing — catch the drift.
+
+        `scenarios_create_from_transcript` sat here long after the synchronous
+        operation was replaced by the `_bg` variant, silently gating nothing.
+        """
+        from openapi_parser import load_openapi_spec
+        from tool_generator import generate_tool_name, should_include_operation
+
+        parser = load_openapi_spec(str(ROOT.parent / "openapi.json"))
+        registered = {
+            generate_tool_name(op)
+            for op in parser.extract_operations()
+            if should_include_operation(op)
+        }
+
+        dead = sorted(t for t in skill_gate.GATED_TOOLS if t not in registered)
+        assert not dead, f"gated tools that no longer exist upstream: {dead}"
 
     def test_generation_and_read_tools_are_not_gated(self):
         for tool in (

--- a/cekura-mcp-server/tests/test_tool_generator.py
+++ b/cekura-mcp-server/tests/test_tool_generator.py
@@ -5,6 +5,7 @@ from tool_generator import (
     generate_tool_description,
     should_include_operation,
     maybe_append_org_project_hint,
+    MAX_DESCRIPTION_LENGTH,
     ORG_PROJECT_HINT,
 )
 from openapi_parser import Operation
@@ -121,7 +122,7 @@ class TestGenerateToolDescription:
 
     def test_generate_description_truncation(self):
         """Test that long descriptions are truncated"""
-        long_desc = "A" * 300
+        long_desc = "A" * (MAX_DESCRIPTION_LENGTH + 100)
         operation = Operation(
             path="/api/v1/test",
             method="GET",
@@ -135,7 +136,7 @@ class TestGenerateToolDescription:
         )
 
         result = generate_tool_description(operation)
-        assert len(result) <= 200
+        assert len(result) <= MAX_DESCRIPTION_LENGTH
         assert result.endswith("...")
 
 


### PR DESCRIPTION
## Problem

`cekura-mcp-server` on `main` has **8 failing tests** and **7 `validate_overlays.py` errors**. Nothing runs either in CI — no workflow invokes `pytest` or `validate_overlays.py` — so the drift accumulated silently. Two of the findings are live bugs, not just stale tests.

## Fix

**Overlay keys** — 7 errors, 2 tests. The v2 call-logs operations gained an `observability_v2_` prefix upstream, so four overlay keys matched no registered tool and their enrichments were **silently dropped from the shipped tool descriptions**:

| stale key | rekeyed to |
|---|---|
| `call_logs_list` | `observability_v2_call_logs_list` |
| `call_logs_retrieve` | `observability_v2_call_logs_retrieve` |
| `call_logs_evaluate_metrics_create` | `observability_v2_call_logs_evaluate_metrics_create` |
| `call_logs_mark_metric_vote_create` | `observability_v2_call_logs_mark_metric_vote_create` |

The list overlay's prose also cross-referenced `` `call_logs_retrieve` `` — the validator only checks keys, so this was pointing the model at a tool that does not exist. Fixed.

Three entries deleted as genuinely gone: `aiagents_toggle_mock_tools_create` / `..._progress_retrieve` (the agent-level toggle was removed in backend #9923 in favour of per-run selection), and `scenarios_create_from_transcript`, a byte-identical duplicate of the correctly-keyed `_bg` entry, left behind when the synchronous operation was replaced by the `_bg` + `_progress` pair.

The same dead name also sat in `skill_gate.GATED_TOOLS`, gating nothing. Removed, and added `test_every_gated_tool_is_a_registered_tool` so any future dead gate name fails loudly.

**Config validation** — 5 tests, and a real bug. Every field on `MCPServerConfig` is populated by a `default_factory`, and pydantic skips validators on defaults unless asked, so `validate_base_url` and `validate_spec_path` **never ran**: a malformed `CEKURA_BASE_URL` was accepted, a trailing slash was never stripped, and a missing spec file went unnoticed until a later confusing failure. Fixed with `validate_default=True`.

The tests also set `CEKURA_OPENAPI_SPEC` while the code reads `CEKURA_OPENAPI_SPEC_PATH`, so every spec path they constructed was ignored — the README documented the wrong name too. `base_url` has an intentional default (`https://api.cekura.ai`), so the "missing base URL raises" test now asserts the documented fallback rather than an error that cannot occur.

**Truncation test** — 1 test. The `<= 200` bound predated `MAX_DESCRIPTION_LENGTH` being raised to 2000, so the 300-char input was no longer truncated at all. Now driven off the constant.

**Dependency pin** — found while wiring CI, and the most urgent item here. `requirements.txt` pins `mcp>=1.27.0`, which resolves to **2.0.0 today**; 2.x drops `mcp.server.fastmcp`, imported at module scope by `openapi_mcp_server.py`. The Dockerfile installs from this file unpinned, so the **next production image build would have produced a server that cannot start**. Capped at `<2`.

**CI** — added `.github/workflows/mcp-server-tests.yml`, running the import check, the overlay validator, and pytest on Python 3.10 (matching the Dockerfile) on pull requests, so this cannot rot unnoticed again.

## Verification

From a clean install of the pinned `requirements.txt`:

| | before | after |
|---|---|---|
| `pytest` | 163 passed, **8 failed** | **172 passed, 0 failed** |
| `validate_overlays.py` | **7 errors**, 11 warnings (exit 1) | **0 errors**, 11 warnings (exit 0) |

Confirmed on both Python 3.10 (production runtime) and 3.12. The pin resolves to `mcp` 1.29.0 and `import openapi_mcp_server` succeeds.

**Not addressed:** the 11 `stale_schema_example_field` warnings. They are warning-level, pre-existing, and each needs a judgement call about the current agent-create API shape (`inbound`, `phone_number`, `agent_name`, `assistant_provider`, `contact_number`, `is_critical` no longer exist in those input schemas). Happy to take them in a follow-up.

## Note for a separate repo

`vocera.backend` still references the removed tool name in two places — `agent_runtime/sandbox/agent_runner.py:1806` and `agent_runtime/tests/test_skill_gate.py:40` both name `scenarios_create_from_transcript`. Out of scope for this docs PR, but worth a look: that gate entry can no longer match a real tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)